### PR TITLE
fix: Add support for environment flag and update tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,20 @@ megaport completion fish > ~/.config/fish/completions/megaport.fish
 megaport completion powershell > megaport.ps1
 ```
 
+## Environment Support
+
+The CLI supports different Megaport environments:
+- Production (default)
+- Staging
+- Development
+
+Specify the environment using the `--env` flag or `MEGAPORT_ENVIRONMENT` variable.
+
 ## Configuration
 
-Configure your CLI credentials using either environment variables or the configure command:
+Configure your CLI credentials using environment variables.
 
 ```sh
-# Using configure command
-megaport configure --access-key YOUR_ACCESS_KEY --secret-key YOUR_SECRET_KEY
-
 # Using environment variables
 export MEGAPORT_ACCESS_KEY=<your-access-key>
 export MEGAPORT_SECRET_KEY=<your-secret-key>
@@ -91,17 +97,6 @@ megaport servicekeys create \
   --description "My Service Key" \
   --max-speed 1000
 ```
-
-## Environment Support
-
-The CLI supports different Megaport environments:
-- Production (default)
-- Staging
-- Development
-
-Specify the environment using the `--env` flag or `MEGAPORT_ENVIRONMENT` variable.
-
-## Contributing
 
 ## Contributing
 


### PR DESCRIPTION
- Updated megaport.go to allow users to specify the environment using the --env flag or MEGAPORT_ENVIRONMENT environment variable.
- Default environment is set to production.
- Updated megaport_test.go to properly verify environment variable handling and ensure correct error handling.
- Updated README.md to reflect the changes and removed references to the configure command.

## Contributions

Please read the (Contribution Guidelines)[https://github.com/megaport/megaportgo/wiki/Contributing.md]
prior to lodging Pull Requests (PR).

## Description

Please include a summary of the change and which issue is fixed. Please also include any relevant motivation and context. 
List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Contributor Agreement

Lodging this Pull Request (PR) indicates agreement with the project's 
(Contributor License Agreement)[https://github.com/megaport/megaportgo/wiki/Megaport_Contributor_Licence_Agreement.md].

Please read the Contributor Licence Agreement (CLA) and affirm your acceptance here:

[I have read an accept the CLA]

**NOTE** If multiple authors have commited to this PR, each one will need to comment on this PR and 
agree to the CLA before this PR can be accepted.
