### PR TITLE
feat: Add MVE images and sizes listing with filtering

### DIFF
--- a/internal/cmd/mve.go
+++ b/internal/cmd/mve.go
@@ -4,6 +4,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	vendorFilter       string
+	productCodeFilter  string
+	idFilter           int
+	versionFilter      string
+	releaseImageFilter bool
+)
+
 // mveCmd is the base command for all Megaport Virtual Edge (MVE) operations.
 var mveCmd = &cobra.Command{
 	Use:   "mve",
@@ -69,8 +77,55 @@ Example usage:
 	RunE: WrapRunE(GetMVE),
 }
 
+// listMVEImagesCmd lists all available MVE images.
+var listMVEImagesCmd = &cobra.Command{
+	Use:   "list-images",
+	Short: "List all available MVE images",
+	Long: `List all available MVE images from the Megaport API.
+
+This command fetches and displays a list of all available MVE images with details such as
+image ID, version, product, and vendor. You can filter the images based on vendor, product code, ID, version, or release image.
+
+Available filters:
+  - vendor: Filter images by vendor.
+  - product-code: Filter images by product code.
+  - id: Filter images by ID.
+  - version: Filter images by version.
+  - release-image: Filter images by release image.
+
+Example usage:
+
+  megaport mve list-images --vendor "Cisco" --product-code "CISCO123" --id 1 --version "1.0" --release-image true
+`,
+	RunE: WrapRunE(ListMVEImages),
+}
+
+// listAvailableMVESizesCmd lists all available MVE sizes.
+var listAvailableMVESizesCmd = &cobra.Command{
+	Use:   "list-sizes",
+	Short: "List all available MVE sizes",
+	Long: `List all available MVE sizes from the Megaport API.
+
+This command fetches and displays a list of all available MVE sizes with details such as
+size, label, CPU core count, and RAM.
+
+Example usage:
+
+  megaport mve list-sizes
+`,
+	RunE: WrapRunE(ListAvailableMVESizes),
+}
+
 func init() {
+	listMVEImagesCmd.Flags().StringVar(&vendorFilter, "vendor", "", "Filter images by vendor")
+	listMVEImagesCmd.Flags().StringVar(&productCodeFilter, "product-code", "", "Filter images by product code")
+	listMVEImagesCmd.Flags().IntVar(&idFilter, "id", 0, "Filter images by ID")
+	listMVEImagesCmd.Flags().StringVar(&versionFilter, "version", "", "Filter images by version")
+	listMVEImagesCmd.Flags().BoolVar(&releaseImageFilter, "release-image", false, "Filter images by release image")
+
 	mveCmd.AddCommand(buyMVECmd)
 	mveCmd.AddCommand(getMVECmd)
+	mveCmd.AddCommand(listMVEImagesCmd)
+	mveCmd.AddCommand(listAvailableMVESizesCmd)
 	rootCmd.AddCommand(mveCmd)
 }

--- a/internal/cmd/mve_actions.go
+++ b/internal/cmd/mve_actions.go
@@ -135,3 +135,63 @@ func GetMVE(cmd *cobra.Command, args []string) error {
 	}
 	return nil
 }
+
+func ListMVEImages(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, err := Login(ctx)
+	if err != nil {
+		return fmt.Errorf("error logging in: %v", err)
+	}
+
+	images, err := client.MVEService.ListMVEImages(ctx)
+	if err != nil {
+		return fmt.Errorf("error listing MVE images: %v", err)
+	}
+
+	if images == nil {
+		return fmt.Errorf("no MVE images found")
+	}
+
+	// Get filter values from flags
+	vendor, _ := cmd.Flags().GetString("vendor")
+	productCode, _ := cmd.Flags().GetString("product-code")
+	id, _ := cmd.Flags().GetInt("id")
+	version, _ := cmd.Flags().GetString("version")
+	releaseImage, _ := cmd.Flags().GetBool("release-image")
+
+	// Apply filters
+	filteredImages := filterMVEImages(images, vendor, productCode, id, version, releaseImage)
+
+	err = printOutput(filteredImages, outputFormat)
+	if err != nil {
+		return fmt.Errorf("error printing MVE images: %v", err)
+	}
+	return nil
+}
+
+func ListAvailableMVESizes(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, err := Login(ctx)
+	if err != nil {
+		return fmt.Errorf("error logging in: %v", err)
+	}
+
+	sizes, err := client.MVEService.ListAvailableMVESizes(ctx)
+	if err != nil {
+		return fmt.Errorf("error listing MVE sizes: %v", err)
+	}
+
+	if sizes == nil {
+		return fmt.Errorf("no MVE sizes found")
+	}
+
+	err = printOutput(sizes, outputFormat)
+	if err != nil {
+		return fmt.Errorf("error printing MVE sizes: %v", err)
+	}
+	return nil
+}

--- a/internal/cmd/mve_utils.go
+++ b/internal/cmd/mve_utils.go
@@ -8,6 +8,30 @@ import (
 	megaport "github.com/megaport/megaportgo"
 )
 
+// filterMVEImages filters the provided MVE images based on the given filters.
+func filterMVEImages(images []*megaport.MVEImage, vendor, productCode string, id int, version string, releaseImage bool) []*megaport.MVEImage {
+	var filtered []*megaport.MVEImage
+	for _, image := range images {
+		if vendor != "" && image.Vendor != vendor {
+			continue
+		}
+		if productCode != "" && image.ProductCode != productCode {
+			continue
+		}
+		if id != 0 && image.ID != id {
+			continue
+		}
+		if version != "" && image.Version != version {
+			continue
+		}
+		if releaseImage && !image.ReleaseImage {
+			continue
+		}
+		filtered = append(filtered, image)
+	}
+	return filtered
+}
+
 // MVEOutput represents the desired fields for JSON output.
 type MVEOutput struct {
 	UID        string `json:"uid"`

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -204,3 +204,25 @@ func captureOutput(f func()) string {
 	os.Stdout = old
 	return string(out)
 }
+
+// captureOutputErr is a helper function to capture stdout output and return any error
+func captureOutputErr(f func() error) (string, error) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := f()
+	if err != nil {
+		return "", err
+	}
+
+	w.Close()
+	var buf strings.Builder
+	_, err = io.Copy(&buf, r)
+	if err != nil {
+		return "", err
+	}
+	os.Stdout = old
+
+	return buf.String(), err
+}


### PR DESCRIPTION
- Implemented  command to list all available MVE images with filtering options for vendor, product code, ID, version, and release image.
- Implemented  command to list all available MVE sizes.
- Added unit tests for  and  commands to ensure proper functionality and filtering.
- Updated  to include the new commands and their respective flags.
- Added mock services and utility functions to support the new commands in tests.

## Contributions

Please read the (Contribution Guidelines)[https://github.com/megaport/megaportgo/wiki/Contributing.md]
prior to lodging Pull Requests (PR).

## Description

Please include a summary of the change and which issue is fixed. Please also include any relevant motivation and context. 
List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Contributor Agreement

Lodging this Pull Request (PR) indicates agreement with the project's 
(Contributor License Agreement)[https://github.com/megaport/megaportgo/wiki/Megaport_Contributor_Licence_Agreement.md].

Please read the Contributor Licence Agreement (CLA) and affirm your acceptance here:

[I have read an accept the CLA]

**NOTE** If multiple authors have commited to this PR, each one will need to comment on this PR and 
agree to the CLA before this PR can be accepted.
