### PR TITLE
feat(output): enhance type safety and reflection handling

### DIFF
--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -51,7 +51,13 @@ type output interface {
 	isOuput()
 }
 
-func printOutput[T any](data []T, format string) error {
+// OutputFields is a marker interface for output-formattable types
+type OutputFields interface {
+	any
+}
+
+// printOutput formats data in the specified output style
+func printOutput[T OutputFields](data []T, format string) error {
 	validFormats := map[string]bool{
 		"table": true,
 		"json":  true,
@@ -72,123 +78,375 @@ func printOutput[T any](data []T, format string) error {
 	}
 }
 
-// printJSON handles JSON output format
-func printJSON[T any](data []T) error {
+// printJSON outputs formatted JSON to stdout
+func printJSON[T OutputFields](data []T) error {
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(data)
 }
 
-// printTable prints a header row (from struct tags) even if data is empty.
-func printTable[T any](data []T) error {
-	// Use the first item if available. Otherwise, create a zero value.
+// printTable formats data as a columnar table
+// Uses struct tags for column headers: header > csv > json
+func printTable[T OutputFields](data []T) error {
+	// Get a sample item to determine fields
 	var sample T
 	if len(data) > 0 {
 		sample = data[0]
 	}
 
-	// Configure tabwriter for left alignment and consistent spacing
+	// Set up tabwriter for readable columns
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	defer w.Flush()
 
-	// Reflect on sample. If sample is a pointer, dereference it.
+	// Get type information via reflection
 	sampleVal := reflect.ValueOf(sample)
-	itemType := sampleVal.Type()
-	if itemType.Kind() == reflect.Ptr {
-		itemType = itemType.Elem()
+	if !sampleVal.IsValid() {
+		// Instead of error, just return empty table for zero values
+		fmt.Fprintln(w, "")
+		return nil
 	}
 
-	// Collect struct fields and headers
-	var headers []string
-	var fields []string
+	itemType := sampleVal.Type()
+	if itemType.Kind() == reflect.Ptr {
+		if sampleVal.IsNil() {
+			// Handle nil pointer by examining the underlying type
+			// Check if we can safely get element type
+			if itemType.Elem().Kind() != reflect.Struct {
+				return nil
+			}
+			itemType = itemType.Elem()
+			// Create a new instance to inspect fields
+			_ = reflect.New(itemType).Elem()
+		} else {
+			sampleVal = sampleVal.Elem()
+			itemType = sampleVal.Type()
+		}
+	}
 
-	// If T is not a struct (e.g., empty interface), just return
+	// Only works with struct types
 	if itemType.Kind() != reflect.Struct {
 		return nil
 	}
 
+	// Extract column headers and field names
+	var headers []string
+	var fields []string
+	var fieldIndices []int // Store field indices for safer access
+
 	for i := 0; i < itemType.NumField(); i++ {
 		field := itemType.Field(i)
-		if tag := field.Tag.Get("json"); tag != "" && tag != "-" {
-			headers = append(headers, tag)
-			fields = append(fields, field.Name)
+
+		// Skip unexported fields
+		if field.PkgPath != "" {
+			continue
 		}
+
+		// Validate field type is compatible with output
+		if !isOutputCompatibleType(field.Type) {
+			continue
+		}
+
+		// Look for header tag first
+		headerTag := field.Tag.Get("header")
+		if headerTag == "-" {
+			continue // Skip this field
+		}
+
+		// Fall back to csv tag
+		if headerTag == "" {
+			headerTag = field.Tag.Get("csv")
+			if headerTag == "-" {
+				continue
+			}
+		}
+
+		// Fall back to json tag
+		if headerTag == "" {
+			headerTag = field.Tag.Get("json")
+			if headerTag == "-" {
+				continue
+			}
+		}
+
+		// If no tags found, use the field name itself
+		if headerTag == "" {
+			headerTag = field.Name
+		}
+
+		headers = append(headers, headerTag)
+		fields = append(fields, field.Name)
+		fieldIndices = append(fieldIndices, i) // Store actual index for direct access
 	}
 
-	// Print headers with tabs
+	// Nothing to show
+	if len(headers) == 0 {
+		return nil
+	}
+
+	// Print header row
 	fmt.Fprintln(w, strings.Join(headers, "\t"))
 
-	// Print data rows (if any)
+	// Print data rows
 	for _, item := range data {
 		itemVal := reflect.ValueOf(item)
+		if !itemVal.IsValid() {
+			continue
+		}
+
 		if itemVal.Kind() == reflect.Ptr {
+			if itemVal.IsNil() {
+				continue
+			}
 			itemVal = itemVal.Elem()
 		}
 
+		// Skip if not a struct
+		if itemVal.Kind() != reflect.Struct {
+			continue
+		}
+
 		var row []string
-		for _, field := range fields {
-			row = append(row, fmt.Sprintf("%v", itemVal.FieldByName(field)))
+		for i, field := range fields {
+			// Try direct field access by index first (faster and safer)
+			var fieldVal reflect.Value
+			if i < len(fieldIndices) && fieldIndices[i] < itemVal.NumField() {
+				fieldVal = itemVal.Field(fieldIndices[i])
+			} else {
+				// Fall back to name-based lookup
+				fieldVal = itemVal.FieldByName(field)
+			}
+
+			if !fieldVal.IsValid() {
+				row = append(row, "")
+				continue
+			}
+
+			// Handle the case where we can't interface (unexported)
+			valueStr := ""
+			if fieldVal.CanInterface() {
+				// Handle nil interface values
+				if fieldVal.Kind() == reflect.Ptr && fieldVal.IsNil() {
+					row = append(row, "")
+					continue
+				}
+
+				// Format value based on kind
+				valueStr = formatFieldValue(fieldVal)
+			}
+			row = append(row, valueStr)
 		}
 		fmt.Fprintln(w, strings.Join(row, "\t"))
 	}
 
-	return w.Flush()
+	return nil
 }
 
-// printCSV prints a header row (from struct tags) even if data is empty.
-func printCSV[T any](data []T) error {
+// printCSV outputs data in comma-separated value format
+// Uses struct tags for column names: csv > json
+func printCSV[T OutputFields](data []T) error {
 	w := csv.NewWriter(os.Stdout)
 	defer w.Flush()
 
-	// Use the first item if available. Otherwise, create a zero value.
+	// Get a sample item to determine fields
 	var sample T
 	if len(data) > 0 {
 		sample = data[0]
 	}
 
+	// Get type information via reflection
 	sampleVal := reflect.ValueOf(sample)
-	t := sampleVal.Type()
-	if t.Kind() == reflect.Ptr {
-		t = t.Elem()
+	if !sampleVal.IsValid() {
+		// For empty values, just write empty header
+		return nil
 	}
 
-	// If T is not a struct (e.g., empty interface), just return
+	t := sampleVal.Type()
+	if t.Kind() == reflect.Ptr {
+		if sampleVal.IsNil() {
+			// Handle nil pointer
+			// Check if we can safely get element type
+			if t.Elem().Kind() != reflect.Struct {
+				return nil
+			}
+			t = t.Elem()
+			// Create a new instance to inspect fields
+			_ = reflect.New(t).Elem()
+		} else {
+			sampleVal = sampleVal.Elem()
+			t = sampleVal.Type()
+		}
+	}
+
+	// Only works with struct types
 	if t.Kind() != reflect.Struct {
 		return nil
 	}
 
-	// Get headers from struct tags
+	// Extract column headers and field names
 	var headers []string
 	var fields []string
+	var fieldIndices []int // Store field indices for safer access
+
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
-		if tag := field.Tag.Get("json"); tag != "" && tag != "-" {
-			headers = append(headers, tag)
-			fields = append(fields, field.Name)
+
+		// Skip unexported fields
+		if field.PkgPath != "" {
+			continue
 		}
+
+		// Validate field type is compatible with output
+		if !isOutputCompatibleType(field.Type) {
+			continue
+		}
+
+		// Look for csv tag first
+		csvTag := field.Tag.Get("csv")
+		if csvTag == "-" {
+			continue // Skip this field
+		}
+
+		// Fall back to json tag
+		if csvTag == "" {
+			csvTag = field.Tag.Get("json")
+			if csvTag == "" || csvTag == "-" {
+				continue
+			}
+		}
+
+		headers = append(headers, csvTag)
+		fields = append(fields, field.Name)
+		fieldIndices = append(fieldIndices, i) // Store actual index
 	}
 
-	// Always print headers
+	// Nothing to show
+	if len(headers) == 0 {
+		return nil
+	}
+
+	// Write header row
 	if err := w.Write(headers); err != nil {
 		return err
 	}
 
-	// Write data rows if present
+	// Write data rows
 	for _, item := range data {
 		v := reflect.ValueOf(item)
+		if !v.IsValid() {
+			continue
+		}
+
 		if v.Kind() == reflect.Ptr {
+			if v.IsNil() {
+				continue
+			}
 			v = v.Elem()
 		}
 
-		var row []string
-		for _, field := range fields {
-			row = append(row, fmt.Sprintf("%v", v.FieldByName(field)))
+		// Skip if not a struct
+		if v.Kind() != reflect.Struct {
+			continue
 		}
+
+		var row []string
+		for i, field := range fields {
+			// Try direct field access by index first (faster and safer)
+			var fieldVal reflect.Value
+			if i < len(fieldIndices) && fieldIndices[i] < v.NumField() {
+				fieldVal = v.Field(fieldIndices[i])
+			} else {
+				// Fall back to name-based lookup
+				fieldVal = v.FieldByName(field)
+			}
+
+			if !fieldVal.IsValid() {
+				row = append(row, "")
+				continue
+			}
+
+			// Handle the case where we can't interface (unexported)
+			valueStr := ""
+			if fieldVal.CanInterface() {
+				// Handle nil interface values
+				if fieldVal.Kind() == reflect.Ptr && fieldVal.IsNil() {
+					row = append(row, "")
+					continue
+				}
+
+				// Format value based on kind
+				valueStr = formatFieldValue(fieldVal)
+			}
+			row = append(row, valueStr)
+		}
+
 		if err := w.Write(row); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// Helper function to check if a field type is compatible with output
+func isOutputCompatibleType(t reflect.Type) bool {
+	// Handle pointer types
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	// Basic supported types
+	switch t.Kind() {
+	case reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64, reflect.String:
+		return true
+	case reflect.Struct, reflect.Interface:
+		// These can be complex but we allow them
+		return true
+	case reflect.Slice, reflect.Array, reflect.Map:
+		// Complex types that may need special handling
+		return true
+	default:
+		// Skip types that don't convert well to string representation
+		return false
+	}
+}
+
+// Helper function to format a field value based on its kind
+func formatFieldValue(v reflect.Value) string {
+	// Do special handling for time.Time, maps, slices, etc.
+	switch v.Kind() {
+	case reflect.String:
+		return v.String()
+	case reflect.Bool:
+		return fmt.Sprintf("%v", v.Bool())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return fmt.Sprintf("%d", v.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return fmt.Sprintf("%d", v.Uint())
+	case reflect.Float32, reflect.Float64:
+		return fmt.Sprintf("%g", v.Float())
+	case reflect.Struct:
+		// Handle common types like time.Time
+		if v.Type().String() == "time.Time" {
+			if method := v.MethodByName("Format"); method.IsValid() {
+				args := []reflect.Value{reflect.ValueOf("2006-01-02")}
+				result := method.Call(args)
+				if len(result) > 0 {
+					return result[0].String()
+				}
+			}
+		}
+		return fmt.Sprintf("%v", v.Interface())
+	case reflect.Map, reflect.Slice, reflect.Array:
+		// For complex types, use json marshaling
+		if bytes, err := json.Marshal(v.Interface()); err == nil {
+			return string(bytes)
+		}
+		return fmt.Sprintf("%v", v.Interface())
+	default:
+		return fmt.Sprintf("%v", v.Interface())
+	}
 }
 
 // captureOutput captures and returns any output written to stdout during execution of f.

--- a/internal/cmd/utils_test.go
+++ b/internal/cmd/utils_test.go
@@ -1,0 +1,471 @@
+package cmd
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test structures
+type SimpleStruct struct {
+	ID     int    `json:"id" csv:"id" header:"ID"`
+	Name   string `json:"name" csv:"name" header:"Name"`
+	Active bool   `json:"active" csv:"active" header:"Active"`
+}
+
+type ComplexStruct struct {
+	ID         int               `json:"id" csv:"id" header:"ID"`
+	Name       string            `json:"name" csv:"name" header:"Name"`
+	Created    time.Time         `json:"created" csv:"created" header:"Created"`
+	Tags       []string          `json:"tags" csv:"tags" header:"Tags"`
+	Metadata   map[string]string `json:"metadata" csv:"metadata" header:"Metadata"`
+	Reference  *SimpleStruct     `json:"reference" csv:"reference" header:"Reference"`
+	unexported string            // This should be skipped
+	Ignored    int               `json:"-" csv:"-" header:"-"` // This should be skipped
+}
+
+type CustomTagStruct struct {
+	ID   int    `json:"id" csv:"csv_id" header:"Custom ID"`
+	Name string `json:"name" csv:"csv_name" header:"Custom Name"`
+}
+
+type NoTagStruct struct {
+	ID   int
+	Name string
+}
+
+// Tests for printTable
+func TestPrintTable_SimpleStruct(t *testing.T) {
+	data := []SimpleStruct{
+		{ID: 1, Name: "Item 1", Active: true},
+		{ID: 2, Name: "Item 2", Active: false},
+	}
+
+	output := captureOutput(func() {
+		err := printTable(data)
+		assert.NoError(t, err)
+	})
+
+	// Use spaces instead of tabs to match tabwriter output
+	assert.Contains(t, output, "ID")
+	assert.Contains(t, output, "Name")
+	assert.Contains(t, output, "Active")
+	assert.Contains(t, output, "1")
+	assert.Contains(t, output, "Item 1")
+	assert.Contains(t, output, "true")
+	assert.Contains(t, output, "2")
+	assert.Contains(t, output, "Item 2")
+	assert.Contains(t, output, "false")
+}
+
+func TestPrintTable_ComplexStruct(t *testing.T) {
+	now := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	data := []ComplexStruct{
+		{
+			ID:      1,
+			Name:    "Complex Item",
+			Created: now,
+			Tags:    []string{"tag1", "tag2"},
+			Metadata: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			Reference:  &SimpleStruct{ID: 100, Name: "Referenced", Active: true},
+			unexported: "hidden",
+			Ignored:    999,
+		},
+	}
+
+	output := captureOutput(func() {
+		err := printTable(data)
+		assert.NoError(t, err)
+	})
+
+	// The output should contain the fields (except unexported and ignored)
+	assert.Contains(t, output, "ID")
+	assert.Contains(t, output, "Name")
+	assert.Contains(t, output, "Created")
+	assert.Contains(t, output, "Tags")
+	assert.Contains(t, output, "Metadata")
+	assert.Contains(t, output, "Reference")
+
+	// Check specific values
+	assert.Contains(t, output, "1")
+	assert.Contains(t, output, "Complex Item")
+	assert.Contains(t, output, "2023-01-01")
+
+	// The unexported and ignored fields should not be in the output
+	assert.NotContains(t, output, "unexported")
+	assert.NotContains(t, output, "hidden")
+	assert.NotContains(t, output, "Ignored")
+	assert.NotContains(t, output, "999")
+}
+
+func TestPrintTable_EmptySlice(t *testing.T) {
+	data := []SimpleStruct{}
+
+	output := captureOutput(func() {
+		err := printTable(data)
+		assert.NoError(t, err)
+	})
+
+	// Check for headers (ignoring exact spacing)
+	assert.Contains(t, output, "ID")
+	assert.Contains(t, output, "Name")
+	assert.Contains(t, output, "Active")
+}
+
+func TestPrintTable_NilSlice(t *testing.T) {
+	var data []SimpleStruct = nil
+
+	_ = captureOutput(func() {
+		err := printTable(data)
+		assert.NoError(t, err)
+	})
+
+	// Should not panic but might not output anything useful
+	assert.NotPanics(t, func() {
+		_ = printTable(data)
+	})
+}
+
+func TestPrintTable_MixedSlice(t *testing.T) {
+	data := []*SimpleStruct{
+		{ID: 1, Name: "Item 1", Active: true},
+		nil,
+		{ID: 3, Name: "Item 3", Active: false},
+	}
+
+	output := captureOutput(func() {
+		err := printTable(data)
+		assert.NoError(t, err)
+	})
+
+	// Should skip the nil entry
+	assert.Contains(t, output, "Item 1")
+	assert.Contains(t, output, "Item 3")
+	assert.NotContains(t, output, "Item 2") // There is no Item 2
+}
+
+func TestPrintTable_CustomTags(t *testing.T) {
+	data := []CustomTagStruct{
+		{ID: 1, Name: "Custom 1"},
+		{ID: 2, Name: "Custom 2"},
+	}
+
+	output := captureOutput(func() {
+		err := printTable(data)
+		assert.NoError(t, err)
+	})
+
+	// Check for expected content rather than exact spacing
+	assert.Contains(t, output, "Custom ID")
+	assert.Contains(t, output, "Custom Name")
+	assert.Contains(t, output, "1")
+	assert.Contains(t, output, "Custom 1")
+	assert.Contains(t, output, "2")
+	assert.Contains(t, output, "Custom 2")
+}
+
+func TestPrintTable_NoTags(t *testing.T) {
+	data := []NoTagStruct{
+		{ID: 1, Name: "No Tags 1"},
+		{ID: 2, Name: "No Tags 2"},
+	}
+
+	output := captureOutput(func() {
+		err := printTable(data)
+		assert.NoError(t, err)
+	})
+
+	// Should use field names as headers
+	assert.Contains(t, output, "ID")
+	assert.Contains(t, output, "Name")
+	assert.Contains(t, output, "No Tags 1")
+	assert.Contains(t, output, "No Tags 2")
+}
+
+// Tests for printCSV
+func TestPrintCSV_SimpleStruct(t *testing.T) {
+	data := []SimpleStruct{
+		{ID: 1, Name: "Item 1", Active: true},
+		{ID: 2, Name: "Item 2", Active: false},
+	}
+
+	output := captureOutput(func() {
+		err := printCSV(data)
+		assert.NoError(t, err)
+	})
+
+	expected := "id,name,active\n" +
+		"1,Item 1,true\n" +
+		"2,Item 2,false\n"
+
+	assert.Equal(t, expected, output)
+}
+
+func TestPrintCSV_ComplexStruct(t *testing.T) {
+	now := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	data := []ComplexStruct{
+		{
+			ID:      1,
+			Name:    "Complex Item",
+			Created: now,
+			Tags:    []string{"tag1", "tag2"},
+			Metadata: map[string]string{
+				"key1": "value1",
+			},
+			Reference: &SimpleStruct{ID: 100, Name: "Referenced", Active: true},
+		},
+	}
+
+	output := captureOutput(func() {
+		err := printCSV(data)
+		assert.NoError(t, err)
+	})
+
+	// The CSV output should have headers
+	assert.Contains(t, output, "id,name,created,tags,metadata,reference")
+
+	// Check specific values
+	assert.Contains(t, output, "1,Complex Item,2023-01-01")
+}
+
+func TestPrintCSV_EmptySlice(t *testing.T) {
+	data := []SimpleStruct{}
+
+	output := captureOutput(func() {
+		err := printCSV(data)
+		assert.NoError(t, err)
+	})
+
+	// Should output headers even with empty data
+	expected := "id,name,active\n"
+	assert.Equal(t, expected, output)
+}
+
+func TestPrintCSV_NilSlice(t *testing.T) {
+	var data []SimpleStruct = nil
+
+	_ = captureOutput(func() {
+		err := printCSV(data)
+		assert.NoError(t, err)
+	})
+
+	// Should not panic but might not output anything useful
+	assert.NotPanics(t, func() {
+		_ = printCSV(data)
+	})
+}
+
+// Tests for printJSON
+func TestPrintJSON(t *testing.T) {
+	data := []SimpleStruct{
+		{ID: 1, Name: "Item 1", Active: true},
+		{ID: 2, Name: "Item 2", Active: false},
+	}
+
+	output := captureOutput(func() {
+		err := printJSON(data)
+		assert.NoError(t, err)
+	})
+
+	// Parse the output back to JSON to compare
+	var parsed []map[string]interface{}
+	err := json.Unmarshal([]byte(output), &parsed)
+	assert.NoError(t, err)
+
+	expected := []map[string]interface{}{
+		{"id": float64(1), "name": "Item 1", "active": true},
+		{"id": float64(2), "name": "Item 2", "active": false},
+	}
+
+	assert.Equal(t, expected, parsed)
+}
+
+// Tests for isOutputCompatibleType
+func TestIsOutputCompatibleType(t *testing.T) {
+	tests := []struct {
+		name      string
+		fieldType reflect.Type
+		expected  bool
+	}{
+		{
+			name:      "String",
+			fieldType: reflect.TypeOf(""),
+			expected:  true,
+		},
+		{
+			name:      "Int",
+			fieldType: reflect.TypeOf(0),
+			expected:  true,
+		},
+		{
+			name:      "Bool",
+			fieldType: reflect.TypeOf(false),
+			expected:  true,
+		},
+		{
+			name:      "Float",
+			fieldType: reflect.TypeOf(0.0),
+			expected:  true,
+		},
+		{
+			name:      "Slice",
+			fieldType: reflect.TypeOf([]string{}),
+			expected:  true,
+		},
+		{
+			name:      "Map",
+			fieldType: reflect.TypeOf(map[string]string{}),
+			expected:  true,
+		},
+		{
+			name:      "Struct",
+			fieldType: reflect.TypeOf(struct{}{}),
+			expected:  true,
+		},
+		{
+			name:      "Pointer",
+			fieldType: reflect.TypeOf(&struct{}{}),
+			expected:  true,
+		},
+		{
+			name:      "Time",
+			fieldType: reflect.TypeOf(time.Time{}),
+			expected:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isOutputCompatibleType(tt.fieldType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Tests for formatFieldValue
+func TestFormatFieldValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    interface{}
+		expected string
+	}{
+		{
+			name:     "String",
+			value:    "test",
+			expected: "test",
+		},
+		{
+			name:     "Int",
+			value:    42,
+			expected: "42",
+		},
+		{
+			name:     "Bool",
+			value:    true,
+			expected: "true",
+		},
+		{
+			name:     "Float",
+			value:    3.14,
+			expected: "3.14",
+		},
+		{
+			name:     "Time",
+			value:    time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+			expected: "2023-01-01",
+		},
+		{
+			name:     "Slice",
+			value:    []string{"one", "two"},
+			expected: `["one","two"]`,
+		},
+		{
+			name:     "Map",
+			value:    map[string]string{"key": "value"},
+			expected: `{"key":"value"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := reflect.ValueOf(tt.value)
+			result := formatFieldValue(v)
+
+			// Handle the special case of JSON formatting
+			if tt.name == "Slice" || tt.name == "Map" {
+				// Compare after normalizing JSON
+				var expected, actual interface{}
+				err := json.Unmarshal([]byte(tt.expected), &expected)
+				assert.NoError(t, err)
+				err = json.Unmarshal([]byte(result), &actual)
+				assert.NoError(t, err)
+				assert.Equal(t, expected, actual)
+			} else {
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+// Test output with mixed fields
+func TestPrintOutput_MixedFields(t *testing.T) {
+	type MixedStruct struct {
+		ID         int       `json:"id" csv:"id" header:"ID"`
+		Name       string    `json:"name" csv:"name" header:"Name"`
+		Created    time.Time `json:"created" csv:"created" header:"Created"`
+		Active     bool      `json:"active" csv:"active" header:"Active"`
+		NilPtr     *string   `json:"nil_ptr" csv:"nil_ptr" header:"Nil Pointer"`
+		unexported string    // This should be skipped
+	}
+
+	timeVal := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	data := []MixedStruct{
+		{
+			ID:         1,
+			Name:       "Test Item",
+			Created:    timeVal,
+			Active:     true,
+			NilPtr:     nil,
+			unexported: "hidden",
+		},
+	}
+
+	formats := []string{"table", "csv", "json"}
+	for _, format := range formats {
+		t.Run(format, func(t *testing.T) {
+			output := captureOutput(func() {
+				err := printOutput(data, format)
+				assert.NoError(t, err)
+			})
+
+			// All formats should include the exported fields
+			assert.Contains(t, output, "Test Item")
+			assert.Contains(t, output, "2023-01-01")
+
+			// None should contain unexported fields
+			assert.NotContains(t, output, "hidden")
+
+			// All should handle nil pointer gracefully
+			assert.NotPanics(t, func() {
+				_ = printOutput(data, format)
+			})
+		})
+	}
+}
+
+// Test error handling
+func TestPrintOutput_InvalidFormat(t *testing.T) {
+	data := []SimpleStruct{{ID: 1, Name: "Test"}}
+
+	err := printOutput(data, "invalid")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output format")
+}


### PR DESCRIPTION
Improve robustness of output formatting functions:
- Add validation for struct field types before printing
- Enhance reflection safety with proper nil and type checks
- Support fields without explicit tags using field names
- Format complex types (time, slices, maps) more consistently
- Prevent runtime panics with defensive reflection patterns
- Add comprehensive test suite covering various edge cases

This ensures more reliable output across all supported formats while maintaining backward compatibility with existing CLI output.

## Contributions

Please read the (Contribution Guidelines)[https://github.com/megaport/megaportgo/wiki/Contributing.md]
prior to lodging Pull Requests (PR).

## Description

Please include a summary of the change and which issue is fixed. Please also include any relevant motivation and context. 
List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Contributor Agreement

Lodging this Pull Request (PR) indicates agreement with the project's 
(Contributor License Agreement)[https://github.com/megaport/megaportgo/wiki/Megaport_Contributor_Licence_Agreement.md].

Please read the Contributor Licence Agreement (CLA) and affirm your acceptance here:

[I have read an accept the CLA]

**NOTE** If multiple authors have commited to this PR, each one will need to comment on this PR and 
agree to the CLA before this PR can be accepted.
