### PR TITLE
fix: resolve golangci-lint cache extraction errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,13 +19,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.21'
-          cache: false
-
-      - name: Remove Go module cache directory
-        run: rm -rf $GOPATH/pkg/mod
-
-      - name: Clean Go module cache
-        run: go clean -modcache
+          cache: true
 
       - name: Install dependencies
         run: go mod download
@@ -35,3 +29,5 @@ jobs:
         with:
           version: v1.56
           args: --timeout 5m
+          skip-pkg-cache: true
+          skip-build-cache: true


### PR DESCRIPTION
Add skip-pkg-cache and skip-build-cache flags to the golangci-lint-action configuration to prevent errors during cache extraction. Previously, the action was failing with "Cannot open: File exists" errors when trying to extract module files that were already present from the Go setup caching.

This change disables golangci-lint's internal caching mechanism while preserving the Go module caching from actions/setup-go, providing a more reliable CI workflow.

## Contributions

Please read the (Contribution Guidelines)[https://github.com/megaport/megaportgo/wiki/Contributing.md]
prior to lodging Pull Requests (PR).

## Description

Please include a summary of the change and which issue is fixed. Please also include any relevant motivation and context. 
List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Contributor Agreement

Lodging this Pull Request (PR) indicates agreement with the project's 
(Contributor License Agreement)[https://github.com/megaport/megaportgo/wiki/Megaport_Contributor_Licence_Agreement.md].

Please read the Contributor Licence Agreement (CLA) and affirm your acceptance here:

[I have read an accept the CLA]

**NOTE** If multiple authors have commited to this PR, each one will need to comment on this PR and 
agree to the CLA before this PR can be accepted.
