### PR TITLE
feat: add MCR IPSec add-on CLI support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/jedib0t/go-pretty/v6 v6.7.9
 	github.com/jmespath/go-jmespath v0.4.0
-	github.com/megaport/megaportgo v1.5.0
+	github.com/megaport/megaportgo v1.6.0
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/mattn/go-runewidth v0.0.17 h1:78v8ZlW0bP43XfmAfPsdXcoNCelfMHsDmd/pkEN
 github.com/mattn/go-runewidth v0.0.17/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/megaport/megaportgo v1.5.0 h1:uPfq5A+nL1mjcmxmboQjFFlzs3G8Zp9wDIoPWzFzw54=
 github.com/megaport/megaportgo v1.5.0/go.mod h1:KgHDAyT1uVg93qBaW/z0M63sQlPvipB04vab4F88dGA=
+github.com/megaport/megaportgo v1.6.0 h1:7Owe/BA0NsL4gOoTzMaL+YJgZPBoB1NnKTxkNnsYEWM=
+github.com/megaport/megaportgo v1.6.0/go.mod h1:KgHDAyT1uVg93qBaW/z0M63sQlPvipB04vab4F88dGA=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=

--- a/internal/base/cmdbuilder/flagsets_test.go
+++ b/internal/base/cmdbuilder/flagsets_test.go
@@ -131,6 +131,20 @@ func TestWithJSONConfigFlags(t *testing.T) {
 	assertFlagType(t, cmd, "json-file", "string")
 }
 
+func TestWithMCRIPSecAddOnFlags(t *testing.T) {
+	cmd := NewCommand("test", "test").WithMCRIPSecAddOnFlags().Build()
+
+	assertFlagExists(t, cmd, "tunnel-count", "0")
+	assertFlagType(t, cmd, "tunnel-count", "int")
+}
+
+func TestWithMCRUpdateIPSecAddOnFlags(t *testing.T) {
+	cmd := NewCommand("test", "test").WithMCRUpdateIPSecAddOnFlags().Build()
+
+	assertFlagExists(t, cmd, "tunnel-count", "0")
+	assertFlagType(t, cmd, "tunnel-count", "int")
+}
+
 // Resource-specific flagset tests
 
 func TestWithPortCreationFlags(t *testing.T) {

--- a/internal/base/cmdbuilder/mcr_flagsets.go
+++ b/internal/base/cmdbuilder/mcr_flagsets.go
@@ -46,7 +46,7 @@ func (b *CommandBuilder) WithMCRPrefixFilterListFlags() *CommandBuilder {
 
 // WithMCRIPSecAddOnFlags adds flags for adding an IPSec add-on to an MCR.
 func (b *CommandBuilder) WithMCRIPSecAddOnFlags() *CommandBuilder {
-	return b.WithIntFlag("tunnel-count", 0, "IPSec tunnel count (10, 20, or 30; defaults to 10 if unset)")
+	return b.WithIntFlag("tunnel-count", 0, "IPSec tunnel count (10, 20, or 30; omit or use 0 to let the API apply its default of 10)")
 }
 
 // WithMCRUpdateIPSecAddOnFlags adds flags for updating an IPSec add-on on an MCR.

--- a/internal/base/cmdbuilder/mcr_flagsets.go
+++ b/internal/base/cmdbuilder/mcr_flagsets.go
@@ -44,6 +44,16 @@ func (b *CommandBuilder) WithMCRPrefixFilterListFlags() *CommandBuilder {
 	return b
 }
 
+// WithMCRIPSecAddOnFlags adds flags for adding an IPSec add-on to an MCR.
+func (b *CommandBuilder) WithMCRIPSecAddOnFlags() *CommandBuilder {
+	return b.WithIntFlag("tunnel-count", 0, "IPSec tunnel count (10, 20, or 30; defaults to 10 if unset)")
+}
+
+// WithMCRUpdateIPSecAddOnFlags adds flags for updating an IPSec add-on on an MCR.
+func (b *CommandBuilder) WithMCRUpdateIPSecAddOnFlags() *CommandBuilder {
+	return b.WithIntFlag("tunnel-count", 0, "New tunnel count (10, 20, or 30); set to 0 to disable IPSec")
+}
+
 // WithMCRFilterFlags adds flags for filtering MCR lists
 func (b *CommandBuilder) WithMCRFilterFlags() *CommandBuilder {
 	b.WithIntFlag("location-id", 0, "Filter MCRs by location ID")

--- a/internal/commands/apply/apply_mock.go
+++ b/internal/commands/apply/apply_mock.go
@@ -124,6 +124,14 @@ func (m *MockMCRService) GetMCRPrefixFilterLists(ctx context.Context, mcrId stri
 	return nil, fmt.Errorf("mock: GetMCRPrefixFilterLists not configured")
 }
 
+func (m *MockMCRService) UpdateMCRWithAddOn(ctx context.Context, mcrID string, req megaport.MCRAddOnRequest) error {
+	return fmt.Errorf("mock: UpdateMCRWithAddOn not configured")
+}
+
+func (m *MockMCRService) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, addOnUID string, tunnelCount int) error {
+	return fmt.Errorf("mock: UpdateMCRIPsecAddOn not configured")
+}
+
 // MockMVEService implements megaport.MVEService for testing.
 type MockMVEService struct {
 	BuyMVEResult        *megaport.BuyMVEResponse

--- a/internal/commands/mcr/mcr.go
+++ b/internal/commands/mcr/mcr.go
@@ -355,7 +355,7 @@ func buildMCRIPSecCommands(rootCmd *cobra.Command) (addIPSec, updateIPSec *cobra
 		WithStandardInputFlags().
 		WithMCRIPSecAddOnFlags().
 		WithLongDesc("Add an IPSec add-on to an existing MCR.\n\nThis command provisions an IPSec add-on on the specified MCR. IPSec add-ons enable encrypted tunnel termination on the MCR.").
-		WithDocumentedRequiredFlag("tunnel-count", "Number of IPSec tunnels (10, 20, or 30; defaults to 10 if unset)").
+		WithDocumentedRequiredFlag("tunnel-count", "Number of IPSec tunnels (10, 20, or 30); omit to use the API default of 10").
 		WithExample("megaport-cli mcr add-ipsec-addon [mcrUID] --tunnel-count 10").
 		WithExample("megaport-cli mcr add-ipsec-addon [mcrUID] --tunnel-count 20").
 		WithExample("megaport-cli mcr add-ipsec-addon [mcrUID] --json '{\"tunnelCount\":10}'").
@@ -363,8 +363,8 @@ func buildMCRIPSecCommands(rootCmd *cobra.Command) (addIPSec, updateIPSec *cobra
 		WithJSONExample(`{
   "tunnelCount": 10
 }`).
-		WithImportantNote("Valid tunnel counts are 10, 20, or 30. Omitting --tunnel-count defaults to 10.").
-		WithImportantNote("Required flag (tunnel-count) can be skipped when using --interactive or --json").
+		WithImportantNote("Valid tunnel counts are 10, 20, or 30. --tunnel-count is required in flag mode.").
+		WithImportantNote("--tunnel-count can be skipped when using --interactive, --json, or --json-file").
 		WithRootCmd(rootCmd).
 		WithConditionalRequirements("tunnel-count").
 		Build()
@@ -384,7 +384,7 @@ func buildMCRIPSecCommands(rootCmd *cobra.Command) (addIPSec, updateIPSec *cobra
   "tunnelCount": 30
 }`).
 		WithImportantNote("Valid tunnel counts are 10, 20, or 30. Set to 0 to disable the IPSec add-on.").
-		WithImportantNote("Required flag (tunnel-count) can be skipped when using --interactive or --json").
+		WithImportantNote("--tunnel-count can be skipped when using --interactive, --json, or --json-file").
 		WithRootCmd(rootCmd).
 		WithConditionalRequirements("tunnel-count").
 		Build()

--- a/internal/commands/mcr/mcr.go
+++ b/internal/commands/mcr/mcr.go
@@ -25,12 +25,14 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 	get, buy, update, del, restore, lock, unlock, list, status, validate := buildMCRCommands(rootCmd)
 	create, listPFL, getPFL, updatePFL, deletePFL := buildMCRPrefixFilterCommands(rootCmd)
 	listTags, updateTags := buildMCRTagCommands()
+	addIPSec, updateIPSec := buildMCRIPSecCommands(rootCmd)
 
 	mcrCmd.AddCommand(
 		get, buy, update, del, restore, lock, unlock,
 		create, listPFL, getPFL, updatePFL, deletePFL,
 		list, status, validate,
 		listTags, updateTags,
+		addIPSec, updateIPSec,
 	)
 	rootCmd.AddCommand(mcrCmd)
 }
@@ -71,6 +73,7 @@ func buildMCRCommands(rootCmd *cobra.Command) (get, buy, update, del, restore, l
 		WithOptionalFlag("cost-centre", "The cost centre for the MCR").
 		WithOptionalFlag("promo-code", "A promotional code for the MCR").
 		WithOptionalFlag("resource-tags", "JSON string of key-value pairs for resource tagging").
+		WithIntFlag("ipsec-tunnel-count", 0, "IPSec tunnel count for an add-on (10, 20, or 30)").
 		WithExample("megaport-cli mcr buy --interactive").
 		WithExample("megaport-cli mcr buy --name \"My MCR\" --term 12 --port-speed 5000 --location-id 123 --marketplace-visibility true --mcr-asn 65000").
 		WithExample("megaport-cli mcr buy --name \"My MCR\" --term 12 --port-speed 5000 --location-id 123 --marketplace-visibility true --resource-tags '{\"env\":\"prod\",\"owner\":\"network-team\"}'").
@@ -86,6 +89,7 @@ func buildMCRCommands(rootCmd *cobra.Command) (get, buy, update, del, restore, l
   "diversityZone": "blue",
   "costCentre": "IT-Networking",
   "promoCode": "SUMMER2024",
+  "tunnelCount": 10,
   "resourceTags": {
     "environment": "production",
     "department": "networking",
@@ -98,6 +102,7 @@ func buildMCRCommands(rootCmd *cobra.Command) (get, buy, update, del, restore, l
 		WithImportantNote("If mcr_asn is not provided, a private ASN will be automatically assigned").
 		WithImportantNote("Resource tags allow you to categorize resources for organization and billing purposes").
 		WithImportantNote("Required flags (name, term, port-speed, location-id, marketplace-visibility) can be skipped when using --interactive, --json, or --json-file").
+		WithImportantNote("IPSec add-on (--ipsec-tunnel-count) is not prompted in interactive mode; use --ipsec-tunnel-count flag or include 'tunnelCount' in the JSON input").
 		WithRootCmd(rootCmd).
 		WithConditionalRequirements("name", "term", "port-speed", "location-id", "marketplace-visibility").
 		Build()
@@ -337,6 +342,51 @@ func buildMCRTagCommands() (listTags, updateTags *cobra.Command) {
 		WithExample("megaport-cli mcr update-tags mcr-abc123 --json '{\"env\":\"production\",\"team\":\"network\"}'").
 		WithExample("megaport-cli mcr update-tags mcr-abc123 --json-file ./tags.json").
 		WithImportantNote("All existing tags will be replaced with the provided tags. To clear all tags, provide an empty tag set.").
+		Build()
+
+	return
+}
+
+// buildMCRIPSecCommands extracts the IPSec add-on command definitions.
+func buildMCRIPSecCommands(rootCmd *cobra.Command) (addIPSec, updateIPSec *cobra.Command) {
+	addIPSec = cmdbuilder.NewCommand("add-ipsec-addon", "Add an IPSec add-on to an existing MCR").
+		WithArgs(cobra.ExactArgs(1)).
+		WithColorAwareRunFunc(AddMCRIPSecAddOn).
+		WithStandardInputFlags().
+		WithMCRIPSecAddOnFlags().
+		WithLongDesc("Add an IPSec add-on to an existing MCR.\n\nThis command provisions an IPSec add-on on the specified MCR. IPSec add-ons enable encrypted tunnel termination on the MCR.").
+		WithDocumentedRequiredFlag("tunnel-count", "Number of IPSec tunnels (10, 20, or 30; defaults to 10 if unset)").
+		WithExample("megaport-cli mcr add-ipsec-addon [mcrUID] --tunnel-count 10").
+		WithExample("megaport-cli mcr add-ipsec-addon [mcrUID] --tunnel-count 20").
+		WithExample("megaport-cli mcr add-ipsec-addon [mcrUID] --json '{\"tunnelCount\":10}'").
+		WithExample("megaport-cli mcr add-ipsec-addon [mcrUID] --interactive").
+		WithJSONExample(`{
+  "tunnelCount": 10
+}`).
+		WithImportantNote("Valid tunnel counts are 10, 20, or 30. Omitting --tunnel-count defaults to 10.").
+		WithImportantNote("Required flag (tunnel-count) can be skipped when using --interactive or --json").
+		WithRootCmd(rootCmd).
+		WithConditionalRequirements("tunnel-count").
+		Build()
+
+	updateIPSec = cmdbuilder.NewCommand("update-ipsec-addon", "Update or disable an IPSec add-on on an MCR").
+		WithArgs(cobra.ExactArgs(2)).
+		WithColorAwareRunFunc(UpdateMCRIPSecAddOn).
+		WithStandardInputFlags().
+		WithMCRUpdateIPSecAddOnFlags().
+		WithLongDesc("Update or disable an existing IPSec add-on on an MCR.\n\nThis command updates the tunnel count on an existing IPSec add-on. Set tunnel-count to 0 to disable the IPSec add-on.").
+		WithDocumentedRequiredFlag("tunnel-count", "New tunnel count (10, 20, or 30); set to 0 to disable IPSec").
+		WithExample("megaport-cli mcr update-ipsec-addon [mcrUID] [addOnUID] --tunnel-count 20").
+		WithExample("megaport-cli mcr update-ipsec-addon [mcrUID] [addOnUID] --tunnel-count 0").
+		WithExample("megaport-cli mcr update-ipsec-addon [mcrUID] [addOnUID] --json '{\"tunnelCount\":30}'").
+		WithExample("megaport-cli mcr update-ipsec-addon [mcrUID] [addOnUID] --interactive").
+		WithJSONExample(`{
+  "tunnelCount": 30
+}`).
+		WithImportantNote("Valid tunnel counts are 10, 20, or 30. Set to 0 to disable the IPSec add-on.").
+		WithImportantNote("Required flag (tunnel-count) can be skipped when using --interactive or --json").
+		WithRootCmd(rootCmd).
+		WithConditionalRequirements("tunnel-count").
 		Build()
 
 	return

--- a/internal/commands/mcr/mcr.go
+++ b/internal/commands/mcr/mcr.go
@@ -74,6 +74,7 @@ func buildMCRCommands(rootCmd *cobra.Command) (get, buy, update, del, restore, l
 		WithOptionalFlag("promo-code", "A promotional code for the MCR").
 		WithOptionalFlag("resource-tags", "JSON string of key-value pairs for resource tagging").
 		WithIntFlag("ipsec-tunnel-count", 0, "IPSec tunnel count for an add-on (10, 20, or 30)").
+		WithOptionalFlag("ipsec-tunnel-count", "IPSec tunnel count for an add-on (10, 20, or 30); omit or set to 0 for API default").
 		WithExample("megaport-cli mcr buy --interactive").
 		WithExample("megaport-cli mcr buy --name \"My MCR\" --term 12 --port-speed 5000 --location-id 123 --marketplace-visibility true --mcr-asn 65000").
 		WithExample("megaport-cli mcr buy --name \"My MCR\" --term 12 --port-speed 5000 --location-id 123 --marketplace-visibility true --resource-tags '{\"env\":\"prod\",\"owner\":\"network-team\"}'").
@@ -355,7 +356,7 @@ func buildMCRIPSecCommands(rootCmd *cobra.Command) (addIPSec, updateIPSec *cobra
 		WithStandardInputFlags().
 		WithMCRIPSecAddOnFlags().
 		WithLongDesc("Add an IPSec add-on to an existing MCR.\n\nThis command provisions an IPSec add-on on the specified MCR. IPSec add-ons enable encrypted tunnel termination on the MCR.").
-		WithDocumentedRequiredFlag("tunnel-count", "Number of IPSec tunnels (10, 20, or 30); omit to use the API default of 10").
+		WithOptionalFlag("tunnel-count", "Number of IPSec tunnels (10, 20, or 30); omit or set to 0 to use the API default of 10").
 		WithExample("megaport-cli mcr add-ipsec-addon [mcrUID] --tunnel-count 10").
 		WithExample("megaport-cli mcr add-ipsec-addon [mcrUID] --tunnel-count 20").
 		WithExample("megaport-cli mcr add-ipsec-addon [mcrUID] --json '{\"tunnelCount\":10}'").
@@ -363,10 +364,9 @@ func buildMCRIPSecCommands(rootCmd *cobra.Command) (addIPSec, updateIPSec *cobra
 		WithJSONExample(`{
   "tunnelCount": 10
 }`).
-		WithImportantNote("Valid tunnel counts are 10, 20, or 30. --tunnel-count is required in flag mode.").
-		WithImportantNote("--tunnel-count can be skipped when using --interactive, --json, or --json-file").
+		WithImportantNote("Valid tunnel counts are 10, 20, or 30. Omit --tunnel-count or set to 0 to use the API default (10).").
+		WithImportantNote("You must provide one of: --tunnel-count, --interactive, --json, or --json-file").
 		WithRootCmd(rootCmd).
-		WithConditionalRequirements("tunnel-count").
 		Build()
 
 	updateIPSec = cmdbuilder.NewCommand("update-ipsec-addon", "Update or disable an IPSec add-on on an MCR").

--- a/internal/commands/mcr/mcr.go
+++ b/internal/commands/mcr/mcr.go
@@ -74,7 +74,7 @@ func buildMCRCommands(rootCmd *cobra.Command) (get, buy, update, del, restore, l
 		WithOptionalFlag("promo-code", "A promotional code for the MCR").
 		WithOptionalFlag("resource-tags", "JSON string of key-value pairs for resource tagging").
 		WithIntFlag("ipsec-tunnel-count", 0, "IPSec tunnel count for an add-on (10, 20, or 30)").
-		WithOptionalFlag("ipsec-tunnel-count", "IPSec tunnel count for an add-on (10, 20, or 30); omit or set to 0 for API default").
+		WithOptionalFlag("ipsec-tunnel-count", "IPSec tunnel count for an add-on (10, 20, or 30); omit to skip IPSec; set to 0 to include with API default (10)").
 		WithExample("megaport-cli mcr buy --interactive").
 		WithExample("megaport-cli mcr buy --name \"My MCR\" --term 12 --port-speed 5000 --location-id 123 --marketplace-visibility true --mcr-asn 65000").
 		WithExample("megaport-cli mcr buy --name \"My MCR\" --term 12 --port-speed 5000 --location-id 123 --marketplace-visibility true --resource-tags '{\"env\":\"prod\",\"owner\":\"network-team\"}'").

--- a/internal/commands/mcr/mcr_actions.go
+++ b/internal/commands/mcr/mcr_actions.go
@@ -11,6 +11,7 @@ import (
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/commands/config"
 	"github.com/megaport/megaport-cli/internal/utils"
+	"github.com/megaport/megaport-cli/internal/validation"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 )
@@ -57,6 +58,26 @@ func BuyMCR(cmd *cobra.Command, args []string, noColor bool) error {
 	req, err := buildMCRRequest(cmd, noColor)
 	if err != nil {
 		return err
+	}
+
+	// If --ipsec-tunnel-count was explicitly set and the resolved request has no
+	// add-ons yet (i.e. the interactive path was used, which doesn't process this
+	// flag), apply it now. JSON and flag paths already populate req.AddOns, so the
+	// len check prevents double-application.
+	if cmd.Flags().Changed("ipsec-tunnel-count") && len(req.AddOns) == 0 {
+		ipsecTunnelCount, _ := cmd.Flags().GetInt("ipsec-tunnel-count")
+		if ipsecTunnelCount < 0 {
+			return fmt.Errorf("ipsec-tunnel-count must be 0 or a positive value (10, 20, or 30)")
+		}
+		if ipsecTunnelCount > 0 {
+			if err := validation.ValidateIPSecTunnelCount(ipsecTunnelCount, false); err != nil {
+				return err
+			}
+		}
+		req.AddOns = append(req.AddOns, &megaport.MCRAddOnIPsecConfig{
+			AddOnType:   megaport.AddOnTypeIPsec,
+			TunnelCount: ipsecTunnelCount,
+		})
 	}
 
 	// Flag read errors are intentionally ignored — flags are registered by the command builder.

--- a/internal/commands/mcr/mcr_actions_ipsec_addon.go
+++ b/internal/commands/mcr/mcr_actions_ipsec_addon.go
@@ -30,11 +30,15 @@ func AddMCRIPSecAddOn(cmd *cobra.Command, args []string, noColor bool) error {
 
 	if jsonStr != "" || jsonFile != "" {
 		output.PrintInfo("Using JSON input", noColor)
-		tunnelCount, err = parseIPSecTunnelCountFromJSON(jsonStr, jsonFile)
-		if err != nil {
-			output.PrintError("Failed to process JSON input: %v", noColor, err)
-			return err
+		countPtr, parseErr := parseIPSecTunnelCountFromJSON(jsonStr, jsonFile)
+		if parseErr != nil {
+			output.PrintError("Failed to process JSON input: %v", noColor, parseErr)
+			return parseErr
 		}
+		if countPtr != nil {
+			tunnelCount = *countPtr
+		}
+		// nil means key absent → tunnelCount stays 0 (API will use its default of 10)
 	} else if flagsProvided {
 		output.PrintInfo("Using flag input", noColor)
 		if tunnelCount, err = cmd.Flags().GetInt("tunnel-count"); err != nil {
@@ -46,7 +50,7 @@ func AddMCRIPSecAddOn(cmd *cobra.Command, args []string, noColor bool) error {
 			return err
 		}
 	} else {
-		return fmt.Errorf("no input provided, use --interactive, --json, or --tunnel-count to specify IPSec add-on details")
+		return fmt.Errorf("no input provided, use --interactive, --json, --json-file, or --tunnel-count to specify IPSec add-on details")
 	}
 
 	// allowZeroDisable=false: for add, 0 means "use API default of 10", not disable
@@ -103,11 +107,15 @@ func UpdateMCRIPSecAddOn(cmd *cobra.Command, args []string, noColor bool) error 
 
 	if jsonStr != "" || jsonFile != "" {
 		output.PrintInfo("Using JSON input", noColor)
-		tunnelCount, err = parseIPSecTunnelCountFromJSON(jsonStr, jsonFile)
-		if err != nil {
-			output.PrintError("Failed to process JSON input: %v", noColor, err)
-			return err
+		countPtr, parseErr := parseIPSecTunnelCountFromJSON(jsonStr, jsonFile)
+		if parseErr != nil {
+			output.PrintError("Failed to process JSON input: %v", noColor, parseErr)
+			return parseErr
 		}
+		if countPtr == nil {
+			return fmt.Errorf("tunnelCount is required in JSON input for update (use 0 to disable IPSec)")
+		}
+		tunnelCount = *countPtr
 	} else if flagsProvided {
 		output.PrintInfo("Using flag input", noColor)
 		if tunnelCount, err = cmd.Flags().GetInt("tunnel-count"); err != nil {
@@ -119,7 +127,7 @@ func UpdateMCRIPSecAddOn(cmd *cobra.Command, args []string, noColor bool) error 
 			return err
 		}
 	} else {
-		return fmt.Errorf("no input provided, use --interactive, --json, or --tunnel-count to specify tunnel count")
+		return fmt.Errorf("no input provided, use --interactive, --json, --json-file, or --tunnel-count to specify tunnel count")
 	}
 
 	// allowZeroDisable=true: for update, 0 means disable IPSec
@@ -153,17 +161,18 @@ func UpdateMCRIPSecAddOn(cmd *cobra.Command, args []string, noColor bool) error 
 }
 
 // parseIPSecTunnelCountFromJSON parses a tunnel count from JSON input.
-// Expects {"tunnelCount": N}.
-func parseIPSecTunnelCountFromJSON(jsonStr, jsonFile string) (int, error) {
+// Returns nil if the "tunnelCount" key is absent from the JSON, allowing
+// callers to distinguish between "not provided" and an explicit 0.
+func parseIPSecTunnelCountFromJSON(jsonStr, jsonFile string) (*int, error) {
 	jsonData, err := utils.ReadJSONInput(jsonStr, jsonFile)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	var data struct {
-		TunnelCount int `json:"tunnelCount"`
+		TunnelCount *int `json:"tunnelCount"`
 	}
 	if err := json.Unmarshal(jsonData, &data); err != nil {
-		return 0, fmt.Errorf("failed to parse JSON: %w", err)
+		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 	return data.TunnelCount, nil
 }

--- a/internal/commands/mcr/mcr_actions_ipsec_addon.go
+++ b/internal/commands/mcr/mcr_actions_ipsec_addon.go
@@ -1,0 +1,169 @@
+package mcr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/commands/config"
+	"github.com/megaport/megaport-cli/internal/utils"
+	"github.com/megaport/megaport-cli/internal/validation"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/spf13/cobra"
+)
+
+// AddMCRIPSecAddOn adds an IPSec add-on to an existing MCR.
+func AddMCRIPSecAddOn(cmd *cobra.Command, args []string, noColor bool) error {
+	ctx, cancel := utils.ContextFromCmd(cmd)
+	defer cancel()
+
+	mcrUID := args[0]
+
+	interactive, _ := cmd.Flags().GetBool("interactive")
+	jsonStr, _ := cmd.Flags().GetString("json")
+	jsonFile, _ := cmd.Flags().GetString("json-file")
+	flagsProvided := cmd.Flags().Changed("tunnel-count")
+
+	var tunnelCount int
+	var err error
+
+	if jsonStr != "" || jsonFile != "" {
+		output.PrintInfo("Using JSON input", noColor)
+		tunnelCount, err = parseIPSecTunnelCountFromJSON(jsonStr, jsonFile)
+		if err != nil {
+			output.PrintError("Failed to process JSON input: %v", noColor, err)
+			return err
+		}
+	} else if flagsProvided {
+		output.PrintInfo("Using flag input", noColor)
+		if tunnelCount, err = cmd.Flags().GetInt("tunnel-count"); err != nil {
+			return fmt.Errorf("invalid tunnel-count flag: %w", err)
+		}
+	} else if interactive {
+		tunnelCount, err = promptForIPSecTunnelCount(noColor)
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("no input provided, use --interactive, --json, or --tunnel-count to specify IPSec add-on details")
+	}
+
+	// allowZeroDisable=false: for add, 0 means "use API default of 10", not disable
+	if tunnelCount != 0 {
+		if err := validation.ValidateIPSecTunnelCount(tunnelCount, false); err != nil {
+			return err
+		}
+	}
+
+	req := megaport.MCRAddOnRequest{
+		AddOn: &megaport.MCRAddOnIPsecConfig{
+			AddOnType:   megaport.AddOnTypeIPsec,
+			TunnelCount: tunnelCount,
+		},
+	}
+
+	client, err := config.Login(ctx)
+	if err != nil {
+		output.PrintError("Failed to log in: %v", noColor, err)
+		return err
+	}
+
+	spinner := output.PrintResourceCreating("IPSec Add-On", mcrUID, noColor)
+	err = utils.WithRetry(ctx, func(ctx context.Context) error {
+		return updateMCRWithAddOnFunc(ctx, client, mcrUID, req)
+	})
+	spinner.Stop()
+
+	if err != nil {
+		output.PrintError("Failed to add IPSec add-on: %v", noColor, err)
+		return err
+	}
+
+	output.PrintSuccess("IPSec add-on added successfully to MCR: %s", noColor, mcrUID)
+	return nil
+}
+
+// UpdateMCRIPSecAddOn updates an existing IPSec add-on on an MCR.
+// Setting tunnel-count to 0 disables IPSec.
+func UpdateMCRIPSecAddOn(cmd *cobra.Command, args []string, noColor bool) error {
+	ctx, cancel := utils.ContextFromCmd(cmd)
+	defer cancel()
+
+	mcrUID := args[0]
+	addOnUID := args[1]
+
+	interactive, _ := cmd.Flags().GetBool("interactive")
+	jsonStr, _ := cmd.Flags().GetString("json")
+	jsonFile, _ := cmd.Flags().GetString("json-file")
+	flagsProvided := cmd.Flags().Changed("tunnel-count")
+
+	var tunnelCount int
+	var err error
+
+	if jsonStr != "" || jsonFile != "" {
+		output.PrintInfo("Using JSON input", noColor)
+		tunnelCount, err = parseIPSecTunnelCountFromJSON(jsonStr, jsonFile)
+		if err != nil {
+			output.PrintError("Failed to process JSON input: %v", noColor, err)
+			return err
+		}
+	} else if flagsProvided {
+		output.PrintInfo("Using flag input", noColor)
+		if tunnelCount, err = cmd.Flags().GetInt("tunnel-count"); err != nil {
+			return fmt.Errorf("invalid tunnel-count flag: %w", err)
+		}
+	} else if interactive {
+		tunnelCount, err = promptForIPSecTunnelCountUpdate(noColor)
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("no input provided, use --interactive, --json, or --tunnel-count to specify tunnel count")
+	}
+
+	// allowZeroDisable=true: for update, 0 means disable IPSec
+	if err := validation.ValidateIPSecTunnelCount(tunnelCount, true); err != nil {
+		return err
+	}
+
+	client, err := config.Login(ctx)
+	if err != nil {
+		output.PrintError("Failed to log in: %v", noColor, err)
+		return err
+	}
+
+	spinner := output.PrintResourceUpdating("IPSec Add-On", addOnUID, noColor)
+	err = utils.WithRetry(ctx, func(ctx context.Context) error {
+		return updateMCRIPsecAddOnFunc(ctx, client, mcrUID, addOnUID, tunnelCount)
+	})
+	spinner.Stop()
+
+	if err != nil {
+		output.PrintError("Failed to update IPSec add-on: %v", noColor, err)
+		return err
+	}
+
+	if tunnelCount == 0 {
+		output.PrintSuccess("IPSec add-on disabled successfully", noColor)
+	} else {
+		output.PrintSuccess("IPSec add-on updated successfully - tunnel count: %d", noColor, tunnelCount)
+	}
+	return nil
+}
+
+// parseIPSecTunnelCountFromJSON parses a tunnel count from JSON input.
+// Expects {"tunnelCount": N}.
+func parseIPSecTunnelCountFromJSON(jsonStr, jsonFile string) (int, error) {
+	jsonData, err := utils.ReadJSONInput(jsonStr, jsonFile)
+	if err != nil {
+		return 0, err
+	}
+	var data struct {
+		TunnelCount int `json:"tunnelCount"`
+	}
+	if err := json.Unmarshal(jsonData, &data); err != nil {
+		return 0, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+	return data.TunnelCount, nil
+}

--- a/internal/commands/mcr/mcr_actions_ipsec_addon.go
+++ b/internal/commands/mcr/mcr_actions_ipsec_addon.go
@@ -50,7 +50,8 @@ func AddMCRIPSecAddOn(cmd *cobra.Command, args []string, noColor bool) error {
 			return err
 		}
 	} else {
-		return fmt.Errorf("no input provided, use --interactive, --json, --json-file, or --tunnel-count to specify IPSec add-on details")
+		output.PrintInfo("No tunnel count specified, using API default (10 tunnels)", noColor)
+		// tunnelCount stays 0; the API will apply its default of 10
 	}
 
 	// allowZeroDisable=false: for add, 0 means "use API default of 10", not disable

--- a/internal/commands/mcr/mcr_actions_ipsec_addon_test.go
+++ b/internal/commands/mcr/mcr_actions_ipsec_addon_test.go
@@ -146,9 +146,11 @@ func TestAddMCRIPSecAddOn_NoInput(t *testing.T) {
 	cmd.Flags().String("json-file", "", "")
 	cmd.Flags().Int("tunnel-count", 0, "")
 
+	var err error
 	out := output.CaptureOutput(func() {
-		_ = AddMCRIPSecAddOn(cmd, []string{"mcr-abc"}, false)
+		err = AddMCRIPSecAddOn(cmd, []string{"mcr-abc"}, false)
 	})
+	assert.NoError(t, err)
 	assert.Contains(t, out, "API default")
 	assert.Equal(t, "mcr-abc", mockSvc.CapturedUpdateMCRWithAddOnMCRID)
 	addon, ok := mockSvc.CapturedUpdateMCRWithAddOnReq.AddOn.(*megaport.MCRAddOnIPsecConfig)

--- a/internal/commands/mcr/mcr_actions_ipsec_addon_test.go
+++ b/internal/commands/mcr/mcr_actions_ipsec_addon_test.go
@@ -128,15 +128,32 @@ func TestAddMCRIPSecAddOn_JSON(t *testing.T) {
 }
 
 func TestAddMCRIPSecAddOn_NoInput(t *testing.T) {
+	// With no tunnel-count/json/interactive provided, add-ipsec-addon proceeds
+	// with tunnelCount=0 (API will apply its default of 10 tunnels).
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
+	defer cleanup()
+
+	mockSvc := &MockMCRService{}
+	config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+		client := &megaport.Client{}
+		client.MCRService = mockSvc
+		return client, nil
+	})
+
 	cmd := &cobra.Command{Use: "add-ipsec-addon [mcrUID]"}
 	cmd.Flags().Bool("interactive", false, "")
 	cmd.Flags().String("json", "", "")
 	cmd.Flags().String("json-file", "", "")
 	cmd.Flags().Int("tunnel-count", 0, "")
 
-	err := AddMCRIPSecAddOn(cmd, []string{"mcr-abc"}, false)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no input provided")
+	out := output.CaptureOutput(func() {
+		_ = AddMCRIPSecAddOn(cmd, []string{"mcr-abc"}, false)
+	})
+	assert.Contains(t, out, "API default")
+	assert.Equal(t, "mcr-abc", mockSvc.CapturedUpdateMCRWithAddOnMCRID)
+	addon, ok := mockSvc.CapturedUpdateMCRWithAddOnReq.AddOn.(*megaport.MCRAddOnIPsecConfig)
+	assert.True(t, ok)
+	assert.Equal(t, 0, addon.TunnelCount)
 }
 
 func TestUpdateMCRIPSecAddOn_Flags(t *testing.T) {

--- a/internal/commands/mcr/mcr_actions_ipsec_addon_test.go
+++ b/internal/commands/mcr/mcr_actions_ipsec_addon_test.go
@@ -260,3 +260,121 @@ func TestUpdateMCRIPSecAddOn_NoInput(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no input provided")
 }
+
+func TestAddMCRIPSecAddOn_InvalidTunnelCount(t *testing.T) {
+	cmd := &cobra.Command{Use: "add-ipsec-addon [mcrUID]"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().Int("tunnel-count", 0, "")
+	_ = cmd.Flags().Set("tunnel-count", "5") // not 10, 20, or 30
+
+	err := AddMCRIPSecAddOn(cmd, []string{"mcr-abc"}, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid IPSec tunnel count")
+}
+
+func TestUpdateMCRIPSecAddOn_InvalidTunnelCount(t *testing.T) {
+	cmd := &cobra.Command{Use: "update-ipsec-addon [mcrUID] [addOnUID]"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().Int("tunnel-count", 0, "")
+	_ = cmd.Flags().Set("tunnel-count", "15") // not 0, 10, 20, or 30
+
+	err := UpdateMCRIPSecAddOn(cmd, []string{"mcr-abc", "addon-abc"}, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid IPSec tunnel count")
+}
+
+func TestAddMCRIPSecAddOn_LoginError(t *testing.T) {
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
+	defer cleanup()
+
+	config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+		return nil, fmt.Errorf("auth failed")
+	})
+
+	cmd := &cobra.Command{Use: "add-ipsec-addon [mcrUID]"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().Int("tunnel-count", 0, "")
+	_ = cmd.Flags().Set("tunnel-count", "10")
+
+	err := AddMCRIPSecAddOn(cmd, []string{"mcr-abc"}, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "auth failed")
+}
+
+func TestUpdateMCRIPSecAddOn_LoginError(t *testing.T) {
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
+	defer cleanup()
+
+	config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+		return nil, fmt.Errorf("auth failed")
+	})
+
+	cmd := &cobra.Command{Use: "update-ipsec-addon [mcrUID] [addOnUID]"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().Int("tunnel-count", 0, "")
+	_ = cmd.Flags().Set("tunnel-count", "10")
+
+	err := UpdateMCRIPSecAddOn(cmd, []string{"mcr-abc", "addon-abc"}, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "auth failed")
+}
+
+func TestParseIPSecTunnelCountFromJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		jsonStr     string
+		expected    int
+		wantErr     bool
+		errContains string
+	}{
+		{"valid tunnelCount", `{"tunnelCount":20}`, 20, false, ""},
+		{"zero tunnelCount", `{"tunnelCount":0}`, 0, false, ""},
+		{"missing field returns zero", `{}`, 0, false, ""},
+		{"invalid JSON", `{bad}`, 0, true, "failed to parse JSON"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			count, err := parseIPSecTunnelCountFromJSON(tt.jsonStr, "")
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, count)
+			}
+		})
+	}
+}
+
+func TestAddMCRIPSecAddOn_BadJSON(t *testing.T) {
+	cmd := &cobra.Command{Use: "add-ipsec-addon [mcrUID]"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", `{bad json}`, "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().Int("tunnel-count", 0, "")
+
+	err := AddMCRIPSecAddOn(cmd, []string{"mcr-abc"}, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse JSON")
+}
+
+func TestUpdateMCRIPSecAddOn_BadJSON(t *testing.T) {
+	cmd := &cobra.Command{Use: "update-ipsec-addon [mcrUID] [addOnUID]"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", `{bad json}`, "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().Int("tunnel-count", 0, "")
+
+	err := UpdateMCRIPSecAddOn(cmd, []string{"mcr-abc", "addon-abc"}, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse JSON")
+}

--- a/internal/commands/mcr/mcr_actions_ipsec_addon_test.go
+++ b/internal/commands/mcr/mcr_actions_ipsec_addon_test.go
@@ -331,28 +331,47 @@ func TestParseIPSecTunnelCountFromJSON(t *testing.T) {
 	tests := []struct {
 		name        string
 		jsonStr     string
+		expectNil   bool
 		expected    int
 		wantErr     bool
 		errContains string
 	}{
-		{"valid tunnelCount", `{"tunnelCount":20}`, 20, false, ""},
-		{"zero tunnelCount", `{"tunnelCount":0}`, 0, false, ""},
-		{"missing field returns zero", `{}`, 0, false, ""},
-		{"invalid JSON", `{bad}`, 0, true, "failed to parse JSON"},
+		{"valid tunnelCount 20", `{"tunnelCount":20}`, false, 20, false, ""},
+		{"explicit zero", `{"tunnelCount":0}`, false, 0, false, ""},
+		{"missing field returns nil", `{}`, true, 0, false, ""},
+		{"invalid JSON", `{bad}`, false, 0, true, "failed to parse JSON"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			count, err := parseIPSecTunnelCountFromJSON(tt.jsonStr, "")
+			ptr, err := parseIPSecTunnelCountFromJSON(tt.jsonStr, "")
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errContains)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.expected, count)
+				if tt.expectNil {
+					assert.Nil(t, ptr)
+				} else {
+					assert.NotNil(t, ptr)
+					assert.Equal(t, tt.expected, *ptr)
+				}
 			}
 		})
 	}
+}
+
+func TestUpdateMCRIPSecAddOn_MissingJSONKey(t *testing.T) {
+	// {} has no tunnelCount key → should error rather than silently disable
+	cmd := &cobra.Command{Use: "update-ipsec-addon [mcrUID] [addOnUID]"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", `{}`, "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().Int("tunnel-count", 0, "")
+
+	err := UpdateMCRIPSecAddOn(cmd, []string{"mcr-abc", "addon-abc"}, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "tunnelCount is required")
 }
 
 func TestAddMCRIPSecAddOn_BadJSON(t *testing.T) {

--- a/internal/commands/mcr/mcr_actions_ipsec_addon_test.go
+++ b/internal/commands/mcr/mcr_actions_ipsec_addon_test.go
@@ -1,0 +1,262 @@
+package mcr
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/commands/config"
+	"github.com/megaport/megaport-cli/internal/testutil"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddMCRIPSecAddOn_Flags(t *testing.T) {
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
+	defer cleanup()
+
+	tests := []struct {
+		name           string
+		mcrUID         string
+		tunnelCount    int
+		setupMock      func(*MockMCRService)
+		expectedError  string
+		expectedOutput string
+		expectCalled   bool
+		expectCount    int
+	}{
+		{
+			name:           "add IPSec addon tunnel-count 10",
+			mcrUID:         "mcr-abc",
+			tunnelCount:    10,
+			setupMock:      func(m *MockMCRService) {},
+			expectCalled:   true,
+			expectCount:    10,
+			expectedOutput: "IPSec add-on added successfully",
+		},
+		{
+			name:           "add IPSec addon tunnel-count 20",
+			mcrUID:         "mcr-abc",
+			tunnelCount:    20,
+			setupMock:      func(m *MockMCRService) {},
+			expectCalled:   true,
+			expectCount:    20,
+			expectedOutput: "IPSec add-on added successfully",
+		},
+		{
+			name:        "service returns error",
+			mcrUID:      "mcr-abc",
+			tunnelCount: 10,
+			setupMock: func(m *MockMCRService) {
+				m.UpdateMCRWithAddOnErr = fmt.Errorf("service unavailable")
+			},
+			expectedError: "service unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockSvc := &MockMCRService{}
+			tt.setupMock(mockSvc)
+
+			config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+				client := &megaport.Client{}
+				client.MCRService = mockSvc
+				return client, nil
+			})
+
+			cmd := &cobra.Command{Use: "add-ipsec-addon [mcrUID]"}
+			cmd.Flags().Bool("interactive", false, "")
+			cmd.Flags().String("json", "", "")
+			cmd.Flags().String("json-file", "", "")
+			cmd.Flags().Int("tunnel-count", 0, "")
+			_ = cmd.Flags().Set("tunnel-count", fmt.Sprintf("%d", tt.tunnelCount))
+
+			var err error
+			out := output.CaptureOutput(func() {
+				err = AddMCRIPSecAddOn(cmd, []string{tt.mcrUID}, false)
+			})
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.Contains(t, out, tt.expectedOutput)
+				if tt.expectCalled {
+					assert.Equal(t, tt.mcrUID, mockSvc.CapturedUpdateMCRWithAddOnMCRID)
+					addon, ok := mockSvc.CapturedUpdateMCRWithAddOnReq.AddOn.(*megaport.MCRAddOnIPsecConfig)
+					assert.True(t, ok)
+					assert.Equal(t, tt.expectCount, addon.TunnelCount)
+					assert.Equal(t, megaport.AddOnTypeIPsec, addon.AddOnType)
+				}
+			}
+		})
+	}
+}
+
+func TestAddMCRIPSecAddOn_JSON(t *testing.T) {
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
+	defer cleanup()
+
+	mockSvc := &MockMCRService{}
+	config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+		client := &megaport.Client{}
+		client.MCRService = mockSvc
+		return client, nil
+	})
+
+	cmd := &cobra.Command{Use: "add-ipsec-addon [mcrUID]"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", `{"tunnelCount":20}`, "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().Int("tunnel-count", 0, "")
+
+	var err error
+	out := output.CaptureOutput(func() {
+		err = AddMCRIPSecAddOn(cmd, []string{"mcr-json"}, false)
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, out, "IPSec add-on added successfully")
+	assert.Equal(t, "mcr-json", mockSvc.CapturedUpdateMCRWithAddOnMCRID)
+	addon, ok := mockSvc.CapturedUpdateMCRWithAddOnReq.AddOn.(*megaport.MCRAddOnIPsecConfig)
+	assert.True(t, ok)
+	assert.Equal(t, 20, addon.TunnelCount)
+}
+
+func TestAddMCRIPSecAddOn_NoInput(t *testing.T) {
+	cmd := &cobra.Command{Use: "add-ipsec-addon [mcrUID]"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().Int("tunnel-count", 0, "")
+
+	err := AddMCRIPSecAddOn(cmd, []string{"mcr-abc"}, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no input provided")
+}
+
+func TestUpdateMCRIPSecAddOn_Flags(t *testing.T) {
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
+	defer cleanup()
+
+	tests := []struct {
+		name           string
+		mcrUID         string
+		addOnUID       string
+		tunnelCount    int
+		setupMock      func(*MockMCRService)
+		expectedError  string
+		expectedOutput string
+		expectCount    int
+	}{
+		{
+			name:           "update tunnel count to 30",
+			mcrUID:         "mcr-abc",
+			addOnUID:       "addon-123",
+			tunnelCount:    30,
+			setupMock:      func(m *MockMCRService) {},
+			expectedOutput: "IPSec add-on updated successfully - tunnel count: 30",
+			expectCount:    30,
+		},
+		{
+			name:           "disable IPSec with tunnel count 0",
+			mcrUID:         "mcr-abc",
+			addOnUID:       "addon-123",
+			tunnelCount:    0,
+			setupMock:      func(m *MockMCRService) {},
+			expectedOutput: "IPSec add-on disabled successfully",
+			expectCount:    0,
+		},
+		{
+			name:        "service returns error",
+			mcrUID:      "mcr-abc",
+			addOnUID:    "addon-123",
+			tunnelCount: 20,
+			setupMock: func(m *MockMCRService) {
+				m.UpdateMCRIPsecAddOnErr = fmt.Errorf("update failed")
+			},
+			expectedError: "update failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockSvc := &MockMCRService{}
+			tt.setupMock(mockSvc)
+
+			config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+				client := &megaport.Client{}
+				client.MCRService = mockSvc
+				return client, nil
+			})
+
+			cmd := &cobra.Command{Use: "update-ipsec-addon [mcrUID] [addOnUID]"}
+			cmd.Flags().Bool("interactive", false, "")
+			cmd.Flags().String("json", "", "")
+			cmd.Flags().String("json-file", "", "")
+			cmd.Flags().Int("tunnel-count", 0, "")
+			_ = cmd.Flags().Set("tunnel-count", fmt.Sprintf("%d", tt.tunnelCount))
+
+			var err error
+			out := output.CaptureOutput(func() {
+				err = UpdateMCRIPSecAddOn(cmd, []string{tt.mcrUID, tt.addOnUID}, false)
+			})
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.Contains(t, out, tt.expectedOutput)
+				assert.Equal(t, tt.mcrUID, mockSvc.CapturedUpdateMCRIPsecAddOnMCRID)
+				assert.Equal(t, tt.addOnUID, mockSvc.CapturedUpdateMCRIPsecAddOnUID)
+				assert.Equal(t, tt.expectCount, mockSvc.CapturedUpdateMCRIPsecTunnelCount)
+			}
+		})
+	}
+}
+
+func TestUpdateMCRIPSecAddOn_JSON(t *testing.T) {
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
+	defer cleanup()
+
+	mockSvc := &MockMCRService{}
+	config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+		client := &megaport.Client{}
+		client.MCRService = mockSvc
+		return client, nil
+	})
+
+	cmd := &cobra.Command{Use: "update-ipsec-addon [mcrUID] [addOnUID]"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", `{"tunnelCount":30}`, "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().Int("tunnel-count", 0, "")
+
+	var err error
+	out := output.CaptureOutput(func() {
+		err = UpdateMCRIPSecAddOn(cmd, []string{"mcr-json", "addon-json"}, false)
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, out, "tunnel count: 30")
+	assert.Equal(t, "mcr-json", mockSvc.CapturedUpdateMCRIPsecAddOnMCRID)
+	assert.Equal(t, "addon-json", mockSvc.CapturedUpdateMCRIPsecAddOnUID)
+	assert.Equal(t, 30, mockSvc.CapturedUpdateMCRIPsecTunnelCount)
+}
+
+func TestUpdateMCRIPSecAddOn_NoInput(t *testing.T) {
+	cmd := &cobra.Command{Use: "update-ipsec-addon [mcrUID] [addOnUID]"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().Int("tunnel-count", 0, "")
+
+	err := UpdateMCRIPSecAddOn(cmd, []string{"mcr-abc", "addon-abc"}, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no input provided")
+}

--- a/internal/commands/mcr/mcr_inputs.go
+++ b/internal/commands/mcr/mcr_inputs.go
@@ -43,12 +43,13 @@ func processJSONMCRInput(jsonStr, jsonFile string) (*megaport.BuyMCRRequest, err
 			if err := validation.ValidateIPSecTunnelCount(*extras.TunnelCount, false); err != nil {
 				return nil, err
 			}
-			req.AddOns = append(req.AddOns, &megaport.MCRAddOnIPsecConfig{
-				AddOnType:   megaport.AddOnTypeIPsec,
-				TunnelCount: *extras.TunnelCount,
-			})
 		}
-		// tunnelCount == 0 means "use API default of 10"; no add-on entry needed
+		// Always include the add-on config when the key is present:
+		// tunnelCount == 0 tells the API to use its default of 10 tunnels.
+		req.AddOns = append(req.AddOns, &megaport.MCRAddOnIPsecConfig{
+			AddOnType:   megaport.AddOnTypeIPsec,
+			TunnelCount: *extras.TunnelCount,
+		})
 	}
 
 	if err := validation.ValidateMCRRequest(req); err != nil {
@@ -99,12 +100,13 @@ func processFlagMCRInput(cmd *cobra.Command) (*megaport.BuyMCRRequest, error) {
 			if err := validation.ValidateIPSecTunnelCount(ipsecTunnelCount, false); err != nil {
 				return nil, err
 			}
-			req.AddOns = append(req.AddOns, &megaport.MCRAddOnIPsecConfig{
-				AddOnType:   megaport.AddOnTypeIPsec,
-				TunnelCount: ipsecTunnelCount,
-			})
 		}
-		// ipsecTunnelCount == 0 means "use API default of 10"; no add-on entry needed
+		// Always include the add-on when the flag is explicitly set:
+		// ipsecTunnelCount == 0 tells the API to use its default of 10 tunnels.
+		req.AddOns = append(req.AddOns, &megaport.MCRAddOnIPsecConfig{
+			AddOnType:   megaport.AddOnTypeIPsec,
+			TunnelCount: ipsecTunnelCount,
+		})
 	}
 
 	if err := validation.ValidateMCRRequest(req); err != nil {

--- a/internal/commands/mcr/mcr_inputs.go
+++ b/internal/commands/mcr/mcr_inputs.go
@@ -35,6 +35,9 @@ func processJSONMCRInput(jsonStr, jsonFile string) (*megaport.BuyMCRRequest, err
 		return nil, fmt.Errorf("failed to parse tunnelCount: %w", err)
 	}
 	if extras.TunnelCount > 0 {
+		if err := validation.ValidateIPSecTunnelCount(extras.TunnelCount, false); err != nil {
+			return nil, err
+		}
 		req.AddOns = append(req.AddOns, &megaport.MCRAddOnIPsecConfig{
 			AddOnType:   megaport.AddOnTypeIPsec,
 			TunnelCount: extras.TunnelCount,
@@ -83,6 +86,9 @@ func processFlagMCRInput(cmd *cobra.Command) (*megaport.BuyMCRRequest, error) {
 	if cmd.Flags().Changed("ipsec-tunnel-count") {
 		ipsecTunnelCount, _ := cmd.Flags().GetInt("ipsec-tunnel-count")
 		if ipsecTunnelCount > 0 {
+			if err := validation.ValidateIPSecTunnelCount(ipsecTunnelCount, false); err != nil {
+				return nil, err
+			}
 			req.AddOns = append(req.AddOns, &megaport.MCRAddOnIPsecConfig{
 				AddOnType:   megaport.AddOnTypeIPsec,
 				TunnelCount: ipsecTunnelCount,

--- a/internal/commands/mcr/mcr_inputs.go
+++ b/internal/commands/mcr/mcr_inputs.go
@@ -27,21 +27,28 @@ func processJSONMCRInput(jsonStr, jsonFile string) (*megaport.BuyMCRRequest, err
 	}
 
 	// BuyMCRRequest.AddOns is []MCRAddOn (interface) and cannot be directly
-	// unmarshaled by the standard library. Read tunnelCount separately.
+	// unmarshaled by the standard library. Read tunnelCount separately using a
+	// pointer so we can distinguish "key absent" from an explicit value.
 	var extras struct {
-		TunnelCount int `json:"tunnelCount"`
+		TunnelCount *int `json:"tunnelCount"`
 	}
 	if err := json.Unmarshal(jsonData, &extras); err != nil {
 		return nil, fmt.Errorf("failed to parse tunnelCount: %w", err)
 	}
-	if extras.TunnelCount > 0 {
-		if err := validation.ValidateIPSecTunnelCount(extras.TunnelCount, false); err != nil {
-			return nil, err
+	if extras.TunnelCount != nil {
+		if *extras.TunnelCount < 0 {
+			return nil, fmt.Errorf("tunnelCount must be 0 or a positive value (10, 20, or 30)")
 		}
-		req.AddOns = append(req.AddOns, &megaport.MCRAddOnIPsecConfig{
-			AddOnType:   megaport.AddOnTypeIPsec,
-			TunnelCount: extras.TunnelCount,
-		})
+		if *extras.TunnelCount > 0 {
+			if err := validation.ValidateIPSecTunnelCount(*extras.TunnelCount, false); err != nil {
+				return nil, err
+			}
+			req.AddOns = append(req.AddOns, &megaport.MCRAddOnIPsecConfig{
+				AddOnType:   megaport.AddOnTypeIPsec,
+				TunnelCount: *extras.TunnelCount,
+			})
+		}
+		// tunnelCount == 0 means "use API default of 10"; no add-on entry needed
 	}
 
 	if err := validation.ValidateMCRRequest(req); err != nil {
@@ -85,6 +92,9 @@ func processFlagMCRInput(cmd *cobra.Command) (*megaport.BuyMCRRequest, error) {
 
 	if cmd.Flags().Changed("ipsec-tunnel-count") {
 		ipsecTunnelCount, _ := cmd.Flags().GetInt("ipsec-tunnel-count")
+		if ipsecTunnelCount < 0 {
+			return nil, fmt.Errorf("ipsec-tunnel-count must be 0 or a positive value (10, 20, or 30)")
+		}
 		if ipsecTunnelCount > 0 {
 			if err := validation.ValidateIPSecTunnelCount(ipsecTunnelCount, false); err != nil {
 				return nil, err
@@ -94,6 +104,7 @@ func processFlagMCRInput(cmd *cobra.Command) (*megaport.BuyMCRRequest, error) {
 				TunnelCount: ipsecTunnelCount,
 			})
 		}
+		// ipsecTunnelCount == 0 means "use API default of 10"; no add-on entry needed
 	}
 
 	if err := validation.ValidateMCRRequest(req); err != nil {

--- a/internal/commands/mcr/mcr_inputs.go
+++ b/internal/commands/mcr/mcr_inputs.go
@@ -26,6 +26,21 @@ func processJSONMCRInput(jsonStr, jsonFile string) (*megaport.BuyMCRRequest, err
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
+	// BuyMCRRequest.AddOns is []MCRAddOn (interface) and cannot be directly
+	// unmarshaled by the standard library. Read tunnelCount separately.
+	var extras struct {
+		TunnelCount int `json:"tunnelCount"`
+	}
+	if err := json.Unmarshal(jsonData, &extras); err != nil {
+		return nil, fmt.Errorf("failed to parse tunnelCount: %w", err)
+	}
+	if extras.TunnelCount > 0 {
+		req.AddOns = append(req.AddOns, &megaport.MCRAddOnIPsecConfig{
+			AddOnType:   megaport.AddOnTypeIPsec,
+			TunnelCount: extras.TunnelCount,
+		})
+	}
+
 	if err := validation.ValidateMCRRequest(req); err != nil {
 		return nil, err
 	}
@@ -63,6 +78,16 @@ func processFlagMCRInput(cmd *cobra.Command) (*megaport.BuyMCRRequest, error) {
 		PromoCode:     promoCode,
 		DiversityZone: diversityZone,
 		ResourceTags:  resourceTags,
+	}
+
+	if cmd.Flags().Changed("ipsec-tunnel-count") {
+		ipsecTunnelCount, _ := cmd.Flags().GetInt("ipsec-tunnel-count")
+		if ipsecTunnelCount > 0 {
+			req.AddOns = append(req.AddOns, &megaport.MCRAddOnIPsecConfig{
+				AddOnType:   megaport.AddOnTypeIPsec,
+				TunnelCount: ipsecTunnelCount,
+			})
+		}
 	}
 
 	if err := validation.ValidateMCRRequest(req); err != nil {

--- a/internal/commands/mcr/mcr_inputs_test.go
+++ b/internal/commands/mcr/mcr_inputs_test.go
@@ -481,6 +481,32 @@ func TestProcessJSONMCRInput_InvalidTunnelCount(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid IPSec tunnel count")
 }
 
+func TestProcessJSONMCRInput_NegativeTunnelCount(t *testing.T) {
+	_, err := processJSONMCRInput(`{"name":"test","term":12,"portSpeed":5000,"locationId":1,"marketplaceVisibility":true,"tunnelCount":-1}`, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "tunnelCount must be")
+}
+
+func TestProcessFlagMCRInput_NegativeIPSecTunnelCount(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("name", "test-mcr", "")
+	cmd.Flags().Int("term", 12, "")
+	cmd.Flags().Int("port-speed", 5000, "")
+	cmd.Flags().Int("location-id", 1, "")
+	cmd.Flags().Int("mcr-asn", 0, "")
+	cmd.Flags().Bool("marketplace-visibility", false, "")
+	cmd.Flags().String("cost-centre", "", "")
+	cmd.Flags().String("promo-code", "", "")
+	cmd.Flags().String("diversity-zone", "", "")
+	cmd.Flags().String("resource-tags", "", "")
+	cmd.Flags().Int("ipsec-tunnel-count", 0, "")
+	require.NoError(t, cmd.Flags().Set("ipsec-tunnel-count", "-1"))
+
+	_, err := processFlagMCRInput(cmd)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ipsec-tunnel-count must be")
+}
+
 func TestProcessFlagMCRInput_ResourceTags(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/commands/mcr/mcr_inputs_test.go
+++ b/internal/commands/mcr/mcr_inputs_test.go
@@ -465,6 +465,20 @@ func TestProcessFlagMCRInput_IPSec(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Empty(t, req.AddOns)
 	})
+
+	t.Run("invalid ipsec-tunnel-count rejected", func(t *testing.T) {
+		cmd := newCmd()
+		require.NoError(t, cmd.Flags().Set("ipsec-tunnel-count", "5"))
+		_, err := processFlagMCRInput(cmd)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid IPSec tunnel count")
+	})
+}
+
+func TestProcessJSONMCRInput_InvalidTunnelCount(t *testing.T) {
+	_, err := processJSONMCRInput(`{"name":"test","term":12,"portSpeed":5000,"locationId":1,"marketplaceVisibility":true,"tunnelCount":5}`, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid IPSec tunnel count")
 }
 
 func TestProcessFlagMCRInput_ResourceTags(t *testing.T) {

--- a/internal/commands/mcr/mcr_inputs_test.go
+++ b/internal/commands/mcr/mcr_inputs_test.go
@@ -374,6 +374,99 @@ func TestProcessFlagUpdatePrefixFilterListInput(t *testing.T) {
 	}
 }
 
+func TestProcessJSONMCRInput_WithTunnelCount(t *testing.T) {
+	tests := []struct {
+		name            string
+		jsonStr         string
+		expectAddOns    bool
+		expectedCount   int
+		expectedError   string
+	}{
+		{
+			name:          "tunnelCount 10 populates AddOns",
+			jsonStr:       `{"name":"test","term":12,"portSpeed":5000,"locationId":1,"marketplaceVisibility":true,"tunnelCount":10}`,
+			expectAddOns:  true,
+			expectedCount: 10,
+		},
+		{
+			name:         "tunnelCount 0 does not populate AddOns",
+			jsonStr:      `{"name":"test","term":12,"portSpeed":5000,"locationId":1,"marketplaceVisibility":true,"tunnelCount":0}`,
+			expectAddOns: false,
+		},
+		{
+			name:         "no tunnelCount field",
+			jsonStr:      `{"name":"test","term":12,"portSpeed":5000,"locationId":1,"marketplaceVisibility":true}`,
+			expectAddOns: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := processJSONMCRInput(tt.jsonStr, "")
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, req)
+			if tt.expectAddOns {
+				assert.Len(t, req.AddOns, 1)
+				addon, ok := req.AddOns[0].(*megaport.MCRAddOnIPsecConfig)
+				assert.True(t, ok)
+				assert.Equal(t, tt.expectedCount, addon.TunnelCount)
+			} else {
+				assert.Empty(t, req.AddOns)
+			}
+		})
+	}
+}
+
+func TestProcessFlagMCRInput_IPSec(t *testing.T) {
+	newCmd := func() *cobra.Command {
+		cmd := &cobra.Command{Use: "test"}
+		cmd.Flags().String("name", "test-mcr", "")
+		cmd.Flags().Int("term", 12, "")
+		cmd.Flags().Int("port-speed", 5000, "")
+		cmd.Flags().Int("location-id", 1, "")
+		cmd.Flags().Int("mcr-asn", 0, "")
+		cmd.Flags().Bool("marketplace-visibility", false, "")
+		cmd.Flags().String("cost-centre", "", "")
+		cmd.Flags().String("promo-code", "", "")
+		cmd.Flags().String("diversity-zone", "", "")
+		cmd.Flags().String("resource-tags", "", "")
+		cmd.Flags().Int("ipsec-tunnel-count", 0, "")
+		return cmd
+	}
+
+	t.Run("ipsec-tunnel-count flag set", func(t *testing.T) {
+		cmd := newCmd()
+		require.NoError(t, cmd.Flags().Set("ipsec-tunnel-count", "20"))
+
+		req, err := processFlagMCRInput(cmd)
+		assert.NoError(t, err)
+		assert.Len(t, req.AddOns, 1)
+		addon, ok := req.AddOns[0].(*megaport.MCRAddOnIPsecConfig)
+		assert.True(t, ok)
+		assert.Equal(t, 20, addon.TunnelCount)
+	})
+
+	t.Run("ipsec-tunnel-count flag not set", func(t *testing.T) {
+		cmd := newCmd()
+		req, err := processFlagMCRInput(cmd)
+		assert.NoError(t, err)
+		assert.Empty(t, req.AddOns)
+	})
+
+	t.Run("ipsec-tunnel-count zero does not add addon", func(t *testing.T) {
+		cmd := newCmd()
+		require.NoError(t, cmd.Flags().Set("ipsec-tunnel-count", "0"))
+		req, err := processFlagMCRInput(cmd)
+		assert.NoError(t, err)
+		assert.Empty(t, req.AddOns)
+	})
+}
+
 func TestProcessFlagMCRInput_ResourceTags(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/commands/mcr/mcr_inputs_test.go
+++ b/internal/commands/mcr/mcr_inputs_test.go
@@ -389,9 +389,10 @@ func TestProcessJSONMCRInput_WithTunnelCount(t *testing.T) {
 			expectedCount: 10,
 		},
 		{
-			name:         "tunnelCount 0 does not populate AddOns",
-			jsonStr:      `{"name":"test","term":12,"portSpeed":5000,"locationId":1,"marketplaceVisibility":true,"tunnelCount":0}`,
-			expectAddOns: false,
+			name:          "tunnelCount 0 includes add-on with API default",
+			jsonStr:       `{"name":"test","term":12,"portSpeed":5000,"locationId":1,"marketplaceVisibility":true,"tunnelCount":0}`,
+			expectAddOns:  true,
+			expectedCount: 0,
 		},
 		{
 			name:         "no tunnelCount field",
@@ -458,12 +459,15 @@ func TestProcessFlagMCRInput_IPSec(t *testing.T) {
 		assert.Empty(t, req.AddOns)
 	})
 
-	t.Run("ipsec-tunnel-count zero does not add addon", func(t *testing.T) {
+	t.Run("ipsec-tunnel-count zero includes add-on with API default", func(t *testing.T) {
 		cmd := newCmd()
 		require.NoError(t, cmd.Flags().Set("ipsec-tunnel-count", "0"))
 		req, err := processFlagMCRInput(cmd)
 		assert.NoError(t, err)
-		assert.Empty(t, req.AddOns)
+		assert.Len(t, req.AddOns, 1)
+		addon, ok := req.AddOns[0].(*megaport.MCRAddOnIPsecConfig)
+		assert.True(t, ok)
+		assert.Equal(t, 0, addon.TunnelCount)
 	})
 
 	t.Run("invalid ipsec-tunnel-count rejected", func(t *testing.T) {

--- a/internal/commands/mcr/mcr_mock.go
+++ b/internal/commands/mcr/mcr_mock.go
@@ -49,6 +49,15 @@ type MockMCRService struct {
 	CapturedModifyPrefixFilterListID         int
 	CapturedModifyPrefixFilterList           *megaport.MCRPrefixFilterList
 	ForceNilGetMCR                           bool
+
+	UpdateMCRWithAddOnErr           error
+	CapturedUpdateMCRWithAddOnMCRID string
+	CapturedUpdateMCRWithAddOnReq   megaport.MCRAddOnRequest
+
+	UpdateMCRIPsecAddOnErr            error
+	CapturedUpdateMCRIPsecAddOnMCRID  string
+	CapturedUpdateMCRIPsecAddOnUID    string
+	CapturedUpdateMCRIPsecTunnelCount int
 }
 
 func (m *MockMCRService) BuyMCR(ctx context.Context, req *megaport.BuyMCRRequest) (*megaport.BuyMCRResponse, error) {
@@ -174,6 +183,19 @@ func (m *MockMCRService) GetMCRPrefixFilterLists(ctx context.Context, mcrID stri
 	return m.GetMCRPrefixFilterListsResult, nil
 }
 
+func (m *MockMCRService) UpdateMCRWithAddOn(ctx context.Context, mcrID string, req megaport.MCRAddOnRequest) error {
+	m.CapturedUpdateMCRWithAddOnMCRID = mcrID
+	m.CapturedUpdateMCRWithAddOnReq = req
+	return m.UpdateMCRWithAddOnErr
+}
+
+func (m *MockMCRService) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, addOnUID string, tunnelCount int) error {
+	m.CapturedUpdateMCRIPsecAddOnMCRID = mcrID
+	m.CapturedUpdateMCRIPsecAddOnUID = addOnUID
+	m.CapturedUpdateMCRIPsecTunnelCount = tunnelCount
+	return m.UpdateMCRIPsecAddOnErr
+}
+
 func (m *MockMCRService) Reset() {
 	m.BuyMCRResult = nil
 	m.BuyMCRErr = nil
@@ -214,4 +236,11 @@ func (m *MockMCRService) Reset() {
 	m.CapturedModifyPrefixFilterListMCRID = ""
 	m.CapturedModifyPrefixFilterListID = 0
 	m.CapturedModifyPrefixFilterList = nil
+	m.UpdateMCRWithAddOnErr = nil
+	m.CapturedUpdateMCRWithAddOnMCRID = ""
+	m.CapturedUpdateMCRWithAddOnReq = megaport.MCRAddOnRequest{}
+	m.UpdateMCRIPsecAddOnErr = nil
+	m.CapturedUpdateMCRIPsecAddOnMCRID = ""
+	m.CapturedUpdateMCRIPsecAddOnUID = ""
+	m.CapturedUpdateMCRIPsecTunnelCount = 0
 }

--- a/internal/commands/mcr/mcr_output.go
+++ b/internal/commands/mcr/mcr_output.go
@@ -10,12 +10,20 @@ import (
 // mcrOutput represents the desired fields for JSON output of MCR details.
 type mcrOutput struct {
 	output.Output      `json:"-" header:"-"`
-	UID                string `json:"uid" header:"UID"`
-	Name               string `json:"name" header:"Name"`
-	LocationID         int    `json:"location_id" header:"Location ID"`
-	ProvisioningStatus string `json:"provisioning_status" header:"Status"`
-	ASN                int    `json:"asn" header:"ASN"`
-	Speed              int    `json:"speed" header:"Speed"`
+	UID                string             `json:"uid" header:"UID"`
+	Name               string             `json:"name" header:"Name"`
+	LocationID         int                `json:"location_id" header:"Location ID"`
+	ProvisioningStatus string             `json:"provisioning_status" header:"Status"`
+	ASN                int                `json:"asn" header:"ASN"`
+	Speed              int                `json:"speed" header:"Speed"`
+	AddOns             []mcrAddOnOutput `json:"add_ons,omitempty" header:"-" csv:"-"`
+}
+
+// mcrAddOnOutput represents an add-on attached to an MCR.
+type mcrAddOnOutput struct {
+	AddOnUID    string `json:"add_on_uid"`
+	AddOnType   string `json:"add_on_type"`
+	TunnelCount int    `json:"tunnel_count"`
 }
 
 // toMCROutput converts a *megaport.MCR to our mcrOutput struct.
@@ -24,7 +32,7 @@ func toMCROutput(mcr *megaport.MCR) (mcrOutput, error) {
 		return mcrOutput{}, fmt.Errorf("invalid MCR: nil value")
 	}
 
-	output := mcrOutput{
+	o := mcrOutput{
 		UID:                mcr.UID,
 		Name:               mcr.Name,
 		LocationID:         mcr.LocationID,
@@ -32,9 +40,20 @@ func toMCROutput(mcr *megaport.MCR) (mcrOutput, error) {
 		Speed:              mcr.PortSpeed,
 	}
 
-	output.ASN = mcr.Resources.VirtualRouter.ASN
+	o.ASN = mcr.Resources.VirtualRouter.ASN
 
-	return output, nil
+	for _, addon := range mcr.AddOns {
+		if addon == nil {
+			continue
+		}
+		o.AddOns = append(o.AddOns, mcrAddOnOutput{
+			AddOnUID:    addon.AddOnUID,
+			AddOnType:   addon.AddOnType,
+			TunnelCount: addon.TunnelCount,
+		})
+	}
+
+	return o, nil
 }
 
 // printMCRs prints a list of MCRs in the specified format.

--- a/internal/commands/mcr/mcr_output_test.go
+++ b/internal/commands/mcr/mcr_output_test.go
@@ -57,6 +57,27 @@ func TestToPrefixFilterListOutput_Valid(t *testing.T) {
 	assert.Equal(t, "permit", out.Entries[0].Action)
 }
 
+func TestToMCROutput_WithAddOns(t *testing.T) {
+	mcr := &megaport.MCR{
+		UID:                "mcr-123",
+		Name:               "Test MCR",
+		LocationID:         1,
+		ProvisioningStatus: "LIVE",
+		PortSpeed:          5000,
+		AddOns: []*megaport.MCRAddOnIPsecConfig{
+			{AddOnUID: "addon-1", AddOnType: "IP_SEC", TunnelCount: 10},
+			nil, // nil entries should be skipped
+		},
+	}
+
+	out, err := toMCROutput(mcr)
+	assert.NoError(t, err)
+	assert.Len(t, out.AddOns, 1)
+	assert.Equal(t, "addon-1", out.AddOns[0].AddOnUID)
+	assert.Equal(t, "IP_SEC", out.AddOns[0].AddOnType)
+	assert.Equal(t, 10, out.AddOns[0].TunnelCount)
+}
+
 func TestDisplayMCRChanges(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/internal/commands/mcr/mcr_prompts.go
+++ b/internal/commands/mcr/mcr_prompts.go
@@ -12,6 +12,43 @@ import (
 	megaport "github.com/megaport/megaportgo"
 )
 
+// promptForIPSecTunnelCount prompts the user to select a tunnel count for a new IPSec add-on.
+// Valid values are 10, 20, or 30 (0 means default to 10).
+func promptForIPSecTunnelCount(noColor bool) (int, error) {
+	prompt := "Enter IPSec tunnel count (10, 20, or 30; leave empty for default of 10): "
+	input, err := utils.ResourcePrompt("mcr", prompt, noColor)
+	if err != nil {
+		return 0, err
+	}
+	if input == "" {
+		return 0, nil
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(input))
+	if err != nil {
+		return 0, fmt.Errorf("invalid tunnel count: %w", err)
+	}
+	return count, nil
+}
+
+// promptForIPSecTunnelCountUpdate prompts the user to select a tunnel count for updating an IPSec add-on.
+// Valid values are 10, 20, or 30. Enter 0 to disable IPSec.
+func promptForIPSecTunnelCountUpdate(noColor bool) (int, error) {
+	prompt := "Enter new IPSec tunnel count (10, 20, or 30; enter 0 to disable IPSec): "
+	input, err := utils.ResourcePrompt("mcr", prompt, noColor)
+	if err != nil {
+		return 0, err
+	}
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return 0, fmt.Errorf("tunnel count is required for update (use 0 to disable IPSec)")
+	}
+	count, err := strconv.Atoi(input)
+	if err != nil {
+		return 0, fmt.Errorf("invalid tunnel count: %w", err)
+	}
+	return count, nil
+}
+
 func promptForUpdateMCRDetails(mcrUID string, noColor bool) (*megaport.ModifyMCRRequest, error) {
 	req := &megaport.ModifyMCRRequest{
 		MCRID: mcrUID,

--- a/internal/commands/mcr/mcr_prompts_test.go
+++ b/internal/commands/mcr/mcr_prompts_test.go
@@ -251,6 +251,75 @@ func TestPromptForPrefixFilterListDetails_NoEntries(t *testing.T) {
 	assert.Contains(t, err.Error(), "at least one entry is required")
 }
 
+func TestPromptForIPSecTunnelCount(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    int
+		wantErr     bool
+		errContains string
+	}{
+		{"empty input uses default", "", 0, false, ""},
+		{"valid count 10", "10", 10, false, ""},
+		{"valid count 20", "20", 20, false, ""},
+		{"valid count 30", "30", 30, false, ""},
+		{"non-numeric input", "abc", 0, true, "invalid tunnel count"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalPrompt := utils.GetResourcePrompt()
+			defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+			utils.SetResourcePrompt(mockPromptSequence([]string{tt.input}))
+
+			count, err := promptForIPSecTunnelCount(true)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, count)
+			}
+		})
+	}
+}
+
+func TestPromptForIPSecTunnelCountUpdate(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    int
+		wantErr     bool
+		errContains string
+	}{
+		{"valid count 10", "10", 10, false, ""},
+		{"valid count 20", "20", 20, false, ""},
+		{"valid count 30", "30", 30, false, ""},
+		{"zero disables IPSec", "0", 0, false, ""},
+		{"empty input requires value", "", 0, true, "tunnel count is required"},
+		{"non-numeric input", "abc", 0, true, "invalid tunnel count"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalPrompt := utils.GetResourcePrompt()
+			defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+			utils.SetResourcePrompt(mockPromptSequence([]string{tt.input}))
+
+			count, err := promptForIPSecTunnelCountUpdate(true)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, count)
+			}
+		})
+	}
+}
+
 func TestPromptUpdateExistingEntries_KeepUnmodified(t *testing.T) {
 	originalPrompt := utils.GetResourcePrompt()
 	defer func() { utils.SetResourcePrompt(originalPrompt) }()

--- a/internal/commands/mcr/mcr_utils.go
+++ b/internal/commands/mcr/mcr_utils.go
@@ -56,6 +56,14 @@ var unlockMCRFunc = func(ctx context.Context, client *megaport.Client, mcrUID st
 	return client.ProductService.ManageProductLock(ctx, &megaport.ManageProductLockRequest{ProductID: mcrUID, ShouldLock: false})
 }
 
+var updateMCRWithAddOnFunc = func(ctx context.Context, client *megaport.Client, mcrID string, req megaport.MCRAddOnRequest) error {
+	return client.MCRService.UpdateMCRWithAddOn(ctx, mcrID, req)
+}
+
+var updateMCRIPsecAddOnFunc = func(ctx context.Context, client *megaport.Client, mcrID, addOnUID string, tunnelCount int) error {
+	return client.MCRService.UpdateMCRIPsecAddOn(ctx, mcrID, addOnUID, tunnelCount)
+}
+
 func filterMCRs(mcrs []*megaport.MCR, locationID, portSpeed int, mcrName string) []*megaport.MCR {
 	return utils.Filter(mcrs, func(mcr *megaport.MCR) bool {
 		if mcr == nil {

--- a/internal/commands/status/status_mock.go
+++ b/internal/commands/status/status_mock.go
@@ -141,6 +141,14 @@ func (m *MockMCRService) GetMCRPrefixFilterLists(_ context.Context, _ string) ([
 	return nil, fmt.Errorf("mock: GetMCRPrefixFilterLists not configured")
 }
 
+func (m *MockMCRService) UpdateMCRWithAddOn(_ context.Context, _ string, _ megaport.MCRAddOnRequest) error {
+	return fmt.Errorf("mock: UpdateMCRWithAddOn not configured")
+}
+
+func (m *MockMCRService) UpdateMCRIPsecAddOn(_ context.Context, _ string, _ string, _ int) error {
+	return fmt.Errorf("mock: UpdateMCRIPsecAddOn not configured")
+}
+
 // MockMVEService is a minimal mock for testing the status dashboard.
 type MockMVEService struct {
 	ListMVEsResult          []*megaport.MVE

--- a/internal/commands/topology/topology_mock.go
+++ b/internal/commands/topology/topology_mock.go
@@ -104,6 +104,14 @@ func (m *MockMCRService) UpdateMCRResourceTags(ctx context.Context, mcrID string
 	return fmt.Errorf("mock: UpdateMCRResourceTags not configured")
 }
 
+func (m *MockMCRService) UpdateMCRWithAddOn(ctx context.Context, mcrID string, req megaport.MCRAddOnRequest) error {
+	return fmt.Errorf("mock: UpdateMCRWithAddOn not configured")
+}
+
+func (m *MockMCRService) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, addOnUID string, tunnelCount int) error {
+	return fmt.Errorf("mock: UpdateMCRIPsecAddOn not configured")
+}
+
 // MockMVEService satisfies megaport.MVEService for testing.
 type MockMVEService struct {
 	ListMVEsResult []*megaport.MVE

--- a/internal/validation/mcr.go
+++ b/internal/validation/mcr.go
@@ -7,8 +7,10 @@ import (
 )
 
 // ValidateIPSecTunnelCount validates a tunnel count for an IPSec add-on.
-// For the add operation, valid values are 10, 20, 30 (0 means use the API default of 10).
-// For the update operation, 0 is also valid and means disable IPSec.
+// Valid non-zero values are always 10, 20, or 30.
+// When allowZeroDisable is true (update mode), 0 is also accepted to disable IPSec.
+// When allowZeroDisable is false (add mode), 0 is rejected; callers that wish to
+// use the API default should skip calling this function when count is 0.
 func ValidateIPSecTunnelCount(count int, allowZeroDisable bool) error {
 	if count == 0 && allowZeroDisable {
 		return nil

--- a/internal/validation/mcr.go
+++ b/internal/validation/mcr.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+	"strings"
 
 	megaport "github.com/megaport/megaportgo"
 )
@@ -20,10 +21,15 @@ func ValidateIPSecTunnelCount(count int, allowZeroDisable bool) error {
 			return nil
 		}
 	}
-	if allowZeroDisable {
-		return fmt.Errorf("invalid IPSec tunnel count %d: must be 10, 20, 30, or 0 to disable", count)
+	counts := make([]string, len(megaport.ValidIPsecTunnelCounts))
+	for i, v := range megaport.ValidIPsecTunnelCounts {
+		counts[i] = fmt.Sprintf("%d", v)
 	}
-	return fmt.Errorf("invalid IPSec tunnel count %d: must be 10, 20, or 30 (0 uses the API default of 10)", count)
+	validStr := strings.Join(counts, ", ")
+	if allowZeroDisable {
+		return fmt.Errorf("invalid IPSec tunnel count %d: must be %s, or 0 to disable", count, validStr)
+	}
+	return fmt.Errorf("invalid IPSec tunnel count %d: must be %s (0 uses the API default of 10)", count, validStr)
 }
 
 // ValidateMCRRequest validates a request to buy/provision a new MCR (Megaport Cloud Router).

--- a/internal/validation/mcr.go
+++ b/internal/validation/mcr.go
@@ -1,8 +1,28 @@
 package validation
 
 import (
+	"fmt"
+
 	megaport "github.com/megaport/megaportgo"
 )
+
+// ValidateIPSecTunnelCount validates a tunnel count for an IPSec add-on.
+// For the add operation, valid values are 10, 20, 30 (0 means use the API default of 10).
+// For the update operation, 0 is also valid and means disable IPSec.
+func ValidateIPSecTunnelCount(count int, allowZeroDisable bool) error {
+	if count == 0 && allowZeroDisable {
+		return nil
+	}
+	for _, valid := range megaport.ValidIPsecTunnelCounts {
+		if count == valid {
+			return nil
+		}
+	}
+	if allowZeroDisable {
+		return fmt.Errorf("invalid IPSec tunnel count %d: must be 10, 20, 30, or 0 to disable", count)
+	}
+	return fmt.Errorf("invalid IPSec tunnel count %d: must be 10, 20, or 30 (0 uses the API default of 10)", count)
+}
 
 // ValidateMCRRequest validates a request to buy/provision a new MCR (Megaport Cloud Router).
 // This function ensures all parameters meet the requirements for creating a new MCR.

--- a/internal/validation/mcr_test.go
+++ b/internal/validation/mcr_test.go
@@ -24,7 +24,7 @@ func TestValidateIPSecTunnelCount(t *testing.T) {
 		{"valid 30 update mode", 30, true, false, ""},
 		{"zero disable update mode", 0, true, false, ""},
 		{"zero add mode is invalid", 0, false, true, "0 uses the API default of 10"},
-		{"invalid count add mode", 5, false, true, "must be 10, 20, or 30"},
+		{"invalid count add mode", 5, false, true, "must be 10, 20, 30"},
 		{"invalid count update mode", 5, true, true, "must be 10, 20, 30, or 0 to disable"},
 		{"negative count", -1, false, true, "must be 10, 20, or 30"},
 	}

--- a/internal/validation/mcr_test.go
+++ b/internal/validation/mcr_test.go
@@ -26,7 +26,7 @@ func TestValidateIPSecTunnelCount(t *testing.T) {
 		{"zero add mode is invalid", 0, false, true, "0 uses the API default of 10"},
 		{"invalid count add mode", 5, false, true, "must be 10, 20, 30"},
 		{"invalid count update mode", 5, true, true, "must be 10, 20, 30, or 0 to disable"},
-		{"negative count", -1, false, true, "must be 10, 20, or 30"},
+		{"negative count", -1, false, true, "must be 10, 20, 30"},
 	}
 
 	for _, tt := range tests {

--- a/internal/validation/mcr_test.go
+++ b/internal/validation/mcr_test.go
@@ -8,6 +8,40 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestValidateIPSecTunnelCount(t *testing.T) {
+	tests := []struct {
+		name             string
+		count            int
+		allowZeroDisable bool
+		wantErr          bool
+		errContains      string
+	}{
+		{"valid 10 add mode", 10, false, false, ""},
+		{"valid 20 add mode", 20, false, false, ""},
+		{"valid 30 add mode", 30, false, false, ""},
+		{"valid 10 update mode", 10, true, false, ""},
+		{"valid 20 update mode", 20, true, false, ""},
+		{"valid 30 update mode", 30, true, false, ""},
+		{"zero disable update mode", 0, true, false, ""},
+		{"zero add mode is invalid", 0, false, true, "0 uses the API default of 10"},
+		{"invalid count add mode", 5, false, true, "must be 10, 20, or 30"},
+		{"invalid count update mode", 5, true, true, "must be 10, 20, 30, or 0 to disable"},
+		{"negative count", -1, false, true, "must be 10, 20, or 30"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateIPSecTunnelCount(tt.count, tt.allowZeroDisable)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestValidateMCRRequest(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Surfaces the IPSec add-on capability added to the SDK in megaportgo PR #113.

Two new commands are added to the `mcr` command group:

- `mcr add-ipsec-addon [mcrUID]` — attaches an IPSec add-on to an existing MCR. Accepts `--tunnel-count` (10, 20, or 30; defaults to 10 if omitted), `--json`/`--json-file` with a `tunnelCount` key, or `--interactive`.
- `mcr update-ipsec-addon [mcrUID] [addOnUID]` — changes the tunnel count on an existing add-on, or disables it entirely with `--tunnel-count 0`.

The `mcr buy` command gains an optional `--ipsec-tunnel-count` flag (and a matching `tunnelCount` JSON key) so an MCR can be provisioned with IPSec in a single call. Interactive mode does not prompt for IPSec; the flag or JSON key must be used explicitly.

`mcr get` JSON output now includes an `add_ons` array when the MCR has active add-ons. The field is excluded from table and CSV output.

A `ValidateIPSecTunnelCount` function is added to the validation package and called in both action handlers before the API call is made.

## Notable changes outside the core feature

- Mock implementations of `UpdateMCRWithAddOn` and `UpdateMCRIPsecAddOn` added to the `apply`, `status`, and `topology` packages to satisfy the updated `MCRService` interface.