### PR TITLE
feat: add locations rtt command for round-trip time queries

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Megaport CLI Documentation
 
-> Generated on April 10, 2026 for version v0.7.0
+> Generated on April 10, 2026 for version v0.7.1
 
 ## Available Commands
 
@@ -75,6 +75,8 @@
 | [megaport-cli locations list-countries docs](megaport-cli_locations_list-countries_docs.md) | Show documentation for this command |
 | [megaport-cli locations list-market-codes](megaport-cli_locations_list-market-codes.md) | List all market codes |
 | [megaport-cli locations list-market-codes docs](megaport-cli_locations_list-market-codes_docs.md) | Show documentation for this command |
+| [megaport-cli locations rtt](megaport-cli_locations_rtt.md) | Query round-trip times between locations |
+| [megaport-cli locations rtt docs](megaport-cli_locations_rtt_docs.md) | Show documentation for this command |
 | [megaport-cli locations search](megaport-cli_locations_search.md) | Search locations by name (fuzzy match) |
 | [megaport-cli locations search docs](megaport-cli_locations_search_docs.md) | Show documentation for this command |
 | [megaport-cli managed-account](megaport-cli_managed-account.md) | Manage partner managed accounts in the Megaport API |

--- a/docs/megaport-cli_locations.md
+++ b/docs/megaport-cli_locations.md
@@ -33,5 +33,6 @@ megaport-cli locations [flags]
 * [list](megaport-cli_locations_list.md)
 * [list-countries](megaport-cli_locations_list-countries.md)
 * [list-market-codes](megaport-cli_locations_list-market-codes.md)
+* [rtt](megaport-cli_locations_rtt.md)
 * [search](megaport-cli_locations_search.md)
 

--- a/docs/megaport-cli_locations_rtt.md
+++ b/docs/megaport-cli_locations_rtt.md
@@ -8,7 +8,7 @@ Query median round-trip times (RTT) between Megaport locations.
 
 This command retrieves latency data between a source location and all other Megaport locations for a given month. Use this for network planning — choosing MCR locations and designing cross-connects based on latency requirements.
 
-By default, returns data for the current month. Use --year and --month to query historical data.
+RTT data is published after month end, so the current month has no data. By default, returns data for the previous month. Use --year and --month to query a specific month.
 
 ### Required Fields
   - `src-location`: Source location ID
@@ -37,9 +37,9 @@ megaport-cli locations rtt [flags]
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
 | `--dst-location` |  | `0` | Filter results to a specific destination location ID | false |
-| `--month` |  | `0` | Month for RTT data (1-12, default: current month) | false |
+| `--month` |  | `0` | Month for RTT data, 1-12 (default: previous month) | false |
 | `--src-location` |  | `0` | Source location ID | true |
-| `--year` |  | `0` | Year for RTT data (default: current year) | false |
+| `--year` |  | `0` | Year for RTT data (default: previous month's year) | false |
 
 ## Subcommands
 * [docs](megaport-cli_locations_rtt_docs.md)

--- a/docs/megaport-cli_locations_rtt.md
+++ b/docs/megaport-cli_locations_rtt.md
@@ -1,0 +1,46 @@
+# rtt
+
+Query round-trip times between locations
+
+## Description
+
+Query median round-trip times (RTT) between Megaport locations.
+
+This command retrieves latency data between a source location and all other Megaport locations for a given month. Use this for network planning — choosing MCR locations and designing cross-connects based on latency requirements.
+
+By default, returns data for the current month. Use --year and --month to query historical data.
+
+### Required Fields
+  - `src-location`: Source location ID
+
+### Example Usage
+
+```sh
+  megaport-cli locations rtt --src-location 67
+  megaport-cli locations rtt --src-location 67 --dst-location 3
+  megaport-cli locations rtt --src-location 67 --year 2026 --month 3
+  megaport-cli locations rtt --src-location 67 --output json
+```
+
+## Usage
+
+```sh
+megaport-cli locations rtt [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli locations](megaport-cli_locations.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+| `--dst-location` |  | `0` | Filter results to a specific destination location ID | false |
+| `--month` |  | `0` | Month for RTT data (1-12, default: current month) | false |
+| `--src-location` |  | `0` | Source location ID | true |
+| `--year` |  | `0` | Year for RTT data (default: current year) | false |
+
+## Subcommands
+* [docs](megaport-cli_locations_rtt_docs.md)
+

--- a/docs/megaport-cli_locations_rtt_docs.md
+++ b/docs/megaport-cli_locations_rtt_docs.md
@@ -1,0 +1,23 @@
+# docs
+
+Show documentation for this command
+
+## Description
+
+Display formatted documentation for this command from markdown files
+
+## Usage
+
+```sh
+megaport-cli locations rtt docs [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli locations rtt](megaport-cli_locations_rtt.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+

--- a/internal/commands/locations/locations.go
+++ b/internal/commands/locations/locations.go
@@ -61,13 +61,14 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 			"This command retrieves latency data between a source location and all other "+
 			"Megaport locations for a given month. Use this for network planning — choosing "+
 			"MCR locations and designing cross-connects based on latency requirements.\n\n"+
-			"By default, returns data for the current month. Use --year and --month to query "+
-			"historical data.").
+			"RTT data is published after month end, so the current month has no data. "+
+			"By default, returns data for the previous month. Use --year and --month to "+
+			"query a specific month.").
 		WithIntFlag("src-location", 0, "Source location ID").
 		WithDocumentedRequiredFlag("src-location", "Source location ID").
 		WithIntFlag("dst-location", 0, "Filter results to a specific destination location ID").
-		WithIntFlag("year", 0, "Year for RTT data (default: current year)").
-		WithIntFlag("month", 0, "Month for RTT data (1-12, default: current month)").
+		WithIntFlag("year", 0, "Year for RTT data (default: previous month's year)").
+		WithIntFlag("month", 0, "Month for RTT data, 1-12 (default: previous month)").
 		WithExample("megaport-cli locations rtt --src-location 67").
 		WithExample("megaport-cli locations rtt --src-location 67 --dst-location 3").
 		WithExample("megaport-cli locations rtt --src-location 67 --year 2026 --month 3").

--- a/internal/commands/locations/locations.go
+++ b/internal/commands/locations/locations.go
@@ -55,6 +55,26 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithRootCmd(rootCmd).
 		Build()
 
-	locationsCmd.AddCommand(listLocationsCmd, getLocationCmd, listCountriesCmd, listMarketCodesCmd, searchCmd)
+	rttCmd := cmdbuilder.NewCommand("rtt", "Query round-trip times between locations").
+		WithOutputFormatRunFunc(GetRoundTripTimes).
+		WithLongDesc("Query median round-trip times (RTT) between Megaport locations.\n\n"+
+			"This command retrieves latency data between a source location and all other "+
+			"Megaport locations for a given month. Use this for network planning — choosing "+
+			"MCR locations and designing cross-connects based on latency requirements.\n\n"+
+			"By default, returns data for the current month. Use --year and --month to query "+
+			"historical data.").
+		WithIntFlag("src-location", 0, "Source location ID").
+		WithDocumentedRequiredFlag("src-location", "Source location ID").
+		WithIntFlag("dst-location", 0, "Filter results to a specific destination location ID").
+		WithIntFlag("year", 0, "Year for RTT data (default: current year)").
+		WithIntFlag("month", 0, "Month for RTT data (1-12, default: current month)").
+		WithExample("megaport-cli locations rtt --src-location 67").
+		WithExample("megaport-cli locations rtt --src-location 67 --dst-location 3").
+		WithExample("megaport-cli locations rtt --src-location 67 --year 2026 --month 3").
+		WithExample("megaport-cli locations rtt --src-location 67 --output json").
+		WithRootCmd(rootCmd).
+		Build()
+
+	locationsCmd.AddCommand(listLocationsCmd, getLocationCmd, listCountriesCmd, listMarketCodesCmd, searchCmd, rttCmd)
 	rootCmd.AddCommand(locationsCmd)
 }

--- a/internal/commands/locations/locations_actions.go
+++ b/internal/commands/locations/locations_actions.go
@@ -235,9 +235,23 @@ func GetRoundTripTimes(cmd *cobra.Command, args []string, noColor bool, outputFo
 		}
 	}
 
+	if year <= 0 {
+		output.PrintError("--year must be a positive integer", noColor)
+		return fmt.Errorf("--year must be a positive integer")
+	}
+
 	if month < 1 || month > 12 {
 		output.PrintError("--month must be between 1 and 12", noColor)
 		return fmt.Errorf("--month must be between 1 and 12")
+	}
+
+	// Validate dst-location if provided
+	if cmd.Flags().Changed("dst-location") {
+		dstLocation, _ := cmd.Flags().GetInt("dst-location")
+		if dstLocation <= 0 {
+			output.PrintError("--dst-location must be a positive integer", noColor)
+			return fmt.Errorf("--dst-location must be a positive integer")
+		}
 	}
 
 	spinner := output.PrintResourceListing("round-trip time", noColor)
@@ -270,7 +284,9 @@ func GetRoundTripTimes(cmd *cobra.Command, args []string, noColor bool, outputFo
 		return printRoundTripTimes(rtts, outputFormat, noColor)
 	}
 
-	output.PrintInfo("Found %d round-trip time entries", noColor, len(rtts))
+	if outputFormat == utils.FormatTable {
+		output.PrintInfo("Found %d round-trip time entries", noColor, len(rtts))
+	}
 	return printRoundTripTimes(rtts, outputFormat, noColor)
 }
 

--- a/internal/commands/locations/locations_actions.go
+++ b/internal/commands/locations/locations_actions.go
@@ -202,6 +202,70 @@ func SearchLocations(cmd *cobra.Command, args []string, noColor bool, outputForm
 	return nil
 }
 
+func GetRoundTripTimes(cmd *cobra.Command, args []string, noColor bool, outputFormat string) error {
+	output.SetOutputFormat(outputFormat)
+
+	ctx, cancel := utils.ContextFromCmd(cmd)
+	defer cancel()
+
+	client, err := config.NewUnauthenticatedClient()
+	if err != nil {
+		output.PrintError("Failed to create API client: %v", noColor, err)
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	srcLocation, _ := cmd.Flags().GetInt("src-location")
+	if srcLocation <= 0 {
+		output.PrintError("--src-location is required and must be a positive integer", noColor)
+		return fmt.Errorf("--src-location is required and must be a positive integer")
+	}
+
+	year, _ := cmd.Flags().GetInt("year")
+	month, _ := cmd.Flags().GetInt("month")
+
+	if year == 0 || month == 0 {
+		now := timeNow()
+		if year == 0 {
+			year = now.Year()
+		}
+		if month == 0 {
+			month = int(now.Month())
+		}
+	}
+
+	spinner := output.PrintResourceListing("round-trip time", noColor)
+
+	rtts, err := getRoundTripTimesFunc(ctx, client, srcLocation, year, month)
+	spinner.Stop()
+
+	if err != nil {
+		output.PrintError("Failed to retrieve round-trip times: %v", noColor, err)
+		return fmt.Errorf("failed to get round-trip times: %w", err)
+	}
+
+	// Filter by destination location if specified
+	if cmd.Flags().Changed("dst-location") {
+		dstLocation, _ := cmd.Flags().GetInt("dst-location")
+		var filtered []*megaport.RoundTripTime
+		for _, rtt := range rtts {
+			if rtt != nil && rtt.DstLocation == dstLocation {
+				filtered = append(filtered, rtt)
+			}
+		}
+		rtts = filtered
+	}
+
+	if len(rtts) == 0 {
+		if outputFormat == utils.FormatTable {
+			output.PrintInfo("No round-trip time data found.", noColor)
+		}
+		return nil
+	}
+
+	output.PrintInfo("Found %d round-trip time entries", noColor, len(rtts))
+	return printRoundTripTimes(rtts, outputFormat, noColor)
+}
+
 func GetLocation(cmd *cobra.Command, args []string, noColor bool, outputFormat string) error {
 	output.SetOutputFormat(outputFormat)
 

--- a/internal/commands/locations/locations_actions.go
+++ b/internal/commands/locations/locations_actions.go
@@ -224,12 +224,14 @@ func GetRoundTripTimes(cmd *cobra.Command, args []string, noColor bool, outputFo
 	month, _ := cmd.Flags().GetInt("month")
 
 	if year == 0 || month == 0 {
-		now := timeNow()
+		// Default to the previous month since RTT data is published after
+		// month end — the current month will always return empty results.
+		prev := timeNow().AddDate(0, -1, 0)
 		if year == 0 {
-			year = now.Year()
+			year = prev.Year()
 		}
 		if month == 0 {
-			month = int(now.Month())
+			month = int(prev.Month())
 		}
 	}
 

--- a/internal/commands/locations/locations_actions.go
+++ b/internal/commands/locations/locations_actions.go
@@ -233,6 +233,11 @@ func GetRoundTripTimes(cmd *cobra.Command, args []string, noColor bool, outputFo
 		}
 	}
 
+	if month < 1 || month > 12 {
+		output.PrintError("--month must be between 1 and 12", noColor)
+		return fmt.Errorf("--month must be between 1 and 12")
+	}
+
 	spinner := output.PrintResourceListing("round-trip time", noColor)
 
 	rtts, err := getRoundTripTimesFunc(ctx, client, srcLocation, year, month)
@@ -258,8 +263,9 @@ func GetRoundTripTimes(cmd *cobra.Command, args []string, noColor bool, outputFo
 	if len(rtts) == 0 {
 		if outputFormat == utils.FormatTable {
 			output.PrintInfo("No round-trip time data found.", noColor)
+			return nil
 		}
-		return nil
+		return printRoundTripTimes(rtts, outputFormat, noColor)
 	}
 
 	output.PrintInfo("Found %d round-trip time entries", noColor, len(rtts))

--- a/internal/commands/locations/locations_actions.go
+++ b/internal/commands/locations/locations_actions.go
@@ -264,12 +264,21 @@ func GetRoundTripTimes(cmd *cobra.Command, args []string, noColor bool, outputFo
 		return fmt.Errorf("failed to get round-trip times: %w", err)
 	}
 
+	// Strip nil entries so length checks and counts are accurate.
+	cleaned := make([]*megaport.RoundTripTime, 0, len(rtts))
+	for _, rtt := range rtts {
+		if rtt != nil {
+			cleaned = append(cleaned, rtt)
+		}
+	}
+	rtts = cleaned
+
 	// Filter by destination location if specified
 	if cmd.Flags().Changed("dst-location") {
 		dstLocation, _ := cmd.Flags().GetInt("dst-location")
 		var filtered []*megaport.RoundTripTime
 		for _, rtt := range rtts {
-			if rtt != nil && rtt.DstLocation == dstLocation {
+			if rtt.DstLocation == dstLocation {
 				filtered = append(filtered, rtt)
 			}
 		}

--- a/internal/commands/locations/locations_mock.go
+++ b/internal/commands/locations/locations_mock.go
@@ -3,7 +3,6 @@ package locations
 
 import (
 	"context"
-	"fmt"
 
 	megaport "github.com/megaport/megaportgo"
 )
@@ -56,6 +55,9 @@ type MockLocationsService struct {
 
 	IsValidMarketCodeResult bool
 	IsValidMarketCodeErr    error
+
+	GetRoundTripTimesResult []*megaport.RoundTripTime
+	GetRoundTripTimesErr    error
 }
 
 // V2 methods
@@ -129,5 +131,8 @@ func (m *MockLocationsService) IsValidMarketCode(ctx context.Context, marketCode
 }
 
 func (m *MockLocationsService) GetRoundTripTimes(_ context.Context, _, _, _ int) ([]*megaport.RoundTripTime, error) {
-	return nil, fmt.Errorf("mock: GetRoundTripTimes not configured")
+	if m.GetRoundTripTimesErr != nil {
+		return nil, m.GetRoundTripTimesErr
+	}
+	return m.GetRoundTripTimesResult, nil
 }

--- a/internal/commands/locations/locations_output.go
+++ b/internal/commands/locations/locations_output.go
@@ -106,6 +106,28 @@ func printMarketCodes(marketCodes []string, format string, noColor bool) error {
 	return output.PrintOutput(outputs, format, noColor)
 }
 
+type rttOutput struct {
+	output.Output `json:"-" header:"-"`
+	SrcLocationID int     `json:"src_location_id" header:"Src Location ID"`
+	DstLocationID int     `json:"dst_location_id" header:"Dst Location ID"`
+	MedianRTTMs   float64 `json:"median_rtt_ms" header:"Median RTT (ms)"`
+}
+
+func printRoundTripTimes(rtts []*megaport.RoundTripTime, format string, noColor bool) error {
+	outputs := make([]rttOutput, 0, len(rtts))
+	for _, rtt := range rtts {
+		if rtt == nil {
+			continue
+		}
+		outputs = append(outputs, rttOutput{
+			SrcLocationID: rtt.SrcLocation,
+			DstLocationID: rtt.DstLocation,
+			MedianRTTMs:   rtt.MedianRTT,
+		})
+	}
+	return output.PrintOutput(outputs, format, noColor)
+}
+
 func printLocations(locations []*megaport.LocationV3, format string, noColor bool) error {
 	if format == utils.FormatTable {
 		tableOutputs := make([]locationTableOutput, 0, len(locations))

--- a/internal/commands/locations/locations_test.go
+++ b/internal/commands/locations/locations_test.go
@@ -411,6 +411,80 @@ func TestGetRoundTripTimesJSONOutput(t *testing.T) {
 	assert.Contains(t, capturedOutput, "median_rtt_ms")
 }
 
+func TestGetRoundTripTimesDefaultsPreviousMonth(t *testing.T) {
+	origClientFunc := config.GetNewUnauthenticatedClientFunc()
+	defer config.SetNewUnauthenticatedClientFunc(origClientFunc)
+
+	origTimeNow := timeNow
+	defer func() { timeNow = origTimeNow }()
+	// Mock time to April 10, 2026 — default should be March 2026.
+	timeNow = func() time.Time { return time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC) }
+
+	var capturedYear, capturedMonth int
+	origRTTFunc := getRoundTripTimesFunc
+	defer func() { getRoundTripTimesFunc = origRTTFunc }()
+
+	config.SetNewUnauthenticatedClientFunc(func() (*megaport.Client, error) {
+		return &megaport.Client{}, nil
+	})
+	getRoundTripTimesFunc = func(_ context.Context, _ *megaport.Client, _ int, year, month int) ([]*megaport.RoundTripTime, error) {
+		capturedYear = year
+		capturedMonth = month
+		return []*megaport.RoundTripTime{}, nil
+	}
+
+	cmd := testutil.NewCommand("rtt", testutil.OutputAdapter(GetRoundTripTimes))
+	cmd.Flags().Int("src-location", 0, "")
+	cmd.Flags().Int("dst-location", 0, "")
+	cmd.Flags().Int("year", 0, "")
+	cmd.Flags().Int("month", 0, "")
+	_ = cmd.Flags().Set("src-location", "67")
+
+	output.CaptureOutput(func() {
+		_ = testutil.OutputAdapter(GetRoundTripTimes)(cmd, nil)
+	})
+
+	assert.Equal(t, 2026, capturedYear, "default year should be from previous month")
+	assert.Equal(t, 3, capturedMonth, "default month should be previous month (March)")
+}
+
+func TestGetRoundTripTimesDefaultsJanuaryRollback(t *testing.T) {
+	origClientFunc := config.GetNewUnauthenticatedClientFunc()
+	defer config.SetNewUnauthenticatedClientFunc(origClientFunc)
+
+	origTimeNow := timeNow
+	defer func() { timeNow = origTimeNow }()
+	// Mock time to January 15, 2026 — default should be December 2025.
+	timeNow = func() time.Time { return time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC) }
+
+	var capturedYear, capturedMonth int
+	origRTTFunc := getRoundTripTimesFunc
+	defer func() { getRoundTripTimesFunc = origRTTFunc }()
+
+	config.SetNewUnauthenticatedClientFunc(func() (*megaport.Client, error) {
+		return &megaport.Client{}, nil
+	})
+	getRoundTripTimesFunc = func(_ context.Context, _ *megaport.Client, _ int, year, month int) ([]*megaport.RoundTripTime, error) {
+		capturedYear = year
+		capturedMonth = month
+		return []*megaport.RoundTripTime{}, nil
+	}
+
+	cmd := testutil.NewCommand("rtt", testutil.OutputAdapter(GetRoundTripTimes))
+	cmd.Flags().Int("src-location", 0, "")
+	cmd.Flags().Int("dst-location", 0, "")
+	cmd.Flags().Int("year", 0, "")
+	cmd.Flags().Int("month", 0, "")
+	_ = cmd.Flags().Set("src-location", "67")
+
+	output.CaptureOutput(func() {
+		_ = testutil.OutputAdapter(GetRoundTripTimes)(cmd, nil)
+	})
+
+	assert.Equal(t, 2025, capturedYear, "default year should roll back to 2025")
+	assert.Equal(t, 12, capturedMonth, "default month should be December")
+}
+
 func TestPrintRoundTripTimes_Table(t *testing.T) {
 	var err error
 	capturedOutput := output.CaptureOutput(func() {

--- a/internal/commands/locations/locations_test.go
+++ b/internal/commands/locations/locations_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/megaport/megaport-cli/internal/commands/config"
 	"github.com/megaport/megaport-cli/internal/testutil"
 	megaport "github.com/megaport/megaportgo"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -253,9 +254,10 @@ var testRTTs = []*megaport.RoundTripTime{
 }
 
 // setupRTTMock configures mocks for RTT tests and returns a cleanup function
-// that restores the original getRoundTripTimesFunc.
+// that restores both getRoundTripTimesFunc and the unauthenticated client func.
 func setupRTTMock(rtts []*megaport.RoundTripTime, err error) func() {
-	origFunc := getRoundTripTimesFunc
+	origRTTFunc := getRoundTripTimesFunc
+	origClientFunc := config.GetNewUnauthenticatedClientFunc()
 	config.SetNewUnauthenticatedClientFunc(func() (*megaport.Client, error) {
 		client := &megaport.Client{}
 		client.LocationService = &MockLocationsService{
@@ -267,13 +269,13 @@ func setupRTTMock(rtts []*megaport.RoundTripTime, err error) func() {
 	getRoundTripTimesFunc = func(ctx context.Context, client *megaport.Client, srcLocationID, year, month int) ([]*megaport.RoundTripTime, error) {
 		return client.LocationService.GetRoundTripTimes(ctx, srcLocationID, year, month)
 	}
-	return func() { getRoundTripTimesFunc = origFunc }
+	return func() {
+		getRoundTripTimesFunc = origRTTFunc
+		config.SetNewUnauthenticatedClientFunc(origClientFunc)
+	}
 }
 
 func TestGetRoundTripTimes(t *testing.T) {
-	origClientFunc := config.GetNewUnauthenticatedClientFunc()
-	defer config.SetNewUnauthenticatedClientFunc(origClientFunc)
-
 	origTimeNow := timeNow
 	defer func() { timeNow = origTimeNow }()
 	// Fixed date for deterministic default year/month in tests.
@@ -335,6 +337,20 @@ func TestGetRoundTripTimes(t *testing.T) {
 			month:         "13",
 			expectedError: "--month must be between 1 and 12",
 		},
+		{
+			name:          "negative year",
+			srcLocation:   "67",
+			year:          "-1",
+			month:         "3",
+			expectedError: "--year must be a positive integer",
+		},
+		{
+			name:          "invalid dst-location",
+			srcLocation:   "67",
+			dstLocation:   "0",
+			mockRTTs:      testRTTs,
+			expectedError: "--dst-location must be a positive integer",
+		},
 	}
 
 	for _, tt := range tests {
@@ -383,12 +399,6 @@ func TestGetRoundTripTimes(t *testing.T) {
 }
 
 func TestGetRoundTripTimesJSONOutput(t *testing.T) {
-	origClientFunc := config.GetNewUnauthenticatedClientFunc()
-	defer config.SetNewUnauthenticatedClientFunc(origClientFunc)
-
-	origTimeNow := timeNow
-	defer func() { timeNow = origTimeNow }()
-
 	cleanup := setupRTTMock(testRTTs, nil)
 	defer cleanup()
 
@@ -521,4 +531,41 @@ func TestPrintRoundTripTimes_Empty(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, "[]\n", capturedOutput)
+}
+
+func TestAddCommandsTo(t *testing.T) {
+	root := &cobra.Command{Use: "megaport-cli"}
+	AddCommandsTo(root)
+
+	locationsFound := false
+	for _, cmd := range root.Commands() {
+		if cmd.Use == "locations" {
+			locationsFound = true
+			rttFound := false
+			for _, sub := range cmd.Commands() {
+				if sub.Use == "rtt" {
+					rttFound = true
+				}
+			}
+			assert.True(t, rttFound, "rtt subcommand should be registered under locations")
+		}
+	}
+	assert.True(t, locationsFound, "locations command should be registered")
+}
+
+func TestLocationsModule(t *testing.T) {
+	m := NewModule()
+	assert.Equal(t, "locations", m.Name())
+
+	root := &cobra.Command{Use: "megaport-cli"}
+	m.RegisterCommands(root)
+
+	found := false
+	for _, cmd := range root.Commands() {
+		if cmd.Use == "locations" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "RegisterCommands should add locations command")
 }

--- a/internal/commands/locations/locations_test.go
+++ b/internal/commands/locations/locations_test.go
@@ -1,9 +1,14 @@
 package locations
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/commands/config"
+	"github.com/megaport/megaport-cli/internal/testutil"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/stretchr/testify/assert"
 )
@@ -237,4 +242,188 @@ func TestPrintLocations_EmptySlice(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	assert.Equal(t, "[]\n", jsonOutput)
+}
+
+// RTT tests
+
+var testRTTs = []*megaport.RoundTripTime{
+	{SrcLocation: 67, DstLocation: 3, MedianRTT: 1.5},
+	{SrcLocation: 67, DstLocation: 12, MedianRTT: 150.3},
+	{SrcLocation: 67, DstLocation: 56, MedianRTT: 180.7},
+}
+
+func setupRTTMock(rtts []*megaport.RoundTripTime, err error) {
+	config.SetNewUnauthenticatedClientFunc(func() (*megaport.Client, error) {
+		client := &megaport.Client{}
+		client.LocationService = &MockLocationsService{
+			GetRoundTripTimesResult: rtts,
+			GetRoundTripTimesErr:    err,
+		}
+		return client, nil
+	})
+	getRoundTripTimesFunc = func(ctx context.Context, client *megaport.Client, srcLocationID, year, month int) ([]*megaport.RoundTripTime, error) {
+		return client.LocationService.GetRoundTripTimes(ctx, srcLocationID, year, month)
+	}
+}
+
+func TestGetRoundTripTimes(t *testing.T) {
+	origClientFunc := config.GetNewUnauthenticatedClientFunc()
+	defer config.SetNewUnauthenticatedClientFunc(origClientFunc)
+
+	origTimeNow := timeNow
+	defer func() { timeNow = origTimeNow }()
+	timeNow = func() time.Time { return time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC) }
+
+	tests := []struct {
+		name          string
+		srcLocation   string
+		dstLocation   string
+		year          string
+		month         string
+		mockRTTs      []*megaport.RoundTripTime
+		mockErr       error
+		expectedError string
+		expectedOut   string
+	}{
+		{
+			name:        "success with results",
+			srcLocation: "67",
+			mockRTTs:    testRTTs,
+			expectedOut: "67",
+		},
+		{
+			name:        "success with dst-location filter",
+			srcLocation: "67",
+			dstLocation: "3",
+			mockRTTs:    testRTTs,
+			expectedOut: "1.5",
+		},
+		{
+			name:        "success with explicit year and month",
+			srcLocation: "67",
+			year:        "2025",
+			month:       "6",
+			mockRTTs:    testRTTs,
+			expectedOut: "67",
+		},
+		{
+			name:          "API error",
+			srcLocation:   "67",
+			mockErr:       fmt.Errorf("API failure"),
+			expectedError: "API failure",
+		},
+		{
+			name:        "empty results",
+			srcLocation: "67",
+			mockRTTs:    []*megaport.RoundTripTime{},
+		},
+		{
+			name:          "missing src-location",
+			srcLocation:   "0",
+			expectedError: "--src-location is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupRTTMock(tt.mockRTTs, tt.mockErr)
+
+			cmd := testutil.NewCommand("rtt", testutil.OutputAdapter(GetRoundTripTimes))
+			cmd.Flags().Int("src-location", 0, "")
+			cmd.Flags().Int("dst-location", 0, "")
+			cmd.Flags().Int("year", 0, "")
+			cmd.Flags().Int("month", 0, "")
+
+			if tt.srcLocation != "" {
+				_ = cmd.Flags().Set("src-location", tt.srcLocation)
+			}
+			if tt.dstLocation != "" {
+				_ = cmd.Flags().Set("dst-location", tt.dstLocation)
+			}
+			if tt.year != "" {
+				_ = cmd.Flags().Set("year", tt.year)
+			}
+			if tt.month != "" {
+				_ = cmd.Flags().Set("month", tt.month)
+			}
+
+			var err error
+			capturedOutput := output.CaptureOutput(func() {
+				err = testutil.OutputAdapter(GetRoundTripTimes)(cmd, nil)
+			})
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+				if tt.expectedOut != "" {
+					assert.Contains(t, capturedOutput, tt.expectedOut)
+				}
+			}
+		})
+	}
+}
+
+func TestGetRoundTripTimesJSONOutput(t *testing.T) {
+	origClientFunc := config.GetNewUnauthenticatedClientFunc()
+	defer config.SetNewUnauthenticatedClientFunc(origClientFunc)
+
+	setupRTTMock(testRTTs, nil)
+
+	cmd := testutil.NewCommand("rtt", testutil.OutputAdapter(GetRoundTripTimes))
+	cmd.Flags().Int("src-location", 0, "")
+	cmd.Flags().Int("dst-location", 0, "")
+	cmd.Flags().Int("year", 0, "")
+	cmd.Flags().Int("month", 0, "")
+	_ = cmd.Flags().Set("src-location", "67")
+	_ = cmd.Flags().Set("output", "json")
+
+	var err error
+	capturedOutput := output.CaptureOutput(func() {
+		err = cmd.RunE(cmd, nil)
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, capturedOutput, "src_location_id")
+	assert.Contains(t, capturedOutput, "dst_location_id")
+	assert.Contains(t, capturedOutput, "median_rtt_ms")
+}
+
+func TestPrintRoundTripTimes_Table(t *testing.T) {
+	var err error
+	capturedOutput := output.CaptureOutput(func() {
+		err = printRoundTripTimes(testRTTs, "table", noColor)
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, capturedOutput, "SRC LOCATION ID")
+	assert.Contains(t, capturedOutput, "DST LOCATION ID")
+	assert.Contains(t, capturedOutput, "MEDIAN RTT (MS)")
+	assert.Contains(t, capturedOutput, "67")
+	assert.Contains(t, capturedOutput, "1.5")
+}
+
+func TestPrintRoundTripTimes_NilEntries(t *testing.T) {
+	rtts := []*megaport.RoundTripTime{
+		nil,
+		{SrcLocation: 1, DstLocation: 2, MedianRTT: 5.0},
+	}
+	var err error
+	capturedOutput := output.CaptureOutput(func() {
+		err = printRoundTripTimes(rtts, "table", noColor)
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, capturedOutput, "5")
+}
+
+func TestPrintRoundTripTimes_Empty(t *testing.T) {
+	var err error
+	capturedOutput := output.CaptureOutput(func() {
+		err = printRoundTripTimes([]*megaport.RoundTripTime{}, "json", noColor)
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "[]\n", capturedOutput)
 }

--- a/internal/commands/locations/locations_test.go
+++ b/internal/commands/locations/locations_test.go
@@ -252,7 +252,10 @@ var testRTTs = []*megaport.RoundTripTime{
 	{SrcLocation: 67, DstLocation: 56, MedianRTT: 180.7},
 }
 
-func setupRTTMock(rtts []*megaport.RoundTripTime, err error) {
+// setupRTTMock configures mocks for RTT tests and returns a cleanup function
+// that restores the original getRoundTripTimesFunc.
+func setupRTTMock(rtts []*megaport.RoundTripTime, err error) func() {
+	origFunc := getRoundTripTimesFunc
 	config.SetNewUnauthenticatedClientFunc(func() (*megaport.Client, error) {
 		client := &megaport.Client{}
 		client.LocationService = &MockLocationsService{
@@ -264,6 +267,7 @@ func setupRTTMock(rtts []*megaport.RoundTripTime, err error) {
 	getRoundTripTimesFunc = func(ctx context.Context, client *megaport.Client, srcLocationID, year, month int) ([]*megaport.RoundTripTime, error) {
 		return client.LocationService.GetRoundTripTimes(ctx, srcLocationID, year, month)
 	}
+	return func() { getRoundTripTimesFunc = origFunc }
 }
 
 func TestGetRoundTripTimes(t *testing.T) {
@@ -272,18 +276,20 @@ func TestGetRoundTripTimes(t *testing.T) {
 
 	origTimeNow := timeNow
 	defer func() { timeNow = origTimeNow }()
+	// Fixed date for deterministic default year/month in tests.
 	timeNow = func() time.Time { return time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC) }
 
 	tests := []struct {
-		name          string
-		srcLocation   string
-		dstLocation   string
-		year          string
-		month         string
-		mockRTTs      []*megaport.RoundTripTime
-		mockErr       error
-		expectedError string
-		expectedOut   string
+		name           string
+		srcLocation    string
+		dstLocation    string
+		year           string
+		month          string
+		mockRTTs       []*megaport.RoundTripTime
+		mockErr        error
+		expectedError  string
+		expectedOut    string
+		notExpectedOut string
 	}{
 		{
 			name:        "success with results",
@@ -292,11 +298,12 @@ func TestGetRoundTripTimes(t *testing.T) {
 			expectedOut: "67",
 		},
 		{
-			name:        "success with dst-location filter",
-			srcLocation: "67",
-			dstLocation: "3",
-			mockRTTs:    testRTTs,
-			expectedOut: "1.5",
+			name:           "success with dst-location filter excludes non-matches",
+			srcLocation:    "67",
+			dstLocation:    "3",
+			mockRTTs:       testRTTs,
+			expectedOut:    "1.5",
+			notExpectedOut: "150.3",
 		},
 		{
 			name:        "success with explicit year and month",
@@ -322,11 +329,18 @@ func TestGetRoundTripTimes(t *testing.T) {
 			srcLocation:   "0",
 			expectedError: "--src-location is required",
 		},
+		{
+			name:          "invalid month",
+			srcLocation:   "67",
+			month:         "13",
+			expectedError: "--month must be between 1 and 12",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setupRTTMock(tt.mockRTTs, tt.mockErr)
+			cleanup := setupRTTMock(tt.mockRTTs, tt.mockErr)
+			defer cleanup()
 
 			cmd := testutil.NewCommand("rtt", testutil.OutputAdapter(GetRoundTripTimes))
 			cmd.Flags().Int("src-location", 0, "")
@@ -360,6 +374,9 @@ func TestGetRoundTripTimes(t *testing.T) {
 				if tt.expectedOut != "" {
 					assert.Contains(t, capturedOutput, tt.expectedOut)
 				}
+				if tt.notExpectedOut != "" {
+					assert.NotContains(t, capturedOutput, tt.notExpectedOut)
+				}
 			}
 		})
 	}
@@ -369,7 +386,11 @@ func TestGetRoundTripTimesJSONOutput(t *testing.T) {
 	origClientFunc := config.GetNewUnauthenticatedClientFunc()
 	defer config.SetNewUnauthenticatedClientFunc(origClientFunc)
 
-	setupRTTMock(testRTTs, nil)
+	origTimeNow := timeNow
+	defer func() { timeNow = origTimeNow }()
+
+	cleanup := setupRTTMock(testRTTs, nil)
+	defer cleanup()
 
 	cmd := testutil.NewCommand("rtt", testutil.OutputAdapter(GetRoundTripTimes))
 	cmd.Flags().Int("src-location", 0, "")

--- a/internal/commands/locations/locations_utils.go
+++ b/internal/commands/locations/locations_utils.go
@@ -2,10 +2,14 @@ package locations
 
 import (
 	"context"
+	"time"
 
 	"github.com/megaport/megaport-cli/internal/utils"
 	megaport "github.com/megaport/megaportgo"
 )
+
+// timeNow is a mockable time function for testing default year/month.
+var timeNow = time.Now
 
 func filterLocations(locations []*megaport.LocationV3, filters map[string]string) []*megaport.LocationV3 {
 	return utils.Filter(locations, func(loc *megaport.LocationV3) bool {
@@ -42,4 +46,8 @@ var searchLocationsFunc = func(ctx context.Context, client *megaport.Client, sea
 
 var listLocationsFunc = func(ctx context.Context, client *megaport.Client) ([]*megaport.LocationV3, error) {
 	return client.LocationService.ListLocationsV3(ctx)
+}
+
+var getRoundTripTimesFunc = func(ctx context.Context, client *megaport.Client, srcLocationID, year, month int) ([]*megaport.RoundTripTime, error) {
+	return client.LocationService.GetRoundTripTimes(ctx, srcLocationID, year, month)
 }


### PR DESCRIPTION
## Summary

Add `megaport locations rtt` command that exposes the SDK's `GetRoundTripTimes` method, enabling engineers to query median latency between Megaport locations directly from the CLI. This is critical for network planning — choosing MCR placement and designing cross-connects based on latency requirements.

**Flags:** `--src-location` (required), `--dst-location` (optional filter), `--year` and `--month` (default to previous month, since RTT data is published after month end). Supports all output formats (table/json/csv/xml), `--query` JMESPath, and `--fields` filtering. Uses the unauthenticated public API (no credentials needed).

Input validation: `--src-location` and `--dst-location` must be positive, `--year` must be positive, `--month` must be 1-12. Empty results output `[]` for machine-readable formats. Nil entries stripped before counting/display.

## Test plan

- [x] 13 RTT tests: success, dst-location filter (with exclusion assertion), explicit year/month, API error, empty results, missing src-location, invalid month, negative year, invalid dst-location, JSON output, table formatting, nil entries, empty list
- [x] Previous-month default verified (April 2026 defaults to March 2026)
- [x] January rollback verified (January 2026 defaults to December 2025)
- [x] AddCommandsTo and Module registration tests
- [x] `go test ./...` — full suite passes (33 packages)
- [x] `golangci-lint run` — 0 issues
- [x] Code review completed
- [x] Security audit completed — clean, no issues
- [x] Tested against production API — 503 RTT entries returned for Sydney (location 67)
- [x] Auto-generated docs included