### PR TITLE
fix: suppress spinner for CSV/XML output to prevent stream corruption

### DIFF
--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -418,7 +418,9 @@ func PrintResourceGetting(resourceType, uid string, noColor bool) *Spinner {
 
 func PrintResourceGettingWithOutput(resourceType, uid string, noColor bool, outputFormat string) *Spinner {
 	if shouldSuppressSpinnerForFormat(outputFormat) {
-		return newNoOpSpinner()
+		s := newNoOpSpinner()
+		s.outputFormat = outputFormat
+		return s
 	}
 	uidFormatted := FormatUID(uid, noColor)
 	msg := fmt.Sprintf("Getting %s %s details...", resourceType, uidFormatted)

--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -68,12 +68,13 @@ func IsVerbose() bool {
 
 // newNoOpSpinner returns a spinner that is already stopped.
 // Safe to call Start(), Stop(), and StopWithSuccess() on.
-func newNoOpSpinner() *Spinner {
+// noColor is forwarded so StopWithSuccess respects the --no-color flag.
+func newNoOpSpinner(noColor bool) *Spinner {
 	return &Spinner{
 		stop:         make(chan bool, 1),
 		stopped:      true,
 		outputFormat: getOutputFormat(),
-		noColor:      color.NoColor,
+		noColor:      noColor,
 	}
 }
 
@@ -354,7 +355,7 @@ func (s *Spinner) StopWithSuccess(msg string) {
 
 func PrintResourceCreating(resourceType, uid string, noColor bool) *Spinner {
 	if shouldSuppressSpinner() {
-		return newNoOpSpinner()
+		return newNoOpSpinner(noColor)
 	}
 	uidFormatted := FormatUID(uid, noColor)
 	msg := fmt.Sprintf("Creating %s %s...", resourceType, uidFormatted)
@@ -365,7 +366,7 @@ func PrintResourceCreating(resourceType, uid string, noColor bool) *Spinner {
 
 func PrintResourceProvisioning(resourceType, uid string, noColor bool) *Spinner {
 	if shouldSuppressSpinner() {
-		return newNoOpSpinner()
+		return newNoOpSpinner(noColor)
 	}
 	uidFormatted := FormatUID(uid, noColor)
 	msg := fmt.Sprintf("Provisioning %s %s...", resourceType, uidFormatted)
@@ -376,7 +377,7 @@ func PrintResourceProvisioning(resourceType, uid string, noColor bool) *Spinner 
 
 func PrintResourceUpdating(resourceType, uid string, noColor bool) *Spinner {
 	if shouldSuppressSpinner() {
-		return newNoOpSpinner()
+		return newNoOpSpinner(noColor)
 	}
 	uidFormatted := FormatUID(uid, noColor)
 	msg := fmt.Sprintf("Updating %s %s...", resourceType, uidFormatted)
@@ -387,7 +388,7 @@ func PrintResourceUpdating(resourceType, uid string, noColor bool) *Spinner {
 
 func PrintResourceDeleting(resourceType, uid string, noColor bool) *Spinner {
 	if shouldSuppressSpinner() {
-		return newNoOpSpinner()
+		return newNoOpSpinner(noColor)
 	}
 	uidFormatted := FormatUID(uid, noColor)
 	msg := fmt.Sprintf("Deleting %s %s...", resourceType, uidFormatted)
@@ -398,7 +399,7 @@ func PrintResourceDeleting(resourceType, uid string, noColor bool) *Spinner {
 
 func PrintResourceListing(resourceType string, noColor bool) *Spinner {
 	if shouldSuppressSpinner() {
-		return newNoOpSpinner()
+		return newNoOpSpinner(noColor)
 	}
 	msg := fmt.Sprintf("Listing %ss...", resourceType)
 	spinner := NewSpinnerWithOutput(noColor, getOutputFormat())
@@ -408,7 +409,7 @@ func PrintResourceListing(resourceType string, noColor bool) *Spinner {
 
 func PrintResourceGetting(resourceType, uid string, noColor bool) *Spinner {
 	if shouldSuppressSpinner() {
-		return newNoOpSpinner()
+		return newNoOpSpinner(noColor)
 	}
 	uidFormatted := FormatUID(uid, noColor)
 	msg := fmt.Sprintf("Getting %s %s details...", resourceType, uidFormatted)
@@ -422,7 +423,7 @@ func PrintResourceGettingWithOutput(resourceType, uid string, noColor bool, outp
 		outputFormat = getOutputFormat()
 	}
 	if shouldSuppressSpinnerForFormat(outputFormat) {
-		s := newNoOpSpinner()
+		s := newNoOpSpinner(noColor)
 		s.outputFormat = outputFormat
 		return s
 	}
@@ -435,7 +436,7 @@ func PrintResourceGettingWithOutput(resourceType, uid string, noColor bool, outp
 
 func PrintListingResourceTags(resourceType, uid string, noColor bool) *Spinner {
 	if shouldSuppressSpinner() {
-		return newNoOpSpinner()
+		return newNoOpSpinner(noColor)
 	}
 	uidFormatted := FormatUID(uid, noColor)
 	msg := fmt.Sprintf("Listing resource tags for %s %s...", resourceType, uidFormatted)
@@ -446,7 +447,7 @@ func PrintListingResourceTags(resourceType, uid string, noColor bool) *Spinner {
 
 func PrintResourceValidating(resourceType string, noColor bool) *Spinner {
 	if shouldSuppressSpinner() {
-		return newNoOpSpinner()
+		return newNoOpSpinner(noColor)
 	}
 	msg := fmt.Sprintf("Validating %s order...", resourceType)
 	spinner := NewSpinnerWithOutput(noColor, getOutputFormat())
@@ -456,7 +457,7 @@ func PrintResourceValidating(resourceType string, noColor bool) *Spinner {
 
 func PrintLoggingIn(noColor bool) *Spinner {
 	if IsQuiet() {
-		return newNoOpSpinner()
+		return newNoOpSpinner(noColor)
 	}
 	msg := "Logging in to Megaport..."
 	spinner := NewSpinnerWithOutput(noColor, getOutputFormat())
@@ -466,7 +467,7 @@ func PrintLoggingIn(noColor bool) *Spinner {
 
 func PrintLoggingInWithOutput(noColor bool, outputFormat string) *Spinner {
 	if IsQuiet() {
-		return newNoOpSpinner()
+		return newNoOpSpinner(noColor)
 	}
 	if outputFormat == "" {
 		outputFormat = getOutputFormat()
@@ -479,7 +480,7 @@ func PrintLoggingInWithOutput(noColor bool, outputFormat string) *Spinner {
 
 func PrintCustomSpinner(action, resourceId string, noColor bool) *Spinner {
 	if shouldSuppressSpinner() {
-		return newNoOpSpinner()
+		return newNoOpSpinner(noColor)
 	}
 	uidFormatted := FormatUID(resourceId, noColor)
 	msg := fmt.Sprintf("%s %s...", action, uidFormatted)

--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -73,6 +73,7 @@ func newNoOpSpinner() *Spinner {
 		stop:         make(chan bool, 1),
 		stopped:      true,
 		outputFormat: getOutputFormat(),
+		noColor:      color.NoColor,
 	}
 }
 
@@ -88,13 +89,13 @@ func getOutputFormat() string {
 }
 
 // shouldSuppressSpinner returns true when spinner output should be suppressed
-// to avoid corrupting machine-readable output formats (csv, xml, json).
+// to avoid corrupting machine-readable output formats (csv, xml, json, yaml, etc.).
 func shouldSuppressSpinner() bool {
 	return shouldSuppressSpinnerForFormat(getOutputFormat())
 }
 
-// shouldSuppressSpinnerForFormat checks a specific format string, used when the
-// output format is passed explicitly rather than read from the global setting.
+// shouldSuppressSpinnerForFormat checks a specific format string. Spinners are
+// suppressed for any non-table format to avoid corrupting machine-readable output.
 func shouldSuppressSpinnerForFormat(format string) bool {
 	return IsQuiet() || (format != "" && format != "table")
 }

--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -417,6 +417,9 @@ func PrintResourceGetting(resourceType, uid string, noColor bool) *Spinner {
 }
 
 func PrintResourceGettingWithOutput(resourceType, uid string, noColor bool, outputFormat string) *Spinner {
+	if outputFormat == "" {
+		outputFormat = getOutputFormat()
+	}
 	if shouldSuppressSpinnerForFormat(outputFormat) {
 		s := newNoOpSpinner()
 		s.outputFormat = outputFormat

--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -86,6 +86,13 @@ func getOutputFormat() string {
 	return "table"
 }
 
+// shouldSuppressSpinner returns true when spinner output should be suppressed
+// to avoid corrupting machine-readable output formats (csv, xml, json).
+func shouldSuppressSpinner() bool {
+	format := getOutputFormat()
+	return IsQuiet() || (format != "" && format != "table")
+}
+
 // PrintSuccess, PrintError, PrintWarning, PrintInfo are defined in:
 // - messages_native.go for non-WASM builds
 // - messages_wasm.go for WASM builds
@@ -276,7 +283,7 @@ func (s *Spinner) runLoop(prefix string, startTime *time.Time) {
 					msg = fmt.Sprintf("%s (%s elapsed)", prefix, elapsed)
 				}
 
-				if s.outputFormat == "json" || !IsTerminal() {
+				if (s.outputFormat != "" && s.outputFormat != "table") || !IsTerminal() {
 					fmt.Fprintf(os.Stderr, "\r\033[K%s %s", styledFrame, msg)
 				} else {
 					fmt.Printf("\r\033[K%s %s", styledFrame, msg)
@@ -307,7 +314,7 @@ func (s *Spinner) Stop() {
 	s.stopped = true
 	s.mu.Unlock()
 	s.stop <- true
-	if s.outputFormat == "json" || !IsTerminal() {
+	if (s.outputFormat != "" && s.outputFormat != "table") || !IsTerminal() {
 		fmt.Fprint(os.Stderr, "\r\033[K")
 	} else {
 		fmt.Print("\r\033[K")
@@ -319,7 +326,9 @@ func (s *Spinner) StopWithSuccess(msg string) {
 	if IsQuiet() {
 		return
 	}
-	if s.outputFormat == "json" {
+	// Write success message to stderr for non-table formats to avoid corrupting
+	// machine-readable output streams.
+	if (s.outputFormat != "" && s.outputFormat != "table") || !IsTerminal() {
 		if s.noColor {
 			fmt.Fprintf(os.Stderr, "✓ %s\n", msg)
 		} else {
@@ -337,7 +346,7 @@ func (s *Spinner) StopWithSuccess(msg string) {
 }
 
 func PrintResourceCreating(resourceType, uid string, noColor bool) *Spinner {
-	if IsQuiet() {
+	if shouldSuppressSpinner() {
 		return newNoOpSpinner()
 	}
 	uidFormatted := FormatUID(uid, noColor)
@@ -348,7 +357,7 @@ func PrintResourceCreating(resourceType, uid string, noColor bool) *Spinner {
 }
 
 func PrintResourceProvisioning(resourceType, uid string, noColor bool) *Spinner {
-	if IsQuiet() {
+	if shouldSuppressSpinner() {
 		return newNoOpSpinner()
 	}
 	uidFormatted := FormatUID(uid, noColor)
@@ -359,7 +368,7 @@ func PrintResourceProvisioning(resourceType, uid string, noColor bool) *Spinner 
 }
 
 func PrintResourceUpdating(resourceType, uid string, noColor bool) *Spinner {
-	if IsQuiet() {
+	if shouldSuppressSpinner() {
 		return newNoOpSpinner()
 	}
 	uidFormatted := FormatUID(uid, noColor)
@@ -370,7 +379,7 @@ func PrintResourceUpdating(resourceType, uid string, noColor bool) *Spinner {
 }
 
 func PrintResourceDeleting(resourceType, uid string, noColor bool) *Spinner {
-	if IsQuiet() {
+	if shouldSuppressSpinner() {
 		return newNoOpSpinner()
 	}
 	uidFormatted := FormatUID(uid, noColor)
@@ -381,7 +390,7 @@ func PrintResourceDeleting(resourceType, uid string, noColor bool) *Spinner {
 }
 
 func PrintResourceListing(resourceType string, noColor bool) *Spinner {
-	if IsQuiet() {
+	if shouldSuppressSpinner() {
 		return newNoOpSpinner()
 	}
 	msg := fmt.Sprintf("Listing %ss...", resourceType)
@@ -391,7 +400,7 @@ func PrintResourceListing(resourceType string, noColor bool) *Spinner {
 }
 
 func PrintResourceGetting(resourceType, uid string, noColor bool) *Spinner {
-	if IsQuiet() {
+	if shouldSuppressSpinner() {
 		return newNoOpSpinner()
 	}
 	uidFormatted := FormatUID(uid, noColor)
@@ -402,7 +411,7 @@ func PrintResourceGetting(resourceType, uid string, noColor bool) *Spinner {
 }
 
 func PrintResourceGettingWithOutput(resourceType, uid string, noColor bool, outputFormat string) *Spinner {
-	if IsQuiet() {
+	if shouldSuppressSpinner() {
 		return newNoOpSpinner()
 	}
 	uidFormatted := FormatUID(uid, noColor)
@@ -413,7 +422,7 @@ func PrintResourceGettingWithOutput(resourceType, uid string, noColor bool, outp
 }
 
 func PrintListingResourceTags(resourceType, uid string, noColor bool) *Spinner {
-	if IsQuiet() {
+	if shouldSuppressSpinner() {
 		return newNoOpSpinner()
 	}
 	uidFormatted := FormatUID(uid, noColor)
@@ -424,7 +433,7 @@ func PrintListingResourceTags(resourceType, uid string, noColor bool) *Spinner {
 }
 
 func PrintResourceValidating(resourceType string, noColor bool) *Spinner {
-	if IsQuiet() {
+	if shouldSuppressSpinner() {
 		return newNoOpSpinner()
 	}
 	msg := fmt.Sprintf("Validating %s order...", resourceType)
@@ -457,7 +466,7 @@ func PrintLoggingInWithOutput(noColor bool, outputFormat string) *Spinner {
 }
 
 func PrintCustomSpinner(action, resourceId string, noColor bool) *Spinner {
-	if IsQuiet() {
+	if shouldSuppressSpinner() {
 		return newNoOpSpinner()
 	}
 	uidFormatted := FormatUID(resourceId, noColor)

--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -70,8 +70,9 @@ func IsVerbose() bool {
 // Safe to call Start(), Stop(), and StopWithSuccess() on.
 func newNoOpSpinner() *Spinner {
 	return &Spinner{
-		stop:    make(chan bool, 1),
-		stopped: true,
+		stop:         make(chan bool, 1),
+		stopped:      true,
+		outputFormat: getOutputFormat(),
 	}
 }
 

--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -89,7 +89,12 @@ func getOutputFormat() string {
 // shouldSuppressSpinner returns true when spinner output should be suppressed
 // to avoid corrupting machine-readable output formats (csv, xml, json).
 func shouldSuppressSpinner() bool {
-	format := getOutputFormat()
+	return shouldSuppressSpinnerForFormat(getOutputFormat())
+}
+
+// shouldSuppressSpinnerForFormat checks a specific format string, used when the
+// output format is passed explicitly rather than read from the global setting.
+func shouldSuppressSpinnerForFormat(format string) bool {
 	return IsQuiet() || (format != "" && format != "table")
 }
 
@@ -411,7 +416,7 @@ func PrintResourceGetting(resourceType, uid string, noColor bool) *Spinner {
 }
 
 func PrintResourceGettingWithOutput(resourceType, uid string, noColor bool, outputFormat string) *Spinner {
-	if shouldSuppressSpinner() {
+	if shouldSuppressSpinnerForFormat(outputFormat) {
 		return newNoOpSpinner()
 	}
 	uidFormatted := FormatUID(uid, noColor)

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func captureOutput(f func()) string {
@@ -725,7 +726,7 @@ func TestStopWithSuccessDoesNotWriteToStdoutForCSV(t *testing.T) {
 	// Suppress stderr so StopWithSuccess doesn't leak into test output.
 	oldStderr := os.Stderr
 	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer devNull.Close()
 	os.Stderr = devNull
 	defer func() { os.Stderr = oldStderr }()
@@ -746,7 +747,7 @@ func TestStopWithSuccessDoesNotWriteToStdoutForXML(t *testing.T) {
 
 	oldStderr := os.Stderr
 	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer devNull.Close()
 	os.Stderr = devNull
 	defer func() { os.Stderr = oldStderr }()

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -712,7 +712,12 @@ func TestStopWithSuccessDoesNotWriteToStdoutForCSV(t *testing.T) {
 	}()
 
 	spinner := PrintResourceListing("test", true)
-	// Spinner is no-op, but StopWithSuccess should still not write to stdout.
+
+	// Suppress stderr so StopWithSuccess doesn't leak into test output.
+	oldStderr := os.Stderr
+	os.Stderr, _ = os.Open(os.DevNull)
+	defer func() { os.Stderr = oldStderr }()
+
 	stdoutOutput := captureOutput(func() {
 		spinner.StopWithSuccess("done")
 	})
@@ -728,6 +733,11 @@ func TestStopWithSuccessDoesNotWriteToStdoutForXML(t *testing.T) {
 	}()
 
 	spinner := PrintResourceGetting("test", "uid", true)
+
+	oldStderr := os.Stderr
+	os.Stderr, _ = os.Open(os.DevNull)
+	defer func() { os.Stderr = oldStderr }()
+
 	stdoutOutput := captureOutput(func() {
 		spinner.StopWithSuccess("done")
 	})

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -702,3 +702,42 @@ func TestLoginSpinnersNotSuppressedForCSV(t *testing.T) {
 	assert.False(t, spinner2.stopped, "login spinner with output should not be suppressed")
 	spinner2.Stop()
 }
+
+func TestStopWithSuccessDoesNotWriteToStdoutForCSV(t *testing.T) {
+	SetOutputFormat("csv")
+	SetIsTerminal(true)
+	defer func() {
+		SetOutputFormat("table")
+		SetIsTerminal(false)
+	}()
+
+	spinner := PrintResourceListing("test", true)
+	// Spinner is no-op, but StopWithSuccess should still not write to stdout.
+	stdoutOutput := captureOutput(func() {
+		spinner.StopWithSuccess("done")
+	})
+	assert.Empty(t, stdoutOutput, "StopWithSuccess should not write to stdout for csv format")
+}
+
+func TestStopWithSuccessDoesNotWriteToStdoutForXML(t *testing.T) {
+	SetOutputFormat("xml")
+	SetIsTerminal(true)
+	defer func() {
+		SetOutputFormat("table")
+		SetIsTerminal(false)
+	}()
+
+	spinner := PrintResourceGetting("test", "uid", true)
+	stdoutOutput := captureOutput(func() {
+		spinner.StopWithSuccess("done")
+	})
+	assert.Empty(t, stdoutOutput, "StopWithSuccess should not write to stdout for xml format")
+}
+
+func TestNoOpSpinnerCarriesOutputFormat(t *testing.T) {
+	SetOutputFormat("csv")
+	defer SetOutputFormat("table")
+
+	spinner := PrintResourceListing("test", true)
+	assert.Equal(t, "csv", spinner.outputFormat, "no-op spinner should carry the output format")
+}

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -737,7 +737,9 @@ func TestStopWithSuccessDoesNotWriteToStdoutForXML(t *testing.T) {
 	spinner := PrintResourceGetting("test", "uid", true)
 
 	oldStderr := os.Stderr
-	os.Stderr, _ = os.Open(os.DevNull)
+	devNull, _ := os.Open(os.DevNull)
+	defer devNull.Close()
+	os.Stderr = devNull
 	defer func() { os.Stderr = oldStderr }()
 
 	stdoutOutput := captureOutput(func() {

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -622,8 +622,8 @@ func TestShouldSuppressSpinnerForFormat(t *testing.T) {
 	assert.True(t, shouldSuppressSpinnerForFormat("xml"))
 }
 
-// saveOutputFormat captures the current output format and returns a cleanup
-// function that restores it, avoiding hard-coded assumptions about initial state.
+// saveOutputFormat captures the current output format and registers a t.Cleanup
+// to restore it, avoiding hard-coded assumptions about initial state.
 func saveOutputFormat(t *testing.T) {
 	t.Helper()
 	orig := getOutputFormat()

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -622,9 +622,17 @@ func TestShouldSuppressSpinnerForFormat(t *testing.T) {
 	assert.True(t, shouldSuppressSpinnerForFormat("xml"))
 }
 
+// saveOutputFormat captures the current output format and returns a cleanup
+// function that restores it, avoiding hard-coded assumptions about initial state.
+func saveOutputFormat(t *testing.T) {
+	t.Helper()
+	orig := getOutputFormat()
+	t.Cleanup(func() { SetOutputFormat(orig) })
+}
+
 func TestSpinnerNoOpForCSV(t *testing.T) {
+	saveOutputFormat(t)
 	SetOutputFormat("csv")
-	defer SetOutputFormat("table")
 
 	spinner := PrintResourceListing("test", true)
 	// A no-op spinner is already stopped at creation
@@ -632,16 +640,16 @@ func TestSpinnerNoOpForCSV(t *testing.T) {
 }
 
 func TestSpinnerNoOpForXML(t *testing.T) {
+	saveOutputFormat(t)
 	SetOutputFormat("xml")
-	defer SetOutputFormat("table")
 
 	spinner := PrintResourceGetting("test", "uid-123", true)
 	assert.True(t, spinner.stopped, "spinner should be no-op (stopped) for xml format")
 }
 
 func TestSpinnerNoOpForJSON(t *testing.T) {
+	saveOutputFormat(t)
 	SetOutputFormat("json")
-	defer SetOutputFormat("table")
 
 	spinner := PrintResourceListing("test", true)
 	assert.True(t, spinner.stopped, "spinner should be no-op (stopped) for json format")
@@ -651,6 +659,7 @@ func TestSpinnerActiveForTable(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping spinner test in short mode")
 	}
+	saveOutputFormat(t)
 	SetOutputFormat("table")
 	SetIsTerminal(true)
 	defer SetIsTerminal(false)
@@ -661,8 +670,8 @@ func TestSpinnerActiveForTable(t *testing.T) {
 }
 
 func TestAllSpinnerFunctionsSuppressedForCSV(t *testing.T) {
+	saveOutputFormat(t)
 	SetOutputFormat("csv")
-	defer SetOutputFormat("table")
 
 	spinners := []*Spinner{
 		PrintResourceCreating("test", "uid", true),
@@ -686,12 +695,10 @@ func TestLoginSpinnersNotSuppressedForCSV(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping spinner test in short mode")
 	}
+	saveOutputFormat(t)
 	SetOutputFormat("csv")
 	SetIsTerminal(true)
-	defer func() {
-		SetOutputFormat("table")
-		SetIsTerminal(false)
-	}()
+	defer SetIsTerminal(false)
 
 	// Login spinners should still show regardless of output format
 	spinner := PrintLoggingIn(true)
@@ -704,12 +711,10 @@ func TestLoginSpinnersNotSuppressedForCSV(t *testing.T) {
 }
 
 func TestStopWithSuccessDoesNotWriteToStdoutForCSV(t *testing.T) {
+	saveOutputFormat(t)
 	SetOutputFormat("csv")
 	SetIsTerminal(true)
-	defer func() {
-		SetOutputFormat("table")
-		SetIsTerminal(false)
-	}()
+	defer SetIsTerminal(false)
 
 	spinner := PrintResourceListing("test", true)
 
@@ -728,12 +733,10 @@ func TestStopWithSuccessDoesNotWriteToStdoutForCSV(t *testing.T) {
 }
 
 func TestStopWithSuccessDoesNotWriteToStdoutForXML(t *testing.T) {
+	saveOutputFormat(t)
 	SetOutputFormat("xml")
 	SetIsTerminal(true)
-	defer func() {
-		SetOutputFormat("table")
-		SetIsTerminal(false)
-	}()
+	defer SetIsTerminal(false)
 
 	spinner := PrintResourceGetting("test", "uid", true)
 
@@ -751,8 +754,8 @@ func TestStopWithSuccessDoesNotWriteToStdoutForXML(t *testing.T) {
 }
 
 func TestNoOpSpinnerCarriesOutputFormat(t *testing.T) {
+	saveOutputFormat(t)
 	SetOutputFormat("csv")
-	defer SetOutputFormat("table")
 
 	spinner := PrintResourceListing("test", true)
 	assert.Equal(t, "csv", spinner.outputFormat, "no-op spinner should carry the output format")

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -715,7 +715,8 @@ func TestStopWithSuccessDoesNotWriteToStdoutForCSV(t *testing.T) {
 
 	// Suppress stderr so StopWithSuccess doesn't leak into test output.
 	oldStderr := os.Stderr
-	devNull, _ := os.Open(os.DevNull)
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	assert.NoError(t, err)
 	defer devNull.Close()
 	os.Stderr = devNull
 	defer func() { os.Stderr = oldStderr }()
@@ -737,7 +738,8 @@ func TestStopWithSuccessDoesNotWriteToStdoutForXML(t *testing.T) {
 	spinner := PrintResourceGetting("test", "uid", true)
 
 	oldStderr := os.Stderr
-	devNull, _ := os.Open(os.DevNull)
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	assert.NoError(t, err)
 	defer devNull.Close()
 	os.Stderr = devNull
 	defer func() { os.Stderr = oldStderr }()

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -582,7 +582,8 @@ func TestSpinnerStopWithSuccess(t *testing.T) {
 }
 
 func TestShouldSuppressSpinner(t *testing.T) {
-	origQuiet := IsQuiet()
+	origFormat := getOutputFormat()
+	defer SetOutputFormat(origFormat)
 	defer SetVerbosity("normal")
 
 	tests := []struct {
@@ -611,11 +612,14 @@ func TestShouldSuppressSpinner(t *testing.T) {
 			assert.Equal(t, tt.expected, shouldSuppressSpinner())
 		})
 	}
+}
 
-	// Restore
-	_ = origQuiet
-	SetVerbosity("normal")
-	SetOutputFormat("table")
+func TestShouldSuppressSpinnerForFormat(t *testing.T) {
+	assert.False(t, shouldSuppressSpinnerForFormat("table"))
+	assert.False(t, shouldSuppressSpinnerForFormat(""))
+	assert.True(t, shouldSuppressSpinnerForFormat("json"))
+	assert.True(t, shouldSuppressSpinnerForFormat("csv"))
+	assert.True(t, shouldSuppressSpinnerForFormat("xml"))
 }
 
 func TestSpinnerNoOpForCSV(t *testing.T) {

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -580,3 +580,121 @@ func TestSpinnerStopWithSuccess(t *testing.T) {
 	})
 	assert.Contains(t, output, "✓ Operation completed")
 }
+
+func TestShouldSuppressSpinner(t *testing.T) {
+	origQuiet := IsQuiet()
+	defer SetVerbosity("normal")
+
+	tests := []struct {
+		name     string
+		format   string
+		quiet    bool
+		expected bool
+	}{
+		{"table format", "table", false, false},
+		{"empty format defaults to table", "", false, false},
+		{"json format suppressed", "json", false, true},
+		{"csv format suppressed", "csv", false, true},
+		{"xml format suppressed", "xml", false, true},
+		{"quiet mode suppressed", "table", true, true},
+		{"quiet mode with csv", "csv", true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetOutputFormat(tt.format)
+			if tt.quiet {
+				SetVerbosity("quiet")
+			} else {
+				SetVerbosity("normal")
+			}
+			assert.Equal(t, tt.expected, shouldSuppressSpinner())
+		})
+	}
+
+	// Restore
+	_ = origQuiet
+	SetVerbosity("normal")
+	SetOutputFormat("table")
+}
+
+func TestSpinnerNoOpForCSV(t *testing.T) {
+	SetOutputFormat("csv")
+	defer SetOutputFormat("table")
+
+	spinner := PrintResourceListing("test", true)
+	// A no-op spinner is already stopped at creation
+	assert.True(t, spinner.stopped, "spinner should be no-op (stopped) for csv format")
+}
+
+func TestSpinnerNoOpForXML(t *testing.T) {
+	SetOutputFormat("xml")
+	defer SetOutputFormat("table")
+
+	spinner := PrintResourceGetting("test", "uid-123", true)
+	assert.True(t, spinner.stopped, "spinner should be no-op (stopped) for xml format")
+}
+
+func TestSpinnerNoOpForJSON(t *testing.T) {
+	SetOutputFormat("json")
+	defer SetOutputFormat("table")
+
+	spinner := PrintResourceListing("test", true)
+	assert.True(t, spinner.stopped, "spinner should be no-op (stopped) for json format")
+}
+
+func TestSpinnerActiveForTable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping spinner test in short mode")
+	}
+	SetOutputFormat("table")
+	SetIsTerminal(true)
+	defer SetIsTerminal(false)
+
+	spinner := PrintResourceListing("test", true)
+	assert.False(t, spinner.stopped, "spinner should be active for table format")
+	spinner.Stop()
+}
+
+func TestAllSpinnerFunctionsSuppressedForCSV(t *testing.T) {
+	SetOutputFormat("csv")
+	defer SetOutputFormat("table")
+
+	spinners := []*Spinner{
+		PrintResourceCreating("test", "uid", true),
+		PrintResourceProvisioning("test", "uid", true),
+		PrintResourceUpdating("test", "uid", true),
+		PrintResourceDeleting("test", "uid", true),
+		PrintResourceListing("test", true),
+		PrintResourceGetting("test", "uid", true),
+		PrintResourceGettingWithOutput("test", "uid", true, "csv"),
+		PrintListingResourceTags("test", "uid", true),
+		PrintResourceValidating("test", true),
+		PrintCustomSpinner("testing", "uid", true),
+	}
+
+	for i, s := range spinners {
+		assert.True(t, s.stopped, "spinner %d should be no-op for csv format", i)
+	}
+}
+
+func TestLoginSpinnersNotSuppressedForCSV(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping spinner test in short mode")
+	}
+	SetOutputFormat("csv")
+	SetIsTerminal(true)
+	defer func() {
+		SetOutputFormat("table")
+		SetIsTerminal(false)
+	}()
+
+	// Login spinners should still show regardless of output format
+	spinner := PrintLoggingIn(true)
+	assert.False(t, spinner.stopped, "login spinner should not be suppressed for csv format")
+	spinner.Stop()
+
+	spinner2 := PrintLoggingInWithOutput(true, "csv")
+	assert.False(t, spinner2.stopped, "login spinner with output should not be suppressed")
+	spinner2.Stop()
+}

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -715,7 +715,9 @@ func TestStopWithSuccessDoesNotWriteToStdoutForCSV(t *testing.T) {
 
 	// Suppress stderr so StopWithSuccess doesn't leak into test output.
 	oldStderr := os.Stderr
-	os.Stderr, _ = os.Open(os.DevNull)
+	devNull, _ := os.Open(os.DevNull)
+	defer devNull.Close()
+	os.Stderr = devNull
 	defer func() { os.Stderr = oldStderr }()
 
 	stdoutOutput := captureOutput(func() {

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -615,6 +615,10 @@ func TestShouldSuppressSpinner(t *testing.T) {
 }
 
 func TestShouldSuppressSpinnerForFormat(t *testing.T) {
+	// Ensure normal verbosity so IsQuiet() doesn't interfere.
+	defer SetVerbosity("normal")
+	SetVerbosity("normal")
+
 	assert.False(t, shouldSuppressSpinnerForFormat("table"))
 	assert.False(t, shouldSuppressSpinnerForFormat(""))
 	assert.True(t, shouldSuppressSpinnerForFormat("json"))

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -593,7 +593,7 @@ func TestShouldSuppressSpinner(t *testing.T) {
 		expected bool
 	}{
 		{"table format", "table", false, false},
-		{"empty format defaults to table", "", false, false},
+		{"empty format treated like table for spinner suppression", "", false, false},
 		{"json format suppressed", "json", false, true},
 		{"csv format suppressed", "csv", false, true},
 		{"xml format suppressed", "xml", false, true},

--- a/internal/base/output/table_wasm.go
+++ b/internal/base/output/table_wasm.go
@@ -67,7 +67,6 @@ func printTable[T OutputFields](data []T, noColor bool) error {
 	WasmTableWriter.Reset() // Clear previous content
 	t.SetOutputMirror(WasmTableWriter)
 
-
 	// WASM-specific table configuration with improved column widths
 	// This ensures consistent, readable column distribution in the browser
 	columnConfigs := make([]prettytable.ColumnConfig, len(headers))

--- a/internal/base/output/verbosity_test.go
+++ b/internal/base/output/verbosity_test.go
@@ -166,7 +166,7 @@ func TestQuietSuppressesStopWithSuccess(t *testing.T) {
 	resetVerbosity(t)
 	SetVerbosity("quiet")
 
-	spinner := newNoOpSpinner()
+	spinner := newNoOpSpinner(true)
 	out := captureStdout(t, func() {
 		spinner.StopWithSuccess("done message")
 	})


### PR DESCRIPTION
## Summary

The CLI spinner writes ANSI escape sequences and animated characters to stdout during API calls. For `--output json` and non-TTY (piped) output, the spinner already redirected to stderr or suppressed itself. But for `--output csv` and `--output xml`, spinner artifacts were mixed into the data stream, making output unparseable by downstream tools.

This is a codebase-wide fix — it affects every command that uses `PrintResourceListing`, `PrintResourceGetting`, or any spinner helper (30+ call sites). The fix is entirely in the spinner infrastructure so no individual command needed changes.

**What changed:**
- Added `shouldSuppressSpinner()` helper that returns a no-op spinner for any non-table output format, extending the existing `IsQuiet()` pattern
- Updated all 10 spinner-returning `Print*` functions to use `shouldSuppressSpinner()` instead of `IsQuiet()`
- Updated `runLoop`, `Stop`, and `StopWithSuccess` to redirect to stderr for all non-table formats (defense in depth)
- Login spinners (`PrintLoggingIn`, `PrintLoggingInWithOutput`) intentionally not suppressed since they run before output format matters

## Test plan

- [x] `TestShouldSuppressSpinner` — 7 cases: table, empty, json, csv, xml, quiet, quiet+csv
- [x] `TestSpinnerNoOpForCSV/XML/JSON` — verify no-op spinner returned
- [x] `TestSpinnerActiveForTable` — verify real spinner returned
- [x] `TestAllSpinnerFunctionsSuppressedForCSV` — all 10 Print* functions return no-op
- [x] `TestLoginSpinnersNotSuppressedForCSV` — login spinners still active
- [x] `go test ./...` — all 33 packages pass
- [x] `golangci-lint run` — 0 issues