### PR TITLE
feat: add --log-http global flag for API debugging

### DIFF
--- a/cmd/megaport/megaport_common.go
+++ b/cmd/megaport/megaport_common.go
@@ -94,6 +94,6 @@ func InitializeCommon() {
 	rootCmd.PersistentFlags().String("query", "", "JMESPath query to filter JSON output (requires --output json)")
 	rootCmd.PersistentFlags().BoolVar(&utils.NoRetry, "no-retry", false, "Disable automatic retry on transient API failures")
 	rootCmd.PersistentFlags().IntVar(&utils.MaxRetries, "max-retries", 3, "Maximum number of retries for transient API failures")
-	rootCmd.PersistentFlags().BoolVar(&utils.LogHTTP, "log-http", false, "Log raw HTTP requests and responses to stderr for debugging")
+	rootCmd.PersistentFlags().BoolVar(&utils.LogHTTP, "log-http", false, "Log raw HTTP requests/responses to stderr for debugging (may include sensitive data such as auth tokens)")
 	rootCmd.MarkFlagsMutuallyExclusive("quiet", "verbose")
 }

--- a/cmd/megaport/megaport_common.go
+++ b/cmd/megaport/megaport_common.go
@@ -94,5 +94,6 @@ func InitializeCommon() {
 	rootCmd.PersistentFlags().String("query", "", "JMESPath query to filter JSON output (requires --output json)")
 	rootCmd.PersistentFlags().BoolVar(&utils.NoRetry, "no-retry", false, "Disable automatic retry on transient API failures")
 	rootCmd.PersistentFlags().IntVar(&utils.MaxRetries, "max-retries", 3, "Maximum number of retries for transient API failures")
+	rootCmd.PersistentFlags().BoolVar(&utils.LogHTTP, "log-http", false, "Log raw HTTP requests and responses to stderr for debugging")
 	rootCmd.MarkFlagsMutuallyExclusive("quiet", "verbose")
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Megaport CLI Documentation
 
-> Generated on April 10, 2026 for version v0.7.1
+> Generated on April 13, 2026 for version v0.7.1
 
 ## Available Commands
 

--- a/docs/megaport-cli.md
+++ b/docs/megaport-cli.md
@@ -46,7 +46,7 @@ megaport-cli [flags]
 |------|-----------|---------|-------------|----------|
 | `--env` |  |  | Environment to use (prod, dev, or staging) | false |
 | `--fields` |  |  | Comma-separated list of fields to include in output (e.g., uid,name,status); use an unknown name to list available fields | false |
-| `--log-http` |  | `false` | Log raw HTTP requests and responses to stderr for debugging | false |
+| `--log-http` |  | `false` | Log raw HTTP requests/responses to stderr for debugging (may include sensitive data such as auth tokens) | false |
 | `--max-retries` |  | `3` | Maximum number of retries for transient API failures | false |
 | `--no-color` |  | `false` | Disable colorful output | false |
 | `--no-retry` |  | `false` | Disable automatic retry on transient API failures | false |

--- a/docs/megaport-cli.md
+++ b/docs/megaport-cli.md
@@ -46,6 +46,7 @@ megaport-cli [flags]
 |------|-----------|---------|-------------|----------|
 | `--env` |  |  | Environment to use (prod, dev, or staging) | false |
 | `--fields` |  |  | Comma-separated list of fields to include in output (e.g., uid,name,status); use an unknown name to list available fields | false |
+| `--log-http` |  | `false` | Log raw HTTP requests and responses to stderr for debugging | false |
 | `--max-retries` |  | `3` | Maximum number of retries for transient API failures | false |
 | `--no-color` |  | `false` | Disable colorful output | false |
 | `--no-retry` |  | `false` | Disable automatic retry on transient API failures | false |

--- a/internal/commands/config/login.go
+++ b/internal/commands/config/login.go
@@ -6,6 +6,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -202,7 +203,12 @@ var loginFuncWithOutput = func(ctx context.Context, outputFormat string) (*megap
 	envOpt := environmentOption(env)
 	httpClient := &http.Client{Timeout: 30 * time.Second}
 
-	megaportClient, err := megaport.New(httpClient, megaport.WithCredentials(accessKey, secretKey), envOpt)
+	opts := []megaport.ClientOpt{megaport.WithCredentials(accessKey, secretKey), envOpt}
+	if utils.LogHTTP {
+		handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})
+		opts = append(opts, megaport.WithLogHandler(handler), megaport.WithLogResponseBody())
+	}
+	megaportClient, err := megaport.New(httpClient, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +241,13 @@ var newUnauthenticatedClientFunc = func() (*megaport.Client, error) {
 
 	envOpt := environmentOption(env)
 	httpClient := &http.Client{Timeout: 30 * time.Second}
-	return megaport.New(httpClient, envOpt)
+
+	opts := []megaport.ClientOpt{envOpt}
+	if utils.LogHTTP {
+		handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})
+		opts = append(opts, megaport.WithLogHandler(handler), megaport.WithLogResponseBody())
+	}
+	return megaport.New(httpClient, opts...)
 }
 
 // NewUnauthenticatedClient creates an unauthenticated Megaport API client.

--- a/internal/commands/config/login.go
+++ b/internal/commands/config/login.go
@@ -245,11 +245,12 @@ var newUnauthenticatedClientFunc = func() (*megaport.Client, error) {
 // appendLogOpts appends HTTP debug logging options to the client option slice
 // when --log-http is enabled. Logs go to stderr at DEBUG level.
 func appendLogOpts(opts []megaport.ClientOpt) []megaport.ClientOpt {
+	result := append([]megaport.ClientOpt(nil), opts...)
 	if utils.LogHTTP {
 		handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})
-		opts = append(opts, megaport.WithLogHandler(handler), megaport.WithLogResponseBody())
+		result = append(result, megaport.WithLogHandler(handler), megaport.WithLogResponseBody())
 	}
-	return opts
+	return result
 }
 
 // NewUnauthenticatedClient creates an unauthenticated Megaport API client.

--- a/internal/commands/config/login.go
+++ b/internal/commands/config/login.go
@@ -203,11 +203,7 @@ var loginFuncWithOutput = func(ctx context.Context, outputFormat string) (*megap
 	envOpt := environmentOption(env)
 	httpClient := &http.Client{Timeout: 30 * time.Second}
 
-	opts := []megaport.ClientOpt{megaport.WithCredentials(accessKey, secretKey), envOpt}
-	if utils.LogHTTP {
-		handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})
-		opts = append(opts, megaport.WithLogHandler(handler), megaport.WithLogResponseBody())
-	}
+	opts := appendLogOpts([]megaport.ClientOpt{megaport.WithCredentials(accessKey, secretKey), envOpt})
 	megaportClient, err := megaport.New(httpClient, opts...)
 	if err != nil {
 		return nil, err
@@ -242,12 +238,18 @@ var newUnauthenticatedClientFunc = func() (*megaport.Client, error) {
 	envOpt := environmentOption(env)
 	httpClient := &http.Client{Timeout: 30 * time.Second}
 
-	opts := []megaport.ClientOpt{envOpt}
+	opts := appendLogOpts([]megaport.ClientOpt{envOpt})
+	return megaport.New(httpClient, opts...)
+}
+
+// appendLogOpts appends HTTP debug logging options to the client option slice
+// when --log-http is enabled. Logs go to stderr at DEBUG level.
+func appendLogOpts(opts []megaport.ClientOpt) []megaport.ClientOpt {
 	if utils.LogHTTP {
 		handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})
 		opts = append(opts, megaport.WithLogHandler(handler), megaport.WithLogResponseBody())
 	}
-	return megaport.New(httpClient, opts...)
+	return opts
 }
 
 // NewUnauthenticatedClient creates an unauthenticated Megaport API client.

--- a/internal/commands/config/login_test.go
+++ b/internal/commands/config/login_test.go
@@ -625,3 +625,34 @@ func TestLoginFuncAccessors(t *testing.T) {
 		assert.True(t, called)
 	})
 }
+
+func TestAppendLogOpts(t *testing.T) {
+	t.Run("adds log options when LogHTTP is true", func(t *testing.T) {
+		origLogHTTP := utils.LogHTTP
+		defer func() { utils.LogHTTP = origLogHTTP }()
+
+		utils.LogHTTP = true
+		opts := appendLogOpts([]megaport.ClientOpt{})
+		// WithLogHandler and WithLogResponseBody should be appended
+		assert.Len(t, opts, 2, "should add 2 log options when LogHTTP is enabled")
+	})
+
+	t.Run("does not add log options when LogHTTP is false", func(t *testing.T) {
+		origLogHTTP := utils.LogHTTP
+		defer func() { utils.LogHTTP = origLogHTTP }()
+
+		utils.LogHTTP = false
+		opts := appendLogOpts([]megaport.ClientOpt{})
+		assert.Empty(t, opts, "should not add options when LogHTTP is disabled")
+	})
+
+	t.Run("preserves existing options", func(t *testing.T) {
+		origLogHTTP := utils.LogHTTP
+		defer func() { utils.LogHTTP = origLogHTTP }()
+
+		utils.LogHTTP = true
+		existing := []megaport.ClientOpt{megaport.WithEnvironment(megaport.EnvironmentStaging)}
+		opts := appendLogOpts(existing)
+		assert.Len(t, opts, 3, "should preserve existing option and add 2 log options")
+	})
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -39,6 +39,9 @@ var (
 	// MaxRetries overrides the default retry count. Set via --max-retries flag.
 	MaxRetries int
 
+	// LogHTTP enables raw HTTP request/response logging to stderr. Set via --log-http flag.
+	LogHTTP bool
+
 	ValidFormats = []string{FormatTable, FormatJSON, FormatCSV, FormatXML}
 )
 


### PR DESCRIPTION
## Summary

Add a `--log-http` persistent flag that enables raw HTTP request/response logging to stderr, similar to `gcloud --log-http` and `az --debug`. Essential for troubleshooting provisioning failures, proxy/firewall issues, and unexpected API responses without leaving the CLI.

The SDK already has full `slog`-based debug logging — this PR simply wires it up to a CLI flag. When `--log-http` is set, both authenticated and unauthenticated SDK clients are configured with `WithLogHandler()` (stderr, DEBUG level) and `WithLogResponseBody()`. Output includes: HTTP method, URL path, status code, duration, trace ID, and base64-encoded response body.

Output goes to stderr so it doesn't interfere with `--output json/csv/xml` piping.

## Test plan

- [x] `go test ./...` — all 33 packages pass
- [x] `golangci-lint run` — 0 issues
- [x] Manual: `megaport-cli locations list --log-http --output json 2>debug.log` produces debug logs in stderr with request details
- [x] Auto-generated docs updated