### PR TITLE
fix: send x-app: cli header on all API requests

### DIFF
--- a/internal/commands/config/config_shared.go
+++ b/internal/commands/config/config_shared.go
@@ -6,6 +6,9 @@ import (
 	megaport "github.com/megaport/megaportgo"
 )
 
+// cliHeaders identifies CLI traffic to the Megaport API.
+var cliHeaders = map[string]string{"x-app": "cli"}
+
 // ConfigManager handles configuration operations
 type ConfigManager struct {
 	config     *ConfigFile

--- a/internal/commands/config/login.go
+++ b/internal/commands/config/login.go
@@ -202,7 +202,11 @@ var loginFuncWithOutput = func(ctx context.Context, outputFormat string) (*megap
 	envOpt := environmentOption(env)
 	httpClient := &http.Client{Timeout: 30 * time.Second}
 
-	megaportClient, err := megaport.New(httpClient, megaport.WithCredentials(accessKey, secretKey), envOpt)
+	megaportClient, err := megaport.New(httpClient,
+		megaport.WithCredentials(accessKey, secretKey),
+		envOpt,
+		megaport.WithCustomHeaders(cliHeaders),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +239,7 @@ var newUnauthenticatedClientFunc = func() (*megaport.Client, error) {
 
 	envOpt := environmentOption(env)
 	httpClient := &http.Client{Timeout: 30 * time.Second}
-	return megaport.New(httpClient, envOpt)
+	return megaport.New(httpClient, envOpt, megaport.WithCustomHeaders(cliHeaders))
 }
 
 // NewUnauthenticatedClient creates an unauthenticated Megaport API client.

--- a/internal/commands/config/login_test.go
+++ b/internal/commands/config/login_test.go
@@ -661,6 +661,15 @@ func TestAppendLogOpts(t *testing.T) {
 }
 
 func TestCLIHeadersSentOnRequests(t *testing.T) {
+	// Test the real NewUnauthenticatedClient production path to ensure
+	// cliHeaders is actually wired in, not just that the SDK accepts it.
+	originalFunc := GetNewUnauthenticatedClientFunc()
+	defer SetNewUnauthenticatedClientFunc(originalFunc)
+
+	originalEnv := utils.Env
+	defer func() { utils.Env = originalEnv }()
+	utils.Env = "production"
+
 	headersCh := make(chan http.Header, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		headersCh <- r.Header.Clone()
@@ -669,10 +678,17 @@ func TestCLIHeadersSentOnRequests(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := megaport.New(nil,
-		megaport.WithBaseURL(ts.URL+"/"),
-		megaport.WithCustomHeaders(cliHeaders),
-	)
+	// Use a temp config dir so profile resolution doesn't interfere
+	tempDir, err := os.MkdirTemp("", "megaport-header-test")
+	assert.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+	t.Setenv("MEGAPORT_CONFIG_DIR", tempDir)
+
+	client, err := NewUnauthenticatedClient()
+	assert.NoError(t, err)
+
+	// Point the real client at our test server
+	client.BaseURL, err = client.BaseURL.Parse(ts.URL + "/")
 	assert.NoError(t, err)
 
 	req, err := client.NewRequest(context.Background(), http.MethodGet, "/", nil)

--- a/internal/commands/config/login_test.go
+++ b/internal/commands/config/login_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -624,4 +626,28 @@ func TestLoginFuncAccessors(t *testing.T) {
 		assert.NotNil(t, client)
 		assert.True(t, called)
 	})
+}
+
+func TestCLIHeadersSentOnRequests(t *testing.T) {
+	var capturedHeaders http.Header
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"ok"}`))
+	}))
+	defer ts.Close()
+
+	client, err := megaport.New(nil,
+		megaport.WithBaseURL(ts.URL+"/"),
+		megaport.WithCustomHeaders(cliHeaders),
+	)
+	assert.NoError(t, err)
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/", nil)
+	assert.NoError(t, err)
+
+	_, err = client.Do(context.Background(), req, nil)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "cli", capturedHeaders.Get("x-app"))
 }

--- a/internal/commands/config/login_test.go
+++ b/internal/commands/config/login_test.go
@@ -629,9 +629,9 @@ func TestLoginFuncAccessors(t *testing.T) {
 }
 
 func TestCLIHeadersSentOnRequests(t *testing.T) {
-	var capturedHeaders http.Header
+	headersCh := make(chan http.Header, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedHeaders = r.Header
+		headersCh <- r.Header.Clone()
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"message":"ok"}`))
 	}))
@@ -649,5 +649,6 @@ func TestCLIHeadersSentOnRequests(t *testing.T) {
 	_, err = client.Do(context.Background(), req, nil)
 	assert.NoError(t, err)
 
+	capturedHeaders := <-headersCh
 	assert.Equal(t, "cli", capturedHeaders.Get("x-app"))
 }

--- a/internal/commands/config/login_wasm.go
+++ b/internal/commands/config/login_wasm.go
@@ -131,6 +131,7 @@ var loginFunc = func(ctx context.Context) (*megaport.Client, error) {
 			}
 
 			// Create Megaport client with the external token (no OAuth flow needed!)
+			clientOpts = append(clientOpts, megaport.WithCustomHeaders(cliHeaders))
 			megaportClient, err := megaport.New(httpClient, clientOpts...)
 			if err != nil {
 				js.Global().Get("console").Call("error", "Failed to create Megaport client: "+err.Error())
@@ -229,6 +230,7 @@ var loginFunc = func(ctx context.Context) (*megaport.Client, error) {
 	megaportClient, err := megaport.New(httpClient,
 		megaport.WithCredentials(accessKey, secretKey),
 		envOpt,
+		megaport.WithCustomHeaders(cliHeaders),
 	)
 	if err != nil {
 		js.Global().Get("console").Call("error", "Failed to create Megaport client: "+err.Error())
@@ -463,6 +465,7 @@ var newUnauthenticatedClientFunc = func() (*megaport.Client, error) {
 	httpClient := wasmhttp.NewWasmHTTPClient()
 	httpClient.Timeout = 45 * time.Second
 
+	clientOpts = append(clientOpts, megaport.WithCustomHeaders(cliHeaders))
 	return megaport.New(httpClient, clientOpts...)
 }
 


### PR DESCRIPTION
The Terraform provider sends `x-app: terraform` on all API requests via `megaport.WithCustomHeaders()`, but the CLI sends no equivalent header. This adds `x-app: cli` so the API team can distinguish CLI traffic from other sources.

All runtime client construction paths are covered: authenticated, unauthenticated, and WASM (token-based, credentials-based, unauthenticated). The integration test helper in `testutil/integration.go` is intentionally excluded as it is not a production code path.

The header value is defined once in `config_shared.go` and referenced from both `login.go` and `login_wasm.go`.

## Changes
- `config_shared.go` — Add shared `cliHeaders` variable
- `login.go` — Add `WithCustomHeaders(cliHeaders)` to authenticated and unauthenticated native client constructors
- `login_wasm.go` — Add `WithCustomHeaders(cliHeaders)` to all three WASM client constructors
- `login_test.go` — Add `TestCLIHeadersSentOnRequests` exercising the real `NewUnauthenticatedClient()` path via httptest

## Test plan
- [x] `go build -v ./...` passes
- [x] `golangci-lint run` reports 0 issues
- [x] `go test ./...` all pass
- [x] `go test -race` passes
- [x] `TestCLIHeadersSentOnRequests` verifies `x-app: cli` header via the production code path