### PR TITLE
feat: add --no-header flag to suppress table and CSV column headers

### DIFF
--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -6,6 +6,7 @@ package megaport
 import (
 	"fmt"
 
+	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/base/registry"
 	"github.com/megaport/megaport-cli/internal/utils"
 	"github.com/spf13/cobra"
@@ -14,6 +15,7 @@ import (
 // Common variables and declarations for WASM builds
 var (
 	noColor      bool
+	noHeader     bool
 	outputFormat string
 	quiet        bool
 	verbose      bool
@@ -82,11 +84,13 @@ func InitializeCommon() {
 	rootCmd.PersistentFlags().String("query", "", "JMESPath query to filter JSON output (requires --output json)")
 	rootCmd.PersistentFlags().BoolVar(&utils.NoRetry, "no-retry", false, "Disable automatic retry on transient API failures")
 	rootCmd.PersistentFlags().IntVar(&utils.MaxRetries, "max-retries", 3, "Maximum number of retries for transient API failures")
+	rootCmd.PersistentFlags().BoolVar(&noHeader, "no-header", false, "Suppress table and CSV column headers (useful for scripting)")
 	rootCmd.MarkFlagsMutuallyExclusive("quiet", "verbose")
 
 	// Validate retry flags in WASM builds too.
 	existingPreRunE := rootCmd.PersistentPreRunE
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		output.SetNoHeader(noHeader)
 		if utils.MaxRetries < 0 {
 			return fmt.Errorf("--max-retries must be >= 0, got %d", utils.MaxRetries)
 		}

--- a/cmd/megaport/megaport.go
+++ b/cmd/megaport/megaport.go
@@ -76,6 +76,7 @@ func init() {
 			LongDesc:    "Megaport CLI provides a command line interface to interact with the Megaport API.\n\nThe CLI allows you to manage Megaport resources such as ports, VXCs, MCRs, MVEs, service keys, and more.",
 			OptionalFlags: map[string]string{
 				"--no-color":    "Disable colored output",
+				"--no-header":   "Suppress table and CSV column headers (useful for scripting)",
 				"--output":      "Output format (json, yaml, table, csv, xml)",
 				"--help":        "Show help for any command",
 				"--env":         "Environment to use (production, staging, development)",

--- a/cmd/megaport/megaport.go
+++ b/cmd/megaport/megaport.go
@@ -33,6 +33,7 @@ func init() {
 			noColor = true
 			_ = cmd.Flags().Set("no-color", "true")
 		}
+		output.SetNoHeader(noHeader)
 
 		format := strings.ToLower(outputFormat)
 		validFmt := false

--- a/cmd/megaport/megaport_common.go
+++ b/cmd/megaport/megaport_common.go
@@ -33,6 +33,7 @@ import (
 // Common variables and declarations needed by both WASM and non-WASM builds
 var (
 	noColor      bool
+	noHeader     bool
 	outputFormat string
 	quiet        bool
 	verbose      bool
@@ -97,5 +98,6 @@ func InitializeCommon() {
 	rootCmd.PersistentFlags().BoolVar(&utils.NoRetry, "no-retry", false, "Disable automatic retry on transient API failures")
 	rootCmd.PersistentFlags().IntVar(&utils.MaxRetries, "max-retries", 3, "Maximum number of retries for transient API failures")
 	rootCmd.PersistentFlags().BoolVar(&utils.LogHTTP, "log-http", false, "Log raw HTTP requests/responses to stderr for debugging (may include sensitive data such as auth tokens)")
+	rootCmd.PersistentFlags().BoolVar(&noHeader, "no-header", false, "Suppress table and CSV column headers (useful for scripting)")
 	rootCmd.MarkFlagsMutuallyExclusive("quiet", "verbose")
 }

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -8,8 +8,26 @@ import (
 	"testing"
 
 	"github.com/megaport/megaport-cli/internal/base/exitcodes"
+	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// TestNoHeaderFlagWiredThroughPersistentPreRunE verifies that --no-header is
+// registered on the root command and that PersistentPreRunE propagates its
+// value to the output package.
+func TestNoHeaderFlagWiredThroughPersistentPreRunE(t *testing.T) {
+	defer output.SetNoHeader(false)
+
+	// Run a no-auth command through the real rootCmd so PersistentPreRunE fires.
+	rootCmd.SetArgs([]string{"version", "--no-header"})
+	_ = output.CaptureOutput(func() {
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+	})
+
+	assert.True(t, output.GetNoHeader(), "SetNoHeader should have been called with true by PersistentPreRunE")
+}
 
 func TestExitCodeFromError(t *testing.T) {
 	tests := []struct {

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -17,7 +17,13 @@ import (
 // registered on the root command and that PersistentPreRunE propagates its
 // value to the output package.
 func TestNoHeaderFlagWiredThroughPersistentPreRunE(t *testing.T) {
-	defer output.SetNoHeader(false)
+	// Restore both the output package state and the cobra flag/backing variable
+	// so subsequent tests in this package are not affected.
+	defer func() {
+		output.SetNoHeader(false)
+		noHeader = false
+		_ = rootCmd.PersistentFlags().Set("no-header", "false")
+	}()
 
 	// Run a no-auth command through the real rootCmd so PersistentPreRunE fires.
 	rootCmd.SetArgs([]string{"version", "--no-header"})

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -5,6 +5,7 @@ package megaport
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/megaport/megaport-cli/internal/base/exitcodes"
@@ -13,14 +14,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// noHeaderTestItem is a minimal struct used to observe table header suppression.
+type noHeaderTestItem struct {
+	Name string `header:"NAME" json:"name"`
+}
+
 // TestNoHeaderFlagWiredThroughPersistentPreRunE verifies that --no-header is
 // registered on the root command and that PersistentPreRunE propagates its
-// value to the output package.
+// value to the output package by observing that table headers are suppressed.
 func TestNoHeaderFlagWiredThroughPersistentPreRunE(t *testing.T) {
-	// Restore both the output package state and the cobra flag/backing variable
-	// so subsequent tests in this package are not affected.
+	// Restore all output state, the backing var, and the cobra flag so
+	// subsequent tests in this package are not affected.
 	defer func() {
-		output.SetNoHeader(false)
+		output.ResetState()
 		noHeader = false
 		_ = rootCmd.PersistentFlags().Set("no-header", "false")
 	}()
@@ -32,7 +38,12 @@ func TestNoHeaderFlagWiredThroughPersistentPreRunE(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	assert.True(t, output.GetNoHeader(), "SetNoHeader should have been called with true by PersistentPreRunE")
+	// Assert via observable behavior: table output should have no header row.
+	captured := output.CaptureOutput(func() {
+		_ = output.PrintOutput([]noHeaderTestItem{{Name: "row1"}}, "table", true)
+	})
+	assert.False(t, strings.Contains(captured, "NAME"), "header row should be suppressed after --no-header")
+	assert.True(t, strings.Contains(captured, "row1"), "data rows should still appear")
 }
 
 func TestExitCodeFromError(t *testing.T) {

--- a/cmd/megaport/megaport_wasm.go
+++ b/cmd/megaport/megaport_wasm.go
@@ -76,10 +76,11 @@ func init() {
 			ShortDesc:   "A CLI tool to interact with the Megaport API",
 			LongDesc:    "Megaport CLI provides a command line interface to interact with the Megaport API.\n\nThe CLI allows you to manage Megaport resources such as ports, VXCs, MCRs, MVEs, service keys, and more.",
 			OptionalFlags: map[string]string{
-				"--no-color": "Disable colored output",
-				"--output":   "Output format (json, yaml, table, csv, xml)",
-				"--help":     "Show help for any command",
-				"--env":      "Environment to use (production, staging, development)",
+				"--no-color":  "Disable colored output",
+				"--no-header": "Suppress table and CSV column headers (useful for scripting)",
+				"--output":    "Output format (json, yaml, table, csv, xml)",
+				"--help":      "Show help for any command",
+				"--env":       "Environment to use (production, staging, development)",
 			},
 			Examples: []string{
 				"megaport-cli ports list",

--- a/internal/base/output/common.go
+++ b/internal/base/output/common.go
@@ -91,19 +91,15 @@ func getNoHeader() bool {
 	return noHeader
 }
 
-// GetNoHeader returns the current no-header setting. Exported for use in tests
-// that need to verify the flag was wired correctly through PersistentPreRunE.
-func GetNoHeader() bool {
-	return getNoHeader()
-}
-
 // ResetState clears all package-level output configuration back to defaults.
-// Intended for callers such as the WASM entry point that must ensure output
-// state does not bleed between invocations.
+// Intended for callers such as the WASM entry point that must ensure all
+// output-related global state does not bleed between invocations.
 func ResetState() {
 	SetOutputFields(nil)
 	SetOutputQuery("")
 	SetNoHeader(false)
+	SetOutputFormat("table")
+	SetVerbosity("normal")
 }
 
 // applyJMESPath applies a JMESPath query to v and returns the result.

--- a/internal/base/output/common.go
+++ b/internal/base/output/common.go
@@ -68,6 +68,29 @@ func getOutputQuery() string {
 	return outputQuery
 }
 
+// noHeader controls whether table and CSV output suppresses the header row.
+// Set via --no-header flag. Protected by noHeaderMu.
+var (
+	noHeader   bool
+	noHeaderMu sync.RWMutex
+)
+
+// SetNoHeader sets whether table and CSV output should suppress column headers.
+// This function is goroutine-safe. Tests should call defer SetNoHeader(false) to
+// reset state between test cases.
+func SetNoHeader(v bool) {
+	noHeaderMu.Lock()
+	defer noHeaderMu.Unlock()
+	noHeader = v
+}
+
+// getNoHeader returns whether header suppression is active under a read lock.
+func getNoHeader() bool {
+	noHeaderMu.RLock()
+	defer noHeaderMu.RUnlock()
+	return noHeader
+}
+
 // applyJMESPath applies a JMESPath query to v and returns the result.
 // v must be a JSON-compatible value (e.g. []T or []map[string]interface{}).
 // The marshal→unmarshal round-trip is intentional: go-jmespath operates on an

--- a/internal/base/output/common.go
+++ b/internal/base/output/common.go
@@ -91,6 +91,12 @@ func getNoHeader() bool {
 	return noHeader
 }
 
+// GetNoHeader returns the current no-header setting. Exported for use in tests
+// that need to verify the flag was wired correctly through PersistentPreRunE.
+func GetNoHeader() bool {
+	return getNoHeader()
+}
+
 // applyJMESPath applies a JMESPath query to v and returns the result.
 // v must be a JSON-compatible value (e.g. []T or []map[string]interface{}).
 // The marshal→unmarshal round-trip is intentional: go-jmespath operates on an

--- a/internal/base/output/common.go
+++ b/internal/base/output/common.go
@@ -97,6 +97,15 @@ func GetNoHeader() bool {
 	return getNoHeader()
 }
 
+// ResetState clears all package-level output configuration back to defaults.
+// Intended for callers such as the WASM entry point that must ensure output
+// state does not bleed between invocations.
+func ResetState() {
+	SetOutputFields(nil)
+	SetOutputQuery("")
+	SetNoHeader(false)
+}
+
 // applyJMESPath applies a JMESPath query to v and returns the result.
 // v must be a JSON-compatible value (e.g. []T or []map[string]interface{}).
 // The marshal→unmarshal round-trip is intentional: go-jmespath operates on an

--- a/internal/base/output/output.go
+++ b/internal/base/output/output.go
@@ -60,8 +60,10 @@ func printCSV[T OutputFields](data []T) error {
 	if len(headers) == 0 {
 		return nil
 	}
-	if err := w.Write(headers); err != nil {
-		return err
+	if !getNoHeader() {
+		if err := w.Write(headers); err != nil {
+			return err
+		}
 	}
 	for _, item := range data {
 		if isNilOrInvalid(item) {

--- a/internal/base/output/output_test.go
+++ b/internal/base/output/output_test.go
@@ -1289,6 +1289,7 @@ func TestNoHeaderTableSuppressesHeader(t *testing.T) {
 
 func TestNoHeaderTableWithHeaderEnabled(t *testing.T) {
 	SetNoHeader(false)
+	defer SetNoHeader(false)
 
 	data := []SimpleStruct{{ID: 1, Name: "beta", Active: false}}
 	out := CaptureOutput(func() {
@@ -1316,6 +1317,7 @@ func TestNoHeaderCSVSuppressesHeader(t *testing.T) {
 
 func TestNoHeaderCSVWithHeaderEnabled(t *testing.T) {
 	SetNoHeader(false)
+	defer SetNoHeader(false)
 
 	data := []SimpleStruct{{ID: 7, Name: "delta", Active: false}}
 	out := CaptureOutput(func() {

--- a/internal/base/output/output_test.go
+++ b/internal/base/output/output_test.go
@@ -1270,3 +1270,74 @@ func TestApplyJMESPath_MarshalError(t *testing.T) {
 	_, err := applyJMESPath("[*]", make(chan int))
 	assert.Error(t, err)
 }
+
+// ---- --no-header flag ----
+
+func TestNoHeaderTableSuppressesHeader(t *testing.T) {
+	SetNoHeader(true)
+	defer SetNoHeader(false)
+
+	data := []SimpleStruct{{ID: 1, Name: "alpha", Active: true}}
+	out := CaptureOutput(func() {
+		err := PrintOutput(data, "table", true)
+		assert.NoError(t, err)
+	})
+
+	assert.NotContains(t, out, "ID", "header row should be suppressed")
+	assert.Contains(t, out, "alpha", "data row should still appear")
+}
+
+func TestNoHeaderTableWithHeaderEnabled(t *testing.T) {
+	SetNoHeader(false)
+
+	data := []SimpleStruct{{ID: 1, Name: "beta", Active: false}}
+	out := CaptureOutput(func() {
+		err := PrintOutput(data, "table", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "ID", "header row should appear when no-header is false")
+}
+
+func TestNoHeaderCSVSuppressesHeader(t *testing.T) {
+	SetNoHeader(true)
+	defer SetNoHeader(false)
+
+	data := []SimpleStruct{{ID: 42, Name: "gamma", Active: true}}
+	out := CaptureOutput(func() {
+		err := PrintOutput(data, "csv", true)
+		assert.NoError(t, err)
+	})
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	assert.Len(t, lines, 1, "only the data row should appear, not a header row")
+	assert.Contains(t, lines[0], "42")
+}
+
+func TestNoHeaderCSVWithHeaderEnabled(t *testing.T) {
+	SetNoHeader(false)
+
+	data := []SimpleStruct{{ID: 7, Name: "delta", Active: false}}
+	out := CaptureOutput(func() {
+		err := PrintOutput(data, "csv", true)
+		assert.NoError(t, err)
+	})
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	assert.GreaterOrEqual(t, len(lines), 2, "header + data row should both appear")
+	assert.Contains(t, lines[0], "id", "first line should be the header")
+}
+
+func TestNoHeaderDoesNotAffectJSON(t *testing.T) {
+	SetNoHeader(true)
+	defer SetNoHeader(false)
+
+	data := []SimpleStruct{{ID: 3, Name: "epsilon", Active: true}}
+	out := CaptureOutput(func() {
+		err := PrintOutput(data, "json", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, `"name"`, "JSON should include field names regardless of --no-header")
+	assert.Contains(t, out, "epsilon")
+}

--- a/internal/base/output/output_wasm.go
+++ b/internal/base/output/output_wasm.go
@@ -138,8 +138,10 @@ func printCSV[T OutputFields](data []T) error {
 		return nil
 	}
 
-	if err := w.Write(headers); err != nil {
-		return err
+	if !getNoHeader() {
+		if err := w.Write(headers); err != nil {
+			return err
+		}
 	}
 
 	for _, item := range data {

--- a/internal/base/output/table.go
+++ b/internal/base/output/table.go
@@ -127,7 +127,9 @@ func printTable[T OutputFields](data []T, noColor bool) error {
 	for _, header := range headers {
 		headerRow = append(headerRow, strings.ToUpper(header))
 	}
-	t.AppendHeader(headerRow)
+	if !getNoHeader() {
+		t.AppendHeader(headerRow)
+	}
 	for _, item := range data {
 		v := reflect.ValueOf(item)
 		if !v.IsValid() || (v.Kind() == reflect.Ptr && v.IsNil()) {

--- a/internal/base/output/table_wasm.go
+++ b/internal/base/output/table_wasm.go
@@ -169,7 +169,9 @@ func printTable[T OutputFields](data []T, noColor bool) error {
 	for _, header := range headers {
 		headerRow = append(headerRow, strings.ToUpper(header))
 	}
-	t.AppendHeader(headerRow)
+	if !getNoHeader() {
+		t.AppendHeader(headerRow)
+	}
 
 	for _, item := range data {
 		v := reflect.ValueOf(item)

--- a/main_wasm.go
+++ b/main_wasm.go
@@ -157,8 +157,6 @@ func main() {
 	// internal/wasm) to break the import cycle between wasm and output packages.
 	wasm.RegisterOutputStateReset(func() {
 		output.ResetState()
-		output.SetOutputFormat("table")
-		output.SetVerbosity("normal")
 	})
 
 	// Register the embedded documentation with the cmdbuilder package

--- a/main_wasm.go
+++ b/main_wasm.go
@@ -156,8 +156,7 @@ func main() {
 	// Wire output state reset into the wasm package. Done here (rather than in
 	// internal/wasm) to break the import cycle between wasm and output packages.
 	wasm.RegisterOutputStateReset(func() {
-		output.SetOutputFields(nil)
-		output.SetOutputQuery("")
+		output.ResetState()
 		output.SetOutputFormat("table")
 		output.SetVerbosity("normal")
 	})


### PR DESCRIPTION
Adds a global \`--no-header\` persistent flag that suppresses column headers in table and CSV output, making scripting easier (e.g. \`megaport-cli ports list --no-header | awk '{print \$1}'\`). JSON and XML output are unaffected. Follows the same pattern as \`doctl --no-header\` and \`kubectl --no-headers\`.

## Implementation

Follows the existing package-level var + mutex pattern used by \`--fields\` and \`--query\`:

- \`output.SetNoHeader(bool)\` / \`getNoHeader()\` added to \`internal/base/output/common.go\`
- \`--no-header\` registered as a persistent flag in both native (\`megaport_common.go\`) and WASM (\`common_wasm.go\`) builds
- \`output.SetNoHeader(noHeader)\` called in \`PersistentPreRunE\` for both build targets
- \`getNoHeader()\` checked in \`printTable\` and \`printCSV\` in both native and WASM implementations
- No function signature changes required anywhere

## Test plan

- [ ] \`make check\` passes
- [ ] \`GOOS=js GOARCH=wasm go build -tags js,wasm -o /dev/null .\` succeeds
- [ ] \`megaport-cli ports list --no-header\` outputs rows with no header line
- [ ] \`megaport-cli ports list --no-header --output csv\` outputs CSV with no header line
- [ ] \`megaport-cli ports list --no-header --output json\` output is unchanged
- [ ] \`megaport-cli ports list\` (without flag) still shows headers