### PR TITLE
feat: add --generate-skeleton flag to buy/update commands

### DIFF
--- a/internal/base/cmdbuilder/builder.go
+++ b/internal/base/cmdbuilder/builder.go
@@ -170,8 +170,9 @@ func (b *CommandBuilder) WithConditionalRequirements(conditionallyRequiredFlags 
 		jsonStr, _ := cmd.Flags().GetString("json")
 		jsonFile, _ := cmd.Flags().GetString("json-file")
 
-		// Skip validation if interactive mode or JSON input is used
-		if interactive || jsonStr != "" || jsonFile != "" {
+		// Skip validation if interactive mode, JSON input, or skeleton mode is used
+		skeleton, _ := cmd.Flags().GetBool("generate-skeleton")
+		if interactive || jsonStr != "" || jsonFile != "" || skeleton {
 			return nil
 		}
 
@@ -313,6 +314,24 @@ func (b *CommandBuilder) Build() *cobra.Command {
 
 	// Add the docs subcommand
 	b.cmd.AddCommand(docsCmd)
+
+	// Auto-add --generate-skeleton flag for commands that have JSON examples
+	if len(b.jsonExamples) > 0 {
+		b.cmd.Flags().Bool("generate-skeleton", false, "Print a JSON skeleton template for --json input and exit")
+		originalRunE := b.cmd.RunE
+		jsonExamples := b.jsonExamples
+		b.cmd.RunE = func(cmd *cobra.Command, args []string) error {
+			skeleton, _ := cmd.Flags().GetBool("generate-skeleton")
+			if skeleton {
+				fmt.Println(jsonExamples[0])
+				return nil
+			}
+			if originalRunE != nil {
+				return originalRunE(cmd, args)
+			}
+			return nil
+		}
+	}
 
 	return b.cmd
 }

--- a/internal/base/cmdbuilder/builder.go
+++ b/internal/base/cmdbuilder/builder.go
@@ -317,7 +317,7 @@ func (b *CommandBuilder) Build() *cobra.Command {
 
 	// Auto-add --generate-skeleton flag for commands that have JSON examples
 	if len(b.jsonExamples) > 0 {
-		b.cmd.Flags().Bool("generate-skeleton", false, "Print a JSON skeleton template for --json input and exit")
+		b.cmd.Flags().Bool("generate-skeleton", false, "Print a JSON skeleton template for --json or --json-file input and exit")
 		originalArgs := b.cmd.Args
 		originalRunE := b.cmd.RunE
 		jsonExamples := b.jsonExamples

--- a/internal/base/cmdbuilder/builder.go
+++ b/internal/base/cmdbuilder/builder.go
@@ -323,7 +323,7 @@ func (b *CommandBuilder) Build() *cobra.Command {
 		b.cmd.RunE = func(cmd *cobra.Command, args []string) error {
 			skeleton, _ := cmd.Flags().GetBool("generate-skeleton")
 			if skeleton {
-				fmt.Println(jsonExamples[0])
+				fmt.Fprintln(cmd.OutOrStdout(), jsonExamples[0])
 				return nil
 			}
 			if originalRunE != nil {

--- a/internal/base/cmdbuilder/builder.go
+++ b/internal/base/cmdbuilder/builder.go
@@ -323,7 +323,9 @@ func (b *CommandBuilder) Build() *cobra.Command {
 		b.cmd.RunE = func(cmd *cobra.Command, args []string) error {
 			skeleton, _ := cmd.Flags().GetBool("generate-skeleton")
 			if skeleton {
-				fmt.Fprintln(cmd.OutOrStdout(), jsonExamples[0])
+				if _, err := fmt.Fprintln(cmd.OutOrStdout(), jsonExamples[0]); err != nil {
+					return err
+				}
 				return nil
 			}
 			if originalRunE != nil {

--- a/internal/base/cmdbuilder/builder.go
+++ b/internal/base/cmdbuilder/builder.go
@@ -318,8 +318,23 @@ func (b *CommandBuilder) Build() *cobra.Command {
 	// Auto-add --generate-skeleton flag for commands that have JSON examples
 	if len(b.jsonExamples) > 0 {
 		b.cmd.Flags().Bool("generate-skeleton", false, "Print a JSON skeleton template for --json input and exit")
+		originalArgs := b.cmd.Args
 		originalRunE := b.cmd.RunE
 		jsonExamples := b.jsonExamples
+
+		// Bypass positional-arg validation in skeleton mode so update commands
+		// (which require a UID arg) work without a dummy argument.
+		b.cmd.Args = func(cmd *cobra.Command, args []string) error {
+			skeleton, _ := cmd.Flags().GetBool("generate-skeleton")
+			if skeleton {
+				return nil
+			}
+			if originalArgs != nil {
+				return originalArgs(cmd, args)
+			}
+			return nil
+		}
+
 		b.cmd.RunE = func(cmd *cobra.Command, args []string) error {
 			skeleton, _ := cmd.Flags().GetBool("generate-skeleton")
 			if skeleton {

--- a/internal/base/cmdbuilder/builder_test.go
+++ b/internal/base/cmdbuilder/builder_test.go
@@ -3,8 +3,6 @@ package cmdbuilder
 import (
 	"bytes"
 	"errors"
-	"io"
-	"os"
 	"testing"
 	"time"
 
@@ -704,18 +702,10 @@ func TestGenerateSkeletonFlag(t *testing.T) {
 			WithJSONExample(jsonExample).
 			Build()
 
-		// Capture stdout
-		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
 		require.NoError(t, cmd.Flags().Set("generate-skeleton", "true"))
 		err := cmd.RunE(cmd, []string{})
-
-		w.Close()
-		os.Stdout = oldStdout
-		var buf bytes.Buffer
-		_, _ = io.Copy(&buf, r)
 
 		assert.NoError(t, err)
 		assert.False(t, originalCalled)
@@ -757,17 +747,10 @@ func TestGenerateSkeletonFlag(t *testing.T) {
 			WithJSONExample(secondExample).
 			Build()
 
-		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
 		require.NoError(t, cmd.Flags().Set("generate-skeleton", "true"))
 		err := cmd.RunE(cmd, []string{})
-
-		w.Close()
-		os.Stdout = oldStdout
-		var buf bytes.Buffer
-		_, _ = io.Copy(&buf, r)
 
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), jsonExample)

--- a/internal/base/cmdbuilder/builder_test.go
+++ b/internal/base/cmdbuilder/builder_test.go
@@ -1,7 +1,10 @@
 package cmdbuilder
 
 import (
+	"bytes"
 	"errors"
+	"io"
+	"os"
 	"testing"
 	"time"
 
@@ -673,4 +676,101 @@ func TestBuilderChaining(t *testing.T) {
 	}))
 	assert.Equal(t, b, b.WithRootCmd(&cobra.Command{}))
 	assert.Equal(t, b, b.WithAliases([]string{"t"}))
+}
+
+func TestGenerateSkeletonFlag(t *testing.T) {
+	const jsonExample = `{"name": "My Port", "term": 12}`
+
+	t.Run("flag added when JSON example present", func(t *testing.T) {
+		cmd := NewCommand("buy", "Buy a resource").
+			WithJSONExample(jsonExample).
+			Build()
+
+		assert.NotNil(t, cmd.Flags().Lookup("generate-skeleton"))
+	})
+
+	t.Run("flag absent without JSON example", func(t *testing.T) {
+		cmd := NewCommand("buy", "Buy a resource").Build()
+		assert.Nil(t, cmd.Flags().Lookup("generate-skeleton"))
+	})
+
+	t.Run("prints JSON example and returns nil without calling original RunE", func(t *testing.T) {
+		originalCalled := false
+		cmd := NewCommand("buy", "Buy a resource").
+			WithRunFunc(func(cmd *cobra.Command, args []string) error {
+				originalCalled = true
+				return nil
+			}).
+			WithJSONExample(jsonExample).
+			Build()
+
+		// Capture stdout
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		require.NoError(t, cmd.Flags().Set("generate-skeleton", "true"))
+		err := cmd.RunE(cmd, []string{})
+
+		w.Close()
+		os.Stdout = oldStdout
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+
+		assert.NoError(t, err)
+		assert.False(t, originalCalled)
+		assert.Contains(t, buf.String(), jsonExample)
+	})
+
+	t.Run("original RunE called when flag not set", func(t *testing.T) {
+		originalCalled := false
+		cmd := NewCommand("buy", "Buy a resource").
+			WithRunFunc(func(cmd *cobra.Command, args []string) error {
+				originalCalled = true
+				return nil
+			}).
+			WithJSONExample(jsonExample).
+			Build()
+
+		err := cmd.RunE(cmd, []string{})
+		assert.NoError(t, err)
+		assert.True(t, originalCalled)
+	})
+
+	t.Run("skips ConditionalRequirements validation", func(t *testing.T) {
+		cmd := NewCommand("buy", "Buy a resource").
+			WithFlag("name", "", "Resource name").
+			WithJSONExample(jsonExample).
+			WithConditionalRequirements("name").
+			Build()
+
+		require.NoError(t, cmd.Flags().Set("generate-skeleton", "true"))
+		// name is not set — validation should be skipped
+		err := cmd.PreRunE(cmd, []string{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("first example printed when multiple examples present", func(t *testing.T) {
+		const secondExample = `{"name": "Other", "term": 24}`
+		cmd := NewCommand("buy", "Buy a resource").
+			WithJSONExample(jsonExample).
+			WithJSONExample(secondExample).
+			Build()
+
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		require.NoError(t, cmd.Flags().Set("generate-skeleton", "true"))
+		err := cmd.RunE(cmd, []string{})
+
+		w.Close()
+		os.Stdout = oldStdout
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+
+		assert.NoError(t, err)
+		assert.Contains(t, buf.String(), jsonExample)
+		assert.NotContains(t, buf.String(), secondExample)
+	})
 }

--- a/internal/base/cmdbuilder/builder_test.go
+++ b/internal/base/cmdbuilder/builder_test.go
@@ -740,6 +740,43 @@ func TestGenerateSkeletonFlag(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("end-to-end via Execute bypasses ExactArgs validation", func(t *testing.T) {
+		originalCalled := false
+		cmd := NewCommand("update", "Update a resource").
+			WithArgs(cobra.ExactArgs(1)).
+			WithRunFunc(func(cmd *cobra.Command, args []string) error {
+				originalCalled = true
+				return nil
+			}).
+			WithJSONExample(jsonExample).
+			Build()
+
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+		cmd.SetArgs([]string{"--generate-skeleton"})
+		err := cmd.Execute()
+
+		assert.NoError(t, err)
+		assert.False(t, originalCalled)
+		assert.Contains(t, buf.String(), jsonExample)
+	})
+
+	t.Run("ExactArgs validation still enforced without skeleton flag", func(t *testing.T) {
+		cmd := NewCommand("update", "Update a resource").
+			WithArgs(cobra.ExactArgs(1)).
+			WithRunFunc(func(cmd *cobra.Command, args []string) error { return nil }).
+			WithJSONExample(jsonExample).
+			Build()
+
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+		cmd.SetArgs([]string{}) // no args, no skeleton — should fail
+		err := cmd.Execute()
+		assert.Error(t, err)
+	})
+
 	t.Run("no RunE set returns nil when skeleton not requested", func(t *testing.T) {
 		cmd := NewCommand("buy", "Buy a resource").
 			WithJSONExample(jsonExample).

--- a/internal/base/cmdbuilder/builder_test.go
+++ b/internal/base/cmdbuilder/builder_test.go
@@ -740,6 +740,16 @@ func TestGenerateSkeletonFlag(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("no RunE set returns nil when skeleton not requested", func(t *testing.T) {
+		cmd := NewCommand("buy", "Buy a resource").
+			WithJSONExample(jsonExample).
+			Build()
+
+		// No RunFunc set — originalRunE is nil; skeleton flag not set
+		err := cmd.RunE(cmd, []string{})
+		assert.NoError(t, err)
+	})
+
 	t.Run("first example printed when multiple examples present", func(t *testing.T) {
 		const secondExample = `{"name": "Other", "term": 24}`
 		cmd := NewCommand("buy", "Buy a resource").


### PR DESCRIPTION
Adds a \`--generate-skeleton\` flag to all buy/update commands, mirroring the \`aws --generate-cli-skeleton\` UX. When set, the command prints a ready-to-use JSON template to stdout and exits immediately — no API calls are made. This makes the \`--json\` input workflow self-documenting: users can run \`megaport ports buy --generate-skeleton\`, edit the output, and pipe it back with \`--json-file\`.

The flag is wired entirely in the \`cmdbuilder\` package via changes to \`builder.go\`:

- **\`Build()\`** — when a command has registered JSON examples via \`WithJSONExample()\`, the flag is automatically added, \`cmd.Args\` is wrapped to bypass positional-arg validation in skeleton mode (so update commands work without supplying a dummy UID), and \`RunE\` is wrapped to print the first registered example and exit. No per-command changes are required.
- **\`WithConditionalRequirements()\`** — \`--generate-skeleton\` is added to the skip-validation conditions alongside \`--interactive\`, \`--json\`, and \`--json-file\`.

If a command registers multiple JSON examples, the first one is always printed. There is currently no mechanism to select an alternative template.

Output is directed to \`cmd.OutOrStdout()\` so it respects cobra's configurable writer. Tests cover: flag presence/absence, stdout output and no-op RunE, ConditionalRequirements bypass, nil-RunE path, end-to-end execution with \`cmd.Execute()\` bypassing \`cobra.ExactArgs\` validation, and confirmation that args validation is still enforced when the flag is absent.