### PR TITLE
feat: add WithJSONExample to commands missing --generate-skeleton support

### DIFF
--- a/internal/commands/mcr/mcr.go
+++ b/internal/commands/mcr/mcr.go
@@ -342,6 +342,11 @@ func buildMCRTagCommands() (listTags, updateTags *cobra.Command) {
 		WithExample("megaport-cli mcr update-tags mcr-abc123 --interactive").
 		WithExample("megaport-cli mcr update-tags mcr-abc123 --json '{\"env\":\"production\",\"team\":\"network\"}'").
 		WithExample("megaport-cli mcr update-tags mcr-abc123 --json-file ./tags.json").
+		WithJSONExample(`{
+  "environment": "production",
+  "owner": "network-team",
+  "project": "cloud-migration"
+}`).
 		WithImportantNote("All existing tags will be replaced with the provided tags. To clear all tags, provide an empty tag set.").
 		Build()
 

--- a/internal/commands/mcr/mcr_test.go
+++ b/internal/commands/mcr/mcr_test.go
@@ -368,3 +368,8 @@ func TestFilterMCRs(t *testing.T) {
 		})
 	}
 }
+
+func TestMCRUpdateTagsHasGenerateSkeleton(t *testing.T) {
+	_, updateTags := buildMCRTagCommands()
+	assert.NotNil(t, updateTags.Flags().Lookup("generate-skeleton"))
+}

--- a/internal/commands/mve/mve.go
+++ b/internal/commands/mve/mve.go
@@ -201,6 +201,11 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithExample("megaport-cli mve update-tags mve-abc123 --interactive").
 		WithExample("megaport-cli mve update-tags mve-abc123 --json '{\"env\":\"production\",\"team\":\"network\"}'").
 		WithExample("megaport-cli mve update-tags mve-abc123 --json-file ./tags.json").
+		WithJSONExample(`{
+  "environment": "production",
+  "owner": "network-team",
+  "project": "cloud-migration"
+}`).
 		WithImportantNote("All existing tags will be replaced with the provided tags. To clear all tags, provide an empty tag set.").
 		Build()
 

--- a/internal/commands/mve/mve_test.go
+++ b/internal/commands/mve/mve_test.go
@@ -7,6 +7,7 @@ import (
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testMVEs = []*megaport.MVE{
@@ -465,6 +466,8 @@ func TestFilterMVEs(t *testing.T) {
 func TestMVEUpdateTagsHasGenerateSkeleton(t *testing.T) {
 	root := &cobra.Command{Use: "megaport-cli"}
 	AddCommandsTo(root)
-	updateTagsCmd, _, _ := root.Find([]string{"mve", "update-tags"})
+	updateTagsCmd, _, err := root.Find([]string{"mve", "update-tags"})
+	require.NoError(t, err)
+	require.NotNil(t, updateTagsCmd)
 	assert.NotNil(t, updateTagsCmd.Flags().Lookup("generate-skeleton"))
 }

--- a/internal/commands/mve/mve_test.go
+++ b/internal/commands/mve/mve_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/megaport/megaport-cli/internal/base/output"
 	megaport "github.com/megaport/megaportgo"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -459,4 +460,11 @@ func TestFilterMVEs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMVEUpdateTagsHasGenerateSkeleton(t *testing.T) {
+	root := &cobra.Command{Use: "megaport-cli"}
+	AddCommandsTo(root)
+	updateTagsCmd, _, _ := root.Find([]string{"mve", "update-tags"})
+	assert.NotNil(t, updateTagsCmd.Flags().Lookup("generate-skeleton"))
 }

--- a/internal/commands/ports/ports.go
+++ b/internal/commands/ports/ports.go
@@ -134,7 +134,7 @@ func buildPortBuyCommands(rootCmd *cobra.Command) (buy, buyLag, update, validate
 		WithOptionalFlag("term", "The new contract term in months (1, 12, 24, or 36)").
 		WithExample("megaport-cli ports update port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --interactive").
 		WithExample("megaport-cli ports update port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --name \"Updated Port\" --marketplace-visibility true --cost-centre \"Finance\"").
-		WithExample("megaport-cli ports update port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --json '{\"name\":\"Updated Port\",\"marketplaceVisibility\":true,\"costCentre\":\"Finance\"}'").
+		WithExample("megaport-cli ports update port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --json '{\"name\":\"Updated Port\",\"marketPlaceVisibility\":true,\"costCentre\":\"Finance\"}'").
 		WithExample("megaport-cli ports update port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --json-file ./update-port-config.json").
 		WithJSONExample(`{
   "name": "Updated Port",

--- a/internal/commands/ports/ports.go
+++ b/internal/commands/ports/ports.go
@@ -136,6 +136,12 @@ func buildPortBuyCommands(rootCmd *cobra.Command) (buy, buyLag, update, validate
 		WithExample("megaport-cli ports update port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --name \"Updated Port\" --marketplace-visibility true --cost-centre \"Finance\"").
 		WithExample("megaport-cli ports update port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --json '{\"name\":\"Updated Port\",\"marketplaceVisibility\":true,\"costCentre\":\"Finance\"}'").
 		WithExample("megaport-cli ports update port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --json-file ./update-port-config.json").
+		WithJSONExample(`{
+  "name": "Updated Port",
+  "marketPlaceVisibility": true,
+  "costCentre": "IT-2024",
+  "contractTermMonths": 24
+}`).
 		WithImportantNote("At least one update flag must be provided when not using --interactive, --json, or --json-file").
 		WithRootCmd(rootCmd).
 		WithConditionalRequirements("at_least_one:name,marketplace-visibility,cost-centre,term").

--- a/internal/commands/ports/ports_test.go
+++ b/internal/commands/ports/ports_test.go
@@ -378,3 +378,8 @@ func TestFilterPortsWithInactiveFlag(t *testing.T) {
 	filtered = filterPorts(allPorts, 1, 1000, "", true)
 	assert.Len(t, filtered, 2)
 }
+
+func TestPortsUpdateHasGenerateSkeleton(t *testing.T) {
+	_, _, update, _, _ := buildPortBuyCommands(nil)
+	assert.NotNil(t, update.Flags().Lookup("generate-skeleton"))
+}

--- a/internal/commands/users/users.go
+++ b/internal/commands/users/users.go
@@ -86,6 +86,17 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithExample("megaport-cli users update 12345 --interactive").
 		WithExample(`megaport-cli users update 12345 --first-name "Jane" --last-name "Smith"`).
 		WithExample(`megaport-cli users update 12345 --json '{"firstName":"Jane"}'`).
+		WithJSONExample(`{
+  "firstName": "Jane",
+  "lastName": "Smith",
+  "email": "jane.smith@example.com",
+  "phone": "+61400000000",
+  "position": "Network Engineer",
+  "active": true,
+  "notificationEnabled": true,
+  "newsletter": false,
+  "promotions": false
+}`).
 		WithImportantNote("Users with pending invitations cannot be updated").
 		WithRootCmd(rootCmd).
 		Build()

--- a/internal/commands/users/users_test.go
+++ b/internal/commands/users/users_test.go
@@ -5,11 +5,14 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUsersUpdateHasGenerateSkeleton(t *testing.T) {
 	root := &cobra.Command{Use: "megaport-cli"}
 	AddCommandsTo(root)
-	updateCmd, _, _ := root.Find([]string{"users", "update"})
+	updateCmd, _, err := root.Find([]string{"users", "update"})
+	require.NoError(t, err)
+	require.NotNil(t, updateCmd)
 	assert.NotNil(t, updateCmd.Flags().Lookup("generate-skeleton"))
 }

--- a/internal/commands/users/users_test.go
+++ b/internal/commands/users/users_test.go
@@ -1,0 +1,15 @@
+package users
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUsersUpdateHasGenerateSkeleton(t *testing.T) {
+	root := &cobra.Command{Use: "megaport-cli"}
+	AddCommandsTo(root)
+	updateCmd, _, _ := root.Find([]string{"users", "update"})
+	assert.NotNil(t, updateCmd.Flags().Lookup("generate-skeleton"))
+}

--- a/internal/commands/vxc/vxc.go
+++ b/internal/commands/vxc/vxc.go
@@ -189,6 +189,11 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithExample("megaport-cli vxc update-tags vxc-abc123 --interactive").
 		WithExample("megaport-cli vxc update-tags vxc-abc123 --json '{\"env\":\"production\",\"team\":\"network\"}'").
 		WithExample("megaport-cli vxc update-tags vxc-abc123 --json-file ./tags.json").
+		WithJSONExample(`{
+  "environment": "production",
+  "owner": "network-team",
+  "project": "cloud-migration"
+}`).
 		WithImportantNote("All existing tags will be replaced with the provided tags. To clear all tags, provide an empty tag set.").
 		Build()
 

--- a/internal/commands/vxc/vxc_test.go
+++ b/internal/commands/vxc/vxc_test.go
@@ -7,6 +7,7 @@ import (
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testVXCs = []*megaport.VXC{
@@ -542,6 +543,8 @@ func TestToVXCOutput_EdgeCases(t *testing.T) {
 func TestVXCUpdateTagsHasGenerateSkeleton(t *testing.T) {
 	root := &cobra.Command{Use: "megaport-cli"}
 	AddCommandsTo(root)
-	updateTagsCmd, _, _ := root.Find([]string{"vxc", "update-tags"})
+	updateTagsCmd, _, err := root.Find([]string{"vxc", "update-tags"})
+	require.NoError(t, err)
+	require.NotNil(t, updateTagsCmd)
 	assert.NotNil(t, updateTagsCmd.Flags().Lookup("generate-skeleton"))
 }

--- a/internal/commands/vxc/vxc_test.go
+++ b/internal/commands/vxc/vxc_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/megaport/megaport-cli/internal/base/output"
 	megaport "github.com/megaport/megaportgo"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -536,4 +537,11 @@ func TestToVXCOutput_EdgeCases(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVXCUpdateTagsHasGenerateSkeleton(t *testing.T) {
+	root := &cobra.Command{Use: "megaport-cli"}
+	AddCommandsTo(root)
+	updateTagsCmd, _, _ := root.Find([]string{"vxc", "update-tags"})
+	assert.NotNil(t, updateTagsCmd.Flags().Lookup("generate-skeleton"))
 }


### PR DESCRIPTION
Follow-up to #317. Five commands that accept `--json`/`--json-file` input were missing `WithJSONExample()` registrations, so they did not get the `--generate-skeleton` flag automatically. This adds the missing examples and the tests to cover them:

- **`ports update`** — `ModifyPortRequest` fields (name, marketPlaceVisibility, costCentre, contractTermMonths)
- **`users update`** — `UpdateUserRequest` fields (firstName, lastName, email, phone, position, active, notificationEnabled, newsletter, promotions)
- **`vxc update-tags`** — flat `map[string]string` resource tag example
- **`mve update-tags`** — flat `map[string]string` resource tag example
- **`mcr update-tags`** — flat `map[string]string` resource tag example

Each command gets a corresponding test that builds the command tree and asserts `--generate-skeleton` is present. Tests for `vxc`, `mve`, and `users` use `require.NoError` + `require.NotNil` guards on the `Find()` result before checking the flag.