### PR TITLE
feat: add --output go-template support for scriptable output

### DIFF
--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -74,7 +74,7 @@ func InitializeCommon() {
 
 	// Setup persistent flags
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", utils.FormatTable,
-		"Output format (table, json, csv, xml)")
+		"Output format (table, json, csv, xml, go-template; go-template not supported in browser version)")
 	rootCmd.PersistentFlags().String("template", "", "Go template string for --output go-template (not supported in browser version)")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colorful output")
 	rootCmd.PersistentFlags().StringVar(&utils.Env, "env", "", "Environment to use (prod, dev, or staging)")

--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -75,6 +75,7 @@ func InitializeCommon() {
 	// Setup persistent flags
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", utils.FormatTable,
 		"Output format (table, json, csv, xml)")
+	rootCmd.PersistentFlags().String("template", "", "Go template string for --output go-template (not supported in browser version)")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colorful output")
 	rootCmd.PersistentFlags().StringVar(&utils.Env, "env", "", "Environment to use (prod, dev, or staging)")
 	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Suppress informational output, only show errors and data")

--- a/cmd/megaport/megaport_common.go
+++ b/cmd/megaport/megaport_common.go
@@ -86,7 +86,7 @@ func InitializeCommon() {
 
 	// Setup persistent flags
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", utils.FormatTable,
-		"Output format (table, json, csv, xml, go-template)")
+		"Output format (table, json, csv, xml, go-template; requires --template when using go-template)")
 	rootCmd.PersistentFlags().String("template", "", "Go template string for --output go-template (e.g. '{{range .}}{{.Name}}{{\"\\n\"}}{{end}}')")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colorful output")
 	rootCmd.PersistentFlags().StringVar(&utils.Env, "env", "", "Environment to use (prod, dev, or staging)")

--- a/cmd/megaport/megaport_common.go
+++ b/cmd/megaport/megaport_common.go
@@ -86,7 +86,8 @@ func InitializeCommon() {
 
 	// Setup persistent flags
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", utils.FormatTable,
-		"Output format (table, json, csv, xml)")
+		"Output format (table, json, csv, xml, go-template)")
+	rootCmd.PersistentFlags().String("template", "", "Go template string for --output go-template (e.g. '{{range .}}{{.Name}}{{\"\\n\"}}{{end}}')")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colorful output")
 	rootCmd.PersistentFlags().StringVar(&utils.Env, "env", "", "Environment to use (prod, dev, or staging)")
 	rootCmd.PersistentFlags().StringVar(&utils.ProfileOverride, "profile", "", "Use a specific config profile for this command")

--- a/internal/base/output/common.go
+++ b/internal/base/output/common.go
@@ -75,6 +75,28 @@ var (
 	noHeaderMu sync.RWMutex
 )
 
+// templateStr holds the Go template string from --template flag.
+// Empty string means no template. Protected by templateStrMu.
+var (
+	templateStr   string
+	templateStrMu sync.RWMutex
+)
+
+// SetTemplateString sets the Go template string applied by printGoTemplate.
+// Pass "" to disable. This function is goroutine-safe.
+func SetTemplateString(s string) {
+	templateStrMu.Lock()
+	defer templateStrMu.Unlock()
+	templateStr = s
+}
+
+// GetTemplateString returns the current Go template string under a read lock.
+func GetTemplateString() string {
+	templateStrMu.RLock()
+	defer templateStrMu.RUnlock()
+	return templateStr
+}
+
 // SetNoHeader sets whether table and CSV output should suppress column headers.
 // This function is goroutine-safe. Tests should call defer SetNoHeader(false) to
 // reset state between test cases.
@@ -98,6 +120,7 @@ func ResetState() {
 	SetOutputFields(nil)
 	SetOutputQuery("")
 	SetNoHeader(false)
+	SetTemplateString("")
 	SetOutputFormat("table")
 	SetVerbosity("normal")
 }
@@ -198,10 +221,11 @@ type ResourceTag struct {
 // PrintOutput prints data in the specified format
 func PrintOutput[T OutputFields](data []T, format string, noColor bool) error {
 	validFormats := map[string]bool{
-		"table": true,
-		"json":  true,
-		"csv":   true,
-		"xml":   true,
+		"table":       true,
+		"json":        true,
+		"csv":         true,
+		"xml":         true,
+		"go-template": true,
 	}
 	if !validFormats[format] {
 		return fmt.Errorf("invalid output format: %s", format)
@@ -213,6 +237,8 @@ func PrintOutput[T OutputFields](data []T, format string, noColor bool) error {
 		return printCSV(data)
 	case "xml":
 		return printXML(data)
+	case "go-template":
+		return printGoTemplate(data)
 	default:
 		return printTable(data, noColor)
 	}

--- a/internal/base/output/output.go
+++ b/internal/base/output/output.go
@@ -10,7 +10,28 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
+	"text/template"
 )
+
+func printGoTemplate[T OutputFields](data []T) error {
+	tmplStr := GetTemplateString()
+	funcMap := template.FuncMap{
+		"join":  strings.Join,
+		"upper": strings.ToUpper,
+		"lower": strings.ToLower,
+		"trim":  strings.TrimSpace,
+		"json": func(v any) (string, error) {
+			b, err := json.Marshal(v)
+			return string(b), err
+		},
+	}
+	tmpl, err := template.New("output").Funcs(funcMap).Parse(tmplStr)
+	if err != nil {
+		return fmt.Errorf("invalid template: %w", err)
+	}
+	return tmpl.Execute(os.Stdout, data)
+}
 
 func printJSON[T OutputFields](data []T) error {
 	if data == nil {

--- a/internal/base/output/output_test.go
+++ b/internal/base/output/output_test.go
@@ -1343,3 +1343,70 @@ func TestNoHeaderDoesNotAffectJSON(t *testing.T) {
 	assert.Contains(t, out, `"name"`, "JSON should include field names regardless of --no-header")
 	assert.Contains(t, out, "epsilon")
 }
+
+func TestPrintGoTemplate_FieldExtraction(t *testing.T) {
+	SetTemplateString(`{{range .}}{{.Name}}{{"\n"}}{{end}}`)
+	defer SetTemplateString("")
+
+	data := []SimpleStruct{{ID: 1, Name: "alpha", Active: true}, {ID: 2, Name: "beta", Active: false}}
+	out := CaptureOutput(func() {
+		err := PrintOutput(data, "go-template", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "alpha")
+	assert.Contains(t, out, "beta")
+}
+
+func TestPrintGoTemplate_SingleItem(t *testing.T) {
+	SetTemplateString(`{{(index . 0).Name}}`)
+	defer SetTemplateString("")
+
+	data := []SimpleStruct{{ID: 1, Name: "gamma", Active: true}}
+	out := CaptureOutput(func() {
+		err := PrintOutput(data, "go-template", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Equal(t, "gamma", strings.TrimSpace(out))
+}
+
+func TestPrintGoTemplate_FuncMap(t *testing.T) {
+	SetTemplateString(`{{range .}}{{upper .Name}}{{"\n"}}{{end}}`)
+	defer SetTemplateString("")
+
+	data := []SimpleStruct{{ID: 1, Name: "delta"}}
+	out := CaptureOutput(func() {
+		err := PrintOutput(data, "go-template", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "DELTA")
+}
+
+func TestPrintGoTemplate_InvalidTemplate(t *testing.T) {
+	SetTemplateString(`{{invalid`)
+	defer SetTemplateString("")
+
+	data := []SimpleStruct{{ID: 1, Name: "test"}}
+	var err error
+	CaptureOutput(func() {
+		err = PrintOutput(data, "go-template", true)
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid template")
+}
+
+func TestPrintGoTemplate_Count(t *testing.T) {
+	SetTemplateString(`{{len .}}`)
+	defer SetTemplateString("")
+
+	data := []SimpleStruct{{ID: 1, Name: "a"}, {ID: 2, Name: "b"}, {ID: 3, Name: "c"}}
+	out := CaptureOutput(func() {
+		err := PrintOutput(data, "go-template", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Equal(t, "3", strings.TrimSpace(out))
+}

--- a/internal/base/output/output_test.go
+++ b/internal/base/output/output_test.go
@@ -1410,3 +1410,22 @@ func TestPrintGoTemplate_Count(t *testing.T) {
 
 	assert.Equal(t, "3", strings.TrimSpace(out))
 }
+
+func TestPrintGoTemplate_JSONFuncMap(t *testing.T) {
+	SetTemplateString(`{{range .}}{{json .}}{{"\n"}}{{end}}`)
+	defer SetTemplateString("")
+
+	data := []SimpleStruct{{ID: 1, Name: "epsilon", Active: true}}
+	out := CaptureOutput(func() {
+		err := PrintOutput(data, "go-template", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, `"epsilon"`)
+}
+
+func TestResetState_ClearsTemplateString(t *testing.T) {
+	SetTemplateString("{{.}}")
+	ResetState()
+	assert.Equal(t, "", GetTemplateString())
+}

--- a/internal/base/output/output_wasm.go
+++ b/internal/base/output/output_wasm.go
@@ -353,8 +353,9 @@ func printXML[T OutputFields](data []T) error {
 }
 
 // printGoTemplate is not supported in the WASM build.
+// The error message begins with "invalid output format" so classifyError maps it to exitcodes.Usage.
 func printGoTemplate[T OutputFields](_ []T) error {
-	return fmt.Errorf("--output go-template is not supported in the browser version")
+	return fmt.Errorf("invalid output format: go-template is not supported in the browser version")
 }
 
 // calculateColumnWidths calculates the maximum width for each column

--- a/internal/base/output/output_wasm.go
+++ b/internal/base/output/output_wasm.go
@@ -352,6 +352,11 @@ func printXML[T OutputFields](data []T) error {
 	return nil
 }
 
+// printGoTemplate is not supported in the WASM build.
+func printGoTemplate[T OutputFields](_ []T) error {
+	return fmt.Errorf("--output go-template is not supported in the browser version")
+}
+
 // calculateColumnWidths calculates the maximum width for each column
 func calculateColumnWidths(rows [][]string) []int {
 	if len(rows) == 0 {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -67,6 +67,16 @@ func GetCurrentEnv() string {
 	return Env
 }
 
+// applyTemplateFilter reads the --template persistent flag and calls output.SetTemplateString.
+// Called by all RunE wrappers so the template string is always set before PrintOutput is invoked.
+func applyTemplateFilter(cmd *cobra.Command) {
+	tmplStr, err := cmd.Root().PersistentFlags().GetString("template")
+	if err != nil {
+		tmplStr = ""
+	}
+	output.SetTemplateString(tmplStr)
+}
+
 // applyQueryFilter reads the --query persistent flag and calls output.SetOutputQuery.
 // Returns the query string so RunE wrappers can validate it against the selected output format.
 func applyQueryFilter(cmd *cobra.Command) string {
@@ -119,6 +129,7 @@ func applyFieldsFilter(cmd *cobra.Command) {
 func WrapRunE(runE func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		applyFieldsFilter(cmd)
+		applyTemplateFilter(cmd)
 		format, _ := cmd.Root().PersistentFlags().GetString("output")
 		if err := enforceQueryFormatGuard(cmd, applyQueryFilter(cmd), format); err != nil {
 			return err
@@ -144,6 +155,7 @@ func WrapRunE(runE func(cmd *cobra.Command, args []string) error) func(cmd *cobr
 func WrapColorAwareRunE(fn func(cmd *cobra.Command, args []string, noColor bool) error) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		applyFieldsFilter(cmd)
+		applyTemplateFilter(cmd)
 		format, _ := cmd.Root().PersistentFlags().GetString("output")
 		if err := enforceQueryFormatGuard(cmd, applyQueryFilter(cmd), format); err != nil {
 			return err
@@ -205,14 +217,11 @@ func WrapOutputFormatRunE(fn func(cmd *cobra.Command, args []string, noColor boo
 			return exitcodes.NewUsageError(fmt.Errorf("invalid output format: %s. Must be one of: %v", format, ValidFormats))
 		}
 
-		if format == FormatGoTemplate {
-			tmplStr, _ := cmd.Root().PersistentFlags().GetString("template")
-			if tmplStr == "" {
-				cmd.SilenceUsage = true
-				cmd.SilenceErrors = true
-				return exitcodes.NewUsageError(fmt.Errorf("--template is required when --output go-template is used"))
-			}
-			output.SetTemplateString(tmplStr)
+		applyTemplateFilter(cmd)
+		if format == FormatGoTemplate && output.GetTemplateString() == "" {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+			return exitcodes.NewUsageError(fmt.Errorf("--template is required when --output go-template is used"))
 		}
 
 		applyFieldsFilter(cmd)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -13,10 +13,11 @@ import (
 )
 
 const (
-	FormatTable = "table"
-	FormatJSON  = "json"
-	FormatCSV   = "csv"
-	FormatXML   = "xml"
+	FormatTable      = "table"
+	FormatJSON       = "json"
+	FormatCSV        = "csv"
+	FormatXML        = "xml"
+	FormatGoTemplate = "go-template"
 
 	// StatusDecommissioning is used for filtering inactive resources. The SDK
 	// exports STATUS_CANCELLED and STATUS_DECOMMISSIONED but not this one.
@@ -42,7 +43,7 @@ var (
 	// LogHTTP enables raw HTTP request/response logging to stderr. Set via --log-http flag.
 	LogHTTP bool
 
-	ValidFormats = []string{FormatTable, FormatJSON, FormatCSV, FormatXML}
+	ValidFormats = []string{FormatTable, FormatJSON, FormatCSV, FormatXML, FormatGoTemplate}
 )
 
 func ShouldDisableColors() bool {
@@ -202,6 +203,16 @@ func WrapOutputFormatRunE(fn func(cmd *cobra.Command, args []string, noColor boo
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
 			return exitcodes.NewUsageError(fmt.Errorf("invalid output format: %s. Must be one of: %v", format, ValidFormats))
+		}
+
+		if format == FormatGoTemplate {
+			tmplStr, _ := cmd.Root().PersistentFlags().GetString("template")
+			if tmplStr == "" {
+				cmd.SilenceUsage = true
+				cmd.SilenceErrors = true
+				return exitcodes.NewUsageError(fmt.Errorf("--template is required when --output go-template is used"))
+			}
+			output.SetTemplateString(tmplStr)
 		}
 
 		applyFieldsFilter(cmd)

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -334,6 +334,29 @@ func TestWrapOutputFormatRunE(t *testing.T) {
 		assert.Contains(t, err.Error(), "error running get command")
 		assert.Contains(t, err.Error(), "inner failure")
 	})
+
+	t.Run("go-template without --template returns usage error", func(t *testing.T) {
+		wrapped := WrapOutputFormatRunE(func(cmd *cobra.Command, args []string, noColor bool, format string) error {
+			return nil
+		})
+
+		root := &cobra.Command{Use: "root"}
+		root.PersistentFlags().Bool("no-color", false, "")
+		root.PersistentFlags().String("fields", "", "")
+		root.PersistentFlags().String("query", "", "")
+		root.PersistentFlags().String("template", "", "")
+		child := &cobra.Command{Use: "list"}
+		child.Flags().String("output", "go-template", "")
+		root.AddCommand(child)
+
+		err := wrapped(child, []string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--template is required")
+
+		var cliErr *exitcodes.CLIError
+		require.True(t, errors.As(err, &cliErr))
+		assert.Equal(t, exitcodes.Usage, cliErr.Code)
+	})
 }
 
 func TestClassifyError(t *testing.T) {


### PR DESCRIPTION
Adds `--output go-template --template '<expr>'` as a new output format, mirroring `kubectl -o go-template`. This lets power users extract exactly the fields they need in any shape without post-processing with `jq`.

## Usage

```bash
# List all port names
megaport-cli ports list --output go-template --template '{{range .}}{{.Name}}{{"\n"}}{{end}}'

# Get a single field
megaport-cli ports get <uid> --output go-template --template '{{(index . 0).ProvisioningStatus}}'

# Count resources
megaport-cli ports list --output go-template --template '{{len .}}'

# Use built-in functions: upper, lower, trim, join, json
megaport-cli ports list --output go-template --template '{{range .}}{{upper .Name}}{{"\n"}}{{end}}'
```

The template receives the full slice as `.`, consistent with how `kubectl` works. Omitting `--template` when `--output go-template` is set returns a usage error.

## Changes

- `internal/utils/utils.go` — add `FormatGoTemplate` constant, extend `ValidFormats`, add `applyTemplateFilter` helper (mirrors `applyFieldsFilter`), call it from all three RunE wrappers, validate `--template` is non-empty in `WrapOutputFormatRunE`
- `internal/base/output/common.go` — add `SetTemplateString`/`GetTemplateString` global state (same `sync.RWMutex` pattern as other output globals), wire `go-template` into `PrintOutput` dispatcher, reset in `ResetState()` for WASM isolation
- `internal/base/output/output.go` — add `printGoTemplate[T OutputFields]` using `text/template` with funcMap (`upper`, `lower`, `trim`, `join`, `json`)
- `internal/base/output/output_wasm.go` — add `printGoTemplate` stub returning a clear unsupported error (fixes WASM build)
- `cmd/megaport/megaport_common.go` — register `--template` persistent flag, update `--output` usage string
- `cmd/megaport/common_wasm.go` — register `--template` persistent flag in WASM build (flag present, feature unsupported)

## Tests

5 new tests in `output_test.go`: field extraction via `range`, single item via `index`, `upper` funcMap, invalid template error, `len` count.