### PR TITLE
feat: emit structured JSON errors when --output json is active

### DIFF
--- a/cmd/megaport/megaport_wasm.go
+++ b/cmd/megaport/megaport_wasm.go
@@ -8,7 +8,6 @@ import (
 	"io"
 
 	"github.com/megaport/megaport-cli/internal/base/help"
-	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/utils"
 	"github.com/megaport/megaport-cli/internal/wasm"
 	"github.com/spf13/cobra"
@@ -50,8 +49,10 @@ func ExecuteWithArgs(args []string) {
 	if err != nil {
 		// When --output json is active the RunE wrapper already emitted a
 		// structured JSON error via PrintErrorJSON. Skip the plain-text block
-		// to avoid corrupting machine-readable output.
-		if output.GetOutputFormat() == utils.FormatJSON {
+		// to avoid corrupting machine-readable output. Read the parsed flag
+		// value directly because the global output format may not have been set
+		// yet if execution failed before action setup completed.
+		if requestedFormat, flagErr := rootCmd.PersistentFlags().GetString("output"); flagErr == nil && requestedFormat == utils.FormatJSON {
 			return
 		}
 		// Clear the buffer if help was shown automatically

--- a/cmd/megaport/megaport_wasm.go
+++ b/cmd/megaport/megaport_wasm.go
@@ -8,6 +8,8 @@ import (
 	"io"
 
 	"github.com/megaport/megaport-cli/internal/base/help"
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/utils"
 	"github.com/megaport/megaport-cli/internal/wasm"
 	"github.com/spf13/cobra"
 )
@@ -46,6 +48,12 @@ func ExecuteWithArgs(args []string) {
 	err := rootCmd.Execute()
 
 	if err != nil {
+		// When --output json is active the RunE wrapper already emitted a
+		// structured JSON error via PrintErrorJSON. Skip the plain-text block
+		// to avoid corrupting machine-readable output.
+		if output.GetOutputFormat() == utils.FormatJSON {
+			return
+		}
 		// Clear the buffer if help was shown automatically
 		wasm.ResetOutputBuffers()
 

--- a/cmd/megaport/megaport_wasm.go
+++ b/cmd/megaport/megaport_wasm.go
@@ -49,8 +49,11 @@ func ExecuteWithArgs(args []string) {
 	// Set the args on the root command
 	rootCmd.SetArgs(argsToUse)
 
-	// Execute and capture errors
-	err := rootCmd.Execute()
+	// Execute and capture errors. ExecuteC returns the command that ran so we
+	// can resolve --output from the most specific source (local flag on the
+	// executed command, used by WrapOutputFormatRunE, vs. the root persistent
+	// flag, used by WrapRunE / WrapColorAwareRunE).
+	executedCmd, err := rootCmd.ExecuteC()
 
 	if err != nil {
 		// When the error is a *CLIError returned by a RunE wrapper in JSON mode,
@@ -60,10 +63,8 @@ func ExecuteWithArgs(args []string) {
 		// flag) because errors that occur before a wrapper runs (e.g., flag
 		// parse errors) are not *CLIError and still need the plain-text block.
 		var cliErr *exitcodes.CLIError
-		if errors.As(err, &cliErr) {
-			if requestedFormat, flagErr := rootCmd.PersistentFlags().GetString("output"); flagErr == nil && requestedFormat == utils.FormatJSON {
-				return
-			}
+		if errors.As(err, &cliErr) && resolveOutputFormat(executedCmd) == utils.FormatJSON {
+			return
 		}
 		// Clear the buffer if help was shown automatically
 		wasm.ResetOutputBuffers()
@@ -71,6 +72,23 @@ func ExecuteWithArgs(args []string) {
 		fmt.Fprintf(wasm.WasmOutputBuffer, "Error: %v\n\n", err)
 		fmt.Fprintf(wasm.WasmOutputBuffer, "Run 'megaport-cli --help' to see the list of available commands.\n")
 	}
+}
+
+// resolveOutputFormat returns the --output value for the command that ran.
+// It checks the executed command's local --output flag first (used by
+// WrapOutputFormatRunE commands that shadow the persistent root flag), then
+// falls back to the root persistent flag (used by WrapRunE /
+// WrapColorAwareRunE commands).
+func resolveOutputFormat(cmd *cobra.Command) string {
+	if cmd != nil {
+		if f := cmd.Flags().Lookup("output"); f != nil {
+			return f.Value.String()
+		}
+	}
+	if format, err := rootCmd.PersistentFlags().GetString("output"); err == nil {
+		return format
+	}
+	return utils.FormatTable
 }
 
 func EnsureRootCommandOutput(writer io.Writer) {

--- a/cmd/megaport/megaport_wasm.go
+++ b/cmd/megaport/megaport_wasm.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/base/help"
+	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/utils"
 	"github.com/megaport/megaport-cli/internal/wasm"
 	"github.com/spf13/cobra"
@@ -65,6 +66,12 @@ func ExecuteWithArgs(args []string) {
 		// parse errors) are not *CLIError and still need the plain-text block.
 		var cliErr *exitcodes.CLIError
 		if errors.As(err, &cliErr) && resolveOutputFormat(executedCmd) == utils.FormatJSON {
+			// Reset the buffer to remove any plain-text output written before
+			// the error (commands may call output.PrintError etc. before
+			// returning), then re-emit a single clean JSON envelope so the
+			// buffer contains only valid JSON.
+			wasm.ResetOutputBuffers()
+			output.PrintErrorJSON(cliErr.Code, cliErr.Error())
 			return
 		}
 		// Clear the buffer if help was shown automatically

--- a/cmd/megaport/megaport_wasm.go
+++ b/cmd/megaport/megaport_wasm.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/base/help"
@@ -80,15 +81,16 @@ func ExecuteWithArgs(args []string) {
 // falls back to the root persistent flag (used by WrapRunE /
 // WrapColorAwareRunE commands).
 func resolveOutputFormat(cmd *cobra.Command) string {
+	var raw string
 	if cmd != nil {
 		if f := cmd.Flags().Lookup("output"); f != nil {
-			return f.Value.String()
+			raw = f.Value.String()
 		}
 	}
-	if format, err := rootCmd.PersistentFlags().GetString("output"); err == nil {
-		return format
+	if raw == "" {
+		raw, _ = rootCmd.PersistentFlags().GetString("output")
 	}
-	return utils.FormatTable
+	return strings.ToLower(raw)
 }
 
 func EnsureRootCommandOutput(writer io.Writer) {

--- a/cmd/megaport/megaport_wasm.go
+++ b/cmd/megaport/megaport_wasm.go
@@ -4,9 +4,11 @@
 package megaport
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/base/help"
 	"github.com/megaport/megaport-cli/internal/utils"
 	"github.com/megaport/megaport-cli/internal/wasm"
@@ -37,8 +39,12 @@ func ExecuteWithArgs(args []string) {
 		argsToUse = args[1:]
 	}
 
-	// Disable automatic usage on errors so we can control the output
+	// Disable automatic usage on errors so we can control the output.
+	// Also reset SilenceErrors: a prior JSON-mode failure may have set it true
+	// via cmd.Root().SilenceErrors = true in a RunE wrapper, and the command
+	// tree is reused across WASM invocations.
 	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = false
 
 	// Set the args on the root command
 	rootCmd.SetArgs(argsToUse)
@@ -47,13 +53,17 @@ func ExecuteWithArgs(args []string) {
 	err := rootCmd.Execute()
 
 	if err != nil {
-		// When --output json is active the RunE wrapper already emitted a
-		// structured JSON error via PrintErrorJSON. Skip the plain-text block
-		// to avoid corrupting machine-readable output. Read the parsed flag
-		// value directly because the global output format may not have been set
-		// yet if execution failed before action setup completed.
-		if requestedFormat, flagErr := rootCmd.PersistentFlags().GetString("output"); flagErr == nil && requestedFormat == utils.FormatJSON {
-			return
+		// When the error is a *CLIError returned by a RunE wrapper in JSON mode,
+		// the wrapper has already written the structured JSON error via
+		// PrintErrorJSON. Skip the plain-text block to avoid corrupting
+		// machine-readable output. We gate on *CLIError (not just the --output
+		// flag) because errors that occur before a wrapper runs (e.g., flag
+		// parse errors) are not *CLIError and still need the plain-text block.
+		var cliErr *exitcodes.CLIError
+		if errors.As(err, &cliErr) {
+			if requestedFormat, flagErr := rootCmd.PersistentFlags().GetString("output"); flagErr == nil && requestedFormat == utils.FormatJSON {
+				return
+			}
 		}
 		// Clear the buffer if help was shown automatically
 		wasm.ResetOutputBuffers()

--- a/internal/base/exitcodes/exitcodes.go
+++ b/internal/base/exitcodes/exitcodes.go
@@ -23,3 +23,20 @@ func NewUsageError(err error) *CLIError     { return &CLIError{Code: Usage, Err:
 func NewAuthError(err error) *CLIError      { return &CLIError{Code: Authentication, Err: err} }
 func NewAPIError(err error) *CLIError       { return &CLIError{Code: API, Err: err} }
 func NewCancelledError(err error) *CLIError { return &CLIError{Code: Cancelled, Err: err} }
+
+// TypeName returns the string error type name for a given exit code.
+// Used when emitting structured JSON error output (--output json).
+func TypeName(code int) string {
+	switch code {
+	case Usage:
+		return "usage_error"
+	case Authentication:
+		return "auth_error"
+	case API:
+		return "api_error"
+	case Cancelled:
+		return "cancelled"
+	default:
+		return "general_error"
+	}
+}

--- a/internal/base/exitcodes/exitcodes_test.go
+++ b/internal/base/exitcodes/exitcodes_test.go
@@ -43,6 +43,24 @@ func TestCLIError(t *testing.T) {
 	})
 }
 
+func TestTypeName(t *testing.T) {
+	tests := []struct {
+		code int
+		want string
+	}{
+		{Success, "general_error"}, // Success (0) has no specific type — falls through to default
+		{General, "general_error"},
+		{Usage, "usage_error"},
+		{Authentication, "auth_error"},
+		{API, "api_error"},
+		{Cancelled, "cancelled"},
+		{99, "general_error"}, // unknown code → default
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, TypeName(tt.code))
+	}
+}
+
 func TestConstructors(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/base/output/common.go
+++ b/internal/base/output/common.go
@@ -82,6 +82,18 @@ var (
 	templateStrMu sync.RWMutex
 )
 
+// errorBody and errorEnvelope are the JSON error envelope types shared by
+// PrintErrorJSON across native and WASM builds.
+type errorBody struct {
+	Code    int    `json:"code"`
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+type errorEnvelope struct {
+	Error errorBody `json:"error"`
+}
+
 // SetTemplateString sets the Go template string applied by printGoTemplate.
 // Pass "" to disable. This function is goroutine-safe.
 func SetTemplateString(s string) {

--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -89,6 +89,10 @@ func getOutputFormat() string {
 	return "table"
 }
 
+// GetOutputFormat returns the currently active output format (e.g. "table", "json").
+// Exported so that packages such as utils can check the format without an additional import.
+func GetOutputFormat() string { return getOutputFormat() }
+
 // shouldSuppressSpinner returns true when spinner output should be suppressed
 // to avoid corrupting machine-readable output formats (csv, xml, json, yaml, etc.).
 func shouldSuppressSpinner() bool {

--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -90,7 +90,7 @@ func getOutputFormat() string {
 }
 
 // GetOutputFormat returns the currently active output format (e.g. "table", "json").
-// Exported so that packages such as utils can check the format without an additional import.
+// Exported so other packages can read the current output format without relying on an unexported helper.
 func GetOutputFormat() string { return getOutputFormat() }
 
 // shouldSuppressSpinner returns true when spinner output should be suppressed

--- a/internal/base/output/messages_native.go
+++ b/internal/base/output/messages_native.go
@@ -16,14 +16,6 @@ import (
 // Used by RunE wrappers when --output json is active so automation scripts
 // can parse errors programmatically instead of scraping plain text.
 func PrintErrorJSON(code int, message string) {
-	type errorBody struct {
-		Code    int    `json:"code"`
-		Type    string `json:"type"`
-		Message string `json:"message"`
-	}
-	type errorEnvelope struct {
-		Error errorBody `json:"error"`
-	}
 	payload := errorEnvelope{
 		Error: errorBody{
 			Code:    code,

--- a/internal/base/output/messages_native.go
+++ b/internal/base/output/messages_native.go
@@ -4,11 +4,37 @@
 package output
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/fatih/color"
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 )
+
+// PrintErrorJSON writes a structured JSON error to stderr.
+// Used by RunE wrappers when --output json is active so automation scripts
+// can parse errors programmatically instead of scraping plain text.
+func PrintErrorJSON(code int, message string) {
+	type errorBody struct {
+		Code    int    `json:"code"`
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	}
+	type errorEnvelope struct {
+		Error errorBody `json:"error"`
+	}
+	payload := errorEnvelope{
+		Error: errorBody{
+			Code:    code,
+			Type:    exitcodes.TypeName(code),
+			Message: message,
+		},
+	}
+	enc := json.NewEncoder(os.Stderr)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(payload) // best-effort; stderr write failures are not actionable
+}
 
 // Native (non-WASM) implementations that write to stdout/stderr directly
 

--- a/internal/base/output/messages_native_test.go
+++ b/internal/base/output/messages_native_test.go
@@ -1,0 +1,58 @@
+//go:build !wasm
+// +build !wasm
+
+package output
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintErrorJSON_GeneralError(t *testing.T) {
+	out := captureStderr(t, func() {
+		PrintErrorJSON(1, "something went wrong")
+	})
+	var env struct {
+		Error struct {
+			Code    int    `json:"code"`
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	assert.NoError(t, json.Unmarshal([]byte(out), &env))
+	assert.Equal(t, 1, env.Error.Code)
+	assert.Equal(t, "general_error", env.Error.Type)
+	assert.Equal(t, "something went wrong", env.Error.Message)
+}
+
+func TestPrintErrorJSON_APIError(t *testing.T) {
+	out := captureStderr(t, func() {
+		PrintErrorJSON(4, "resource not found")
+	})
+	var env struct {
+		Error struct {
+			Code int    `json:"code"`
+			Type string `json:"type"`
+		} `json:"error"`
+	}
+	assert.NoError(t, json.Unmarshal([]byte(out), &env))
+	assert.Equal(t, 4, env.Error.Code)
+	assert.Equal(t, "api_error", env.Error.Type)
+}
+
+func TestPrintErrorJSON_UsageError(t *testing.T) {
+	out := captureStderr(t, func() {
+		PrintErrorJSON(2, "bad flag value")
+	})
+	var env struct {
+		Error struct {
+			Code int    `json:"code"`
+			Type string `json:"type"`
+		} `json:"error"`
+	}
+	assert.NoError(t, json.Unmarshal([]byte(out), &env))
+	assert.Equal(t, 2, env.Error.Code)
+	assert.Equal(t, "usage_error", env.Error.Type)
+}

--- a/internal/base/output/messages_wasm.go
+++ b/internal/base/output/messages_wasm.go
@@ -260,14 +260,6 @@ func ClearScreen() {}
 
 // PrintErrorJSON writes a structured JSON error to the WASM output buffer.
 func PrintErrorJSON(code int, message string) {
-	type errorBody struct {
-		Code    int    `json:"code"`
-		Type    string `json:"type"`
-		Message string `json:"message"`
-	}
-	type errorEnvelope struct {
-		Error errorBody `json:"error"`
-	}
 	payload := errorEnvelope{
 		Error: errorBody{
 			Code:    code,

--- a/internal/base/output/messages_wasm.go
+++ b/internal/base/output/messages_wasm.go
@@ -267,6 +267,15 @@ func PrintErrorJSON(code int, message string) {
 			Message: message,
 		},
 	}
-	b, _ := json.Marshal(payload)
+	b, err := json.Marshal(payload)
+	if err != nil {
+		// errorEnvelope contains only primitive types so Marshal should never
+		// fail. If it somehow does, emit a minimal hard-coded envelope so
+		// callers always receive valid JSON.
+		msgJSON, _ := json.Marshal(message)
+		fmt.Fprintf(wasm.WasmOutputBuffer, `{"error":{"code":%d,"type":"general_error","message":%s}}`+"\n",
+			code, msgJSON)
+		return
+	}
 	fmt.Fprintln(wasm.WasmOutputBuffer, string(b))
 }

--- a/internal/base/output/messages_wasm.go
+++ b/internal/base/output/messages_wasm.go
@@ -273,8 +273,8 @@ func PrintErrorJSON(code int, message string) {
 		// fail. If it somehow does, emit a minimal hard-coded envelope so
 		// callers always receive valid JSON.
 		msgJSON, _ := json.Marshal(message)
-		fmt.Fprintf(wasm.WasmOutputBuffer, `{"error":{"code":%d,"type":"general_error","message":%s}}`+"\n",
-			code, msgJSON)
+		fmt.Fprintf(wasm.WasmOutputBuffer, `{"error":{"code":%d,"type":"%s","message":%s}}`+"\n",
+			code, exitcodes.TypeName(code), msgJSON)
 		return
 	}
 	fmt.Fprintln(wasm.WasmOutputBuffer, string(b))

--- a/internal/base/output/messages_wasm.go
+++ b/internal/base/output/messages_wasm.go
@@ -4,10 +4,12 @@
 package output
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/wasm"
 )
 
@@ -255,3 +257,24 @@ func PrintInfo(format string, noColor bool, args ...interface{}) {
 
 // ClearScreen is a no-op in the WASM environment.
 func ClearScreen() {}
+
+// PrintErrorJSON writes a structured JSON error to the WASM output buffer.
+func PrintErrorJSON(code int, message string) {
+	type errorBody struct {
+		Code    int    `json:"code"`
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	}
+	type errorEnvelope struct {
+		Error errorBody `json:"error"`
+	}
+	payload := errorEnvelope{
+		Error: errorBody{
+			Code:    code,
+			Type:    exitcodes.TypeName(code),
+			Message: message,
+		},
+	}
+	b, _ := json.Marshal(payload)
+	fmt.Fprintln(wasm.WasmOutputBuffer, string(b))
+}

--- a/internal/base/output/output_test.go
+++ b/internal/base/output/output_test.go
@@ -1429,3 +1429,56 @@ func TestResetState_ClearsTemplateString(t *testing.T) {
 	ResetState()
 	assert.Equal(t, "", GetTemplateString())
 }
+
+func TestGetOutputFormat(t *testing.T) {
+	SetOutputFormat("json")
+	defer SetOutputFormat("table")
+	assert.Equal(t, "json", GetOutputFormat())
+}
+
+func TestPrintErrorJSON_GeneralError(t *testing.T) {
+	out := captureStderr(t, func() {
+		PrintErrorJSON(1, "something went wrong")
+	})
+	var env struct {
+		Error struct {
+			Code    int    `json:"code"`
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	assert.NoError(t, json.Unmarshal([]byte(out), &env))
+	assert.Equal(t, 1, env.Error.Code)
+	assert.Equal(t, "general_error", env.Error.Type)
+	assert.Equal(t, "something went wrong", env.Error.Message)
+}
+
+func TestPrintErrorJSON_APIError(t *testing.T) {
+	out := captureStderr(t, func() {
+		PrintErrorJSON(4, "resource not found")
+	})
+	var env struct {
+		Error struct {
+			Code int    `json:"code"`
+			Type string `json:"type"`
+		} `json:"error"`
+	}
+	assert.NoError(t, json.Unmarshal([]byte(out), &env))
+	assert.Equal(t, 4, env.Error.Code)
+	assert.Equal(t, "api_error", env.Error.Type)
+}
+
+func TestPrintErrorJSON_UsageError(t *testing.T) {
+	out := captureStderr(t, func() {
+		PrintErrorJSON(2, "bad flag value")
+	})
+	var env struct {
+		Error struct {
+			Code int    `json:"code"`
+			Type string `json:"type"`
+		} `json:"error"`
+	}
+	assert.NoError(t, json.Unmarshal([]byte(out), &env))
+	assert.Equal(t, 2, env.Error.Code)
+	assert.Equal(t, "usage_error", env.Error.Type)
+}

--- a/internal/base/output/output_test.go
+++ b/internal/base/output/output_test.go
@@ -1431,54 +1431,8 @@ func TestResetState_ClearsTemplateString(t *testing.T) {
 }
 
 func TestGetOutputFormat(t *testing.T) {
+	orig := GetOutputFormat()
+	t.Cleanup(func() { SetOutputFormat(orig) })
 	SetOutputFormat("json")
-	defer SetOutputFormat("table")
 	assert.Equal(t, "json", GetOutputFormat())
-}
-
-func TestPrintErrorJSON_GeneralError(t *testing.T) {
-	out := captureStderr(t, func() {
-		PrintErrorJSON(1, "something went wrong")
-	})
-	var env struct {
-		Error struct {
-			Code    int    `json:"code"`
-			Type    string `json:"type"`
-			Message string `json:"message"`
-		} `json:"error"`
-	}
-	assert.NoError(t, json.Unmarshal([]byte(out), &env))
-	assert.Equal(t, 1, env.Error.Code)
-	assert.Equal(t, "general_error", env.Error.Type)
-	assert.Equal(t, "something went wrong", env.Error.Message)
-}
-
-func TestPrintErrorJSON_APIError(t *testing.T) {
-	out := captureStderr(t, func() {
-		PrintErrorJSON(4, "resource not found")
-	})
-	var env struct {
-		Error struct {
-			Code int    `json:"code"`
-			Type string `json:"type"`
-		} `json:"error"`
-	}
-	assert.NoError(t, json.Unmarshal([]byte(out), &env))
-	assert.Equal(t, 4, env.Error.Code)
-	assert.Equal(t, "api_error", env.Error.Type)
-}
-
-func TestPrintErrorJSON_UsageError(t *testing.T) {
-	out := captureStderr(t, func() {
-		PrintErrorJSON(2, "bad flag value")
-	})
-	var env struct {
-		Error struct {
-			Code int    `json:"code"`
-			Type string `json:"type"`
-		} `json:"error"`
-	}
-	assert.NoError(t, json.Unmarshal([]byte(out), &env))
-	assert.Equal(t, 2, env.Error.Code)
-	assert.Equal(t, "usage_error", env.Error.Type)
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -131,6 +131,11 @@ func WrapRunE(runE func(cmd *cobra.Command, args []string) error) func(cmd *cobr
 		applyFieldsFilter(cmd)
 		applyTemplateFilter(cmd)
 		format, _ := cmd.Root().PersistentFlags().GetString("output")
+		if format == FormatGoTemplate && output.GetTemplateString() == "" {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+			return exitcodes.NewUsageError(fmt.Errorf("--template is required when --output go-template is used"))
+		}
 		if err := enforceQueryFormatGuard(cmd, applyQueryFilter(cmd), format); err != nil {
 			return err
 		}
@@ -158,6 +163,11 @@ func WrapColorAwareRunE(fn func(cmd *cobra.Command, args []string, noColor bool)
 		applyFieldsFilter(cmd)
 		applyTemplateFilter(cmd)
 		format, _ := cmd.Root().PersistentFlags().GetString("output")
+		if format == FormatGoTemplate && output.GetTemplateString() == "" {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+			return exitcodes.NewUsageError(fmt.Errorf("--template is required when --output go-template is used"))
+		}
 		if err := enforceQueryFormatGuard(cmd, applyQueryFilter(cmd), format); err != nil {
 			return err
 		}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -130,10 +130,10 @@ func WrapRunE(runE func(cmd *cobra.Command, args []string) error) func(cmd *cobr
 	return func(cmd *cobra.Command, args []string) error {
 		applyFieldsFilter(cmd)
 		applyTemplateFilter(cmd)
-		format, _ := cmd.Root().PersistentFlags().GetString("output")
+		rawFormat, _ := cmd.Root().PersistentFlags().GetString("output")
+		format := strings.ToLower(rawFormat)
 		if format == FormatGoTemplate && output.GetTemplateString() == "" {
 			cmd.SilenceUsage = true
-			cmd.SilenceErrors = true
 			return exitcodes.NewUsageError(fmt.Errorf("--template is required when --output go-template is used"))
 		}
 		if err := enforceQueryFormatGuard(cmd, applyQueryFilter(cmd), format); err != nil {
@@ -162,10 +162,10 @@ func WrapColorAwareRunE(fn func(cmd *cobra.Command, args []string, noColor bool)
 	return func(cmd *cobra.Command, args []string) error {
 		applyFieldsFilter(cmd)
 		applyTemplateFilter(cmd)
-		format, _ := cmd.Root().PersistentFlags().GetString("output")
+		rawFormat, _ := cmd.Root().PersistentFlags().GetString("output")
+		format := strings.ToLower(rawFormat)
 		if format == FormatGoTemplate && output.GetTemplateString() == "" {
 			cmd.SilenceUsage = true
-			cmd.SilenceErrors = true
 			return exitcodes.NewUsageError(fmt.Errorf("--template is required when --output go-template is used"))
 		}
 		if err := enforceQueryFormatGuard(cmd, applyQueryFilter(cmd), format); err != nil {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -136,13 +136,14 @@ func WrapRunE(runE func(cmd *cobra.Command, args []string) error) func(cmd *cobr
 		}
 		err := runE(cmd, args)
 		if err != nil {
-			// Prevent usage output if an error occurs
 			cmd.SilenceUsage = true
-			// Silence duplicate error message
 			cmd.SilenceErrors = true
-
-			// Return a formatted error message with additional context
 			code := classifyError(err)
+			if output.GetOutputFormat() == FormatJSON {
+				output.PrintErrorJSON(code, err.Error())
+				cmd.Root().SilenceErrors = true
+				return exitcodes.New(code, err)
+			}
 			wrapped := fmt.Errorf("error running %s command\n\nError: %v\nCommand: %s\nArguments: %v\n\nFor more information, use the --help flag", cmd.Name(), err, cmd.Name(), args)
 			return exitcodes.New(code, wrapped)
 		}
@@ -171,13 +172,14 @@ func WrapColorAwareRunE(fn func(cmd *cobra.Command, args []string, noColor bool)
 
 		// Error handling from WrapRunE
 		if err != nil {
-			// Prevent usage output if an error occurs
 			cmd.SilenceUsage = true
-			// Silence duplicate error message
 			cmd.SilenceErrors = true
-
-			// Return a formatted error message with additional context
 			code := classifyError(err)
+			if output.GetOutputFormat() == FormatJSON {
+				output.PrintErrorJSON(code, err.Error())
+				cmd.Root().SilenceErrors = true
+				return exitcodes.New(code, err)
+			}
 			wrapped := fmt.Errorf("error running %s command\n\nError: %v\nCommand: %s\nArguments: %v\n\nFor more information, use the --help flag",
 				cmd.Name(), err, cmd.Name(), args)
 			return exitcodes.New(code, wrapped)
@@ -237,13 +239,14 @@ func WrapOutputFormatRunE(fn func(cmd *cobra.Command, args []string, noColor boo
 
 		// Error handling from WrapRunE
 		if err != nil {
-			// Prevent usage output if an error occurs
 			cmd.SilenceUsage = true
-			// Silence duplicate error message
 			cmd.SilenceErrors = true
-
-			// Return a formatted error message with additional context
 			code := classifyError(err)
+			if output.GetOutputFormat() == FormatJSON {
+				output.PrintErrorJSON(code, err.Error())
+				cmd.Root().SilenceErrors = true
+				return exitcodes.New(code, err)
+			}
 			wrapped := fmt.Errorf("error running %s command\n\nError: %v\nCommand: %s\nArguments: %v\n\nFor more information, use the --help flag",
 				cmd.Name(), err, cmd.Name(), args)
 			return exitcodes.New(code, wrapped)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -144,7 +144,7 @@ func WrapRunE(runE func(cmd *cobra.Command, args []string) error) func(cmd *cobr
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
 			code := classifyError(err)
-			if output.GetOutputFormat() == FormatJSON {
+			if format == FormatJSON {
 				output.PrintErrorJSON(code, err.Error())
 				cmd.Root().SilenceErrors = true
 				return exitcodes.New(code, err)
@@ -185,7 +185,7 @@ func WrapColorAwareRunE(fn func(cmd *cobra.Command, args []string, noColor bool)
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
 			code := classifyError(err)
-			if output.GetOutputFormat() == FormatJSON {
+			if format == FormatJSON {
 				output.PrintErrorJSON(code, err.Error())
 				cmd.Root().SilenceErrors = true
 				return exitcodes.New(code, err)
@@ -252,7 +252,7 @@ func WrapOutputFormatRunE(fn func(cmd *cobra.Command, args []string, noColor boo
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
 			code := classifyError(err)
-			if output.GetOutputFormat() == FormatJSON {
+			if format == FormatJSON {
 				output.PrintErrorJSON(code, err.Error())
 				cmd.Root().SilenceErrors = true
 				return exitcodes.New(code, err)

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -20,7 +20,7 @@ import (
 // Do not call t.Parallel() in tests that use this helper.
 // The read end is drained concurrently to prevent pipe-buffer deadlocks when
 // fn() writes more data than the OS pipe buffer can hold.
-func captureStderr(t *testing.T, fn func()) string {
+func captureStderr(t *testing.T, fn func()) (result string) {
 	t.Helper()
 	old := os.Stderr
 	r, w, err := os.Pipe()
@@ -36,11 +36,18 @@ func captureStderr(t *testing.T, fn func()) string {
 		_, _ = io.Copy(&buf, r)
 	}()
 
+	// Use defers for cleanup so runtime.Goexit (from t.Fatal/require.*) inside
+	// fn() does not leave the pipe open and the goroutine blocked forever.
+	// result is set after the goroutine drains the pipe, via the named return.
+	defer func() {
+		_ = w.Close() // signal EOF to the goroutine
+		<-done        // wait for all data to be read
+		_ = r.Close()
+		result = buf.String()
+	}()
+
 	fn()
-	_ = w.Close() // signal EOF to the goroutine
-	<-done        // wait for all data to be read
-	_ = r.Close()
-	return buf.String()
+	return
 }
 
 // buildJSONChild builds a minimal cobra root+child command tree with the flags

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,16 +1,50 @@
 package utils
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"testing"
 
 	"github.com/megaport/megaport-cli/internal/base/exitcodes"
+	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// captureStderr captures what the function writes to os.Stderr.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	fn()
+	w.Close()
+	os.Stderr = old
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String()
+}
+
+// buildJSONChild builds a minimal cobra root+child command tree with the flags
+// needed by WrapOutputFormatRunE and WrapColorAwareRunE, with --output pre-set
+// to the given format. Returns only the child command.
+func buildJSONChild(format string) *cobra.Command {
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().Bool("no-color", false, "")
+	root.PersistentFlags().String("fields", "", "")
+	root.PersistentFlags().String("query", "", "")
+	root.PersistentFlags().String("template", "", "")
+	child := &cobra.Command{Use: "list"}
+	child.Flags().String("output", format, "")
+	root.AddCommand(child)
+	return child
+}
 
 func TestShouldDisableColors(t *testing.T) {
 	origArgs := os.Args
@@ -493,4 +527,86 @@ func TestWrapRunE_APIError(t *testing.T) {
 	var cliErr *exitcodes.CLIError
 	require.True(t, errors.As(err, &cliErr))
 	assert.Equal(t, exitcodes.API, cliErr.Code)
+}
+
+// parseErrorJSON unmarshals a JSON error envelope from s.
+func parseErrorJSON(t *testing.T, s string) (code int, errType, message string) {
+	t.Helper()
+	var env struct {
+		Error struct {
+			Code    int    `json:"code"`
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(s), &env), "stderr was not valid JSON: %q", s)
+	return env.Error.Code, env.Error.Type, env.Error.Message
+}
+
+func TestWrapRunE_JSONErrorOutput(t *testing.T) {
+	output.SetOutputFormat("json")
+	defer output.SetOutputFormat("table")
+
+	wrapped := WrapRunE(func(cmd *cobra.Command, args []string) error {
+		return errors.New("inner api error")
+	})
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("fields", "", "")
+	root.PersistentFlags().String("query", "", "")
+	root.PersistentFlags().String("template", "", "")
+	child := &cobra.Command{Use: "list"}
+	root.AddCommand(child)
+
+	stderr := captureStderr(t, func() {
+		err := wrapped(child, []string{})
+		require.Error(t, err)
+		// In JSON mode the error is not verbose-wrapped.
+		assert.Equal(t, "inner api error", err.Error())
+	})
+
+	code, errType, msg := parseErrorJSON(t, stderr)
+	assert.Equal(t, exitcodes.General, code)
+	assert.Equal(t, "general_error", errType)
+	assert.Equal(t, "inner api error", msg)
+}
+
+func TestWrapColorAwareRunE_JSONErrorOutput(t *testing.T) {
+	output.SetOutputFormat("json")
+	defer output.SetOutputFormat("table")
+
+	wrapped := WrapColorAwareRunE(func(cmd *cobra.Command, args []string, noColor bool) error {
+		return errors.New("auth failure")
+	})
+	child := buildJSONChild("json") // output flag not used by this wrapper; format read from global
+
+	stderr := captureStderr(t, func() {
+		err := wrapped(child, []string{})
+		require.Error(t, err)
+		assert.Equal(t, "auth failure", err.Error())
+	})
+
+	code, _, msg := parseErrorJSON(t, stderr)
+	assert.Equal(t, exitcodes.General, code)
+	assert.Equal(t, "auth failure", msg)
+}
+
+func TestWrapOutputFormatRunE_JSONErrorOutput(t *testing.T) {
+	output.SetOutputFormat("json")
+	defer output.SetOutputFormat("table")
+
+	wrapped := WrapOutputFormatRunE(func(cmd *cobra.Command, args []string, noColor bool, format string) error {
+		return errors.New("failed to get port: not found")
+	})
+	child := buildJSONChild("json")
+
+	stderr := captureStderr(t, func() {
+		err := wrapped(child, []string{})
+		require.Error(t, err)
+		assert.Equal(t, "failed to get port: not found", err.Error())
+	})
+
+	code, errType, msg := parseErrorJSON(t, stderr)
+	assert.Equal(t, exitcodes.API, code)
+	assert.Equal(t, "api_error", errType)
+	assert.Equal(t, "failed to get port: not found", msg)
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -18,28 +18,29 @@ import (
 // captureStderr captures what the function writes to os.Stderr.
 // Not parallel-safe: it redirects the global os.Stderr via os.Pipe.
 // Do not call t.Parallel() in tests that use this helper.
-func captureStderr(t *testing.T, fn func()) (captured string) {
+// The read end is drained concurrently to prevent pipe-buffer deadlocks when
+// fn() writes more data than the OS pipe buffer can hold.
+func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
 	old := os.Stderr
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
-	var buf bytes.Buffer
 	os.Stderr = w
-	defer func() {
-		os.Stderr = old
-	}()
-	defer func() {
-		_ = r.Close()
-	}()
-	defer func() {
+	defer func() { os.Stderr = old }()
+
+	// Drain the read end concurrently so fn() cannot block on a full pipe buffer.
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
 		_, _ = io.Copy(&buf, r)
-		captured = buf.String()
 	}()
-	defer func() {
-		_ = w.Close()
-	}()
+
 	fn()
-	return captured
+	_ = w.Close() // signal EOF to the goroutine
+	<-done        // wait for all data to be read
+	_ = r.Close()
+	return buf.String()
 }
 
 // buildJSONChild builds a minimal cobra root+child command tree with the flags

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 // captureStderr captures what the function writes to os.Stderr.
+// Not parallel-safe: it redirects the global os.Stderr via os.Pipe.
+// Do not call t.Parallel() in tests that use this helper.
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
 	old := os.Stderr
@@ -173,6 +175,27 @@ func TestWrapRunE(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, called)
 	})
+
+	t.Run("go-template without --template returns usage error", func(t *testing.T) {
+		wrapped := WrapRunE(func(cmd *cobra.Command, args []string) error {
+			return nil
+		})
+		root := &cobra.Command{Use: "root"}
+		root.PersistentFlags().String("fields", "", "")
+		root.PersistentFlags().String("query", "", "")
+		root.PersistentFlags().String("template", "", "")
+		root.PersistentFlags().String("output", "go-template", "")
+		child := &cobra.Command{Use: "list"}
+		root.AddCommand(child)
+
+		err := wrapped(child, []string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--template is required")
+
+		var cliErr *exitcodes.CLIError
+		require.True(t, errors.As(err, &cliErr))
+		assert.Equal(t, exitcodes.Usage, cliErr.Code)
+	})
 }
 
 func TestWrapColorAwareRunE(t *testing.T) {
@@ -265,6 +288,28 @@ func TestWrapColorAwareRunE(t *testing.T) {
 		err := wrapped(child, []string{})
 		assert.NoError(t, err)
 		assert.True(t, called)
+	})
+
+	t.Run("go-template without --template returns usage error", func(t *testing.T) {
+		wrapped := WrapColorAwareRunE(func(cmd *cobra.Command, args []string, noColor bool) error {
+			return nil
+		})
+		root := &cobra.Command{Use: "root"}
+		root.PersistentFlags().Bool("no-color", false, "")
+		root.PersistentFlags().String("fields", "", "")
+		root.PersistentFlags().String("query", "", "")
+		root.PersistentFlags().String("template", "", "")
+		root.PersistentFlags().String("output", "go-template", "")
+		child := &cobra.Command{Use: "list"}
+		root.AddCommand(child)
+
+		err := wrapped(child, []string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--template is required")
+
+		var cliErr *exitcodes.CLIError
+		require.True(t, errors.As(err, &cliErr))
+		assert.Equal(t, exitcodes.Usage, cliErr.Code)
 	})
 }
 

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/megaport/megaport-cli/internal/base/exitcodes"
-	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,18 +18,28 @@ import (
 // captureStderr captures what the function writes to os.Stderr.
 // Not parallel-safe: it redirects the global os.Stderr via os.Pipe.
 // Do not call t.Parallel() in tests that use this helper.
-func captureStderr(t *testing.T, fn func()) string {
+func captureStderr(t *testing.T, fn func()) (captured string) {
 	t.Helper()
 	old := os.Stderr
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
-	os.Stderr = w
-	fn()
-	w.Close()
-	os.Stderr = old
 	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
-	return buf.String()
+	os.Stderr = w
+	defer func() {
+		os.Stderr = old
+	}()
+	defer func() {
+		_ = r.Close()
+	}()
+	defer func() {
+		_, _ = io.Copy(&buf, r)
+		captured = buf.String()
+	}()
+	defer func() {
+		_ = w.Close()
+	}()
+	fn()
+	return captured
 }
 
 // buildJSONChild builds a minimal cobra root+child command tree with the flags
@@ -589,9 +598,6 @@ func parseErrorJSON(t *testing.T, s string) (code int, errType, message string) 
 }
 
 func TestWrapRunE_JSONErrorOutput(t *testing.T) {
-	output.SetOutputFormat("json")
-	defer output.SetOutputFormat("table")
-
 	wrapped := WrapRunE(func(cmd *cobra.Command, args []string) error {
 		return errors.New("inner api error")
 	})
@@ -599,6 +605,7 @@ func TestWrapRunE_JSONErrorOutput(t *testing.T) {
 	root.PersistentFlags().String("fields", "", "")
 	root.PersistentFlags().String("query", "", "")
 	root.PersistentFlags().String("template", "", "")
+	root.PersistentFlags().String("output", "json", "")
 	child := &cobra.Command{Use: "list"}
 	root.AddCommand(child)
 
@@ -616,13 +623,18 @@ func TestWrapRunE_JSONErrorOutput(t *testing.T) {
 }
 
 func TestWrapColorAwareRunE_JSONErrorOutput(t *testing.T) {
-	output.SetOutputFormat("json")
-	defer output.SetOutputFormat("table")
-
 	wrapped := WrapColorAwareRunE(func(cmd *cobra.Command, args []string, noColor bool) error {
 		return errors.New("auth failure")
 	})
-	child := buildJSONChild("json") // output flag not used by this wrapper; format read from global
+	// WrapColorAwareRunE reads --output from root persistent flags.
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().Bool("no-color", false, "")
+	root.PersistentFlags().String("fields", "", "")
+	root.PersistentFlags().String("query", "", "")
+	root.PersistentFlags().String("template", "", "")
+	root.PersistentFlags().String("output", "json", "")
+	child := &cobra.Command{Use: "list"}
+	root.AddCommand(child)
 
 	stderr := captureStderr(t, func() {
 		err := wrapped(child, []string{})
@@ -636,9 +648,6 @@ func TestWrapColorAwareRunE_JSONErrorOutput(t *testing.T) {
 }
 
 func TestWrapOutputFormatRunE_JSONErrorOutput(t *testing.T) {
-	output.SetOutputFormat("json")
-	defer output.SetOutputFormat("table")
-
 	wrapped := WrapOutputFormatRunE(func(cmd *cobra.Command, args []string, noColor bool, format string) error {
 		return errors.New("failed to get port: not found")
 	})


### PR DESCRIPTION
CI/CD pipelines and automation scripts need to parse CLI errors programmatically. When `--output json` is active and a command fails, the CLI previously printed verbose plain-text to stderr and let cobra echo it again — making reliable error parsing impossible.

This change makes all three RunE wrappers intercept errors in JSON mode, emit a single structured JSON object to stderr, and silence cobra's plain-text printing. The exit code is preserved via `CLIError` so `os.Exit` still receives the correct value.

## JSON error shape

```json
{
  "error": {
    "code": 4,
    "type": "api_error",
    "message": "failed to get port: resource not found"
  }
}
```

Exit code → type mapping: `1` general_error, `2` usage_error, `3` auth_error, `4` api_error, `5` cancelled.

## Changes

- `internal/base/exitcodes/exitcodes.go` — `TypeName(code int) string` maps exit codes to string identifiers
- `internal/base/output/common.go` — shared `errorBody`/`errorEnvelope` types defined once for both build targets
- `internal/base/output/messages.go` — export `GetOutputFormat()` so utils can check format without a new import cycle
- `internal/base/output/messages_native.go` — `PrintErrorJSON` writes indented JSON to stderr
- `internal/base/output/messages_wasm.go` — `PrintErrorJSON` writes compact JSON to `WasmOutputBuffer`
- `internal/utils/utils.go` — JSON error branch + `go-template` guard in all three wrappers

## Test plan

- `go test -v ./...` — all packages pass
- `GOOS=js GOARCH=wasm go build -tags js,wasm -o /dev/null .` — WASM build clean
- `golangci-lint run` — zero issues
- New tests: `TestTypeName`, `TestGetOutputFormat`, `TestPrintErrorJSON_{General,API,Usage}Error`, `TestWrap{RunE,ColorAwareRunE,OutputFormatRunE}_JSONErrorOutput`, go-template guard tests for all three wrappers