### PR TITLE
feat: add pager integration and did-you-mean suggestions

### DIFF
--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -16,6 +16,7 @@ import (
 var (
 	noColor      bool
 	noHeader     bool
+	noPager      bool
 	outputFormat string
 	quiet        bool
 	verbose      bool
@@ -86,6 +87,7 @@ func InitializeCommon() {
 	rootCmd.PersistentFlags().BoolVar(&utils.NoRetry, "no-retry", false, "Disable automatic retry on transient API failures")
 	rootCmd.PersistentFlags().IntVar(&utils.MaxRetries, "max-retries", 3, "Maximum number of retries for transient API failures")
 	rootCmd.PersistentFlags().BoolVar(&noHeader, "no-header", false, "Suppress table and CSV column headers (useful for scripting)")
+	rootCmd.PersistentFlags().BoolVar(&noPager, "no-pager", false, "Disable pager for long table output (no-op in browser version)")
 	rootCmd.MarkFlagsMutuallyExclusive("quiet", "verbose")
 	rootCmd.SuggestionsMinimumDistance = 2
 
@@ -93,6 +95,7 @@ func InitializeCommon() {
 	existingPreRunE := rootCmd.PersistentPreRunE
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		output.SetNoHeader(noHeader)
+		output.SetNoPager(noPager) // no-op in WASM; keeps flag wiring symmetric with native
 		if utils.MaxRetries < 0 {
 			return fmt.Errorf("--max-retries must be >= 0, got %d", utils.MaxRetries)
 		}

--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -87,6 +87,7 @@ func InitializeCommon() {
 	rootCmd.PersistentFlags().IntVar(&utils.MaxRetries, "max-retries", 3, "Maximum number of retries for transient API failures")
 	rootCmd.PersistentFlags().BoolVar(&noHeader, "no-header", false, "Suppress table and CSV column headers (useful for scripting)")
 	rootCmd.MarkFlagsMutuallyExclusive("quiet", "verbose")
+	rootCmd.SuggestionsMinimumDistance = 2
 
 	// Validate retry flags in WASM builds too.
 	existingPreRunE := rootCmd.PersistentPreRunE

--- a/cmd/megaport/megaport.go
+++ b/cmd/megaport/megaport.go
@@ -79,7 +79,7 @@ func init() {
 				"--no-color":    "Disable colored output",
 				"--no-header":   "Suppress table and CSV column headers (useful for scripting)",
 				"--no-pager":    "Disable pager for long table output",
-				"--output":      "Output format (json, yaml, table, csv, xml)",
+				"--output":      "Output format (table, json, csv, xml, go-template)",
 				"--help":        "Show help for any command",
 				"--env":         "Environment to use (production, staging, development)",
 				"--quiet":       "Suppress informational output, only show errors and data",

--- a/cmd/megaport/megaport.go
+++ b/cmd/megaport/megaport.go
@@ -80,6 +80,7 @@ func init() {
 				"--no-header":   "Suppress table and CSV column headers (useful for scripting)",
 				"--no-pager":    "Disable pager for long table output",
 				"--output":      "Output format (table, json, csv, xml, go-template)",
+				"--template":    "Go template string for --output go-template",
 				"--help":        "Show help for any command",
 				"--env":         "Environment to use (production, staging, development)",
 				"--quiet":       "Suppress informational output, only show errors and data",

--- a/cmd/megaport/megaport.go
+++ b/cmd/megaport/megaport.go
@@ -34,6 +34,7 @@ func init() {
 			_ = cmd.Flags().Set("no-color", "true")
 		}
 		output.SetNoHeader(noHeader)
+		output.SetNoPager(noPager)
 
 		format := strings.ToLower(outputFormat)
 		validFmt := false
@@ -77,6 +78,7 @@ func init() {
 			OptionalFlags: map[string]string{
 				"--no-color":    "Disable colored output",
 				"--no-header":   "Suppress table and CSV column headers (useful for scripting)",
+				"--no-pager":    "Disable pager for long table output",
 				"--output":      "Output format (json, yaml, table, csv, xml)",
 				"--help":        "Show help for any command",
 				"--env":         "Environment to use (production, staging, development)",
@@ -212,6 +214,20 @@ func applyDefaultSettings(cmd *cobra.Command) {
 					return
 				}
 				verbose = boolVal
+			}
+		}
+	}
+
+	// Apply "no-pager" default
+	if !cmd.Flags().Changed("no-pager") {
+		if val, exists := manager.GetDefault("no-pager"); exists {
+			if boolVal, ok := val.(bool); ok {
+				err := cmd.Flags().Set("no-pager", fmt.Sprintf("%t", boolVal))
+				if err != nil {
+					log.Printf("Error setting no-pager flag: %v\n", err)
+					return
+				}
+				noPager = boolVal
 			}
 		}
 	}

--- a/cmd/megaport/megaport_common.go
+++ b/cmd/megaport/megaport_common.go
@@ -34,6 +34,7 @@ import (
 var (
 	noColor      bool
 	noHeader     bool
+	noPager      bool
 	outputFormat string
 	quiet        bool
 	verbose      bool
@@ -100,5 +101,7 @@ func InitializeCommon() {
 	rootCmd.PersistentFlags().IntVar(&utils.MaxRetries, "max-retries", 3, "Maximum number of retries for transient API failures")
 	rootCmd.PersistentFlags().BoolVar(&utils.LogHTTP, "log-http", false, "Log raw HTTP requests/responses to stderr for debugging (may include sensitive data such as auth tokens)")
 	rootCmd.PersistentFlags().BoolVar(&noHeader, "no-header", false, "Suppress table and CSV column headers (useful for scripting)")
+	rootCmd.PersistentFlags().BoolVar(&noPager, "no-pager", false, "Disable pager for long table output")
 	rootCmd.MarkFlagsMutuallyExclusive("quiet", "verbose")
+	rootCmd.SuggestionsMinimumDistance = 2
 }

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -48,8 +48,9 @@ func TestNoHeaderFlagWiredThroughPersistentPreRunE(t *testing.T) {
 }
 
 // TestNoPagerDefaultApplied verifies that a "no-pager" default persisted in
-// the config file is picked up by applyDefaultSettings and wired into the
-// output package via PersistentPreRunE.
+// the config file is read by applyDefaultSettings AND forwarded to the output
+// package via output.SetNoPager in PersistentPreRunE. Both sides of the
+// wiring are asserted so that removing either call causes the test to fail.
 func TestNoPagerDefaultApplied(t *testing.T) {
 	// Use an isolated config directory so this test doesn't touch the real one.
 	dir := t.TempDir()
@@ -74,8 +75,10 @@ func TestNoPagerDefaultApplied(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	// The default should have been applied.
+	// Assert the flag var was set (applyDefaultSettings path).
 	assert.True(t, noPager, "noPager package var should be true after config default is applied")
+	// Assert the output package was notified (output.SetNoPager wiring path).
+	assert.True(t, output.GetNoPager(), "output.GetNoPager() should be true after PersistentPreRunE wires SetNoPager")
 }
 
 func TestExitCodeFromError(t *testing.T) {

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -70,7 +70,8 @@ func TestNoPagerDefaultApplied(t *testing.T) {
 	// Fire a lightweight command through the real rootCmd so PersistentPreRunE runs.
 	rootCmd.SetArgs([]string{"version"})
 	_ = output.CaptureOutput(func() {
-		_ = rootCmd.Execute()
+		err := rootCmd.Execute()
+		require.NoError(t, err)
 	})
 
 	// The default should have been applied.

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/commands/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,6 +45,36 @@ func TestNoHeaderFlagWiredThroughPersistentPreRunE(t *testing.T) {
 	})
 	assert.False(t, strings.Contains(captured, "NAME"), "header row should be suppressed after --no-header")
 	assert.True(t, strings.Contains(captured, "row1"), "data rows should still appear")
+}
+
+// TestNoPagerDefaultApplied verifies that a "no-pager" default persisted in
+// the config file is picked up by applyDefaultSettings and wired into the
+// output package via PersistentPreRunE.
+func TestNoPagerDefaultApplied(t *testing.T) {
+	// Use an isolated config directory so this test doesn't touch the real one.
+	dir := t.TempDir()
+	t.Setenv("MEGAPORT_CONFIG_DIR", dir)
+
+	// Write no-pager = true as a config default.
+	mgr, err := config.NewConfigManager()
+	require.NoError(t, err)
+	require.NoError(t, mgr.SetDefault("no-pager", true))
+
+	// Restore package-level state and cobra flag after the test.
+	defer func() {
+		output.ResetState()
+		noPager = false
+		_ = rootCmd.PersistentFlags().Set("no-pager", "false")
+	}()
+
+	// Fire a lightweight command through the real rootCmd so PersistentPreRunE runs.
+	rootCmd.SetArgs([]string{"version"})
+	_ = output.CaptureOutput(func() {
+		_ = rootCmd.Execute()
+	})
+
+	// The default should have been applied.
+	assert.True(t, noPager, "noPager package var should be true after config default is applied")
 }
 
 func TestExitCodeFromError(t *testing.T) {

--- a/cmd/megaport/megaport_wasm.go
+++ b/cmd/megaport/megaport_wasm.go
@@ -172,8 +172,5 @@ func init() {
 	rootCmd.SilenceErrors = false
 	rootCmd.SilenceUsage = false
 
-	// Add suggestions for similar commands
-	rootCmd.SuggestionsMinimumDistance = 1
-
 	moduleRegistry.RegisterAll(rootCmd)
 }

--- a/cmd/megaport/megaport_wasm.go
+++ b/cmd/megaport/megaport_wasm.go
@@ -128,7 +128,9 @@ func init() {
 			OptionalFlags: map[string]string{
 				"--no-color":  "Disable colored output",
 				"--no-header": "Suppress table and CSV column headers (useful for scripting)",
-				"--output":    "Output format (json, yaml, table, csv, xml)",
+				"--no-pager":  "Disable pager for long table output (no-op in browser version)",
+				"--output":    "Output format (table, json, csv, xml, go-template)",
+				"--template":  "Go template string for --output go-template",
 				"--help":      "Show help for any command",
 				"--env":       "Environment to use (production, staging, development)",
 			},

--- a/cmd/megaport/megaport_wasm.go
+++ b/cmd/megaport/megaport_wasm.go
@@ -90,7 +90,11 @@ func ExecuteWithArgs(args []string) {
 func resolveOutputFormat(cmd *cobra.Command) string {
 	var raw string
 	if cmd != nil {
-		if f := cmd.Flags().Lookup("output"); f != nil {
+		// Only use the local --output flag if the user explicitly set it.
+		// WrapOutputFormatRunE commands always register a local --output flag
+		// whose default is "table"; reading it unconditionally would mask the
+		// user's intent expressed via the root persistent flag.
+		if f := cmd.Flags().Lookup("output"); f != nil && f.Changed {
 			raw = f.Value.String()
 		}
 	}

--- a/internal/base/output/common.go
+++ b/internal/base/output/common.go
@@ -132,6 +132,7 @@ func ResetState() {
 	SetOutputFields(nil)
 	SetOutputQuery("")
 	SetNoHeader(false)
+	SetNoPager(false)
 	SetTemplateString("")
 	SetOutputFormat("table")
 	SetVerbosity("normal")
@@ -252,7 +253,9 @@ func PrintOutput[T OutputFields](data []T, format string, noColor bool) error {
 	case "go-template":
 		return printGoTemplate(data)
 	default:
-		return printTable(data, noColor)
+		return RunWithPager(func() error {
+			return printTable(data, noColor)
+		})
 	}
 }
 

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -1,0 +1,144 @@
+//go:build !wasm
+// +build !wasm
+
+package output
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"golang.org/x/term"
+)
+
+var (
+	noPagerMu  sync.RWMutex
+	noPagerVal bool
+)
+
+// SetNoPager disables or enables the pager. When true, output is always written
+// directly to stdout even if it exceeds the terminal height.
+func SetNoPager(v bool) {
+	noPagerMu.Lock()
+	defer noPagerMu.Unlock()
+	noPagerVal = v
+}
+
+func getNoPager() bool {
+	noPagerMu.RLock()
+	defer noPagerMu.RUnlock()
+	return noPagerVal
+}
+
+// resolvePager returns the pager command to use.
+// Precedence: MEGAPORT_PAGER > PAGER > "less -R".
+func resolvePager() string {
+	if v := os.Getenv("MEGAPORT_PAGER"); v != "" {
+		return v
+	}
+	if v := os.Getenv("PAGER"); v != "" {
+		return v
+	}
+	return "less -R"
+}
+
+// terminalHeightOverride, when > 0, replaces automatic terminal height
+// detection. Set via SetTerminalHeightForTesting; reset by passing 0.
+var terminalHeightOverride int
+
+// SetTerminalHeightForTesting overrides terminal height detection for tests.
+// Pass 0 to restore automatic detection.
+func SetTerminalHeightForTesting(h int) {
+	terminalHeightOverride = h
+}
+
+// pagerMu serialises RunWithPager calls. A separate mutex from stdoutMu is
+// used intentionally so that CaptureOutput (which holds stdoutMu) can safely
+// call code that goes through RunWithPager without deadlocking.
+var pagerMu sync.Mutex
+
+// RunWithPager runs fn, capturing its stdout output. If stdout is a TTY, the
+// pager is not disabled, and the captured line count exceeds the terminal
+// height, the output is piped through the configured pager. Otherwise the
+// output is written directly to stdout.
+func RunWithPager(fn func() error) error {
+	if !IsTerminal() || getNoPager() {
+		return fn()
+	}
+
+	pagerMu.Lock()
+	defer pagerMu.Unlock()
+
+	origStdout := os.Stdout
+
+	// Use a temp file to buffer output. An os.Pipe would deadlock once the
+	// pipe buffer fills up for large tables, while a temp file does not.
+	tmp, err := os.CreateTemp("", "pager-*")
+	if err != nil {
+		// Cannot create temp file; render directly.
+		return fn()
+	}
+	defer os.Remove(tmp.Name())
+	defer tmp.Close()
+
+	os.Stdout = tmp
+	fnErr := fn()
+	os.Stdout = origStdout
+
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		return fnErr
+	}
+	content, err := io.ReadAll(tmp)
+	if err != nil || len(content) == 0 {
+		return fnErr
+	}
+
+	// Determine terminal height.
+	height := terminalHeightOverride
+	if height <= 0 {
+		_, h, sizeErr := term.GetSize(int(origStdout.Fd()))
+		if sizeErr != nil || h <= 0 {
+			// Cannot determine terminal size; write directly.
+			_, _ = origStdout.Write(content)
+			return fnErr
+		}
+		height = h
+	}
+
+	if bytes.Count(content, []byte("\n")) <= height {
+		_, _ = origStdout.Write(content)
+		return fnErr
+	}
+
+	// Output exceeds terminal height: pipe through pager.
+	if err := runPager(resolvePager(), content, origStdout); err != nil {
+		// Pager failed; fall back to direct write so output is not lost.
+		_, _ = origStdout.Write(content)
+	}
+	return fnErr
+}
+
+// runPager spawns pagerCmd, pipes content to its stdin, and waits for it to exit.
+func runPager(pagerCmd string, content []byte, stdout *os.File) error {
+	parts := strings.Fields(pagerCmd)
+	if len(parts) == 0 {
+		return fmt.Errorf("empty pager command")
+	}
+	cmd := exec.Command(parts[0], parts[1:]...) //nolint:gosec // pager command comes from trusted env var / default
+	cmd.Stdout = stdout
+	cmd.Stderr = os.Stderr
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	_, _ = stdin.Write(content)
+	_ = stdin.Close()
+	return cmd.Wait()
+}

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -4,7 +4,6 @@
 package output
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -73,6 +72,9 @@ var pagerMu sync.Mutex
 // height, the output is piped through the configured pager. Otherwise the
 // output is written directly to stdout.
 //
+// Terminal dimensions are read before os.Stdout is redirected so that table
+// rendering (which calls getTerminalWidth via printTable) uses the real TTY
+// width for column layout even while output is being buffered to a temp file.
 // The temp file is streamed rather than loaded into memory, so paging large
 // tables does not require holding the full output in RAM.
 func RunWithPager(fn func() error) error {
@@ -84,6 +86,24 @@ func RunWithPager(fn func() error) error {
 	defer pagerMu.Unlock()
 
 	origStdout := os.Stdout
+
+	// Capture real terminal dimensions before swapping os.Stdout so that both
+	// column-width layout and the height gate use the actual TTY geometry.
+	height := int(terminalHeightOverride.Load())
+	if height <= 0 {
+		w, h, sizeErr := term.GetSize(int(origStdout.Fd()))
+		if sizeErr == nil {
+			if h > 0 {
+				height = h
+			}
+			if w > 0 {
+				// Override width so printTable uses the real TTY width while
+				// os.Stdout is redirected to the temp file.
+				terminalWidthOverride.Store(int64(w))
+				defer terminalWidthOverride.Store(0)
+			}
+		}
+	}
 
 	// Use a temp file to buffer output. An os.Pipe would deadlock once the
 	// pipe buffer fills up for large tables, while a temp file does not.
@@ -106,9 +126,16 @@ func RunWithPager(fn func() error) error {
 	fnErr := fn()
 
 	// Count lines by scanning the file incrementally — avoids loading the
-	// entire output into memory.
+	// entire output into memory and has no token-size limit.
 	lineCount, err := countLines(tmp)
-	if err != nil || lineCount == 0 {
+	if err != nil {
+		// If counting fails, fall back to direct write so output is not lost.
+		if _, seekErr := tmp.Seek(0, io.SeekStart); seekErr == nil {
+			_, _ = io.Copy(origStdout, tmp)
+		}
+		return fnErr
+	}
+	if lineCount == 0 {
 		return fnErr
 	}
 
@@ -117,16 +144,10 @@ func RunWithPager(fn func() error) error {
 		return fnErr
 	}
 
-	// Determine terminal height.
-	height := int(terminalHeightOverride.Load())
 	if height <= 0 {
-		_, h, sizeErr := term.GetSize(int(origStdout.Fd()))
-		if sizeErr != nil || h <= 0 {
-			// Cannot determine terminal size; write directly.
-			_, _ = io.Copy(origStdout, tmp)
-			return fnErr
-		}
-		height = h
+		// Terminal height unknown; write directly.
+		_, _ = io.Copy(origStdout, tmp)
+		return fnErr
 	}
 
 	if lineCount <= height {
@@ -144,19 +165,30 @@ func RunWithPager(fn func() error) error {
 	return fnErr
 }
 
-// countLines counts the number of newline-terminated lines in r by scanning
-// incrementally, then seeks r back to the start. Returns 0 and an error if
-// either the scan or the seek fails.
+// countLines counts the number of newline characters in r by reading in
+// chunks, then seeks r back to the start. Unlike bufio.Scanner, this approach
+// has no token-size limit and handles arbitrarily wide table rows.
 func countLines(r io.ReadSeeker) (int, error) {
 	if _, err := r.Seek(0, io.SeekStart); err != nil {
 		return 0, err
 	}
 	count := 0
-	scanner := bufio.NewScanner(r)
-	for scanner.Scan() {
-		count++
+	buf := make([]byte, 32*1024)
+	for {
+		n, readErr := r.Read(buf)
+		for _, b := range buf[:n] {
+			if b == '\n' {
+				count++
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return count, readErr
+		}
 	}
-	return count, scanner.Err()
+	return count, nil
 }
 
 // runPager spawns pagerCmd, streams content to its stdin, and waits for it to exit.

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -4,7 +4,7 @@
 package output
 
 import (
-	"bytes"
+	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -72,6 +72,9 @@ var pagerMu sync.Mutex
 // pager is not disabled, and the captured line count exceeds the terminal
 // height, the output is piped through the configured pager. Otherwise the
 // output is written directly to stdout.
+//
+// The temp file is streamed rather than loaded into memory, so paging large
+// tables does not require holding the full output in RAM.
 func RunWithPager(fn func() error) error {
 	if !IsTerminal() || getNoPager() {
 		return fn()
@@ -102,11 +105,15 @@ func RunWithPager(fn func() error) error {
 
 	fnErr := fn()
 
-	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+	// Count lines by scanning the file incrementally — avoids loading the
+	// entire output into memory.
+	lineCount, err := countLines(tmp)
+	if err != nil || lineCount == 0 {
 		return fnErr
 	}
-	content, err := io.ReadAll(tmp)
-	if err != nil || len(content) == 0 {
+
+	// Seek to start for the subsequent copy.
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
 		return fnErr
 	}
 
@@ -116,27 +123,44 @@ func RunWithPager(fn func() error) error {
 		_, h, sizeErr := term.GetSize(int(origStdout.Fd()))
 		if sizeErr != nil || h <= 0 {
 			// Cannot determine terminal size; write directly.
-			_, _ = origStdout.Write(content)
+			_, _ = io.Copy(origStdout, tmp)
 			return fnErr
 		}
 		height = h
 	}
 
-	if bytes.Count(content, []byte("\n")) <= height {
-		_, _ = origStdout.Write(content)
+	if lineCount <= height {
+		_, _ = io.Copy(origStdout, tmp)
 		return fnErr
 	}
 
 	// Output exceeds terminal height: pipe through pager.
-	if err := runPager(resolvePager(), content, origStdout); err != nil {
-		// Pager failed; fall back to direct write so output is not lost.
-		_, _ = origStdout.Write(content)
+	if err := runPager(resolvePager(), tmp, origStdout); err != nil {
+		// Pager failed; seek back and fall back to direct write so output is not lost.
+		if _, seekErr := tmp.Seek(0, io.SeekStart); seekErr == nil {
+			_, _ = io.Copy(origStdout, tmp)
+		}
 	}
 	return fnErr
 }
 
-// runPager spawns pagerCmd, pipes content to its stdin, and waits for it to exit.
-func runPager(pagerCmd string, content []byte, stdout *os.File) error {
+// countLines counts the number of newline-terminated lines in r by scanning
+// incrementally, then seeks r back to the start. Returns 0 and an error if
+// either the scan or the seek fails.
+func countLines(r io.ReadSeeker) (int, error) {
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return 0, err
+	}
+	count := 0
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		count++
+	}
+	return count, scanner.Err()
+}
+
+// runPager spawns pagerCmd, streams content to its stdin, and waits for it to exit.
+func runPager(pagerCmd string, content io.Reader, stdout *os.File) error {
 	parts := strings.Fields(pagerCmd)
 	if len(parts) == 0 {
 		return fmt.Errorf("empty pager command")
@@ -153,7 +177,7 @@ func runPager(pagerCmd string, content []byte, stdout *os.File) error {
 	if err := cmd.Start(); err != nil {
 		return err
 	}
-	_, _ = stdin.Write(content)
+	_, _ = io.Copy(stdin, content)
 	_ = stdin.Close()
 	return cmd.Wait()
 }

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -34,6 +34,12 @@ func getNoPager() bool {
 	return noPagerVal
 }
 
+// GetNoPager returns the current no-pager setting. Intended for tests that
+// need to assert the output package was correctly wired by PersistentPreRunE.
+func GetNoPager() bool {
+	return getNoPager()
+}
+
 // resolvePager returns the pager command to use.
 // Precedence: MEGAPORT_PAGER > PAGER > "less -R".
 //

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"golang.org/x/term"
 )
@@ -36,6 +37,11 @@ func getNoPager() bool {
 
 // resolvePager returns the pager command to use.
 // Precedence: MEGAPORT_PAGER > PAGER > "less -R".
+//
+// The pager value is fully controlled by the process environment, which is
+// trusted to the same degree as the user running the process — consistent with
+// how git(1) and gh(1) handle $GIT_PAGER / $PAGER. In automated or shared
+// environments, pass --no-pager or set MEGAPORT_PAGER="" to disable paging.
 func resolvePager() string {
 	if v := os.Getenv("MEGAPORT_PAGER"); v != "" {
 		return v
@@ -47,13 +53,14 @@ func resolvePager() string {
 }
 
 // terminalHeightOverride, when > 0, replaces automatic terminal height
-// detection. Set via SetTerminalHeightForTesting; reset by passing 0.
-var terminalHeightOverride int
+// detection. Protected by atomic load/store so parallel tests do not race.
+var terminalHeightOverride atomic.Int64
 
-// SetTerminalHeightForTesting overrides terminal height detection for tests.
-// Pass 0 to restore automatic detection.
-func SetTerminalHeightForTesting(h int) {
-	terminalHeightOverride = h
+// setTerminalHeightForTesting overrides terminal height detection for tests.
+// Pass 0 to restore automatic detection. Unexported to keep test scaffolding
+// out of the public API while still being accessible within the package.
+func setTerminalHeightForTesting(h int) {
+	terminalHeightOverride.Store(int64(h))
 }
 
 // pagerMu serialises RunWithPager calls. A separate mutex from stdoutMu is
@@ -82,8 +89,8 @@ func RunWithPager(fn func() error) error {
 		// Cannot create temp file; render directly.
 		return fn()
 	}
-	defer os.Remove(tmp.Name())
-	defer tmp.Close()
+	// Close before Remove so the file handle is released first (required on Windows).
+	defer func() { _ = tmp.Close(); _ = os.Remove(tmp.Name()) }()
 
 	os.Stdout = tmp
 	fnErr := fn()
@@ -98,7 +105,7 @@ func RunWithPager(fn func() error) error {
 	}
 
 	// Determine terminal height.
-	height := terminalHeightOverride
+	height := int(terminalHeightOverride.Load())
 	if height <= 0 {
 		_, h, sizeErr := term.GetSize(int(origStdout.Fd()))
 		if sizeErr != nil || h <= 0 {
@@ -128,7 +135,9 @@ func runPager(pagerCmd string, content []byte, stdout *os.File) error {
 	if len(parts) == 0 {
 		return fmt.Errorf("empty pager command")
 	}
-	cmd := exec.Command(parts[0], parts[1:]...) //nolint:gosec // pager command comes from trusted env var / default
+	//nolint:gosec // pager command is user-controlled via MEGAPORT_PAGER/PAGER env vars,
+	// which are trusted to the same degree as the calling user (see resolvePager).
+	cmd := exec.Command(parts[0], parts[1:]...)
 	cmd.Stdout = stdout
 	cmd.Stderr = os.Stderr
 	stdin, err := cmd.StdinPipe()

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -41,7 +41,7 @@ func getNoPager() bool {
 // The pager value is fully controlled by the process environment, which is
 // trusted to the same degree as the user running the process — consistent with
 // how git(1) and gh(1) handle $GIT_PAGER / $PAGER. In automated or shared
-// environments, pass --no-pager or set MEGAPORT_PAGER="" to disable paging.
+// environments, pass --no-pager to disable paging.
 func resolvePager() string {
 	if v := os.Getenv("MEGAPORT_PAGER"); v != "" {
 		return v
@@ -93,8 +93,14 @@ func RunWithPager(fn func() error) error {
 	defer func() { _ = tmp.Close(); _ = os.Remove(tmp.Name()) }()
 
 	os.Stdout = tmp
+	defer func() {
+		os.Stdout = origStdout
+		if r := recover(); r != nil {
+			panic(r)
+		}
+	}()
+
 	fnErr := fn()
-	os.Stdout = origStdout
 
 	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
 		return fnErr

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -136,7 +136,21 @@ func RunWithPager(fn func() error) error {
 		return fnErr
 	}
 	if lineCount == 0 {
-		return fnErr
+		// fn() may have written content without a trailing newline (countLines
+		// counts '\n' only). Check the file size: if non-zero, treat the
+		// partial last line as a single line rather than dropping it.
+		info, statErr := tmp.Stat()
+		if statErr != nil {
+			// Cannot determine size; fall back to direct write.
+			if _, seekErr := tmp.Seek(0, io.SeekStart); seekErr == nil {
+				_, _ = io.Copy(origStdout, tmp)
+			}
+			return fnErr
+		}
+		if info.Size() == 0 {
+			return fnErr
+		}
+		lineCount = 1
 	}
 
 	// Seek to start for the subsequent copy.

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -126,8 +126,9 @@ func RunWithPager(fn func() error) error {
 	fnErr := fn()
 
 	// Count lines by scanning the file incrementally — avoids loading the
-	// entire output into memory and has no token-size limit.
-	lineCount, err := countLines(tmp)
+	// entire output into memory and stops early once output exceeds height.
+	// countLines rewinds tmp to offset 0 on success.
+	lineCount, err := countLines(tmp, height)
 	if err != nil {
 		// If counting fails, fall back to direct write so output is not lost.
 		if _, seekErr := tmp.Seek(0, io.SeekStart); seekErr == nil {
@@ -136,25 +137,9 @@ func RunWithPager(fn func() error) error {
 		return fnErr
 	}
 	if lineCount == 0 {
-		// fn() may have written content without a trailing newline (countLines
-		// counts '\n' only). Check the file size: if non-zero, treat the
-		// partial last line as a single line rather than dropping it.
-		info, statErr := tmp.Stat()
-		if statErr != nil {
-			// Cannot determine size; fall back to direct write.
-			// countLines already rewound on success but failed here, so seek manually.
-			if _, seekErr := tmp.Seek(0, io.SeekStart); seekErr == nil {
-				_, _ = io.Copy(origStdout, tmp)
-			}
-			return fnErr
-		}
-		if info.Size() == 0 {
-			return fnErr
-		}
-		lineCount = 1
+		return fnErr // truly empty file
 	}
 
-	// countLines rewinds r to offset 0 on success, so tmp is ready to copy.
 	if height <= 0 {
 		// Terminal height unknown; write directly.
 		_, _ = io.Copy(origStdout, tmp)
@@ -176,22 +161,34 @@ func RunWithPager(fn func() error) error {
 	return fnErr
 }
 
-// countLines counts the number of newline characters in r by reading in
-// chunks. It seeks r to the start before counting and back to the start
-// before returning, so callers always receive r positioned at offset 0.
-// Unlike bufio.Scanner this approach has no token-size limit and handles
-// arbitrarily wide table rows.
-func countLines(r io.ReadSeeker) (int, error) {
+// countLines counts the number of lines in r. A line ends at '\n'; a
+// non-empty file that does not end with '\n' contributes one additional
+// partial line. If limit > 0, counting stops as soon as the count exceeds
+// limit — useful for the "does output exceed terminal height?" check without
+// scanning the whole file. It seeks r to the start before counting and back
+// to the start before returning, so callers always receive r at offset 0.
+func countLines(r io.ReadSeeker, limit int) (int, error) {
 	if _, err := r.Seek(0, io.SeekStart); err != nil {
 		return 0, err
 	}
 	count := 0
+	var lastByte byte
+	hasContent := false
 	buf := make([]byte, 32*1024)
 	for {
 		n, readErr := r.Read(buf)
 		for _, b := range buf[:n] {
+			hasContent = true
+			lastByte = b
 			if b == '\n' {
 				count++
+				if limit > 0 && count > limit {
+					// Already know output exceeds the threshold; no need to read more.
+					if _, seekErr := r.Seek(0, io.SeekStart); seekErr != nil {
+						return count, seekErr
+					}
+					return count, nil
+				}
 			}
 		}
 		if readErr == io.EOF {
@@ -200,6 +197,10 @@ func countLines(r io.ReadSeeker) (int, error) {
 		if readErr != nil {
 			return count, readErr
 		}
+	}
+	// A non-empty file whose last byte is not '\n' has a partial final line.
+	if hasContent && lastByte != '\n' {
+		count++
 	}
 	if _, err := r.Seek(0, io.SeekStart); err != nil {
 		return count, err

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -223,16 +223,8 @@ func runPager(pagerCmd string, content io.Reader, stdout *os.File) error {
 	//nolint:gosec // pager command is user-controlled via MEGAPORT_PAGER/PAGER env vars,
 	// which are trusted to the same degree as the calling user (see resolvePager).
 	cmd := exec.Command(parts[0], parts[1:]...)
+	cmd.Stdin = content
 	cmd.Stdout = stdout
 	cmd.Stderr = os.Stderr
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return err
-	}
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-	_, _ = io.Copy(stdin, content)
-	_ = stdin.Close()
-	return cmd.Wait()
+	return cmd.Run()
 }

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -142,6 +142,7 @@ func RunWithPager(fn func() error) error {
 		info, statErr := tmp.Stat()
 		if statErr != nil {
 			// Cannot determine size; fall back to direct write.
+			// countLines already rewound on success but failed here, so seek manually.
 			if _, seekErr := tmp.Seek(0, io.SeekStart); seekErr == nil {
 				_, _ = io.Copy(origStdout, tmp)
 			}
@@ -153,11 +154,7 @@ func RunWithPager(fn func() error) error {
 		lineCount = 1
 	}
 
-	// Seek to start for the subsequent copy.
-	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
-		return fnErr
-	}
-
+	// countLines rewinds r to offset 0 on success, so tmp is ready to copy.
 	if height <= 0 {
 		// Terminal height unknown; write directly.
 		_, _ = io.Copy(origStdout, tmp)
@@ -180,8 +177,10 @@ func RunWithPager(fn func() error) error {
 }
 
 // countLines counts the number of newline characters in r by reading in
-// chunks, then seeks r back to the start. Unlike bufio.Scanner, this approach
-// has no token-size limit and handles arbitrarily wide table rows.
+// chunks. It seeks r to the start before counting and back to the start
+// before returning, so callers always receive r positioned at offset 0.
+// Unlike bufio.Scanner this approach has no token-size limit and handles
+// arbitrarily wide table rows.
 func countLines(r io.ReadSeeker) (int, error) {
 	if _, err := r.Seek(0, io.SeekStart); err != nil {
 		return 0, err
@@ -201,6 +200,9 @@ func countLines(r io.ReadSeeker) (int, error) {
 		if readErr != nil {
 			return count, readErr
 		}
+	}
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return count, err
 	}
 	return count, nil
 }

--- a/internal/base/output/pager_test.go
+++ b/internal/base/output/pager_test.go
@@ -196,10 +196,11 @@ func TestRunWithPager_LongOutput_PagerFailure(t *testing.T) {
 
 	lines := strings.Repeat("x\n", 10)
 	out := CaptureOutput(func() {
-		_ = RunWithPager(func() error {
+		err := RunWithPager(func() error {
 			fmt.Print(lines)
 			return nil
 		})
+		require.NoError(t, err)
 	})
 	// Output must still appear (fallback path).
 	assert.Equal(t, lines, out)

--- a/internal/base/output/pager_test.go
+++ b/internal/base/output/pager_test.go
@@ -5,12 +5,24 @@ package output
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// passthroughPager returns a shell command that copies stdin to stdout
+// unchanged, for use as a test pager. On Windows, "cat" is not available
+// by default, so the test is skipped on that platform.
+func passthroughPager(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("test requires 'cat'; not available by default on Windows")
+	}
+	return "cat"
+}
 
 func TestResolvePager_Precedence(t *testing.T) {
 	t.Setenv("MEGAPORT_PAGER", "")
@@ -67,7 +79,7 @@ func TestRunWithPager_ShortOutput(t *testing.T) {
 	setTerminalHeightForTesting(1000)
 	t.Cleanup(func() { setTerminalHeightForTesting(0) })
 
-	t.Setenv("MEGAPORT_PAGER", "cat")
+	t.Setenv("MEGAPORT_PAGER", passthroughPager(t))
 
 	out := CaptureOutput(func() {
 		err := RunWithPager(func() error {
@@ -93,8 +105,8 @@ func TestRunWithPager_LongOutput(t *testing.T) {
 	setTerminalHeightForTesting(3)
 	t.Cleanup(func() { setTerminalHeightForTesting(0) })
 
-	// Use "cat" as the pager so output passes through unchanged.
-	t.Setenv("MEGAPORT_PAGER", "cat")
+	// Use a pass-through pager so output arrives unchanged.
+	t.Setenv("MEGAPORT_PAGER", passthroughPager(t))
 
 	out := CaptureOutput(func() {
 		err := RunWithPager(func() error {
@@ -128,6 +140,30 @@ func TestSetNoPager_RoundTrip(t *testing.T) {
 	assert.True(t, getNoPager())
 	SetNoPager(false)
 	assert.False(t, getNoPager())
+}
+
+// TestRunWithPager_NoTrailingNewline verifies that output without a trailing
+// newline is not silently dropped (regression: countLines counts '\n' only,
+// so a single line without '\n' returns lineCount==0).
+func TestRunWithPager_NoTrailingNewline(t *testing.T) {
+	orig := isTerminalCached.Load()
+	SetIsTerminal(true)
+	t.Cleanup(func() { isTerminalCached.Store(orig) })
+
+	SetNoPager(false)
+	t.Cleanup(func() { SetNoPager(false) })
+
+	setTerminalHeightForTesting(1000)
+	t.Cleanup(func() { setTerminalHeightForTesting(0) })
+
+	out := CaptureOutput(func() {
+		err := RunWithPager(func() error {
+			fmt.Print("no-newline-here") // deliberate: no '\n'
+			return nil
+		})
+		require.NoError(t, err)
+	})
+	assert.Equal(t, "no-newline-here", out)
 }
 
 // TestRunWithPager_EmptyOutput verifies that when fn writes nothing to stdout,

--- a/internal/base/output/pager_test.go
+++ b/internal/base/output/pager_test.go
@@ -130,6 +130,56 @@ func TestSetNoPager_RoundTrip(t *testing.T) {
 	assert.False(t, getNoPager())
 }
 
+// TestRunWithPager_EmptyOutput verifies that when fn writes nothing to stdout,
+// RunWithPager returns cleanly without writing any output.
+func TestRunWithPager_EmptyOutput(t *testing.T) {
+	orig := isTerminalCached.Load()
+	SetIsTerminal(true)
+	t.Cleanup(func() { isTerminalCached.Store(orig) })
+
+	SetNoPager(false)
+	t.Cleanup(func() { SetNoPager(false) })
+
+	setTerminalHeightForTesting(5)
+	t.Cleanup(func() { setTerminalHeightForTesting(0) })
+
+	out := CaptureOutput(func() {
+		err := RunWithPager(func() error {
+			// Write nothing to os.Stdout — content will be empty.
+			return nil
+		})
+		require.NoError(t, err)
+	})
+	assert.Empty(t, out)
+}
+
+// TestRunWithPager_TermSizeFailure verifies that when terminal size cannot be
+// determined (origStdout is not a real TTY and no override is set), output is
+// written directly rather than being dropped.
+func TestRunWithPager_TermSizeFailure(t *testing.T) {
+	orig := isTerminalCached.Load()
+	SetIsTerminal(true)
+	t.Cleanup(func() { isTerminalCached.Store(orig) })
+
+	SetNoPager(false)
+	t.Cleanup(func() { SetNoPager(false) })
+
+	// Leave terminalHeightOverride at 0 (default). RunWithPager will call
+	// term.GetSize on origStdout, which is a temp file (not a TTY) when
+	// wrapped with CaptureOutput. That call fails, so the code falls through
+	// to the direct-write path rather than invoking the pager.
+	// (Do NOT call setTerminalHeightForTesting here.)
+
+	out := CaptureOutput(func() {
+		err := RunWithPager(func() error {
+			fmt.Println("direct-write-line")
+			return nil
+		})
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "direct-write-line")
+}
+
 func TestRunWithPager_LongOutput_PagerFailure(t *testing.T) {
 	orig := isTerminalCached.Load()
 	SetIsTerminal(true)

--- a/internal/base/output/pager_test.go
+++ b/internal/base/output/pager_test.go
@@ -64,8 +64,8 @@ func TestRunWithPager_ShortOutput(t *testing.T) {
 	t.Cleanup(func() { SetNoPager(false) })
 
 	// Set a tall terminal so output never exceeds height.
-	SetTerminalHeightForTesting(1000)
-	t.Cleanup(func() { SetTerminalHeightForTesting(0) })
+	setTerminalHeightForTesting(1000)
+	t.Cleanup(func() { setTerminalHeightForTesting(0) })
 
 	t.Setenv("MEGAPORT_PAGER", "cat")
 
@@ -90,8 +90,8 @@ func TestRunWithPager_LongOutput(t *testing.T) {
 	t.Cleanup(func() { SetNoPager(false) })
 
 	// Terminal height of 3 lines; output will be 10 lines — triggers pager.
-	SetTerminalHeightForTesting(3)
-	t.Cleanup(func() { SetTerminalHeightForTesting(0) })
+	setTerminalHeightForTesting(3)
+	t.Cleanup(func() { setTerminalHeightForTesting(0) })
 
 	// Use "cat" as the pager so output passes through unchanged.
 	t.Setenv("MEGAPORT_PAGER", "cat")
@@ -138,8 +138,8 @@ func TestRunWithPager_LongOutput_PagerFailure(t *testing.T) {
 	SetNoPager(false)
 	t.Cleanup(func() { SetNoPager(false) })
 
-	SetTerminalHeightForTesting(3)
-	t.Cleanup(func() { SetTerminalHeightForTesting(0) })
+	setTerminalHeightForTesting(3)
+	t.Cleanup(func() { setTerminalHeightForTesting(0) })
 
 	// Point to a nonexistent pager — RunWithPager should fall back to direct write.
 	t.Setenv("MEGAPORT_PAGER", "/nonexistent-pager-cmd")

--- a/internal/base/output/pager_test.go
+++ b/internal/base/output/pager_test.go
@@ -143,8 +143,8 @@ func TestSetNoPager_RoundTrip(t *testing.T) {
 }
 
 // TestRunWithPager_NoTrailingNewline verifies that output without a trailing
-// newline is not silently dropped (regression: countLines counts '\n' only,
-// so a single line without '\n' returns lineCount==0).
+// newline is not silently dropped. countLines must count the partial final
+// line so the pager decision is correct.
 func TestRunWithPager_NoTrailingNewline(t *testing.T) {
 	orig := isTerminalCached.Load()
 	SetIsTerminal(true)
@@ -164,6 +164,34 @@ func TestRunWithPager_NoTrailingNewline(t *testing.T) {
 		require.NoError(t, err)
 	})
 	assert.Equal(t, "no-newline-here", out)
+}
+
+// TestRunWithPager_MultiLineNoTrailingNewline verifies that multi-line output
+// without a trailing newline is counted correctly (e.g., "a\nb\nc" is 3 lines,
+// not 2). An off-by-one here would cause the pager to trigger one line late.
+func TestRunWithPager_MultiLineNoTrailingNewline(t *testing.T) {
+	orig := isTerminalCached.Load()
+	SetIsTerminal(true)
+	t.Cleanup(func() { isTerminalCached.Store(orig) })
+
+	SetNoPager(false)
+	t.Cleanup(func() { SetNoPager(false) })
+
+	// Terminal height of 2. Output is "a\nb\nc" — 3 lines (no trailing '\n').
+	// With a correct count the pager fires; with an off-by-one it would not.
+	setTerminalHeightForTesting(2)
+	t.Cleanup(func() { setTerminalHeightForTesting(0) })
+
+	t.Setenv("MEGAPORT_PAGER", passthroughPager(t))
+
+	out := CaptureOutput(func() {
+		err := RunWithPager(func() error {
+			fmt.Print("a\nb\nc") // 3 lines, last has no '\n'
+			return nil
+		})
+		require.NoError(t, err)
+	})
+	assert.Equal(t, "a\nb\nc", out)
 }
 
 // TestRunWithPager_EmptyOutput verifies that when fn writes nothing to stdout,

--- a/internal/base/output/pager_test.go
+++ b/internal/base/output/pager_test.go
@@ -1,0 +1,156 @@
+//go:build !wasm
+// +build !wasm
+
+package output
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePager_Precedence(t *testing.T) {
+	t.Setenv("MEGAPORT_PAGER", "")
+	t.Setenv("PAGER", "")
+	assert.Equal(t, "less -R", resolvePager())
+
+	t.Setenv("PAGER", "more")
+	assert.Equal(t, "more", resolvePager())
+
+	t.Setenv("MEGAPORT_PAGER", "bat")
+	assert.Equal(t, "bat", resolvePager())
+}
+
+func TestRunWithPager_NonTTY(t *testing.T) {
+	orig := isTerminalCached.Load()
+	SetIsTerminal(false)
+	t.Cleanup(func() { isTerminalCached.Store(orig) })
+
+	called := false
+	err := RunWithPager(func() error {
+		called = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
+func TestRunWithPager_NoPager(t *testing.T) {
+	orig := isTerminalCached.Load()
+	SetIsTerminal(true)
+	t.Cleanup(func() { isTerminalCached.Store(orig) })
+
+	SetNoPager(true)
+	t.Cleanup(func() { SetNoPager(false) })
+
+	called := false
+	err := RunWithPager(func() error {
+		called = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
+func TestRunWithPager_ShortOutput(t *testing.T) {
+	orig := isTerminalCached.Load()
+	SetIsTerminal(true)
+	t.Cleanup(func() { isTerminalCached.Store(orig) })
+
+	SetNoPager(false)
+	t.Cleanup(func() { SetNoPager(false) })
+
+	// Set a tall terminal so output never exceeds height.
+	SetTerminalHeightForTesting(1000)
+	t.Cleanup(func() { SetTerminalHeightForTesting(0) })
+
+	t.Setenv("MEGAPORT_PAGER", "cat")
+
+	out := CaptureOutput(func() {
+		err := RunWithPager(func() error {
+			fmt.Println("line1")
+			fmt.Println("line2")
+			return nil
+		})
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "line1")
+	assert.Contains(t, out, "line2")
+}
+
+func TestRunWithPager_LongOutput(t *testing.T) {
+	orig := isTerminalCached.Load()
+	SetIsTerminal(true)
+	t.Cleanup(func() { isTerminalCached.Store(orig) })
+
+	SetNoPager(false)
+	t.Cleanup(func() { SetNoPager(false) })
+
+	// Terminal height of 3 lines; output will be 10 lines — triggers pager.
+	SetTerminalHeightForTesting(3)
+	t.Cleanup(func() { SetTerminalHeightForTesting(0) })
+
+	// Use "cat" as the pager so output passes through unchanged.
+	t.Setenv("MEGAPORT_PAGER", "cat")
+
+	out := CaptureOutput(func() {
+		err := RunWithPager(func() error {
+			for i := range 10 {
+				fmt.Printf("line%d\n", i)
+			}
+			return nil
+		})
+		require.NoError(t, err)
+	})
+
+	for i := range 10 {
+		assert.Contains(t, out, fmt.Sprintf("line%d", i))
+	}
+}
+
+func TestRunWithPager_PropagatesFnError(t *testing.T) {
+	orig := isTerminalCached.Load()
+	SetIsTerminal(false) // non-TTY so RunWithPager short-circuits cleanly
+	t.Cleanup(func() { isTerminalCached.Store(orig) })
+
+	err := RunWithPager(func() error {
+		return fmt.Errorf("inner error")
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inner error")
+}
+
+func TestSetNoPager_RoundTrip(t *testing.T) {
+	SetNoPager(true)
+	assert.True(t, getNoPager())
+	SetNoPager(false)
+	assert.False(t, getNoPager())
+}
+
+func TestRunWithPager_LongOutput_PagerFailure(t *testing.T) {
+	orig := isTerminalCached.Load()
+	SetIsTerminal(true)
+	t.Cleanup(func() { isTerminalCached.Store(orig) })
+
+	SetNoPager(false)
+	t.Cleanup(func() { SetNoPager(false) })
+
+	SetTerminalHeightForTesting(3)
+	t.Cleanup(func() { SetTerminalHeightForTesting(0) })
+
+	// Point to a nonexistent pager — RunWithPager should fall back to direct write.
+	t.Setenv("MEGAPORT_PAGER", "/nonexistent-pager-cmd")
+
+	lines := strings.Repeat("x\n", 10)
+	out := CaptureOutput(func() {
+		_ = RunWithPager(func() error {
+			fmt.Print(lines)
+			return nil
+		})
+	})
+	// Output must still appear (fallback path).
+	assert.Equal(t, lines, out)
+}

--- a/internal/base/output/pager_wasm.go
+++ b/internal/base/output/pager_wasm.go
@@ -1,0 +1,12 @@
+//go:build js && wasm
+// +build js,wasm
+
+package output
+
+// SetNoPager is a no-op in the WASM build. The browser environment has no
+// terminal and cannot spawn pager processes.
+func SetNoPager(_ bool) {}
+
+// RunWithPager in the WASM build simply calls fn directly. There is no
+// terminal to detect and no process to spawn.
+func RunWithPager(fn func() error) error { return fn() }

--- a/internal/base/output/pager_wasm.go
+++ b/internal/base/output/pager_wasm.go
@@ -7,6 +7,9 @@ package output
 // terminal and cannot spawn pager processes.
 func SetNoPager(_ bool) {}
 
+// GetNoPager always returns false in the WASM build; paging is never active.
+func GetNoPager() bool { return false }
+
 // RunWithPager in the WASM build simply calls fn directly. There is no
 // terminal to detect and no process to spawn.
 func RunWithPager(fn func() error) error { return fn() }

--- a/internal/base/output/table.go
+++ b/internal/base/output/table.go
@@ -19,6 +19,12 @@ import (
 // goroutine safety (spinner goroutines read this concurrently).
 var isTerminalCached atomic.Bool
 
+// terminalWidthOverride, when > 0, is used by getTerminalWidth in place of
+// the width reported by os.Stdout. RunWithPager sets this before redirecting
+// os.Stdout to a temp file so that printTable uses the real TTY width for
+// column layout even while output is being buffered.
+var terminalWidthOverride atomic.Int64
+
 func init() {
 	isTerminalCached.Store(term.IsTerminal(int(os.Stdout.Fd())))
 }
@@ -34,6 +40,9 @@ func SetIsTerminal(val bool) {
 }
 
 func getTerminalWidth() int {
+	if ov := int(terminalWidthOverride.Load()); ov > 0 {
+		return ov
+	}
 	width, _, err := term.GetSize(int(os.Stdout.Fd()))
 	if err != nil || width <= 0 {
 		return 100

--- a/internal/commands/config/config_actions.go
+++ b/internal/commands/config/config_actions.go
@@ -205,9 +205,14 @@ func SetDefault(cmd *cobra.Command, args []string, noColor bool) error {
 
 	allowedSettings := map[string]func(string) (interface{}, error){
 		"output": func(v string) (interface{}, error) {
-			validFormats := map[string]bool{"table": true, "json": true, "csv": true, "xml": true, "go-template": true}
+			v = strings.ToLower(v)
+			validFormats := make(map[string]bool, len(utils.ValidFormats))
+			for _, f := range utils.ValidFormats {
+				validFormats[f] = true
+			}
 			if !validFormats[v] {
-				return nil, fmt.Errorf("output format must be one of: table, json, csv, xml, go-template")
+				return nil, fmt.Errorf("output format must be one of: %s",
+					strings.Join(utils.ValidFormats, ", "))
 			}
 			return v, nil
 		},

--- a/internal/commands/config/config_actions.go
+++ b/internal/commands/config/config_actions.go
@@ -235,6 +235,14 @@ func SetDefault(cmd *cobra.Command, args []string, noColor bool) error {
 			}
 			return nil, fmt.Errorf("verbose must be true or false")
 		},
+		"no-pager": func(v string) (interface{}, error) {
+			if strings.ToLower(v) == "true" {
+				return true, nil
+			} else if strings.ToLower(v) == "false" {
+				return false, nil
+			}
+			return nil, fmt.Errorf("no-pager must be true or false")
+		},
 	}
 
 	validator, exists := allowedSettings[key]

--- a/internal/commands/config/config_actions.go
+++ b/internal/commands/config/config_actions.go
@@ -205,9 +205,9 @@ func SetDefault(cmd *cobra.Command, args []string, noColor bool) error {
 
 	allowedSettings := map[string]func(string) (interface{}, error){
 		"output": func(v string) (interface{}, error) {
-			validFormats := map[string]bool{"json": true, "yaml": true, "table": true}
+			validFormats := map[string]bool{"table": true, "json": true, "csv": true, "xml": true, "go-template": true}
 			if !validFormats[v] {
-				return nil, fmt.Errorf("output format must be one of: json, yaml, table")
+				return nil, fmt.Errorf("output format must be one of: table, json, csv, xml, go-template")
 			}
 			return v, nil
 		},

--- a/internal/commands/config/config_actions_test.go
+++ b/internal/commands/config/config_actions_test.go
@@ -608,6 +608,53 @@ func TestSetDefault(t *testing.T) {
 	})
 }
 
+func TestSetDefault_NoPager(t *testing.T) {
+	t.Run("set true", func(t *testing.T) {
+		setupTestConfigEnv(t)
+
+		cmd, _ := setupTestCmd()
+		outputText, err := captureOutputFromAction(func() error {
+			return SetDefault(cmd, []string{"no-pager", "true"}, false)
+		})
+		require.NoError(t, err)
+		assert.Contains(t, outputText, "Default 'no-pager' set to 'true'")
+
+		manager, err := NewConfigManager()
+		require.NoError(t, err)
+		val, exists := manager.GetDefault("no-pager")
+		assert.True(t, exists)
+		assert.Equal(t, true, val)
+	})
+
+	t.Run("set false", func(t *testing.T) {
+		setupTestConfigEnv(t)
+
+		cmd, _ := setupTestCmd()
+		outputText, err := captureOutputFromAction(func() error {
+			return SetDefault(cmd, []string{"no-pager", "false"}, false)
+		})
+		require.NoError(t, err)
+		assert.Contains(t, outputText, "Default 'no-pager' set to 'false'")
+
+		manager, err := NewConfigManager()
+		require.NoError(t, err)
+		val, exists := manager.GetDefault("no-pager")
+		assert.True(t, exists)
+		assert.Equal(t, false, val)
+	})
+
+	t.Run("invalid value", func(t *testing.T) {
+		setupTestConfigEnv(t)
+
+		cmd, _ := setupTestCmd()
+		_, err := captureOutputFromAction(func() error {
+			return SetDefault(cmd, []string{"no-pager", "badvalue"}, false)
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no-pager must be true or false")
+	})
+}
+
 func TestGetDefault(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		setupTestConfigEnv(t)

--- a/internal/commands/config/config_actions_test.go
+++ b/internal/commands/config/config_actions_test.go
@@ -587,7 +587,7 @@ func TestSetDefault(t *testing.T) {
 			return SetDefault(cmd, []string{"output", ""}, false)
 		})
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "output format must be one of: json, yaml, table")
+		assert.Contains(t, err.Error(), "output format must be one of: table, json, csv, xml, go-template")
 	})
 
 	t.Run("verify persistence", func(t *testing.T) {


### PR DESCRIPTION
Two small UX improvements for the CLI.

## Pager integration

When stdout is a TTY and table output exceeds the terminal height, the CLI now auto-pipes through a pager — the same behaviour as `gh` and `git`.

**How pager is resolved:** `MEGAPORT_PAGER` → `PAGER` → `less -R`

**Flags / config:**
- `--no-pager` disables paging for a single invocation
- `megaport-cli config set-default no-pager true` persists the preference
- Non-TTY stdout (piped output), `--output json/csv/xml` and WASM builds are never paged

**Implementation notes:**
- Output is buffered to a temp file (not a pipe) to avoid deadlocking on large tables
- A separate `pagerMu` is used so `CaptureOutput` (which holds `stdoutMu`) can safely wrap `RunWithPager` in tests without deadlocking
- `terminalHeightOverride` is an `atomic.Int64` so parallel tests are race-free
- WASM stubs (`pager_wasm.go`) are no-ops — browser environments can't spawn processes
- `ResetState()` clears `noPager` between WASM invocations
- `resolveOutputFormat` in WASM now checks `f.Changed` before reading a command's local `--output` flag, so a default `"table"` no longer masks `--output json` on the root persistent flag

## "Did you mean?" suggestions

`rootCmd.SuggestionsMinimumDistance = 2` is now set in `InitializeCommon()` so both native and WASM builds suggest corrections for mistyped commands (e.g. `megaport-cli prot list` → "Did you mean 'ports'?"). The WASM-only value of `1` has been removed.

## Testing

New tests in `pager_test.go`:
- `TestResolvePager_Precedence` — env var priority
- `TestRunWithPager_NonTTY` — non-TTY short-circuits without pager
- `TestRunWithPager_NoPager` — `--no-pager` short-circuits
- `TestRunWithPager_ShortOutput` — output below terminal height → direct write
- `TestRunWithPager_LongOutput` — output above terminal height → pager invoked (`MEGAPORT_PAGER=cat`)
- `TestRunWithPager_PropagatesFnError` — errors from fn are returned
- `TestRunWithPager_LongOutput_PagerFailure` — pager failure falls back to direct write
- `TestSetNoPager_RoundTrip` — getter/setter symmetry