### PR TITLE
feat: add --tag filter flag to ports, vxc, mcr, mve list commands

### DIFF
--- a/internal/base/cmdbuilder/builder.go
+++ b/internal/base/cmdbuilder/builder.go
@@ -115,6 +115,13 @@ func (b *CommandBuilder) WithDurationFlagP(name, shorthand string, defaultVal ti
 	return b
 }
 
+// WithStringArrayFlag adds a repeatable string flag (each --flag value is a separate element).
+// Unlike StringSlice, StringArray does not split on commas.
+func (b *CommandBuilder) WithStringArrayFlag(name, usage string) *CommandBuilder {
+	b.cmd.Flags().StringArray(name, nil, usage)
+	return b
+}
+
 // WithRootCmd sets the root command for help generation
 func (b *CommandBuilder) WithRootCmd(rootCmd *cobra.Command) *CommandBuilder {
 	b.rootCmd = rootCmd

--- a/internal/base/cmdbuilder/builder_test.go
+++ b/internal/base/cmdbuilder/builder_test.go
@@ -674,6 +674,24 @@ func TestBuilderChaining(t *testing.T) {
 	}))
 	assert.Equal(t, b, b.WithRootCmd(&cobra.Command{}))
 	assert.Equal(t, b, b.WithAliases([]string{"t"}))
+	assert.Equal(t, b, b.WithStringArrayFlag("tags", "repeatable flag"))
+}
+
+func TestWithStringArrayFlag(t *testing.T) {
+	cmd := NewCommand("list", "List resources").
+		WithStringArrayFlag("tag", "Filter by tag").
+		Build()
+
+	f := cmd.Flags().Lookup("tag")
+	require.NotNil(t, f, "tag flag should be registered")
+	assert.Equal(t, "stringArray", f.Value.Type())
+
+	// Each --tag value is kept as-is (no comma splitting).
+	require.NoError(t, cmd.Flags().Set("tag", "env=prod"))
+	require.NoError(t, cmd.Flags().Set("tag", "team=a,b"))
+	vals, err := cmd.Flags().GetStringArray("tag")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"env=prod", "team=a,b"}, vals)
 }
 
 func TestGenerateSkeletonFlag(t *testing.T) {

--- a/internal/base/cmdbuilder/tag_flagsets.go
+++ b/internal/base/cmdbuilder/tag_flagsets.go
@@ -1,0 +1,8 @@
+package cmdbuilder
+
+// WithTagFilterFlags adds the --tag repeatable flag for filtering list results by resource tag.
+// Format: --tag key=value (exact match) or --tag key (key-exists match).
+// Multiple --tag flags are AND-ed together.
+func (b *CommandBuilder) WithTagFilterFlags() *CommandBuilder {
+	return b.WithStringArrayFlag("tag", "Filter by resource tag (format: key=value or key; repeatable, AND logic)")
+}

--- a/internal/base/cmdbuilder/tag_flagsets.go
+++ b/internal/base/cmdbuilder/tag_flagsets.go
@@ -4,5 +4,7 @@ package cmdbuilder
 // Format: --tag key=value (exact match) or --tag key (key-exists match).
 // Multiple --tag flags are AND-ed together.
 func (b *CommandBuilder) WithTagFilterFlags() *CommandBuilder {
-	return b.WithStringArrayFlag("tag", "Filter by resource tag (format: key=value or key; repeatable, AND logic)")
+	const desc = "Filter by resource tag (format: key=value or key; repeatable, AND logic)"
+	return b.WithStringArrayFlag("tag", desc).
+		WithOptionalFlag("tag", desc)
 }

--- a/internal/base/cmdbuilder/tag_flagsets_test.go
+++ b/internal/base/cmdbuilder/tag_flagsets_test.go
@@ -1,0 +1,19 @@
+package cmdbuilder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithTagFilterFlags(t *testing.T) {
+	cmd := NewCommand("list", "List resources").
+		WithTagFilterFlags().
+		Build()
+
+	f := cmd.Flags().Lookup("tag")
+	require.NotNil(t, f, "tag flag should be registered by WithTagFilterFlags")
+	assert.Equal(t, "stringArray", f.Value.Type())
+	assert.Contains(t, f.Usage, "key=value")
+}

--- a/internal/commands/mcr/mcr.go
+++ b/internal/commands/mcr/mcr.go
@@ -173,7 +173,7 @@ func buildMCRCommands(rootCmd *cobra.Command) (get, buy, update, del, restore, l
 	// Create list MCRs command
 	list = cmdbuilder.NewCommand("list", "List all MCRs with optional filters").
 		WithOutputFormatRunFunc(ListMCRs).
-		WithLongDesc("List all MCRs available in the Megaport API.\n\nThis command fetches and displays a list of MCRs with details such as MCR ID, name, location, speed, and status. By default, only active MCRs are shown.").
+		WithLongDesc("List all MCRs available in the Megaport API.\n\nThis command fetches and displays a list of MCRs with details such as MCR ID, name, location, speed, and status. By default, only active MCRs are shown. You can also filter by resource tags.").
 		WithMCRFilterFlags().
 		WithTagFilterFlags().
 		WithOptionalFlag("location-id", "Filter MCRs by location ID").

--- a/internal/commands/mcr/mcr.go
+++ b/internal/commands/mcr/mcr.go
@@ -186,6 +186,8 @@ func buildMCRCommands(rootCmd *cobra.Command) (get, buy, update, del, restore, l
 		WithExample("megaport-cli mcr list --name \"My MCR\"").
 		WithExample("megaport-cli mcr list --include-inactive").
 		WithExample("megaport-cli mcr list --location-id 1 --port-speed 10000 --name \"My MCR\"").
+		WithExample("megaport-cli mcr list --tag env=prod").
+		WithExample("megaport-cli mcr list --tag env=prod --tag team=network").
 		WithIntFlag("limit", 0, "Maximum number of results to display (0 = unlimited)").
 		WithRootCmd(rootCmd).
 		WithAliases([]string{"ls"}).

--- a/internal/commands/mcr/mcr.go
+++ b/internal/commands/mcr/mcr.go
@@ -175,6 +175,7 @@ func buildMCRCommands(rootCmd *cobra.Command) (get, buy, update, del, restore, l
 		WithOutputFormatRunFunc(ListMCRs).
 		WithLongDesc("List all MCRs available in the Megaport API.\n\nThis command fetches and displays a list of MCRs with details such as MCR ID, name, location, speed, and status. By default, only active MCRs are shown.").
 		WithMCRFilterFlags().
+		WithTagFilterFlags().
 		WithOptionalFlag("location-id", "Filter MCRs by location ID").
 		WithOptionalFlag("name", "Filter MCRs by name").
 		WithOptionalFlag("port-speed", "Filter MCRs by port speed").

--- a/internal/commands/mcr/mcr_actions.go
+++ b/internal/commands/mcr/mcr_actions.go
@@ -376,28 +376,17 @@ func ListMCRs(cmd *cobra.Command, args []string, noColor bool, outputFormat stri
 	tagFilters, _ := cmd.Flags().GetStringArray("tag")
 	if len(tagFilters) > 0 {
 		tagSpinner := output.PrintCustomSpinner("Fetching tags for", "MCRs", noColor)
-		uids := make([]string, len(filteredMCRs))
-		for i, m := range filteredMCRs {
-			uids[i] = m.UID
-		}
-		allTags, fetchErrs := utils.FetchTagsConcurrently(ctx, uids, func(ctx context.Context, uid string) (map[string]string, error) {
-			return listMCRResourceTagsFunc(ctx, client, uid)
-		})
+		filteredMCRs = utils.ApplyTagFilter(ctx, filteredMCRs,
+			func(m *megaport.MCR) string { return m.UID },
+			func(ctx context.Context, uid string) (map[string]string, error) {
+				return listMCRResourceTagsFunc(ctx, client, uid)
+			},
+			tagFilters, limit,
+			func(uid string, err error) {
+				output.PrintWarning("Failed to fetch tags for MCR %s, skipping: %v", noColor, uid, err)
+			},
+		)
 		tagSpinner.Stop()
-		tagged := make([]*megaport.MCR, 0, len(filteredMCRs))
-		for _, m := range filteredMCRs {
-			if err, ok := fetchErrs[m.UID]; ok {
-				output.PrintWarning("Failed to fetch tags for MCR %s, skipping: %v", noColor, m.UID, err)
-				continue
-			}
-			if utils.MatchesTagFilters(allTags[m.UID], tagFilters) {
-				tagged = append(tagged, m)
-				if limit > 0 && len(tagged) >= limit {
-					break
-				}
-			}
-		}
-		filteredMCRs = tagged
 	}
 	return utils.ApplyLimitAndPrint(filteredMCRs, limit, outputFormat, noColor,
 		"No MCRs found. Create one with 'megaport mcr buy'.", printMCRs)

--- a/internal/commands/mcr/mcr_actions.go
+++ b/internal/commands/mcr/mcr_actions.go
@@ -373,16 +373,19 @@ func ListMCRs(cmd *cobra.Command, args []string, noColor bool, outputFormat stri
 
 	tagFilters, _ := cmd.Flags().GetStringArray("tag")
 	if len(tagFilters) > 0 {
-		var tagged []*megaport.MCR
+		tagSpinner := output.PrintCustomSpinner("Fetching tags for", "MCRs", noColor)
+		tagged := make([]*megaport.MCR, 0, len(filteredMCRs))
 		for _, m := range filteredMCRs {
 			tags, err := listMCRResourceTagsFunc(ctx, client, m.UID)
 			if err != nil {
+				output.PrintWarning("Failed to fetch tags for MCR %s, skipping: %v", noColor, m.UID, err)
 				continue
 			}
 			if utils.MatchesTagFilters(tags, tagFilters) {
 				tagged = append(tagged, m)
 			}
 		}
+		tagSpinner.Stop()
 		filteredMCRs = tagged
 	}
 

--- a/internal/commands/mcr/mcr_actions.go
+++ b/internal/commands/mcr/mcr_actions.go
@@ -371,25 +371,34 @@ func ListMCRs(cmd *cobra.Command, args []string, noColor bool, outputFormat stri
 
 	filteredMCRs := filterMCRs(mcrs, locationID, portSpeed, mcrName)
 
+	limit, _ := cmd.Flags().GetInt("limit")
+
 	tagFilters, _ := cmd.Flags().GetStringArray("tag")
 	if len(tagFilters) > 0 {
 		tagSpinner := output.PrintCustomSpinner("Fetching tags for", "MCRs", noColor)
+		uids := make([]string, len(filteredMCRs))
+		for i, m := range filteredMCRs {
+			uids[i] = m.UID
+		}
+		allTags, fetchErrs := utils.FetchTagsConcurrently(ctx, uids, func(ctx context.Context, uid string) (map[string]string, error) {
+			return listMCRResourceTagsFunc(ctx, client, uid)
+		})
+		tagSpinner.Stop()
 		tagged := make([]*megaport.MCR, 0, len(filteredMCRs))
 		for _, m := range filteredMCRs {
-			tags, err := listMCRResourceTagsFunc(ctx, client, m.UID)
-			if err != nil {
+			if err, ok := fetchErrs[m.UID]; ok {
 				output.PrintWarning("Failed to fetch tags for MCR %s, skipping: %v", noColor, m.UID, err)
 				continue
 			}
-			if utils.MatchesTagFilters(tags, tagFilters) {
+			if utils.MatchesTagFilters(allTags[m.UID], tagFilters) {
 				tagged = append(tagged, m)
+				if limit > 0 && len(tagged) >= limit {
+					break
+				}
 			}
 		}
-		tagSpinner.Stop()
 		filteredMCRs = tagged
 	}
-
-	limit, _ := cmd.Flags().GetInt("limit")
 	return utils.ApplyLimitAndPrint(filteredMCRs, limit, outputFormat, noColor,
 		"No MCRs found. Create one with 'megaport mcr buy'.", printMCRs)
 }

--- a/internal/commands/mcr/mcr_actions.go
+++ b/internal/commands/mcr/mcr_actions.go
@@ -385,6 +385,9 @@ func ListMCRs(cmd *cobra.Command, args []string, noColor bool, outputFormat stri
 			tagFilters, limit,
 		)
 		tagSpinner.Stop()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		for uid, err := range tagErrs {
 			output.PrintWarning("Failed to fetch tags for MCR %s, skipping: %v", noColor, uid, err)
 		}

--- a/internal/commands/mcr/mcr_actions.go
+++ b/internal/commands/mcr/mcr_actions.go
@@ -371,6 +371,21 @@ func ListMCRs(cmd *cobra.Command, args []string, noColor bool, outputFormat stri
 
 	filteredMCRs := filterMCRs(mcrs, locationID, portSpeed, mcrName)
 
+	tagFilters, _ := cmd.Flags().GetStringArray("tag")
+	if len(tagFilters) > 0 {
+		var tagged []*megaport.MCR
+		for _, m := range filteredMCRs {
+			tags, err := listMCRResourceTagsFunc(ctx, client, m.UID)
+			if err != nil {
+				continue
+			}
+			if utils.MatchesTagFilters(tags, tagFilters) {
+				tagged = append(tagged, m)
+			}
+		}
+		filteredMCRs = tagged
+	}
+
 	limit, _ := cmd.Flags().GetInt("limit")
 	return utils.ApplyLimitAndPrint(filteredMCRs, limit, outputFormat, noColor,
 		"No MCRs found. Create one with 'megaport mcr buy'.", printMCRs)

--- a/internal/commands/mcr/mcr_actions.go
+++ b/internal/commands/mcr/mcr_actions.go
@@ -376,17 +376,18 @@ func ListMCRs(cmd *cobra.Command, args []string, noColor bool, outputFormat stri
 	tagFilters, _ := cmd.Flags().GetStringArray("tag")
 	if len(tagFilters) > 0 {
 		tagSpinner := output.PrintCustomSpinner("Fetching tags for", "MCRs", noColor)
-		filteredMCRs = utils.ApplyTagFilter(ctx, filteredMCRs,
+		var tagErrs map[string]error
+		filteredMCRs, tagErrs = utils.ApplyTagFilter(ctx, filteredMCRs,
 			func(m *megaport.MCR) string { return m.UID },
 			func(ctx context.Context, uid string) (map[string]string, error) {
 				return listMCRResourceTagsFunc(ctx, client, uid)
 			},
 			tagFilters, limit,
-			func(uid string, err error) {
-				output.PrintWarning("Failed to fetch tags for MCR %s, skipping: %v", noColor, uid, err)
-			},
 		)
 		tagSpinner.Stop()
+		for uid, err := range tagErrs {
+			output.PrintWarning("Failed to fetch tags for MCR %s, skipping: %v", noColor, uid, err)
+		}
 	}
 	return utils.ApplyLimitAndPrint(filteredMCRs, limit, outputFormat, noColor,
 		"No MCRs found. Create one with 'megaport mcr buy'.", printMCRs)

--- a/internal/commands/mcr/mcr_actions_test.go
+++ b/internal/commands/mcr/mcr_actions_test.go
@@ -2876,10 +2876,11 @@ func TestListMCRs_TagFilter(t *testing.T) {
 			notExpected: []string{"mcr-1", "mcr-2", "mcr-3"},
 		},
 		{
-			name:           "tag fetch error excludes resource gracefully",
-			tagFilters:     []string{"env=prod"},
-			tagFetchErrUID: "mcr-1",
-			notExpected:    []string{"mcr-1"},
+			name:            "tag fetch error excludes resource gracefully",
+			tagFilters:      []string{"env=prod"},
+			tagFetchErrUID:  "mcr-1",
+			notExpected:     []string{"MCR-Alpha"}, // name absent from table; UID appears in warning
+			expectedOutputs: []string{"Failed to fetch tags"},
 		},
 	}
 

--- a/internal/commands/mcr/mcr_actions_test.go
+++ b/internal/commands/mcr/mcr_actions_test.go
@@ -2910,9 +2910,11 @@ func TestListMCRs_TagFilter(t *testing.T) {
 				assert.NoError(t, cmd.Flags().Set("tag", f))
 			}
 
+			var listErr error
 			capturedOutput := output.CaptureOutput(func() {
-				_ = ListMCRs(cmd, nil, true, "table")
+				listErr = ListMCRs(cmd, nil, true, "table")
 			})
+			assert.NoError(t, listErr)
 
 			for _, expected := range tt.expectedOutputs {
 				assert.Contains(t, capturedOutput, expected)

--- a/internal/commands/mcr/mcr_actions_test.go
+++ b/internal/commands/mcr/mcr_actions_test.go
@@ -2820,3 +2820,105 @@ func TestValidateMCR(t *testing.T) {
 		})
 	}
 }
+
+func TestListMCRs_TagFilter(t *testing.T) {
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
+	defer cleanup()
+
+	origListTagsFunc := listMCRResourceTagsFunc
+	defer func() { listMCRResourceTagsFunc = origListTagsFunc }()
+
+	allMCRs := []*megaport.MCR{
+		{UID: "mcr-1", Name: "MCR-Alpha", ProvisioningStatus: "LIVE"},
+		{UID: "mcr-2", Name: "MCR-Beta", ProvisioningStatus: "LIVE"},
+		{UID: "mcr-3", Name: "MCR-Gamma", ProvisioningStatus: "LIVE"},
+	}
+
+	tagsByUID := map[string]map[string]string{
+		"mcr-1": {"env": "prod", "team": "net"},
+		"mcr-2": {"env": "staging"},
+		"mcr-3": {},
+	}
+
+	tests := []struct {
+		name            string
+		tagFilters      []string
+		tagFetchErrUID  string
+		expectedOutputs []string
+		notExpected     []string
+	}{
+		{
+			name:            "no tag filter returns all",
+			tagFilters:      nil,
+			expectedOutputs: []string{"mcr-1", "mcr-2", "mcr-3"},
+		},
+		{
+			name:            "exact match includes only matching resource",
+			tagFilters:      []string{"env=prod"},
+			expectedOutputs: []string{"mcr-1"},
+			notExpected:     []string{"mcr-2", "mcr-3"},
+		},
+		{
+			name:            "AND logic requires all filters to match",
+			tagFilters:      []string{"env=prod", "team=net"},
+			expectedOutputs: []string{"mcr-1"},
+			notExpected:     []string{"mcr-2", "mcr-3"},
+		},
+		{
+			name:            "key-exists match",
+			tagFilters:      []string{"env"},
+			expectedOutputs: []string{"mcr-1", "mcr-2"},
+			notExpected:     []string{"mcr-3"},
+		},
+		{
+			name:        "no match returns empty",
+			tagFilters:  []string{"env=nonexistent"},
+			notExpected: []string{"mcr-1", "mcr-2", "mcr-3"},
+		},
+		{
+			name:           "tag fetch error excludes resource gracefully",
+			tagFilters:     []string{"env=prod"},
+			tagFetchErrUID: "mcr-1",
+			notExpected:    []string{"mcr-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			listMCRResourceTagsFunc = func(ctx context.Context, client *megaport.Client, uid string) (map[string]string, error) {
+				if tt.tagFetchErrUID != "" && uid == tt.tagFetchErrUID {
+					return nil, fmt.Errorf("tag fetch error")
+				}
+				return tagsByUID[uid], nil
+			}
+
+			mockSvc := &MockMCRService{ListMCRsResult: allMCRs}
+			config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+				return &megaport.Client{MCRService: mockSvc}, nil
+			})
+
+			cmd := &cobra.Command{Use: "list"}
+			cmd.Flags().String("name", "", "")
+			cmd.Flags().Int("location-id", 0, "")
+			cmd.Flags().Int("port-speed", 0, "")
+			cmd.Flags().Bool("include-inactive", false, "")
+			cmd.Flags().Int("limit", 0, "")
+			cmd.Flags().StringArray("tag", nil, "")
+
+			for _, f := range tt.tagFilters {
+				assert.NoError(t, cmd.Flags().Set("tag", f))
+			}
+
+			capturedOutput := output.CaptureOutput(func() {
+				_ = ListMCRs(cmd, nil, true, "table")
+			})
+
+			for _, expected := range tt.expectedOutputs {
+				assert.Contains(t, capturedOutput, expected)
+			}
+			for _, notExp := range tt.notExpected {
+				assert.NotContains(t, capturedOutput, notExp)
+			}
+		})
+	}
+}

--- a/internal/commands/mcr/mcr_test.go
+++ b/internal/commands/mcr/mcr_test.go
@@ -1,11 +1,14 @@
 package mcr
 
 import (
+	"context"
 	"testing"
 
 	"github.com/megaport/megaport-cli/internal/base/output"
 	megaport "github.com/megaport/megaportgo"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var noColor = true
@@ -372,4 +375,37 @@ func TestFilterMCRs(t *testing.T) {
 func TestMCRUpdateTagsHasGenerateSkeleton(t *testing.T) {
 	_, updateTags := buildMCRTagCommands()
 	assert.NotNil(t, updateTags.Flags().Lookup("generate-skeleton"))
+}
+
+func TestMCRListHasTagFlag(t *testing.T) {
+	_, _, _, _, _, _, _, list, _, _ := buildMCRCommands(nil)
+	require.NotNil(t, list.Flags().Lookup("tag"), "list command should have --tag flag")
+}
+
+func TestMCRModule(t *testing.T) {
+	m := NewModule()
+	assert.Equal(t, "mcr", m.Name())
+
+	root := &cobra.Command{Use: "megaport-cli"}
+	m.RegisterCommands(root)
+
+	found := false
+	for _, cmd := range root.Commands() {
+		if cmd.Use == "mcr" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "RegisterCommands should add mcr command")
+}
+
+func TestListMCRResourceTagsFunc(t *testing.T) {
+	want := map[string]string{"env": "staging"}
+	mockSvc := &MockMCRService{ListMCRResourceTagsResult: want}
+	client := &megaport.Client{}
+	client.MCRService = mockSvc
+
+	got, err := listMCRResourceTagsFunc(context.Background(), client, "mcr-uid-1")
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
 }

--- a/internal/commands/mcr/mcr_utils.go
+++ b/internal/commands/mcr/mcr_utils.go
@@ -48,6 +48,10 @@ var restoreMCRFunc = func(ctx context.Context, client *megaport.Client, mcrUID s
 	return client.MCRService.RestoreMCR(ctx, mcrUID)
 }
 
+var listMCRResourceTagsFunc = func(ctx context.Context, client *megaport.Client, mcrUID string) (map[string]string, error) {
+	return client.MCRService.ListMCRResourceTags(ctx, mcrUID)
+}
+
 var lockMCRFunc = func(ctx context.Context, client *megaport.Client, mcrUID string) (*megaport.ManageProductLockResponse, error) {
 	return client.ProductService.ManageProductLock(ctx, &megaport.ManageProductLockRequest{ProductID: mcrUID, ShouldLock: true})
 }

--- a/internal/commands/mve/mve.go
+++ b/internal/commands/mve/mve.go
@@ -169,6 +169,8 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithExample("megaport-cli mve list --name \"Edge Router\"").
 		WithExample("megaport-cli mve list --include-inactive").
 		WithExample("megaport-cli mve list --location-id 123 --vendor \"Cisco\" --name \"Edge\"").
+		WithExample("megaport-cli mve list --tag env=prod").
+		WithExample("megaport-cli mve list --tag env=prod --tag team=network").
 		WithIntFlag("limit", 0, "Maximum number of results to display (0 = unlimited)").
 		WithRootCmd(rootCmd).
 		WithAliases([]string{"ls"}).

--- a/internal/commands/mve/mve.go
+++ b/internal/commands/mve/mve.go
@@ -162,7 +162,7 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithOutputFormatRunFunc(ListMVEs).
 		WithMVEFilterFlags().
 		WithTagFilterFlags().
-		WithLongDesc("List all MVEs available in the Megaport API.\n\nThis command fetches and displays a list of MVEs with details such as MVE ID, name, location, vendor, and status. By default, only active MVEs are shown.").
+		WithLongDesc("List all MVEs available in the Megaport API.\n\nThis command fetches and displays a list of MVEs with details such as MVE ID, name, location, vendor, and status. By default, only active MVEs are shown. You can also filter by resource tags.").
 		WithExample("megaport-cli mve list").
 		WithExample("megaport-cli mve list --location-id 123").
 		WithExample("megaport-cli mve list --vendor \"Cisco\"").

--- a/internal/commands/mve/mve.go
+++ b/internal/commands/mve/mve.go
@@ -161,6 +161,7 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 	listMVEsCmd := cmdbuilder.NewCommand("list", "List all MVEs with optional filters").
 		WithOutputFormatRunFunc(ListMVEs).
 		WithMVEFilterFlags().
+		WithTagFilterFlags().
 		WithLongDesc("List all MVEs available in the Megaport API.\n\nThis command fetches and displays a list of MVEs with details such as MVE ID, name, location, vendor, and status. By default, only active MVEs are shown.").
 		WithExample("megaport-cli mve list").
 		WithExample("megaport-cli mve list --location-id 123").

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -104,6 +104,9 @@ func ListMVEs(cmd *cobra.Command, args []string, noColor bool, outputFormat stri
 			tagFilters, limit,
 		)
 		tagSpinner.Stop()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		for uid, err := range tagErrs {
 			output.PrintWarning("Failed to fetch tags for MVE %s, skipping: %v", noColor, uid, err)
 		}

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -90,6 +90,21 @@ func ListMVEs(cmd *cobra.Command, args []string, noColor bool, outputFormat stri
 
 	filteredMVEs := filterMVEs(mves, locationID, vendor, name)
 
+	tagFilters, _ := cmd.Flags().GetStringArray("tag")
+	if len(tagFilters) > 0 {
+		var tagged []*megaport.MVE
+		for _, m := range filteredMVEs {
+			tags, err := listMVEResourceTagsFunc(ctx, client, m.UID)
+			if err != nil {
+				continue
+			}
+			if utils.MatchesTagFilters(tags, tagFilters) {
+				tagged = append(tagged, m)
+			}
+		}
+		filteredMVEs = tagged
+	}
+
 	limit, _ := cmd.Flags().GetInt("limit")
 	return utils.ApplyLimitAndPrint(filteredMVEs, limit, outputFormat, noColor,
 		"No MVEs found. Create one with 'megaport mve buy'.", printMVEs)

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -95,28 +95,17 @@ func ListMVEs(cmd *cobra.Command, args []string, noColor bool, outputFormat stri
 	tagFilters, _ := cmd.Flags().GetStringArray("tag")
 	if len(tagFilters) > 0 {
 		tagSpinner := output.PrintCustomSpinner("Fetching tags for", "MVEs", noColor)
-		uids := make([]string, len(filteredMVEs))
-		for i, m := range filteredMVEs {
-			uids[i] = m.UID
-		}
-		allTags, fetchErrs := utils.FetchTagsConcurrently(ctx, uids, func(ctx context.Context, uid string) (map[string]string, error) {
-			return listMVEResourceTagsFunc(ctx, client, uid)
-		})
+		filteredMVEs = utils.ApplyTagFilter(ctx, filteredMVEs,
+			func(m *megaport.MVE) string { return m.UID },
+			func(ctx context.Context, uid string) (map[string]string, error) {
+				return listMVEResourceTagsFunc(ctx, client, uid)
+			},
+			tagFilters, limit,
+			func(uid string, err error) {
+				output.PrintWarning("Failed to fetch tags for MVE %s, skipping: %v", noColor, uid, err)
+			},
+		)
 		tagSpinner.Stop()
-		tagged := make([]*megaport.MVE, 0, len(filteredMVEs))
-		for _, m := range filteredMVEs {
-			if err, ok := fetchErrs[m.UID]; ok {
-				output.PrintWarning("Failed to fetch tags for MVE %s, skipping: %v", noColor, m.UID, err)
-				continue
-			}
-			if utils.MatchesTagFilters(allTags[m.UID], tagFilters) {
-				tagged = append(tagged, m)
-				if limit > 0 && len(tagged) >= limit {
-					break
-				}
-			}
-		}
-		filteredMVEs = tagged
 	}
 	return utils.ApplyLimitAndPrint(filteredMVEs, limit, outputFormat, noColor,
 		"No MVEs found. Create one with 'megaport mve buy'.", printMVEs)

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -90,25 +90,34 @@ func ListMVEs(cmd *cobra.Command, args []string, noColor bool, outputFormat stri
 
 	filteredMVEs := filterMVEs(mves, locationID, vendor, name)
 
+	limit, _ := cmd.Flags().GetInt("limit")
+
 	tagFilters, _ := cmd.Flags().GetStringArray("tag")
 	if len(tagFilters) > 0 {
 		tagSpinner := output.PrintCustomSpinner("Fetching tags for", "MVEs", noColor)
+		uids := make([]string, len(filteredMVEs))
+		for i, m := range filteredMVEs {
+			uids[i] = m.UID
+		}
+		allTags, fetchErrs := utils.FetchTagsConcurrently(ctx, uids, func(ctx context.Context, uid string) (map[string]string, error) {
+			return listMVEResourceTagsFunc(ctx, client, uid)
+		})
+		tagSpinner.Stop()
 		tagged := make([]*megaport.MVE, 0, len(filteredMVEs))
 		for _, m := range filteredMVEs {
-			tags, err := listMVEResourceTagsFunc(ctx, client, m.UID)
-			if err != nil {
+			if err, ok := fetchErrs[m.UID]; ok {
 				output.PrintWarning("Failed to fetch tags for MVE %s, skipping: %v", noColor, m.UID, err)
 				continue
 			}
-			if utils.MatchesTagFilters(tags, tagFilters) {
+			if utils.MatchesTagFilters(allTags[m.UID], tagFilters) {
 				tagged = append(tagged, m)
+				if limit > 0 && len(tagged) >= limit {
+					break
+				}
 			}
 		}
-		tagSpinner.Stop()
 		filteredMVEs = tagged
 	}
-
-	limit, _ := cmd.Flags().GetInt("limit")
 	return utils.ApplyLimitAndPrint(filteredMVEs, limit, outputFormat, noColor,
 		"No MVEs found. Create one with 'megaport mve buy'.", printMVEs)
 }

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -95,17 +95,18 @@ func ListMVEs(cmd *cobra.Command, args []string, noColor bool, outputFormat stri
 	tagFilters, _ := cmd.Flags().GetStringArray("tag")
 	if len(tagFilters) > 0 {
 		tagSpinner := output.PrintCustomSpinner("Fetching tags for", "MVEs", noColor)
-		filteredMVEs = utils.ApplyTagFilter(ctx, filteredMVEs,
+		var tagErrs map[string]error
+		filteredMVEs, tagErrs = utils.ApplyTagFilter(ctx, filteredMVEs,
 			func(m *megaport.MVE) string { return m.UID },
 			func(ctx context.Context, uid string) (map[string]string, error) {
 				return listMVEResourceTagsFunc(ctx, client, uid)
 			},
 			tagFilters, limit,
-			func(uid string, err error) {
-				output.PrintWarning("Failed to fetch tags for MVE %s, skipping: %v", noColor, uid, err)
-			},
 		)
 		tagSpinner.Stop()
+		for uid, err := range tagErrs {
+			output.PrintWarning("Failed to fetch tags for MVE %s, skipping: %v", noColor, uid, err)
+		}
 	}
 	return utils.ApplyLimitAndPrint(filteredMVEs, limit, outputFormat, noColor,
 		"No MVEs found. Create one with 'megaport mve buy'.", printMVEs)

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -92,16 +92,19 @@ func ListMVEs(cmd *cobra.Command, args []string, noColor bool, outputFormat stri
 
 	tagFilters, _ := cmd.Flags().GetStringArray("tag")
 	if len(tagFilters) > 0 {
-		var tagged []*megaport.MVE
+		tagSpinner := output.PrintCustomSpinner("Fetching tags for", "MVEs", noColor)
+		tagged := make([]*megaport.MVE, 0, len(filteredMVEs))
 		for _, m := range filteredMVEs {
 			tags, err := listMVEResourceTagsFunc(ctx, client, m.UID)
 			if err != nil {
+				output.PrintWarning("Failed to fetch tags for MVE %s, skipping: %v", noColor, m.UID, err)
 				continue
 			}
 			if utils.MatchesTagFilters(tags, tagFilters) {
 				tagged = append(tagged, m)
 			}
 		}
+		tagSpinner.Stop()
 		filteredMVEs = tagged
 	}
 

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -2408,10 +2408,11 @@ func TestListMVEs_TagFilter(t *testing.T) {
 			notExpected: []string{"mve-1", "mve-2", "mve-3"},
 		},
 		{
-			name:           "tag fetch error excludes resource gracefully",
-			tagFilters:     []string{"env=prod"},
-			tagFetchErrUID: "mve-1",
-			notExpected:    []string{"mve-1"},
+			name:            "tag fetch error excludes resource gracefully",
+			tagFilters:      []string{"env=prod"},
+			tagFetchErrUID:  "mve-1",
+			notExpected:     []string{"MVE-Alpha"}, // name absent from table; UID appears in warning
+			expectedOutputs: []string{"Failed to fetch tags"},
 		},
 	}
 

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -2442,9 +2442,11 @@ func TestListMVEs_TagFilter(t *testing.T) {
 				assert.NoError(t, cmd.Flags().Set("tag", f))
 			}
 
+			var listErr error
 			capturedOutput := output.CaptureOutput(func() {
-				_ = ListMVEs(cmd, nil, true, "table")
+				listErr = ListMVEs(cmd, nil, true, "table")
 			})
+			assert.NoError(t, listErr)
 
 			for _, expected := range tt.expectedOutputs {
 				assert.Contains(t, capturedOutput, expected)

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -2352,3 +2352,105 @@ func TestListAvailableMVESizes_LoginError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "auth failed")
 }
+
+func TestListMVEs_TagFilter(t *testing.T) {
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
+	defer cleanup()
+
+	origListTagsFunc := listMVEResourceTagsFunc
+	defer func() { listMVEResourceTagsFunc = origListTagsFunc }()
+
+	allMVEs := []*megaport.MVE{
+		{UID: "mve-1", Name: "MVE-Alpha", ProvisioningStatus: "LIVE"},
+		{UID: "mve-2", Name: "MVE-Beta", ProvisioningStatus: "LIVE"},
+		{UID: "mve-3", Name: "MVE-Gamma", ProvisioningStatus: "LIVE"},
+	}
+
+	tagsByUID := map[string]map[string]string{
+		"mve-1": {"env": "prod", "team": "net"},
+		"mve-2": {"env": "staging"},
+		"mve-3": {},
+	}
+
+	tests := []struct {
+		name            string
+		tagFilters      []string
+		tagFetchErrUID  string
+		expectedOutputs []string
+		notExpected     []string
+	}{
+		{
+			name:            "no tag filter returns all",
+			tagFilters:      nil,
+			expectedOutputs: []string{"mve-1", "mve-2", "mve-3"},
+		},
+		{
+			name:            "exact match includes only matching resource",
+			tagFilters:      []string{"env=prod"},
+			expectedOutputs: []string{"mve-1"},
+			notExpected:     []string{"mve-2", "mve-3"},
+		},
+		{
+			name:            "AND logic requires all filters to match",
+			tagFilters:      []string{"env=prod", "team=net"},
+			expectedOutputs: []string{"mve-1"},
+			notExpected:     []string{"mve-2", "mve-3"},
+		},
+		{
+			name:            "key-exists match",
+			tagFilters:      []string{"env"},
+			expectedOutputs: []string{"mve-1", "mve-2"},
+			notExpected:     []string{"mve-3"},
+		},
+		{
+			name:        "no match returns empty",
+			tagFilters:  []string{"env=nonexistent"},
+			notExpected: []string{"mve-1", "mve-2", "mve-3"},
+		},
+		{
+			name:           "tag fetch error excludes resource gracefully",
+			tagFilters:     []string{"env=prod"},
+			tagFetchErrUID: "mve-1",
+			notExpected:    []string{"mve-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			listMVEResourceTagsFunc = func(ctx context.Context, client *megaport.Client, uid string) (map[string]string, error) {
+				if tt.tagFetchErrUID != "" && uid == tt.tagFetchErrUID {
+					return nil, fmt.Errorf("tag fetch error")
+				}
+				return tagsByUID[uid], nil
+			}
+
+			mockSvc := &MockMVEService{ListMVEsResult: allMVEs}
+			config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+				return &megaport.Client{MVEService: mockSvc}, nil
+			})
+
+			cmd := &cobra.Command{Use: "list"}
+			cmd.Flags().Bool("include-inactive", false, "")
+			cmd.Flags().Int("location-id", 0, "")
+			cmd.Flags().String("vendor", "", "")
+			cmd.Flags().String("name", "", "")
+			cmd.Flags().Int("limit", 0, "")
+			cmd.Flags().StringArray("tag", nil, "")
+
+			for _, f := range tt.tagFilters {
+				assert.NoError(t, cmd.Flags().Set("tag", f))
+			}
+
+			capturedOutput := output.CaptureOutput(func() {
+				_ = ListMVEs(cmd, nil, true, "table")
+			})
+
+			for _, expected := range tt.expectedOutputs {
+				assert.Contains(t, capturedOutput, expected)
+			}
+			for _, notExp := range tt.notExpected {
+				assert.NotContains(t, capturedOutput, notExp)
+			}
+		})
+	}
+}

--- a/internal/commands/ports/ports.go
+++ b/internal/commands/ports/ports.go
@@ -193,7 +193,7 @@ func buildPortManagementCommands(rootCmd *cobra.Command) (list, get, status, del
 		WithOutputFormatRunFunc(ListPorts).
 		WithPortFilterFlags().
 		WithTagFilterFlags().
-		WithLongDesc("List all ports available in the Megaport API.\n\nThis command fetches and displays a list of ports with details such as port ID, name, location, speed, and status. By default, only active ports are shown.").
+		WithLongDesc("List all ports available in the Megaport API.\n\nThis command fetches and displays a list of ports with details such as port ID, name, location, speed, and status. By default, only active ports are shown. You can also filter by resource tags.").
 		WithOptionalFlag("location-id", "Filter ports by location ID").
 		WithOptionalFlag("port-speed", "Filter ports by port speed").
 		WithOptionalFlag("port-name", "Filter ports by port name").

--- a/internal/commands/ports/ports.go
+++ b/internal/commands/ports/ports.go
@@ -204,6 +204,8 @@ func buildPortManagementCommands(rootCmd *cobra.Command) (list, get, status, del
 		WithExample("megaport-cli ports list --port-name \"Data Center Primary\"").
 		WithExample("megaport-cli ports list --include-inactive").
 		WithExample("megaport-cli ports list --location-id 1 --port-speed 10000 --port-name \"Data Center Primary\"").
+		WithExample("megaport-cli ports list --tag env=prod").
+		WithExample("megaport-cli ports list --tag env=prod --tag team=network").
 		WithIntFlag("limit", 0, "Maximum number of results to display (0 = unlimited)").
 		WithRootCmd(rootCmd).
 		WithAliases([]string{"ls"}).

--- a/internal/commands/ports/ports.go
+++ b/internal/commands/ports/ports.go
@@ -192,6 +192,7 @@ func buildPortManagementCommands(rootCmd *cobra.Command) (list, get, status, del
 	list = cmdbuilder.NewCommand("list", "List all ports with optional filters").
 		WithOutputFormatRunFunc(ListPorts).
 		WithPortFilterFlags().
+		WithTagFilterFlags().
 		WithLongDesc("List all ports available in the Megaport API.\n\nThis command fetches and displays a list of ports with details such as port ID, name, location, speed, and status. By default, only active ports are shown.").
 		WithOptionalFlag("location-id", "Filter ports by location ID").
 		WithOptionalFlag("port-speed", "Filter ports by port speed").

--- a/internal/commands/ports/ports_actions.go
+++ b/internal/commands/ports/ports_actions.go
@@ -303,16 +303,19 @@ func ListPorts(cmd *cobra.Command, args []string, noColor bool, outputFormat str
 
 	tagFilters, _ := cmd.Flags().GetStringArray("tag")
 	if len(tagFilters) > 0 {
-		var tagged []*megaport.Port
+		tagSpinner := output.PrintCustomSpinner("Fetching tags for", "ports", noColor)
+		tagged := make([]*megaport.Port, 0, len(filteredPorts))
 		for _, p := range filteredPorts {
 			tags, err := listPortResourceTagsFunc(ctx, client, p.UID)
 			if err != nil {
+				output.PrintWarning("Failed to fetch tags for port %s, skipping: %v", noColor, p.UID, err)
 				continue
 			}
 			if utils.MatchesTagFilters(tags, tagFilters) {
 				tagged = append(tagged, p)
 			}
 		}
+		tagSpinner.Stop()
 		filteredPorts = tagged
 	}
 

--- a/internal/commands/ports/ports_actions.go
+++ b/internal/commands/ports/ports_actions.go
@@ -301,25 +301,34 @@ func ListPorts(cmd *cobra.Command, args []string, noColor bool, outputFormat str
 
 	filteredPorts := filterPorts(ports, locationID, portSpeed, portName, includeInactive)
 
+	limit, _ := cmd.Flags().GetInt("limit")
+
 	tagFilters, _ := cmd.Flags().GetStringArray("tag")
 	if len(tagFilters) > 0 {
 		tagSpinner := output.PrintCustomSpinner("Fetching tags for", "ports", noColor)
+		uids := make([]string, len(filteredPorts))
+		for i, p := range filteredPorts {
+			uids[i] = p.UID
+		}
+		allTags, fetchErrs := utils.FetchTagsConcurrently(ctx, uids, func(ctx context.Context, uid string) (map[string]string, error) {
+			return listPortResourceTagsFunc(ctx, client, uid)
+		})
+		tagSpinner.Stop()
 		tagged := make([]*megaport.Port, 0, len(filteredPorts))
 		for _, p := range filteredPorts {
-			tags, err := listPortResourceTagsFunc(ctx, client, p.UID)
-			if err != nil {
+			if err, ok := fetchErrs[p.UID]; ok {
 				output.PrintWarning("Failed to fetch tags for port %s, skipping: %v", noColor, p.UID, err)
 				continue
 			}
-			if utils.MatchesTagFilters(tags, tagFilters) {
+			if utils.MatchesTagFilters(allTags[p.UID], tagFilters) {
 				tagged = append(tagged, p)
+				if limit > 0 && len(tagged) >= limit {
+					break
+				}
 			}
 		}
-		tagSpinner.Stop()
 		filteredPorts = tagged
 	}
-
-	limit, _ := cmd.Flags().GetInt("limit")
 	return utils.ApplyLimitAndPrint(filteredPorts, limit, outputFormat, noColor,
 		"No ports found. Create one with 'megaport ports buy'.", printPorts)
 }

--- a/internal/commands/ports/ports_actions.go
+++ b/internal/commands/ports/ports_actions.go
@@ -315,6 +315,9 @@ func ListPorts(cmd *cobra.Command, args []string, noColor bool, outputFormat str
 			tagFilters, limit,
 		)
 		tagSpinner.Stop()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		for uid, err := range tagErrs {
 			output.PrintWarning("Failed to fetch tags for port %s, skipping: %v", noColor, uid, err)
 		}

--- a/internal/commands/ports/ports_actions.go
+++ b/internal/commands/ports/ports_actions.go
@@ -306,28 +306,17 @@ func ListPorts(cmd *cobra.Command, args []string, noColor bool, outputFormat str
 	tagFilters, _ := cmd.Flags().GetStringArray("tag")
 	if len(tagFilters) > 0 {
 		tagSpinner := output.PrintCustomSpinner("Fetching tags for", "ports", noColor)
-		uids := make([]string, len(filteredPorts))
-		for i, p := range filteredPorts {
-			uids[i] = p.UID
-		}
-		allTags, fetchErrs := utils.FetchTagsConcurrently(ctx, uids, func(ctx context.Context, uid string) (map[string]string, error) {
-			return listPortResourceTagsFunc(ctx, client, uid)
-		})
+		filteredPorts = utils.ApplyTagFilter(ctx, filteredPorts,
+			func(p *megaport.Port) string { return p.UID },
+			func(ctx context.Context, uid string) (map[string]string, error) {
+				return listPortResourceTagsFunc(ctx, client, uid)
+			},
+			tagFilters, limit,
+			func(uid string, err error) {
+				output.PrintWarning("Failed to fetch tags for port %s, skipping: %v", noColor, uid, err)
+			},
+		)
 		tagSpinner.Stop()
-		tagged := make([]*megaport.Port, 0, len(filteredPorts))
-		for _, p := range filteredPorts {
-			if err, ok := fetchErrs[p.UID]; ok {
-				output.PrintWarning("Failed to fetch tags for port %s, skipping: %v", noColor, p.UID, err)
-				continue
-			}
-			if utils.MatchesTagFilters(allTags[p.UID], tagFilters) {
-				tagged = append(tagged, p)
-				if limit > 0 && len(tagged) >= limit {
-					break
-				}
-			}
-		}
-		filteredPorts = tagged
 	}
 	return utils.ApplyLimitAndPrint(filteredPorts, limit, outputFormat, noColor,
 		"No ports found. Create one with 'megaport ports buy'.", printPorts)

--- a/internal/commands/ports/ports_actions.go
+++ b/internal/commands/ports/ports_actions.go
@@ -306,17 +306,18 @@ func ListPorts(cmd *cobra.Command, args []string, noColor bool, outputFormat str
 	tagFilters, _ := cmd.Flags().GetStringArray("tag")
 	if len(tagFilters) > 0 {
 		tagSpinner := output.PrintCustomSpinner("Fetching tags for", "ports", noColor)
-		filteredPorts = utils.ApplyTagFilter(ctx, filteredPorts,
+		var tagErrs map[string]error
+		filteredPorts, tagErrs = utils.ApplyTagFilter(ctx, filteredPorts,
 			func(p *megaport.Port) string { return p.UID },
 			func(ctx context.Context, uid string) (map[string]string, error) {
 				return listPortResourceTagsFunc(ctx, client, uid)
 			},
 			tagFilters, limit,
-			func(uid string, err error) {
-				output.PrintWarning("Failed to fetch tags for port %s, skipping: %v", noColor, uid, err)
-			},
 		)
 		tagSpinner.Stop()
+		for uid, err := range tagErrs {
+			output.PrintWarning("Failed to fetch tags for port %s, skipping: %v", noColor, uid, err)
+		}
 	}
 	return utils.ApplyLimitAndPrint(filteredPorts, limit, outputFormat, noColor,
 		"No ports found. Create one with 'megaport ports buy'.", printPorts)

--- a/internal/commands/ports/ports_actions.go
+++ b/internal/commands/ports/ports_actions.go
@@ -301,6 +301,21 @@ func ListPorts(cmd *cobra.Command, args []string, noColor bool, outputFormat str
 
 	filteredPorts := filterPorts(ports, locationID, portSpeed, portName, includeInactive)
 
+	tagFilters, _ := cmd.Flags().GetStringArray("tag")
+	if len(tagFilters) > 0 {
+		var tagged []*megaport.Port
+		for _, p := range filteredPorts {
+			tags, err := listPortResourceTagsFunc(ctx, client, p.UID)
+			if err != nil {
+				continue
+			}
+			if utils.MatchesTagFilters(tags, tagFilters) {
+				tagged = append(tagged, p)
+			}
+		}
+		filteredPorts = tagged
+	}
+
 	limit, _ := cmd.Flags().GetInt("limit")
 	return utils.ApplyLimitAndPrint(filteredPorts, limit, outputFormat, noColor,
 		"No ports found. Create one with 'megaport ports buy'.", printPorts)

--- a/internal/commands/ports/ports_actions_test.go
+++ b/internal/commands/ports/ports_actions_test.go
@@ -2389,9 +2389,11 @@ func TestListPorts_TagFilter(t *testing.T) {
 				require.NoError(t, cmd.Flags().Set("tag", f))
 			}
 
+			var listErr error
 			capturedOutput := output.CaptureOutput(func() {
-				_ = ListPorts(cmd, nil, true, "table")
+				listErr = ListPorts(cmd, nil, true, "table")
 			})
+			assert.NoError(t, listErr)
 
 			for _, expected := range tt.expectedOutputs {
 				assert.Contains(t, capturedOutput, expected)

--- a/internal/commands/ports/ports_actions_test.go
+++ b/internal/commands/ports/ports_actions_test.go
@@ -2356,10 +2356,11 @@ func TestListPorts_TagFilter(t *testing.T) {
 			notExpected: []string{"port-1", "port-2", "port-3"},
 		},
 		{
-			name:           "tag fetch error excludes resource gracefully",
-			tagFilters:     []string{"env=prod"},
-			tagFetchErrUID: "port-1",
-			notExpected:    []string{"port-1"},
+			name:            "tag fetch error excludes resource gracefully",
+			tagFilters:      []string{"env=prod"},
+			tagFetchErrUID:  "port-1",
+			notExpected:     []string{"PortAlpha"}, // name absent from table; UID appears in warning
+			expectedOutputs: []string{"Failed to fetch tags"},
 		},
 	}
 

--- a/internal/commands/ports/ports_actions_test.go
+++ b/internal/commands/ports/ports_actions_test.go
@@ -2286,3 +2286,118 @@ func TestMockPortServiceReset(t *testing.T) {
 	assert.Nil(t, m.BuyPortErr)
 	assert.False(t, m.ForceNilGetPort)
 }
+
+func TestListPorts_TagFilter(t *testing.T) {
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
+	defer cleanup()
+
+	origListPortsFunc := listPortsFunc
+	origListTagsFunc := listPortResourceTagsFunc
+	defer func() {
+		listPortsFunc = origListPortsFunc
+		listPortResourceTagsFunc = origListTagsFunc
+	}()
+
+	allPorts := []*megaport.Port{
+		{UID: "port-1", Name: "PortAlpha", ProvisioningStatus: "LIVE"},
+		{UID: "port-2", Name: "PortBeta", ProvisioningStatus: "LIVE"},
+		{UID: "port-3", Name: "PortGamma", ProvisioningStatus: "LIVE"},
+	}
+
+	tagsByUID := map[string]map[string]string{
+		"port-1": {"env": "prod", "team": "net"},
+		"port-2": {"env": "staging"},
+		"port-3": {},
+	}
+
+	listPortsFunc = func(ctx context.Context, client *megaport.Client) ([]*megaport.Port, error) {
+		return allPorts, nil
+	}
+
+	tests := []struct {
+		name            string
+		tagFilters      []string
+		tagFetchErrUID  string // UID that returns an error
+		expectedOutputs []string
+		notExpected     []string
+	}{
+		{
+			name:            "no tag filter returns all",
+			tagFilters:      nil,
+			expectedOutputs: []string{"port-1", "port-2", "port-3"},
+		},
+		{
+			name:            "exact match includes only matching resource",
+			tagFilters:      []string{"env=prod"},
+			expectedOutputs: []string{"port-1"},
+			notExpected:     []string{"port-2", "port-3"},
+		},
+		{
+			name:            "exact match excludes non-matching value",
+			tagFilters:      []string{"env=staging"},
+			expectedOutputs: []string{"port-2"},
+			notExpected:     []string{"port-1", "port-3"},
+		},
+		{
+			name:            "AND logic requires all filters to match",
+			tagFilters:      []string{"env=prod", "team=net"},
+			expectedOutputs: []string{"port-1"},
+			notExpected:     []string{"port-2", "port-3"},
+		},
+		{
+			name:            "key-exists match",
+			tagFilters:      []string{"env"},
+			expectedOutputs: []string{"port-1", "port-2"},
+			notExpected:     []string{"port-3"},
+		},
+		{
+			name:        "no match returns empty",
+			tagFilters:  []string{"env=nonexistent"},
+			notExpected: []string{"port-1", "port-2", "port-3"},
+		},
+		{
+			name:           "tag fetch error excludes resource gracefully",
+			tagFilters:     []string{"env=prod"},
+			tagFetchErrUID: "port-1",
+			notExpected:    []string{"port-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			listPortResourceTagsFunc = func(ctx context.Context, client *megaport.Client, uid string) (map[string]string, error) {
+				if tt.tagFetchErrUID != "" && uid == tt.tagFetchErrUID {
+					return nil, fmt.Errorf("tag fetch error")
+				}
+				return tagsByUID[uid], nil
+			}
+
+			config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+				return &megaport.Client{PortService: &MockPortService{}}, nil
+			})
+
+			cmd := &cobra.Command{Use: "list"}
+			cmd.Flags().Int("location-id", 0, "")
+			cmd.Flags().Int("port-speed", 0, "")
+			cmd.Flags().String("port-name", "", "")
+			cmd.Flags().Bool("include-inactive", false, "")
+			cmd.Flags().Int("limit", 0, "")
+			cmd.Flags().StringArray("tag", nil, "")
+
+			for _, f := range tt.tagFilters {
+				require.NoError(t, cmd.Flags().Set("tag", f))
+			}
+
+			capturedOutput := output.CaptureOutput(func() {
+				_ = ListPorts(cmd, nil, true, "table")
+			})
+
+			for _, expected := range tt.expectedOutputs {
+				assert.Contains(t, capturedOutput, expected)
+			}
+			for _, notExp := range tt.notExpected {
+				assert.NotContains(t, capturedOutput, notExp)
+			}
+		})
+	}
+}

--- a/internal/commands/ports/ports_test.go
+++ b/internal/commands/ports/ports_test.go
@@ -5,7 +5,9 @@ import (
 
 	op "github.com/megaport/megaport-cli/internal/base/output"
 	megaport "github.com/megaport/megaportgo"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testPorts = []*megaport.Port{
@@ -382,4 +384,26 @@ func TestFilterPortsWithInactiveFlag(t *testing.T) {
 func TestPortsUpdateHasGenerateSkeleton(t *testing.T) {
 	_, _, update, _, _ := buildPortBuyCommands(nil)
 	assert.NotNil(t, update.Flags().Lookup("generate-skeleton"))
+}
+
+func TestPortsListHasTagFlag(t *testing.T) {
+	list, _, _, _, _, _, _, _ := buildPortManagementCommands(nil)
+	require.NotNil(t, list.Flags().Lookup("tag"), "list command should have --tag flag")
+}
+
+func TestPortsModule(t *testing.T) {
+	m := NewModule()
+	assert.Equal(t, "ports", m.Name())
+
+	root := &cobra.Command{Use: "megaport-cli"}
+	m.RegisterCommands(root)
+
+	found := false
+	for _, cmd := range root.Commands() {
+		if cmd.Use == "ports" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "RegisterCommands should add ports command")
 }

--- a/internal/commands/vxc/vxc.go
+++ b/internal/commands/vxc/vxc.go
@@ -36,6 +36,8 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithExample("megaport-cli vxc list --a-end-uid port-abc123").
 		WithExample("megaport-cli vxc list --status LIVE,CONFIGURED").
 		WithExample("megaport-cli vxc list --include-inactive").
+		WithExample("megaport-cli vxc list --tag env=prod").
+		WithExample("megaport-cli vxc list --tag env=prod --tag team=network").
 		WithIntFlag("limit", 0, "Maximum number of results to display (0 = unlimited)").
 		WithRootCmd(rootCmd).
 		WithAliases([]string{"ls"}).

--- a/internal/commands/vxc/vxc.go
+++ b/internal/commands/vxc/vxc.go
@@ -22,6 +22,7 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 	listVXCsCmd := cmdbuilder.NewCommand("list", "List all VXCs with optional filters").
 		WithOutputFormatRunFunc(ListVXCs).
 		WithVXCFilterFlags().
+		WithTagFilterFlags().
 		WithLongDesc("List all VXCs available in the Megaport API.\n\nThis command retrieves all Virtual Cross Connects (VXCs) associated with your account. You can filter results by name, rate limit, A-End UID, B-End UID, or status.").
 		WithOptionalFlag("name", "Filter VXCs by name (partial match)").
 		WithOptionalFlag("name-contains", "Filter VXCs by partial name match (server-side)").

--- a/internal/commands/vxc/vxc.go
+++ b/internal/commands/vxc/vxc.go
@@ -23,7 +23,7 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithOutputFormatRunFunc(ListVXCs).
 		WithVXCFilterFlags().
 		WithTagFilterFlags().
-		WithLongDesc("List all VXCs available in the Megaport API.\n\nThis command retrieves all Virtual Cross Connects (VXCs) associated with your account. You can filter results by name, rate limit, A-End UID, B-End UID, or status.").
+		WithLongDesc("List all VXCs available in the Megaport API.\n\nThis command retrieves all Virtual Cross Connects (VXCs) associated with your account. You can filter results by name, rate limit, A-End UID, B-End UID, status, or resource tags.").
 		WithOptionalFlag("name", "Filter VXCs by name (partial match)").
 		WithOptionalFlag("name-contains", "Filter VXCs by partial name match (server-side)").
 		WithOptionalFlag("rate-limit", "Filter VXCs by rate limit in Mbps").

--- a/internal/commands/vxc/vxc_actions.go
+++ b/internal/commands/vxc/vxc_actions.go
@@ -124,16 +124,19 @@ func ListVXCs(cmd *cobra.Command, args []string, noColor bool, outputFormat stri
 
 	tagFilters, _ := cmd.Flags().GetStringArray("tag")
 	if len(tagFilters) > 0 {
-		var tagged []*megaport.VXC
+		tagSpinner := output.PrintCustomSpinner("Fetching tags for", "VXCs", noColor)
+		tagged := make([]*megaport.VXC, 0, len(filteredVXCs))
 		for _, v := range filteredVXCs {
 			tags, err := listVXCResourceTagsFunc(ctx, client, v.UID)
 			if err != nil {
+				output.PrintWarning("Failed to fetch tags for VXC %s, skipping: %v", noColor, v.UID, err)
 				continue
 			}
 			if utils.MatchesTagFilters(tags, tagFilters) {
 				tagged = append(tagged, v)
 			}
 		}
+		tagSpinner.Stop()
 		filteredVXCs = tagged
 	}
 

--- a/internal/commands/vxc/vxc_actions.go
+++ b/internal/commands/vxc/vxc_actions.go
@@ -122,25 +122,34 @@ func ListVXCs(cmd *cobra.Command, args []string, noColor bool, outputFormat stri
 
 	filteredVXCs := filterVXCs(vxcs, name)
 
+	limit, _ := cmd.Flags().GetInt("limit")
+
 	tagFilters, _ := cmd.Flags().GetStringArray("tag")
 	if len(tagFilters) > 0 {
 		tagSpinner := output.PrintCustomSpinner("Fetching tags for", "VXCs", noColor)
+		uids := make([]string, len(filteredVXCs))
+		for i, v := range filteredVXCs {
+			uids[i] = v.UID
+		}
+		allTags, fetchErrs := utils.FetchTagsConcurrently(ctx, uids, func(ctx context.Context, uid string) (map[string]string, error) {
+			return listVXCResourceTagsFunc(ctx, client, uid)
+		})
+		tagSpinner.Stop()
 		tagged := make([]*megaport.VXC, 0, len(filteredVXCs))
 		for _, v := range filteredVXCs {
-			tags, err := listVXCResourceTagsFunc(ctx, client, v.UID)
-			if err != nil {
+			if err, ok := fetchErrs[v.UID]; ok {
 				output.PrintWarning("Failed to fetch tags for VXC %s, skipping: %v", noColor, v.UID, err)
 				continue
 			}
-			if utils.MatchesTagFilters(tags, tagFilters) {
+			if utils.MatchesTagFilters(allTags[v.UID], tagFilters) {
 				tagged = append(tagged, v)
+				if limit > 0 && len(tagged) >= limit {
+					break
+				}
 			}
 		}
-		tagSpinner.Stop()
 		filteredVXCs = tagged
 	}
-
-	limit, _ := cmd.Flags().GetInt("limit")
 	return utils.ApplyLimitAndPrint(filteredVXCs, limit, outputFormat, noColor,
 		"No VXCs found. Create one with 'megaport vxc buy'.", printVXCs)
 }

--- a/internal/commands/vxc/vxc_actions.go
+++ b/internal/commands/vxc/vxc_actions.go
@@ -136,6 +136,9 @@ func ListVXCs(cmd *cobra.Command, args []string, noColor bool, outputFormat stri
 			tagFilters, limit,
 		)
 		tagSpinner.Stop()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		for uid, err := range tagErrs {
 			output.PrintWarning("Failed to fetch tags for VXC %s, skipping: %v", noColor, uid, err)
 		}

--- a/internal/commands/vxc/vxc_actions.go
+++ b/internal/commands/vxc/vxc_actions.go
@@ -127,17 +127,18 @@ func ListVXCs(cmd *cobra.Command, args []string, noColor bool, outputFormat stri
 	tagFilters, _ := cmd.Flags().GetStringArray("tag")
 	if len(tagFilters) > 0 {
 		tagSpinner := output.PrintCustomSpinner("Fetching tags for", "VXCs", noColor)
-		filteredVXCs = utils.ApplyTagFilter(ctx, filteredVXCs,
+		var tagErrs map[string]error
+		filteredVXCs, tagErrs = utils.ApplyTagFilter(ctx, filteredVXCs,
 			func(v *megaport.VXC) string { return v.UID },
 			func(ctx context.Context, uid string) (map[string]string, error) {
 				return listVXCResourceTagsFunc(ctx, client, uid)
 			},
 			tagFilters, limit,
-			func(uid string, err error) {
-				output.PrintWarning("Failed to fetch tags for VXC %s, skipping: %v", noColor, uid, err)
-			},
 		)
 		tagSpinner.Stop()
+		for uid, err := range tagErrs {
+			output.PrintWarning("Failed to fetch tags for VXC %s, skipping: %v", noColor, uid, err)
+		}
 	}
 	return utils.ApplyLimitAndPrint(filteredVXCs, limit, outputFormat, noColor,
 		"No VXCs found. Create one with 'megaport vxc buy'.", printVXCs)

--- a/internal/commands/vxc/vxc_actions.go
+++ b/internal/commands/vxc/vxc_actions.go
@@ -122,6 +122,21 @@ func ListVXCs(cmd *cobra.Command, args []string, noColor bool, outputFormat stri
 
 	filteredVXCs := filterVXCs(vxcs, name)
 
+	tagFilters, _ := cmd.Flags().GetStringArray("tag")
+	if len(tagFilters) > 0 {
+		var tagged []*megaport.VXC
+		for _, v := range filteredVXCs {
+			tags, err := listVXCResourceTagsFunc(ctx, client, v.UID)
+			if err != nil {
+				continue
+			}
+			if utils.MatchesTagFilters(tags, tagFilters) {
+				tagged = append(tagged, v)
+			}
+		}
+		filteredVXCs = tagged
+	}
+
 	limit, _ := cmd.Flags().GetInt("limit")
 	return utils.ApplyLimitAndPrint(filteredVXCs, limit, outputFormat, noColor,
 		"No VXCs found. Create one with 'megaport vxc buy'.", printVXCs)

--- a/internal/commands/vxc/vxc_actions.go
+++ b/internal/commands/vxc/vxc_actions.go
@@ -127,28 +127,17 @@ func ListVXCs(cmd *cobra.Command, args []string, noColor bool, outputFormat stri
 	tagFilters, _ := cmd.Flags().GetStringArray("tag")
 	if len(tagFilters) > 0 {
 		tagSpinner := output.PrintCustomSpinner("Fetching tags for", "VXCs", noColor)
-		uids := make([]string, len(filteredVXCs))
-		for i, v := range filteredVXCs {
-			uids[i] = v.UID
-		}
-		allTags, fetchErrs := utils.FetchTagsConcurrently(ctx, uids, func(ctx context.Context, uid string) (map[string]string, error) {
-			return listVXCResourceTagsFunc(ctx, client, uid)
-		})
+		filteredVXCs = utils.ApplyTagFilter(ctx, filteredVXCs,
+			func(v *megaport.VXC) string { return v.UID },
+			func(ctx context.Context, uid string) (map[string]string, error) {
+				return listVXCResourceTagsFunc(ctx, client, uid)
+			},
+			tagFilters, limit,
+			func(uid string, err error) {
+				output.PrintWarning("Failed to fetch tags for VXC %s, skipping: %v", noColor, uid, err)
+			},
+		)
 		tagSpinner.Stop()
-		tagged := make([]*megaport.VXC, 0, len(filteredVXCs))
-		for _, v := range filteredVXCs {
-			if err, ok := fetchErrs[v.UID]; ok {
-				output.PrintWarning("Failed to fetch tags for VXC %s, skipping: %v", noColor, v.UID, err)
-				continue
-			}
-			if utils.MatchesTagFilters(allTags[v.UID], tagFilters) {
-				tagged = append(tagged, v)
-				if limit > 0 && len(tagged) >= limit {
-					break
-				}
-			}
-		}
-		filteredVXCs = tagged
 	}
 	return utils.ApplyLimitAndPrint(filteredVXCs, limit, outputFormat, noColor,
 		"No VXCs found. Create one with 'megaport vxc buy'.", printVXCs)

--- a/internal/commands/vxc/vxc_actions_test.go
+++ b/internal/commands/vxc/vxc_actions_test.go
@@ -2446,3 +2446,108 @@ func TestMockVXCServiceReset(t *testing.T) {
 	assert.Nil(t, m.DeleteVXCError)
 	assert.False(t, m.ForceNilGetVXC)
 }
+
+func TestListVXCs_TagFilter(t *testing.T) {
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
+	defer cleanup()
+
+	origListTagsFunc := listVXCResourceTagsFunc
+	defer func() { listVXCResourceTagsFunc = origListTagsFunc }()
+
+	allVXCs := []*megaport.VXC{
+		{UID: "vxc-1", Name: "VXC-Alpha", ProvisioningStatus: "LIVE"},
+		{UID: "vxc-2", Name: "VXC-Beta", ProvisioningStatus: "LIVE"},
+		{UID: "vxc-3", Name: "VXC-Gamma", ProvisioningStatus: "LIVE"},
+	}
+
+	tagsByUID := map[string]map[string]string{
+		"vxc-1": {"env": "prod", "team": "net"},
+		"vxc-2": {"env": "staging"},
+		"vxc-3": {},
+	}
+
+	tests := []struct {
+		name            string
+		tagFilters      []string
+		tagFetchErrUID  string
+		expectedOutputs []string
+		notExpected     []string
+	}{
+		{
+			name:            "no tag filter returns all",
+			tagFilters:      nil,
+			expectedOutputs: []string{"vxc-1", "vxc-2", "vxc-3"},
+		},
+		{
+			name:            "exact match includes only matching resource",
+			tagFilters:      []string{"env=prod"},
+			expectedOutputs: []string{"vxc-1"},
+			notExpected:     []string{"vxc-2", "vxc-3"},
+		},
+		{
+			name:            "AND logic requires all filters to match",
+			tagFilters:      []string{"env=prod", "team=net"},
+			expectedOutputs: []string{"vxc-1"},
+			notExpected:     []string{"vxc-2", "vxc-3"},
+		},
+		{
+			name:            "key-exists match",
+			tagFilters:      []string{"env"},
+			expectedOutputs: []string{"vxc-1", "vxc-2"},
+			notExpected:     []string{"vxc-3"},
+		},
+		{
+			name:        "no match returns empty",
+			tagFilters:  []string{"env=nonexistent"},
+			notExpected: []string{"vxc-1", "vxc-2", "vxc-3"},
+		},
+		{
+			name:           "tag fetch error excludes resource gracefully",
+			tagFilters:     []string{"env=prod"},
+			tagFetchErrUID: "vxc-1",
+			notExpected:    []string{"vxc-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			listVXCResourceTagsFunc = func(ctx context.Context, client *megaport.Client, uid string) (map[string]string, error) {
+				if tt.tagFetchErrUID != "" && uid == tt.tagFetchErrUID {
+					return nil, fmt.Errorf("tag fetch error")
+				}
+				return tagsByUID[uid], nil
+			}
+
+			mockSvc := &MockVXCService{ListVXCResponse: allVXCs}
+			config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+				return &megaport.Client{VXCService: mockSvc}, nil
+			})
+
+			cmd := &cobra.Command{Use: "list"}
+			cmd.Flags().String("name", "", "")
+			cmd.Flags().String("name-contains", "", "")
+			cmd.Flags().Int("rate-limit", 0, "")
+			cmd.Flags().String("a-end-uid", "", "")
+			cmd.Flags().String("b-end-uid", "", "")
+			cmd.Flags().Bool("include-inactive", false, "")
+			cmd.Flags().String("status", "", "")
+			cmd.Flags().Int("limit", 0, "")
+			cmd.Flags().StringArray("tag", nil, "")
+
+			for _, f := range tt.tagFilters {
+				assert.NoError(t, cmd.Flags().Set("tag", f))
+			}
+
+			capturedOutput := output.CaptureOutput(func() {
+				_ = ListVXCs(cmd, nil, true, "table")
+			})
+
+			for _, expected := range tt.expectedOutputs {
+				assert.Contains(t, capturedOutput, expected)
+			}
+			for _, notExp := range tt.notExpected {
+				assert.NotContains(t, capturedOutput, notExp)
+			}
+		})
+	}
+}

--- a/internal/commands/vxc/vxc_actions_test.go
+++ b/internal/commands/vxc/vxc_actions_test.go
@@ -2539,9 +2539,11 @@ func TestListVXCs_TagFilter(t *testing.T) {
 				assert.NoError(t, cmd.Flags().Set("tag", f))
 			}
 
+			var listErr error
 			capturedOutput := output.CaptureOutput(func() {
-				_ = ListVXCs(cmd, nil, true, "table")
+				listErr = ListVXCs(cmd, nil, true, "table")
 			})
+			assert.NoError(t, listErr)
 
 			for _, expected := range tt.expectedOutputs {
 				assert.Contains(t, capturedOutput, expected)

--- a/internal/commands/vxc/vxc_actions_test.go
+++ b/internal/commands/vxc/vxc_actions_test.go
@@ -2502,10 +2502,11 @@ func TestListVXCs_TagFilter(t *testing.T) {
 			notExpected: []string{"vxc-1", "vxc-2", "vxc-3"},
 		},
 		{
-			name:           "tag fetch error excludes resource gracefully",
-			tagFilters:     []string{"env=prod"},
-			tagFetchErrUID: "vxc-1",
-			notExpected:    []string{"vxc-1"},
+			name:            "tag fetch error excludes resource gracefully",
+			tagFilters:      []string{"env=prod"},
+			tagFetchErrUID:  "vxc-1",
+			notExpected:     []string{"VXC-Alpha"}, // name absent from table; UID appears in warning
+			expectedOutputs: []string{"Failed to fetch tags"},
 		},
 	}
 

--- a/internal/commands/vxc/vxc_test.go
+++ b/internal/commands/vxc/vxc_test.go
@@ -1,6 +1,7 @@
 package vxc
 
 import (
+	"context"
 	"testing"
 
 	"github.com/megaport/megaport-cli/internal/base/output"
@@ -547,4 +548,24 @@ func TestVXCUpdateTagsHasGenerateSkeleton(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, updateTagsCmd)
 	assert.NotNil(t, updateTagsCmd.Flags().Lookup("generate-skeleton"))
+}
+
+func TestVXCListHasTagFlag(t *testing.T) {
+	root := &cobra.Command{Use: "megaport-cli"}
+	AddCommandsTo(root)
+	listCmd, _, err := root.Find([]string{"vxc", "list"})
+	require.NoError(t, err)
+	require.NotNil(t, listCmd)
+	assert.NotNil(t, listCmd.Flags().Lookup("tag"), "list command should have --tag flag")
+}
+
+func TestListVXCResourceTagsFunc(t *testing.T) {
+	want := map[string]string{"env": "prod"}
+	mockSvc := &MockVXCService{ListVXCResourceTagsResult: want}
+	client := &megaport.Client{}
+	client.VXCService = mockSvc
+
+	got, err := listVXCResourceTagsFunc(context.Background(), client, "vxc-uid-1")
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
 }

--- a/internal/commands/vxc/vxc_utils.go
+++ b/internal/commands/vxc/vxc_utils.go
@@ -51,6 +51,10 @@ var getPartnerPortUID = func(ctx context.Context, svc megaport.VXCService, key, 
 	return res.ProductUID, nil
 }
 
+var listVXCResourceTagsFunc = func(ctx context.Context, client *megaport.Client, vxcUID string) (map[string]string, error) {
+	return client.VXCService.ListVXCResourceTags(ctx, vxcUID)
+}
+
 // filterVXCs applies client-side case-insensitive name filtering as a safety
 // net alongside server-side NameContains filtering.
 func filterVXCs(vxcs []*megaport.VXC, name string) []*megaport.VXC {

--- a/internal/utils/tag_fetch.go
+++ b/internal/utils/tag_fetch.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-// defaultTagFetchConcurrency is the maximum number of parallel tag-fetch API calls.
+// defaultTagFetchConcurrency is the size of the fixed worker pool used when fetching tags.
 const defaultTagFetchConcurrency = 20
 
 type tagFetchResult struct {
@@ -14,8 +14,9 @@ type tagFetchResult struct {
 	err  error
 }
 
-// FetchTagsConcurrently fetches resource tags for multiple UIDs in parallel,
-// bounding concurrency to defaultTagFetchConcurrency outstanding requests.
+// FetchTagsConcurrently fetches resource tags for multiple UIDs using a fixed worker pool
+// capped at defaultTagFetchConcurrency, so neither goroutine count nor channel buffer
+// grows with the number of UIDs.
 // It returns two maps: uid→tags for successful fetches and uid→error for failures.
 func FetchTagsConcurrently(
 	ctx context.Context,
@@ -26,21 +27,33 @@ func FetchTagsConcurrently(
 		return nil, nil
 	}
 
-	results := make(chan tagFetchResult, len(uids))
-	sem := make(chan struct{}, defaultTagFetchConcurrency)
+	workerCount := defaultTagFetchConcurrency
+	if len(uids) < workerCount {
+		workerCount = len(uids)
+	}
+
+	jobs := make(chan string, workerCount)
+	results := make(chan tagFetchResult, workerCount)
 
 	var wg sync.WaitGroup
-	for _, uid := range uids {
-		uid := uid
+	for range workerCount {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-			tags, err := fetch(ctx, uid)
-			results <- tagFetchResult{uid: uid, tags: tags, err: err}
+			for uid := range jobs {
+				tags, err := fetch(ctx, uid)
+				results <- tagFetchResult{uid: uid, tags: tags, err: err}
+			}
 		}()
 	}
+
+	go func() {
+		for _, uid := range uids {
+			jobs <- uid
+		}
+		close(jobs)
+	}()
+
 	go func() {
 		wg.Wait()
 		close(results)

--- a/internal/utils/tag_fetch.go
+++ b/internal/utils/tag_fetch.go
@@ -100,17 +100,27 @@ func FetchTagsConcurrently(
 		go func() {
 			defer wg.Done()
 			for uid := range jobs {
+				// Propagate cancellation without making a redundant API call.
+				if err := ctx.Err(); err != nil {
+					results <- tagFetchResult{uid: uid, err: err}
+					continue
+				}
 				tags, err := fetch(ctx, uid)
 				results <- tagFetchResult{uid: uid, tags: tags, err: err}
 			}
 		}()
 	}
 
+	// Stop enqueuing new jobs as soon as the context is done.
 	go func() {
+		defer close(jobs)
 		for _, uid := range uids {
-			jobs <- uid
+			select {
+			case jobs <- uid:
+			case <-ctx.Done():
+				return
+			}
 		}
-		close(jobs)
 	}()
 
 	go func() {

--- a/internal/utils/tag_fetch.go
+++ b/internal/utils/tag_fetch.go
@@ -26,6 +26,9 @@ func ApplyTagFilter[T any](
 		result := make([]T, 0, limit)
 		var fetchErrs map[string]error
 		for _, r := range resources {
+			if err := ctx.Err(); err != nil {
+				break
+			}
 			uid := uidFunc(r)
 			tags, err := fetch(ctx, uid)
 			if err != nil {

--- a/internal/utils/tag_fetch.go
+++ b/internal/utils/tag_fetch.go
@@ -11,8 +11,9 @@ import (
 //   - limit == 0: parallel fetch via FetchTagsConcurrently (minimises wall-clock time
 //     when all results are needed)
 //
-// onErr is called for each resource whose tags could not be fetched; that resource is
-// then excluded from the results.
+// Resources whose tags could not be fetched are excluded from the results; their UIDs
+// and errors are returned in the second map so the caller can report them after any
+// spinner has been stopped (avoiding interleaved terminal output).
 func ApplyTagFilter[T any](
 	ctx context.Context,
 	resources []T,
@@ -20,15 +21,18 @@ func ApplyTagFilter[T any](
 	fetch func(context.Context, string) (map[string]string, error),
 	tagFilters []string,
 	limit int,
-	onErr func(uid string, err error),
-) []T {
+) ([]T, map[string]error) {
 	if limit > 0 {
 		result := make([]T, 0, limit)
+		var fetchErrs map[string]error
 		for _, r := range resources {
 			uid := uidFunc(r)
 			tags, err := fetch(ctx, uid)
 			if err != nil {
-				onErr(uid, err)
+				if fetchErrs == nil {
+					fetchErrs = make(map[string]error)
+				}
+				fetchErrs[uid] = err
 				continue
 			}
 			if MatchesTagFilters(tags, tagFilters) {
@@ -38,7 +42,7 @@ func ApplyTagFilter[T any](
 				}
 			}
 		}
-		return result
+		return result, fetchErrs
 	}
 
 	// Unlimited: fetch all tags in parallel for minimal wall-clock time.
@@ -50,15 +54,14 @@ func ApplyTagFilter[T any](
 	result := make([]T, 0, len(resources))
 	for _, r := range resources {
 		uid := uidFunc(r)
-		if err, ok := fetchErrs[uid]; ok {
-			onErr(uid, err)
+		if _, failed := fetchErrs[uid]; failed {
 			continue
 		}
 		if MatchesTagFilters(allTags[uid], tagFilters) {
 			result = append(result, r)
 		}
 	}
-	return result
+	return result, fetchErrs
 }
 
 // defaultTagFetchConcurrency is the size of the fixed worker pool used when fetching tags.

--- a/internal/utils/tag_fetch.go
+++ b/internal/utils/tag_fetch.go
@@ -1,0 +1,59 @@
+package utils
+
+import (
+	"context"
+	"sync"
+)
+
+// defaultTagFetchConcurrency is the maximum number of parallel tag-fetch API calls.
+const defaultTagFetchConcurrency = 20
+
+type tagFetchResult struct {
+	uid  string
+	tags map[string]string
+	err  error
+}
+
+// FetchTagsConcurrently fetches resource tags for multiple UIDs in parallel,
+// bounding concurrency to defaultTagFetchConcurrency outstanding requests.
+// It returns two maps: uid→tags for successful fetches and uid→error for failures.
+func FetchTagsConcurrently(
+	ctx context.Context,
+	uids []string,
+	fetch func(ctx context.Context, uid string) (map[string]string, error),
+) (map[string]map[string]string, map[string]error) {
+	if len(uids) == 0 {
+		return nil, nil
+	}
+
+	results := make(chan tagFetchResult, len(uids))
+	sem := make(chan struct{}, defaultTagFetchConcurrency)
+
+	var wg sync.WaitGroup
+	for _, uid := range uids {
+		uid := uid
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			tags, err := fetch(ctx, uid)
+			results <- tagFetchResult{uid: uid, tags: tags, err: err}
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	tagMap := make(map[string]map[string]string, len(uids))
+	errMap := make(map[string]error)
+	for r := range results {
+		if r.err != nil {
+			errMap[r.uid] = r.err
+		} else {
+			tagMap[r.uid] = r.tags
+		}
+	}
+	return tagMap, errMap
+}

--- a/internal/utils/tag_fetch.go
+++ b/internal/utils/tag_fetch.go
@@ -5,6 +5,62 @@ import (
 	"sync"
 )
 
+// ApplyTagFilter filters resources by tag, choosing the optimal fetch strategy:
+//   - limit > 0: sequential fetch with early stopping (avoids unnecessary API calls
+//     once enough matches are found)
+//   - limit == 0: parallel fetch via FetchTagsConcurrently (minimises wall-clock time
+//     when all results are needed)
+//
+// onErr is called for each resource whose tags could not be fetched; that resource is
+// then excluded from the results.
+func ApplyTagFilter[T any](
+	ctx context.Context,
+	resources []T,
+	uidFunc func(T) string,
+	fetch func(context.Context, string) (map[string]string, error),
+	tagFilters []string,
+	limit int,
+	onErr func(uid string, err error),
+) []T {
+	if limit > 0 {
+		result := make([]T, 0, limit)
+		for _, r := range resources {
+			uid := uidFunc(r)
+			tags, err := fetch(ctx, uid)
+			if err != nil {
+				onErr(uid, err)
+				continue
+			}
+			if MatchesTagFilters(tags, tagFilters) {
+				result = append(result, r)
+				if len(result) >= limit {
+					break
+				}
+			}
+		}
+		return result
+	}
+
+	// Unlimited: fetch all tags in parallel for minimal wall-clock time.
+	uids := make([]string, len(resources))
+	for i, r := range resources {
+		uids[i] = uidFunc(r)
+	}
+	allTags, fetchErrs := FetchTagsConcurrently(ctx, uids, fetch)
+	result := make([]T, 0, len(resources))
+	for _, r := range resources {
+		uid := uidFunc(r)
+		if err, ok := fetchErrs[uid]; ok {
+			onErr(uid, err)
+			continue
+		}
+		if MatchesTagFilters(allTags[uid], tagFilters) {
+			result = append(result, r)
+		}
+	}
+	return result
+}
+
 // defaultTagFetchConcurrency is the size of the fixed worker pool used when fetching tags.
 const defaultTagFetchConcurrency = 20
 

--- a/internal/utils/tag_fetch_test.go
+++ b/internal/utils/tag_fetch_test.go
@@ -1,0 +1,93 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchTagsConcurrently_Empty(t *testing.T) {
+	called := false
+	tagMap, errMap := FetchTagsConcurrently(context.Background(), nil, func(_ context.Context, _ string) (map[string]string, error) {
+		called = true
+		return nil, nil
+	})
+	assert.Nil(t, tagMap)
+	assert.Nil(t, errMap)
+	assert.False(t, called)
+}
+
+func TestFetchTagsConcurrently_AllSuccess(t *testing.T) {
+	data := map[string]map[string]string{
+		"uid-1": {"env": "prod"},
+		"uid-2": {"env": "staging"},
+		"uid-3": {},
+	}
+	uids := []string{"uid-1", "uid-2", "uid-3"}
+
+	tagMap, errMap := FetchTagsConcurrently(context.Background(), uids, func(_ context.Context, uid string) (map[string]string, error) {
+		return data[uid], nil
+	})
+
+	require.Empty(t, errMap)
+	assert.Equal(t, data["uid-1"], tagMap["uid-1"])
+	assert.Equal(t, data["uid-2"], tagMap["uid-2"])
+	assert.Equal(t, data["uid-3"], tagMap["uid-3"])
+}
+
+func TestFetchTagsConcurrently_PartialErrors(t *testing.T) {
+	fetchErr := errors.New("not found")
+	uids := []string{"uid-ok", "uid-err"}
+
+	tagMap, errMap := FetchTagsConcurrently(context.Background(), uids, func(_ context.Context, uid string) (map[string]string, error) {
+		if uid == "uid-err" {
+			return nil, fetchErr
+		}
+		return map[string]string{"k": "v"}, nil
+	})
+
+	assert.Equal(t, map[string]string{"k": "v"}, tagMap["uid-ok"])
+	assert.Equal(t, fetchErr, errMap["uid-err"])
+	assert.NotContains(t, tagMap, "uid-err")
+}
+
+func TestFetchTagsConcurrently_BoundedConcurrency(t *testing.T) {
+	// Verify that no more than defaultTagFetchConcurrency goroutines fetch at once.
+	var inflight atomic.Int64
+	var maxSeen atomic.Int64
+
+	uids := make([]string, defaultTagFetchConcurrency*3)
+	for i := range uids {
+		uids[i] = "uid"
+	}
+
+	FetchTagsConcurrently(context.Background(), uids, func(_ context.Context, _ string) (map[string]string, error) {
+		cur := inflight.Add(1)
+		for {
+			m := maxSeen.Load()
+			if cur <= m || maxSeen.CompareAndSwap(m, cur) {
+				break
+			}
+		}
+		inflight.Add(-1)
+		return nil, nil
+	})
+
+	assert.LessOrEqual(t, maxSeen.Load(), int64(defaultTagFetchConcurrency))
+}
+
+func TestFetchTagsConcurrently_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	uids := []string{"uid-1", "uid-2"}
+	_, errMap := FetchTagsConcurrently(ctx, uids, func(ctx context.Context, uid string) (map[string]string, error) {
+		return nil, ctx.Err()
+	})
+
+	assert.Len(t, errMap, 2)
+}

--- a/internal/utils/tag_fetch_test.go
+++ b/internal/utils/tag_fetch_test.go
@@ -112,3 +112,98 @@ func TestFetchTagsConcurrently_ContextCancelled(t *testing.T) {
 
 	assert.Len(t, errMap, 2)
 }
+
+// --- ApplyTagFilter tests ---
+
+type testResource struct {
+	uid  string
+	tags map[string]string
+}
+
+func makeTagFetch(resources []testResource) func(context.Context, string) (map[string]string, error) {
+	m := make(map[string]map[string]string, len(resources))
+	for _, r := range resources {
+		m[r.uid] = r.tags
+	}
+	return func(_ context.Context, uid string) (map[string]string, error) {
+		return m[uid], nil
+	}
+}
+
+func TestApplyTagFilter_NoLimit_AllMatch(t *testing.T) {
+	resources := []testResource{
+		{uid: "a", tags: map[string]string{"env": "prod"}},
+		{uid: "b", tags: map[string]string{"env": "prod"}},
+	}
+	got := ApplyTagFilter(context.Background(), resources,
+		func(r testResource) string { return r.uid },
+		makeTagFetch(resources),
+		[]string{"env=prod"}, 0,
+		func(uid string, err error) { t.Errorf("unexpected error for %s: %v", uid, err) },
+	)
+	assert.Len(t, got, 2)
+}
+
+func TestApplyTagFilter_NoLimit_SomeMatch(t *testing.T) {
+	resources := []testResource{
+		{uid: "a", tags: map[string]string{"env": "prod"}},
+		{uid: "b", tags: map[string]string{"env": "staging"}},
+		{uid: "c", tags: map[string]string{"env": "prod"}},
+	}
+	got := ApplyTagFilter(context.Background(), resources,
+		func(r testResource) string { return r.uid },
+		makeTagFetch(resources),
+		[]string{"env=prod"}, 0,
+		func(uid string, err error) { t.Errorf("unexpected error for %s: %v", uid, err) },
+	)
+	require.Len(t, got, 2)
+	assert.Equal(t, "a", got[0].uid)
+	assert.Equal(t, "c", got[1].uid)
+}
+
+func TestApplyTagFilter_WithLimit_StopsEarly(t *testing.T) {
+	var callCount int
+	resources := []testResource{
+		{uid: "a", tags: map[string]string{"env": "prod"}},
+		{uid: "b", tags: map[string]string{"env": "prod"}},
+		{uid: "c", tags: map[string]string{"env": "prod"}},
+	}
+	fetch := func(_ context.Context, uid string) (map[string]string, error) {
+		callCount++
+		for _, r := range resources {
+			if r.uid == uid {
+				return r.tags, nil
+			}
+		}
+		return nil, nil
+	}
+	got := ApplyTagFilter(context.Background(), resources,
+		func(r testResource) string { return r.uid },
+		fetch,
+		[]string{"env=prod"}, 2,
+		func(uid string, err error) { t.Errorf("unexpected error for %s: %v", uid, err) },
+	)
+	assert.Len(t, got, 2)
+	// With limit=2, should stop after 2 matches — only 2 API calls needed.
+	assert.Equal(t, 2, callCount)
+}
+
+func TestApplyTagFilter_FetchError_Excluded(t *testing.T) {
+	var warnedUID string
+	resources := []testResource{{uid: "ok"}, {uid: "err"}}
+	fetch := func(_ context.Context, uid string) (map[string]string, error) {
+		if uid == "err" {
+			return nil, errors.New("fetch failed")
+		}
+		return map[string]string{"env": "prod"}, nil
+	}
+	got := ApplyTagFilter(context.Background(), resources,
+		func(r testResource) string { return r.uid },
+		fetch,
+		[]string{"env=prod"}, 0,
+		func(uid string, _ error) { warnedUID = uid },
+	)
+	require.Len(t, got, 1)
+	assert.Equal(t, "ok", got[0].uid)
+	assert.Equal(t, "err", warnedUID)
+}

--- a/internal/utils/tag_fetch_test.go
+++ b/internal/utils/tag_fetch_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 
@@ -56,28 +57,48 @@ func TestFetchTagsConcurrently_PartialErrors(t *testing.T) {
 }
 
 func TestFetchTagsConcurrently_BoundedConcurrency(t *testing.T) {
-	// Verify that no more than defaultTagFetchConcurrency goroutines fetch at once.
+	// Use exactly defaultTagFetchConcurrency UIDs so each worker handles one UID.
+	// This ensures a single barrier cycle with no multi-batch re-send to ready.
 	var inflight atomic.Int64
 	var maxSeen atomic.Int64
 
-	uids := make([]string, defaultTagFetchConcurrency*3)
+	// ready is signalled once per inflight fetch so the test can wait for full saturation.
+	ready := make(chan struct{}, defaultTagFetchConcurrency)
+	// release is closed to unblock all workers at once.
+	release := make(chan struct{})
+
+	uids := make([]string, defaultTagFetchConcurrency)
 	for i := range uids {
-		uids[i] = "uid"
+		uids[i] = fmt.Sprintf("uid-%d", i)
 	}
 
-	FetchTagsConcurrently(context.Background(), uids, func(_ context.Context, _ string) (map[string]string, error) {
-		cur := inflight.Add(1)
-		for {
-			m := maxSeen.Load()
-			if cur <= m || maxSeen.CompareAndSwap(m, cur) {
-				break
+	done := make(chan struct{})
+	go func() {
+		FetchTagsConcurrently(context.Background(), uids, func(_ context.Context, _ string) (map[string]string, error) {
+			cur := inflight.Add(1)
+			for {
+				m := maxSeen.Load()
+				if cur <= m || maxSeen.CompareAndSwap(m, cur) {
+					break
+				}
 			}
-		}
-		inflight.Add(-1)
-		return nil, nil
-	})
+			ready <- struct{}{} // signal: this fetch is inflight
+			<-release           // block until test observes full saturation
+			inflight.Add(-1)
+			return nil, nil
+		})
+		close(done)
+	}()
 
-	assert.LessOrEqual(t, maxSeen.Load(), int64(defaultTagFetchConcurrency))
+	// Wait for all workers to be simultaneously inflight.
+	for i := 0; i < defaultTagFetchConcurrency; i++ {
+		<-ready
+	}
+	// All workers are blocked: maxSeen reflects true simultaneous inflight count.
+	assert.Equal(t, int64(defaultTagFetchConcurrency), maxSeen.Load())
+
+	close(release) // unblock workers so the function can complete
+	<-done
 }
 
 func TestFetchTagsConcurrently_ContextCancelled(t *testing.T) {

--- a/internal/utils/tag_fetch_test.go
+++ b/internal/utils/tag_fetch_test.go
@@ -105,12 +105,18 @@ func TestFetchTagsConcurrently_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel
 
-	uids := []string{"uid-1", "uid-2"}
+	// With a pre-cancelled context the producer stops enqueuing early, so the
+	// number of errors is non-deterministic (0 – len(uids)). What matters is:
+	// (a) the call returns without deadlocking, and
+	// (b) every error in errMap is a context error.
+	uids := []string{"uid-1", "uid-2", "uid-3", "uid-4", "uid-5"}
 	_, errMap := FetchTagsConcurrently(ctx, uids, func(ctx context.Context, uid string) (map[string]string, error) {
 		return nil, ctx.Err()
 	})
 
-	assert.Len(t, errMap, 2)
+	for uid, err := range errMap {
+		assert.ErrorIs(t, err, context.Canceled, "error for %s should be context.Canceled", uid)
+	}
 }
 
 // --- ApplyTagFilter tests ---

--- a/internal/utils/tag_fetch_test.go
+++ b/internal/utils/tag_fetch_test.go
@@ -135,13 +135,13 @@ func TestApplyTagFilter_NoLimit_AllMatch(t *testing.T) {
 		{uid: "a", tags: map[string]string{"env": "prod"}},
 		{uid: "b", tags: map[string]string{"env": "prod"}},
 	}
-	got := ApplyTagFilter(context.Background(), resources,
+	got, errs := ApplyTagFilter(context.Background(), resources,
 		func(r testResource) string { return r.uid },
 		makeTagFetch(resources),
 		[]string{"env=prod"}, 0,
-		func(uid string, err error) { t.Errorf("unexpected error for %s: %v", uid, err) },
 	)
 	assert.Len(t, got, 2)
+	assert.Empty(t, errs)
 }
 
 func TestApplyTagFilter_NoLimit_SomeMatch(t *testing.T) {
@@ -150,13 +150,13 @@ func TestApplyTagFilter_NoLimit_SomeMatch(t *testing.T) {
 		{uid: "b", tags: map[string]string{"env": "staging"}},
 		{uid: "c", tags: map[string]string{"env": "prod"}},
 	}
-	got := ApplyTagFilter(context.Background(), resources,
+	got, errs := ApplyTagFilter(context.Background(), resources,
 		func(r testResource) string { return r.uid },
 		makeTagFetch(resources),
 		[]string{"env=prod"}, 0,
-		func(uid string, err error) { t.Errorf("unexpected error for %s: %v", uid, err) },
 	)
 	require.Len(t, got, 2)
+	assert.Empty(t, errs)
 	assert.Equal(t, "a", got[0].uid)
 	assert.Equal(t, "c", got[1].uid)
 }
@@ -177,19 +177,18 @@ func TestApplyTagFilter_WithLimit_StopsEarly(t *testing.T) {
 		}
 		return nil, nil
 	}
-	got := ApplyTagFilter(context.Background(), resources,
+	got, errs := ApplyTagFilter(context.Background(), resources,
 		func(r testResource) string { return r.uid },
 		fetch,
 		[]string{"env=prod"}, 2,
-		func(uid string, err error) { t.Errorf("unexpected error for %s: %v", uid, err) },
 	)
 	assert.Len(t, got, 2)
+	assert.Empty(t, errs)
 	// With limit=2, should stop after 2 matches — only 2 API calls needed.
 	assert.Equal(t, 2, callCount)
 }
 
 func TestApplyTagFilter_FetchError_Excluded(t *testing.T) {
-	var warnedUID string
 	resources := []testResource{{uid: "ok"}, {uid: "err"}}
 	fetch := func(_ context.Context, uid string) (map[string]string, error) {
 		if uid == "err" {
@@ -197,13 +196,13 @@ func TestApplyTagFilter_FetchError_Excluded(t *testing.T) {
 		}
 		return map[string]string{"env": "prod"}, nil
 	}
-	got := ApplyTagFilter(context.Background(), resources,
+	got, errs := ApplyTagFilter(context.Background(), resources,
 		func(r testResource) string { return r.uid },
 		fetch,
 		[]string{"env=prod"}, 0,
-		func(uid string, _ error) { warnedUID = uid },
 	)
 	require.Len(t, got, 1)
 	assert.Equal(t, "ok", got[0].uid)
-	assert.Equal(t, "err", warnedUID)
+	assert.Contains(t, errs, "err")
+	assert.EqualError(t, errs["err"], "fetch failed")
 }

--- a/internal/utils/tag_filter.go
+++ b/internal/utils/tag_filter.go
@@ -7,13 +7,20 @@ import "strings"
 // An empty filters slice always returns true.
 // A nil tags map is treated as an empty map: key-exists and exact-match filters
 // will both return false, consistent with Go's zero-value map lookup semantics.
+// Filters with an empty key (e.g. "" or "=value") never match.
 func MatchesTagFilters(tags map[string]string, filters []string) bool {
 	for _, f := range filters {
 		if key, value, hasValue := strings.Cut(f, "="); hasValue {
+			if key == "" {
+				return false
+			}
 			if v, ok := tags[key]; !ok || v != value {
 				return false
 			}
 		} else {
+			if f == "" {
+				return false
+			}
 			if _, ok := tags[f]; !ok {
 				return false
 			}

--- a/internal/utils/tag_filter.go
+++ b/internal/utils/tag_filter.go
@@ -5,6 +5,8 @@ import "strings"
 // MatchesTagFilters returns true if the tags map satisfies all filter specs.
 // Each filter is either "key=value" (exact match) or "key" (key-exists match).
 // An empty filters slice always returns true.
+// A nil tags map is treated as an empty map: key-exists and exact-match filters
+// will both return false, consistent with Go's zero-value map lookup semantics.
 func MatchesTagFilters(tags map[string]string, filters []string) bool {
 	for _, f := range filters {
 		if key, value, hasValue := strings.Cut(f, "="); hasValue {

--- a/internal/utils/tag_filter.go
+++ b/internal/utils/tag_filter.go
@@ -1,0 +1,21 @@
+package utils
+
+import "strings"
+
+// MatchesTagFilters returns true if the tags map satisfies all filter specs.
+// Each filter is either "key=value" (exact match) or "key" (key-exists match).
+// An empty filters slice always returns true.
+func MatchesTagFilters(tags map[string]string, filters []string) bool {
+	for _, f := range filters {
+		if key, value, hasValue := strings.Cut(f, "="); hasValue {
+			if v, ok := tags[key]; !ok || v != value {
+				return false
+			}
+		} else {
+			if _, ok := tags[f]; !ok {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/internal/utils/tag_filter_test.go
+++ b/internal/utils/tag_filter_test.go
@@ -1,0 +1,102 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchesTagFilters(t *testing.T) {
+	tests := []struct {
+		name    string
+		tags    map[string]string
+		filters []string
+		want    bool
+	}{
+		{
+			name:    "no filters always matches",
+			tags:    map[string]string{"env": "prod"},
+			filters: nil,
+			want:    true,
+		},
+		{
+			name:    "empty filters always matches",
+			tags:    map[string]string{"env": "prod"},
+			filters: []string{},
+			want:    true,
+		},
+		{
+			name:    "exact match hit",
+			tags:    map[string]string{"env": "prod"},
+			filters: []string{"env=prod"},
+			want:    true,
+		},
+		{
+			name:    "exact match miss - wrong value",
+			tags:    map[string]string{"env": "staging"},
+			filters: []string{"env=prod"},
+			want:    false,
+		},
+		{
+			name:    "exact match miss - key absent",
+			tags:    map[string]string{"team": "net"},
+			filters: []string{"env=prod"},
+			want:    false,
+		},
+		{
+			name:    "key-exists match hit",
+			tags:    map[string]string{"env": "anything"},
+			filters: []string{"env"},
+			want:    true,
+		},
+		{
+			name:    "key-exists match miss",
+			tags:    map[string]string{"team": "net"},
+			filters: []string{"env"},
+			want:    false,
+		},
+		{
+			name:    "AND logic - all match",
+			tags:    map[string]string{"env": "prod", "team": "net"},
+			filters: []string{"env=prod", "team=net"},
+			want:    true,
+		},
+		{
+			name:    "AND logic - one misses",
+			tags:    map[string]string{"env": "prod", "team": "ops"},
+			filters: []string{"env=prod", "team=net"},
+			want:    false,
+		},
+		{
+			name:    "mixed exact and key-exists",
+			tags:    map[string]string{"env": "prod", "owner": "alice"},
+			filters: []string{"env=prod", "owner"},
+			want:    true,
+		},
+		{
+			name:    "nil tags map with key filter",
+			tags:    nil,
+			filters: []string{"env"},
+			want:    false,
+		},
+		{
+			name:    "nil tags map with no filters",
+			tags:    nil,
+			filters: nil,
+			want:    true,
+		},
+		{
+			name:    "value containing equals sign",
+			tags:    map[string]string{"key": "a=b"},
+			filters: []string{"key=a=b"},
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MatchesTagFilters(tt.tags, tt.filters)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/utils/tag_filter_test.go
+++ b/internal/utils/tag_filter_test.go
@@ -91,6 +91,18 @@ func TestMatchesTagFilters(t *testing.T) {
 			filters: []string{"key=a=b"},
 			want:    true,
 		},
+		{
+			name:    "empty filter string never matches",
+			tags:    map[string]string{"": "anything"},
+			filters: []string{""},
+			want:    false,
+		},
+		{
+			name:    "empty key in key=value form never matches",
+			tags:    map[string]string{"": "v"},
+			filters: []string{"=v"},
+			want:    false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Add a repeatable `--tag` flag to the `list` subcommands for ports, VXCs, MCRs, and MVEs. This enables kubectl-style label filtering so operators can narrow results to resources with specific tags without post-processing the output.

Tag filters use AND logic: `--tag env=prod --tag team=network` returns only resources that have both tags. The format supports both exact match (`key=value`) and key-exists (`key`) forms.

Because tag data is not returned inline by the list API, the implementation makes one extra `ListXxxResourceTags` call per resource only when `--tag` is specified (zero extra calls without the flag). A spinner is shown during the fetch loop, and tag-fetch errors emit a warning and skip the resource rather than aborting the whole operation.

IX resources are excluded — the megaportgo SDK has no tag methods for IX.

## Notable changes

- `internal/utils/tag_filter.go` — new shared `MatchesTagFilters` utility (nil-safe, handles values with embedded `=` via `strings.Cut`)
- `internal/base/cmdbuilder/builder.go` — new `WithStringArrayFlag` method (`StringArray` not `StringSlice`, so comma-separated values are never split)
- `internal/base/cmdbuilder/tag_flagsets.go` — new `WithTagFilterFlags` builder shorthand
- Per-resource: added `listVXCResourceTagsFunc` / `listMCRResourceTagsFunc` injectable vars for test overrideability (ports and MVE already had these)
- 6 new subtests per resource (`TestListXxx_TagFilter`): exact match, key-only, AND logic, no filter, tag fetch error (graceful skip + warning)