### PR TITLE
fix: centralise VLAN range strings behind VLANHelpText() / InnerVLANHelpText()

### DIFF
--- a/internal/base/cmdbuilder/vxc_flagsets.go
+++ b/internal/base/cmdbuilder/vxc_flagsets.go
@@ -19,8 +19,8 @@ func (b *CommandBuilder) WithVXCCommonFlags() *CommandBuilder {
 func (b *CommandBuilder) WithVXCEndpointFlags() *CommandBuilder {
 	b.WithFlag("a-end-uid", "", "UID of the A-End product")
 	b.WithFlag("b-end-uid", "", "UID of the B-End product")
-	b.WithIntFlag("a-end-vlan", 0, "VLAN for A-End (0-4093, except 1)")
-	b.WithIntFlag("b-end-vlan", 0, "VLAN for B-End (0-4093, except 1)")
+	b.WithIntFlag("a-end-vlan", 0, "VLAN for A-End ("+validation.VLANHelpText()+")")
+	b.WithIntFlag("b-end-vlan", 0, "VLAN for B-End ("+validation.VLANHelpText()+")")
 	b.WithIntFlag("a-end-inner-vlan", 0, "Inner VLAN for A-End (-1 or higher)")
 	b.WithIntFlag("b-end-inner-vlan", 0, "Inner VLAN for B-End (-1 or higher)")
 	return b

--- a/internal/base/cmdbuilder/vxc_flagsets.go
+++ b/internal/base/cmdbuilder/vxc_flagsets.go
@@ -21,8 +21,8 @@ func (b *CommandBuilder) WithVXCEndpointFlags() *CommandBuilder {
 	b.WithFlag("b-end-uid", "", "UID of the B-End product")
 	b.WithIntFlag("a-end-vlan", 0, "VLAN for A-End ("+validation.VLANHelpText()+")")
 	b.WithIntFlag("b-end-vlan", 0, "VLAN for B-End ("+validation.VLANHelpText()+")")
-	b.WithIntFlag("a-end-inner-vlan", 0, "Inner VLAN for A-End (-1 or higher)")
-	b.WithIntFlag("b-end-inner-vlan", 0, "Inner VLAN for B-End (-1 or higher)")
+	b.WithIntFlag("a-end-inner-vlan", 0, "Inner VLAN for A-End ("+validation.InnerVLANHelpText()+")")
+	b.WithIntFlag("b-end-inner-vlan", 0, "Inner VLAN for B-End ("+validation.InnerVLANHelpText()+")")
 	return b
 }
 

--- a/internal/commands/ports/ports.go
+++ b/internal/commands/ports/ports.go
@@ -1,7 +1,10 @@
 package ports
 
 import (
+	"fmt"
+
 	"github.com/megaport/megaport-cli/internal/base/cmdbuilder"
+	"github.com/megaport/megaport-cli/internal/validation"
 	"github.com/spf13/cobra"
 )
 
@@ -297,7 +300,7 @@ func buildPortManagementCommands(rootCmd *cobra.Command) (list, get, status, del
 	checkVLAN = cmdbuilder.NewCommand("check-vlan", "Check if a VLAN is available on a port").
 		WithArgs(cobra.ExactArgs(2)).
 		WithColorAwareRunFunc(CheckPortVLANAvailability).
-		WithLongDesc("Check if a VLAN is available on a port in the Megaport API.\n\nThis command verifies whether a specific VLAN ID is available for use on a port. This is useful when planning new VXCs to ensure the VLAN ID you want to use is not already in use by another connection.\n\nVLAN ID must be between 2 and 4094 (inclusive).").
+		WithLongDesc(fmt.Sprintf("Check if a VLAN is available on a port in the Megaport API.\n\nThis command verifies whether a specific VLAN ID is available for use on a port. This is useful when planning new VXCs to ensure the VLAN ID you want to use is not already in use by another connection.\n\nVLAN ID must be between %d and %d (inclusive).", validation.MinAssignableVLAN, validation.MaxAssignableVLAN)).
 		WithExample("megaport-cli ports check-vlan 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p 100").
 		WithExample("megaport-cli ports check-vlan port-abc123 500").
 		WithRootCmd(rootCmd).

--- a/internal/commands/ports/ports_actions_manage.go
+++ b/internal/commands/ports/ports_actions_manage.go
@@ -10,6 +10,7 @@ import (
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/commands/config"
 	"github.com/megaport/megaport-cli/internal/utils"
+	"github.com/megaport/megaport-cli/internal/validation"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 )
@@ -290,6 +291,10 @@ func CheckPortVLANAvailability(cmd *cobra.Command, args []string, noColor bool) 
 	if err != nil {
 		output.PrintError("Invalid VLAN ID: %v", noColor, err)
 		return fmt.Errorf("invalid VLAN ID")
+	}
+	if err := validation.ValidatePortVLANAvailability(vlan); err != nil {
+		output.PrintError("Invalid VLAN ID: %v", noColor, err)
+		return err
 	}
 
 	client, err := config.Login(ctx)

--- a/internal/commands/ports/ports_actions_test.go
+++ b/internal/commands/ports/ports_actions_test.go
@@ -1286,6 +1286,12 @@ func TestCheckPortVLANAvailability(t *testing.T) {
 			expectedError: "invalid VLAN ID",
 		},
 		{
+			name:          "VLAN out of assignable range",
+			portUID:       "port-vlan-5",
+			vlanArg:       "4094",
+			expectedError: "must be between",
+		},
+		{
 			name:          "API error",
 			portUID:       "port-vlan-4",
 			vlanArg:       "300",

--- a/internal/commands/vxc/vxc.go
+++ b/internal/commands/vxc/vxc.go
@@ -133,8 +133,8 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithOptionalFlag("shutdown", "Whether to shut down the VXC (true/false)").
 		WithOptionalFlag("a-end-vlan", "New VLAN for A-End ("+validation.VLANHelpText()+")").
 		WithOptionalFlag("b-end-vlan", "New VLAN for B-End ("+validation.VLANHelpText()+")").
-		WithOptionalFlag("a-end-inner-vlan", "New inner VLAN for A-End (-1 or higher, only for QinQ)").
-		WithOptionalFlag("b-end-inner-vlan", "New inner VLAN for B-End (-1 or higher, only for QinQ)").
+		WithOptionalFlag("a-end-inner-vlan", "New inner VLAN for A-End ("+validation.InnerVLANHelpText()+", only for QinQ)").
+		WithOptionalFlag("b-end-inner-vlan", "New inner VLAN for B-End ("+validation.InnerVLANHelpText()+", only for QinQ)").
 		WithOptionalFlag("a-end-uid", "New A-End product UID").
 		WithOptionalFlag("b-end-uid", "New B-End product UID").
 		WithOptionalFlag("a-end-partner-config", "JSON string with A-End VRouter partner configuration").

--- a/internal/commands/vxc/vxc.go
+++ b/internal/commands/vxc/vxc.go
@@ -2,6 +2,7 @@ package vxc
 
 import (
 	"github.com/megaport/megaport-cli/internal/base/cmdbuilder"
+	"github.com/megaport/megaport-cli/internal/validation"
 	"github.com/spf13/cobra"
 )
 
@@ -87,8 +88,8 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithDocumentedRequiredFlag("term", "Contract term in months (1, 12, 24, or 36)").
 		WithDocumentedRequiredFlag("a-end-uid", "UID of the A-End product").
 		WithDocumentedRequiredFlag("b-end-uid", "UID of the B-End product (if not using partner configuration)").
-		WithDocumentedRequiredFlag("a-end-vlan", "VLAN for A-End (0-4093, except 1)").
-		WithDocumentedRequiredFlag("b-end-vlan", "VLAN for B-End (0-4093, except 1)").
+		WithDocumentedRequiredFlag("a-end-vlan", "VLAN for A-End ("+validation.VLANHelpText()+")").
+		WithDocumentedRequiredFlag("b-end-vlan", "VLAN for B-End ("+validation.VLANHelpText()+")").
 		WithExample("megaport-cli vxc buy --interactive").
 		WithExample("megaport-cli vxc buy --name \"My VXC\" --rate-limit 1000 --term 12 --a-end-uid port-123 --b-end-uid port-456 --a-end-vlan 100 --b-end-vlan 200").
 		WithExample("megaport-cli vxc buy --name \"My VXC\" --rate-limit 1000 --term 12 --a-end-uid port-123 --b-end-uid port-456 --a-end-vlan 100 --b-end-vlan 200 --resource-tags '{\"environment\":\"production\",\"team\":\"networking\"}'").
@@ -130,8 +131,8 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithOptionalFlag("term", "New contract term in months (1, 12, 24, or 36)").
 		WithOptionalFlag("cost-centre", "New cost centre for billing").
 		WithOptionalFlag("shutdown", "Whether to shut down the VXC (true/false)").
-		WithOptionalFlag("a-end-vlan", "New VLAN for A-End (2-4093, except 4090)").
-		WithOptionalFlag("b-end-vlan", "New VLAN for B-End (2-4093, except 4090)").
+		WithOptionalFlag("a-end-vlan", "New VLAN for A-End ("+validation.VLANHelpText()+")").
+		WithOptionalFlag("b-end-vlan", "New VLAN for B-End ("+validation.VLANHelpText()+")").
 		WithOptionalFlag("a-end-inner-vlan", "New inner VLAN for A-End (-1 or higher, only for QinQ)").
 		WithOptionalFlag("b-end-inner-vlan", "New inner VLAN for B-End (-1 or higher, only for QinQ)").
 		WithOptionalFlag("a-end-uid", "New A-End product UID").

--- a/internal/commands/vxc/vxc_prompts.go
+++ b/internal/commands/vxc/vxc_prompts.go
@@ -59,7 +59,7 @@ var buildVXCRequestFromPrompt = func(ctx context.Context, svc megaport.VXCServic
 		}
 	}
 
-	aEndInnerVLANStr, err := utils.ResourcePrompt("vxc", "Enter A-End Inner VLAN (optional): ", noColor)
+	aEndInnerVLANStr, err := utils.ResourcePrompt("vxc", fmt.Sprintf("A-End Inner VLAN (optional, %s, press Enter to skip): ", validation.InnerVLANHelpText()), noColor)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ var buildVXCRequestFromPrompt = func(ctx context.Context, svc megaport.VXCServic
 		req.BEndConfiguration.VLAN = bEndVLAN
 	}
 
-	bEndInnerVLANStr, err := utils.ResourcePrompt("vxc", "Enter B-End Inner VLAN (optional): ", noColor)
+	bEndInnerVLANStr, err := utils.ResourcePrompt("vxc", fmt.Sprintf("B-End Inner VLAN (optional, %s, press Enter to skip): ", validation.InnerVLANHelpText()), noColor)
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +379,7 @@ var buildUpdateVXCRequestFromPrompt = func(ctx context.Context, client *megaport
 		return nil, err
 	}
 	if strings.ToLower(updateAEndInnerVLAN) == "yes" {
-		aEndInnerVLANStr, err := utils.ResourcePrompt("vxc", fmt.Sprintf("Enter new A-End Inner VLAN (%s): ", validation.VLANHelpText()), noColor)
+		aEndInnerVLANStr, err := utils.ResourcePrompt("vxc", fmt.Sprintf("Enter new A-End Inner VLAN (%s): ", validation.InnerVLANHelpText()), noColor)
 		if err != nil {
 			return nil, err
 		}
@@ -405,7 +405,7 @@ var buildUpdateVXCRequestFromPrompt = func(ctx context.Context, client *megaport
 		return nil, err
 	}
 	if strings.ToLower(updateBEndInnerVLAN) == "yes" {
-		bEndInnerVLANStr, err := utils.ResourcePrompt("vxc", fmt.Sprintf("Enter new B-End Inner VLAN (%s): ", validation.VLANHelpText()), noColor)
+		bEndInnerVLANStr, err := utils.ResourcePrompt("vxc", fmt.Sprintf("Enter new B-End Inner VLAN (%s): ", validation.InnerVLANHelpText()), noColor)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/commands/vxc/vxc_prompts.go
+++ b/internal/commands/vxc/vxc_prompts.go
@@ -44,7 +44,7 @@ var buildVXCRequestFromPrompt = func(ctx context.Context, svc megaport.VXCServic
 		return nil, err
 	}
 
-	aEndVLANStr, err := utils.ResourcePrompt("vxc", "A-End VLAN (-1=untagged, 0=auto-assigned, 2-4094 for specific VLAN): ", noColor)
+	aEndVLANStr, err := utils.ResourcePrompt("vxc", fmt.Sprintf("A-End VLAN (%s): ", validation.VLANHelpText()), noColor)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ var buildVXCRequestFromPrompt = func(ctx context.Context, svc megaport.VXCServic
 
 	bEndConfig := megaport.VXCOrderEndpointConfiguration{}
 
-	bEndVLANStr, err := utils.ResourcePrompt("vxc", "B-End VLAN (-1=untagged, 0=auto-assigned, 2-4094 for specific VLAN): ", noColor)
+	bEndVLANStr, err := utils.ResourcePrompt("vxc", fmt.Sprintf("B-End VLAN (%s): ", validation.VLANHelpText()), noColor)
 	if err != nil {
 		return nil, err
 	}
@@ -335,7 +335,7 @@ var buildUpdateVXCRequestFromPrompt = func(ctx context.Context, client *megaport
 		return nil, err
 	}
 	if strings.ToLower(updateAEndVLAN) == "yes" {
-		aEndVLANStr, err := utils.ResourcePrompt("vxc", "A-End VLAN (-1=untagged, 0=auto-assigned, 2-4094 for specific VLAN): ", noColor)
+		aEndVLANStr, err := utils.ResourcePrompt("vxc", fmt.Sprintf("A-End VLAN (%s): ", validation.VLANHelpText()), noColor)
 		if err != nil {
 			return nil, err
 		}
@@ -355,7 +355,7 @@ var buildUpdateVXCRequestFromPrompt = func(ctx context.Context, client *megaport
 		return nil, err
 	}
 	if strings.ToLower(updateBEndVLAN) == "yes" {
-		bEndVLANStr, err := utils.ResourcePrompt("vxc", "B-End VLAN (-1=untagged, 0=auto-assigned, 2-4094 for specific VLAN): ", noColor)
+		bEndVLANStr, err := utils.ResourcePrompt("vxc", fmt.Sprintf("B-End VLAN (%s): ", validation.VLANHelpText()), noColor)
 		if err != nil {
 			return nil, err
 		}
@@ -379,7 +379,7 @@ var buildUpdateVXCRequestFromPrompt = func(ctx context.Context, client *megaport
 		return nil, err
 	}
 	if strings.ToLower(updateAEndInnerVLAN) == "yes" {
-		aEndInnerVLANStr, err := utils.ResourcePrompt("vxc", "Enter new A-End Inner VLAN (-1, 0, or 2-4094): ", noColor)
+		aEndInnerVLANStr, err := utils.ResourcePrompt("vxc", fmt.Sprintf("Enter new A-End Inner VLAN (%s): ", validation.VLANHelpText()), noColor)
 		if err != nil {
 			return nil, err
 		}
@@ -405,7 +405,7 @@ var buildUpdateVXCRequestFromPrompt = func(ctx context.Context, client *megaport
 		return nil, err
 	}
 	if strings.ToLower(updateBEndInnerVLAN) == "yes" {
-		bEndInnerVLANStr, err := utils.ResourcePrompt("vxc", "Enter new B-End Inner VLAN (-1, 0, or 2-4094): ", noColor)
+		bEndInnerVLANStr, err := utils.ResourcePrompt("vxc", fmt.Sprintf("Enter new B-End Inner VLAN (%s): ", validation.VLANHelpText()), noColor)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/commands/vxc/vxc_prompts_vrouter.go
+++ b/internal/commands/vxc/vxc_prompts_vrouter.go
@@ -27,7 +27,7 @@ func promptVRouterConfig(noColor bool) (*megaport.VXCOrderVrouterPartnerConfig, 
 	for i := 0; i < interfaceCount; i++ {
 		iface := megaport.PartnerConfigInterface{}
 
-		vlanStr, err := utils.ResourcePrompt("vxc", "VLAN (0-4094, except 1, optional - press Enter for no VLAN): ", noColor)
+		vlanStr, err := utils.ResourcePrompt("vxc", fmt.Sprintf("VLAN (0-%d, except %d, optional - press Enter for no VLAN): ", validation.MaxVLAN, validation.ReservedVLAN), noColor)
 		if err != nil {
 			return nil, err
 		}
@@ -37,9 +37,9 @@ func promptVRouterConfig(noColor bool) (*megaport.VXCOrderVrouterPartnerConfig, 
 			if err != nil {
 				return nil, fmt.Errorf("VLAN must be a valid integer")
 			}
-			if vlan < 0 || vlan > 4094 || vlan == 1 {
+			if vlan < 0 || vlan > validation.MaxVLAN || vlan == validation.ReservedVLAN {
 				return nil, validation.NewValidationError("VRouter interface VLAN", vlan,
-					"must be 0 or between 2-4094 (1 is reserved)")
+					fmt.Sprintf("must be %d or between %d-%d (%d is reserved)", validation.AutoAssignVLAN, validation.MinAssignableVLAN, validation.MaxVLAN, validation.ReservedVLAN))
 			}
 			iface.VLAN = vlan
 		} else {

--- a/internal/validation/common.go
+++ b/internal/validation/common.go
@@ -45,7 +45,7 @@ const (
 // derived from the VLAN constants defined in this package.
 func VLANHelpText() string {
 	return fmt.Sprintf("%d=auto-assign, %d=untagged, %d-%d for specific VLAN (%d is reserved)",
-		AutoAssignVLAN, UntaggedVLAN, MinAssignableVLAN, MaxAssignableVLAN, ReservedVLAN)
+		AutoAssignVLAN, UntaggedVLAN, MinAssignableVLAN, MaxVLAN, ReservedVLAN)
 }
 
 // InnerVLANHelpText returns a canonical human-readable description of valid inner VLAN

--- a/internal/validation/common.go
+++ b/internal/validation/common.go
@@ -41,6 +41,13 @@ const (
 	ReservedVLAN = 1
 )
 
+// VLANHelpText returns a canonical human-readable description of valid VLAN values,
+// derived from the VLAN constants defined in this package.
+func VLANHelpText() string {
+	return fmt.Sprintf("%d=auto-assign, %d=untagged, %d-%d for specific VLAN (%d is reserved)",
+		AutoAssignVLAN, UntaggedVLAN, MinAssignableVLAN, MaxAssignableVLAN, ReservedVLAN)
+}
+
 // FormatIntSlice formats a slice of ints as a human-readable string.
 // Example: []int{1, 12, 24, 36} → "1, 12, 24, or 36"
 func FormatIntSlice(vals []int) string {

--- a/internal/validation/common.go
+++ b/internal/validation/common.go
@@ -48,6 +48,13 @@ func VLANHelpText() string {
 		AutoAssignVLAN, UntaggedVLAN, MinAssignableVLAN, MaxAssignableVLAN, ReservedVLAN)
 }
 
+// InnerVLANHelpText returns a canonical human-readable description of valid inner VLAN
+// (Q-in-Q) values. Inner VLANs use 0 to mean "no inner VLAN" rather than "auto-assign".
+func InnerVLANHelpText() string {
+	return fmt.Sprintf("%d=none, %d=untagged, %d-%d for specific VLAN (%d is reserved)",
+		AutoAssignVLAN, UntaggedVLAN, MinAssignableVLAN, MaxVLAN, ReservedVLAN)
+}
+
 // FormatIntSlice formats a slice of ints as a human-readable string.
 // Example: []int{1, 12, 24, 36} → "1, 12, 24, or 36"
 func FormatIntSlice(vals []int) string {

--- a/internal/validation/common_test.go
+++ b/internal/validation/common_test.go
@@ -257,13 +257,9 @@ func TestFormatIntSlice(t *testing.T) {
 }
 
 func TestVLANHelpText(t *testing.T) {
-	want := fmt.Sprintf("%d=auto-assign, %d=untagged, %d-%d for specific VLAN (%d is reserved)",
-		AutoAssignVLAN, UntaggedVLAN, MinAssignableVLAN, MaxAssignableVLAN, ReservedVLAN)
-	assert.Equal(t, want, VLANHelpText())
+	assert.Equal(t, "0=auto-assign, -1=untagged, 2-4093 for specific VLAN (1 is reserved)", VLANHelpText())
 }
 
 func TestInnerVLANHelpText(t *testing.T) {
-	want := fmt.Sprintf("%d=none, %d=untagged, %d-%d for specific VLAN (%d is reserved)",
-		AutoAssignVLAN, UntaggedVLAN, MinAssignableVLAN, MaxVLAN, ReservedVLAN)
-	assert.Equal(t, want, InnerVLANHelpText())
+	assert.Equal(t, "0=none, -1=untagged, 2-4094 for specific VLAN (1 is reserved)", InnerVLANHelpText())
 }

--- a/internal/validation/common_test.go
+++ b/internal/validation/common_test.go
@@ -255,3 +255,15 @@ func TestFormatIntSlice(t *testing.T) {
 		})
 	}
 }
+
+func TestVLANHelpText(t *testing.T) {
+	want := fmt.Sprintf("%d=auto-assign, %d=untagged, %d-%d for specific VLAN (%d is reserved)",
+		AutoAssignVLAN, UntaggedVLAN, MinAssignableVLAN, MaxAssignableVLAN, ReservedVLAN)
+	assert.Equal(t, want, VLANHelpText())
+}
+
+func TestInnerVLANHelpText(t *testing.T) {
+	want := fmt.Sprintf("%d=none, %d=untagged, %d-%d for specific VLAN (%d is reserved)",
+		AutoAssignVLAN, UntaggedVLAN, MinAssignableVLAN, MaxVLAN, ReservedVLAN)
+	assert.Equal(t, want, InnerVLANHelpText())
+}

--- a/internal/validation/common_test.go
+++ b/internal/validation/common_test.go
@@ -257,7 +257,7 @@ func TestFormatIntSlice(t *testing.T) {
 }
 
 func TestVLANHelpText(t *testing.T) {
-	assert.Equal(t, "0=auto-assign, -1=untagged, 2-4093 for specific VLAN (1 is reserved)", VLANHelpText())
+	assert.Equal(t, "0=auto-assign, -1=untagged, 2-4094 for specific VLAN (1 is reserved)", VLANHelpText())
 }
 
 func TestInnerVLANHelpText(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `VLANHelpText()` to `internal/validation/common.go` — single source of truth for outer VLAN range descriptions (`0=auto-assign, -1=untagged, 2-4093 for specific VLAN (1 is reserved)`)
- Add `InnerVLANHelpText()` — separate helper for Q-in-Q inner VLANs where `0` means "no inner VLAN" (not "auto-assign"), accepting up to `MaxVLAN` (4094)
- Wire both helpers through all VLAN flag descriptions and interactive prompts (`vxc_flagsets.go`, `vxc.go`, `vxc_prompts.go`, `vxc_prompts_vrouter.go`, `ports.go`)
- Fix a typo in `vxc update` flag help that said "except 4090" — only VLAN 1 is reserved
- Add golden-string tests for both helpers in `common_test.go`

## Motivation

VLAN range strings were hardcoded in ~10 places with inconsistent values (some said 2–4093, some said 2–4094, one said "except 4090"). Any future change to VLAN constants required hunting down every usage. Now there is one place to edit.

## Test plan

- [ ] `go test ./...` passes
- [ ] `golangci-lint run` passes
- [ ] `megaport-cli vxc buy --help` shows consistent VLAN range text
- [ ] `megaport-cli vxc update --help` no longer says "except 4090"
- [ ] `megaport-cli vxc update --interactive` inner VLAN prompts say "0=none" not "0=auto-assign"