### PR TITLE
ESD-826: extract shared resolvePartnerPortUID to deduplicate partner config logic

### DIFF
--- a/internal/commands/vxc/vxc_inputs.go
+++ b/internal/commands/vxc/vxc_inputs.go
@@ -71,38 +71,13 @@ var buildVXCRequestFromFlags = func(cmd *cobra.Command, ctx context.Context, svc
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse a-end-partner-config: %w", err)
 		}
-		// If the A End UID is not provided, attempt to look it up from the partner port key
+		aEndConfig.PartnerConfig = aEndPartnerConfig
 		if aEndUID == "" {
-			switch aEndPartnerConfig := aEndPartnerConfig.(type) {
-			case *megaport.VXCPartnerConfigAzure:
-				if aEndPartnerConfig.ServiceKey == "" {
-					return nil, fmt.Errorf("serviceKey is required for Azure configuration")
-				}
-				uid, err := getPartnerPortUID(ctx, svc, aEndPartnerConfig.ServiceKey, "AZURE")
-				if err != nil {
-					return nil, fmt.Errorf("failed to look up Azure Partner Port: %w", err)
-				}
-				aEndUID = uid
-			case *megaport.VXCPartnerConfigGoogle:
-				if aEndPartnerConfig.PairingKey == "" {
-					return nil, fmt.Errorf("pairingKey is required for Google configuration")
-				}
-				uid, err := getPartnerPortUID(ctx, svc, aEndPartnerConfig.PairingKey, "GOOGLE")
-				if err != nil {
-					return nil, fmt.Errorf("failed to look up Google Partner Port: %w", err)
-				}
-				aEndUID = uid
-			case *megaport.VXCPartnerConfigOracle:
-				if aEndPartnerConfig.VirtualCircuitId == "" {
-					return nil, fmt.Errorf("virtualCircuitId is required for Oracle configuration")
-				}
-				uid, err := getPartnerPortUID(ctx, svc, aEndPartnerConfig.VirtualCircuitId, "ORACLE")
-				if err != nil {
-					return nil, fmt.Errorf("failed to look up Oracle Partner Port: %w", err)
-				}
-				aEndUID = uid
-				aEndConfig.PartnerConfig = aEndPartnerConfig
+			uid, err := resolvePartnerPortUID(ctx, svc, aEndPartnerConfig)
+			if err != nil {
+				return nil, fmt.Errorf("failed to look up A-End Partner Port: %w", err)
 			}
+			aEndUID = uid
 		}
 	}
 
@@ -130,36 +105,12 @@ var buildVXCRequestFromFlags = func(cmd *cobra.Command, ctx context.Context, svc
 	bEndUID, _ := cmd.Flags().GetString("b-end-uid")
 
 	// Attempt to look up partner port UID if not provided
-	if bEndUID == "" {
-		switch bEndPartnerConfig := bEndConfig.PartnerConfig.(type) {
-		case *megaport.VXCPartnerConfigAzure:
-			if bEndPartnerConfig.ServiceKey == "" {
-				return nil, fmt.Errorf("serviceKey is required for Azure configuration")
-			}
-			uid, err := getPartnerPortUID(ctx, svc, bEndPartnerConfig.ServiceKey, "AZURE")
-			if err != nil {
-				return nil, fmt.Errorf("failed to look up Azure Partner Port: %w", err)
-			}
-			bEndUID = uid
-		case *megaport.VXCPartnerConfigGoogle:
-			if bEndPartnerConfig.PairingKey == "" {
-				return nil, fmt.Errorf("pairingKey is required for Google configuration")
-			}
-			uid, err := getPartnerPortUID(ctx, svc, bEndPartnerConfig.PairingKey, "GOOGLE")
-			if err != nil {
-				return nil, fmt.Errorf("failed to look up Google Partner Port: %w", err)
-			}
-			bEndUID = uid
-		case *megaport.VXCPartnerConfigOracle:
-			if bEndPartnerConfig.VirtualCircuitId == "" {
-				return nil, fmt.Errorf("virtualCircuitId is required for Oracle configuration")
-			}
-			uid, err := getPartnerPortUID(ctx, svc, bEndPartnerConfig.VirtualCircuitId, "ORACLE")
-			if err != nil {
-				return nil, fmt.Errorf("failed to look up Oracle Partner Port: %w", err)
-			}
-			bEndUID = uid
+	if bEndUID == "" && bEndConfig.PartnerConfig != nil {
+		uid, err := resolvePartnerPortUID(ctx, svc, bEndConfig.PartnerConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to look up B-End Partner Port: %w", err)
 		}
+		bEndUID = uid
 	}
 
 	if bEndUID == "" {

--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -1,10 +1,14 @@
 package vxc
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	megaport "github.com/megaport/megaportgo"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParsePartnerConfigFromJSON(t *testing.T) {
@@ -757,6 +761,242 @@ func TestBuildUpdateVXCRequestFromJSON_PartnerConfigs(t *testing.T) {
 				assert.NoError(t, err)
 				if tt.validate != nil {
 					tt.validate(t, result)
+				}
+			}
+		})
+	}
+}
+
+func TestResolvePartnerPortUID(t *testing.T) {
+	origGetPartnerPortUID := getPartnerPortUID
+	defer func() { getPartnerPortUID = origGetPartnerPortUID }()
+
+	tests := []struct {
+		name          string
+		partnerConfig megaport.VXCPartnerConfiguration
+		mockUID       string
+		mockErr       error
+		expectedUID   string
+		expectedError string
+	}{
+		{
+			name:          "Azure success",
+			partnerConfig: &megaport.VXCPartnerConfigAzure{ServiceKey: "azure-key-123"},
+			mockUID:       "azure-port-uid",
+			expectedUID:   "azure-port-uid",
+		},
+		{
+			name:          "Google success",
+			partnerConfig: &megaport.VXCPartnerConfigGoogle{PairingKey: "google-key-456"},
+			mockUID:       "google-port-uid",
+			expectedUID:   "google-port-uid",
+		},
+		{
+			name:          "Oracle success",
+			partnerConfig: &megaport.VXCPartnerConfigOracle{VirtualCircuitId: "oracle-vc-789"},
+			mockUID:       "oracle-port-uid",
+			expectedUID:   "oracle-port-uid",
+		},
+		{
+			name:          "Azure empty service key",
+			partnerConfig: &megaport.VXCPartnerConfigAzure{ServiceKey: ""},
+			expectedError: "serviceKey is required for Azure configuration",
+		},
+		{
+			name:          "Google empty pairing key",
+			partnerConfig: &megaport.VXCPartnerConfigGoogle{PairingKey: ""},
+			expectedError: "pairingKey is required for Google configuration",
+		},
+		{
+			name:          "Oracle empty virtual circuit ID",
+			partnerConfig: &megaport.VXCPartnerConfigOracle{VirtualCircuitId: ""},
+			expectedError: "virtualCircuitId is required for Oracle configuration",
+		},
+		{
+			name:          "Azure lookup error wraps with partner name",
+			partnerConfig: &megaport.VXCPartnerConfigAzure{ServiceKey: "bad-key"},
+			mockErr:       fmt.Errorf("failed to look up partner port: API error"),
+			expectedError: "azure partner port:",
+		},
+		{
+			name:          "unsupported partner type returns empty",
+			partnerConfig: &megaport.VXCPartnerConfigAWS{OwnerAccount: "123"},
+			expectedUID:   "",
+		},
+		{
+			name:          "transit partner type returns empty",
+			partnerConfig: &megaport.VXCPartnerConfigTransit{ConnectType: "TRANSIT"},
+			expectedUID:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getPartnerPortUID = func(_ context.Context, _ megaport.VXCService, _, _ string) (string, error) {
+				return tt.mockUID, tt.mockErr
+			}
+
+			ctx := context.Background()
+			mockSvc := &MockVXCService{}
+
+			uid, err := resolvePartnerPortUID(ctx, mockSvc, tt.partnerConfig)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedUID, uid)
+			}
+		})
+	}
+}
+
+func TestBuildVXCRequestFromFlags_PartnerConfig(t *testing.T) {
+	origResolve := resolvePartnerPortUID
+	defer func() { resolvePartnerPortUID = origResolve }()
+
+	newBuyCmd := func() *cobra.Command {
+		cmd := &cobra.Command{Use: "buy"}
+		cmd.Flags().String("a-end-uid", "", "")
+		cmd.Flags().String("b-end-uid", "", "")
+		cmd.Flags().String("name", "", "")
+		cmd.Flags().Int("rate-limit", 0, "")
+		cmd.Flags().Int("term", 0, "")
+		cmd.Flags().Int("a-end-vlan", 0, "")
+		cmd.Flags().Int("b-end-vlan", 0, "")
+		cmd.Flags().Int("a-end-inner-vlan", 0, "")
+		cmd.Flags().Int("b-end-inner-vlan", 0, "")
+		cmd.Flags().Int("a-end-vnic-index", 0, "")
+		cmd.Flags().Int("b-end-vnic-index", 0, "")
+		cmd.Flags().String("promo-code", "", "")
+		cmd.Flags().String("service-key", "", "")
+		cmd.Flags().String("cost-centre", "", "")
+		cmd.Flags().String("a-end-partner-config", "", "")
+		cmd.Flags().String("b-end-partner-config", "", "")
+		return cmd
+	}
+
+	tests := []struct {
+		name            string
+		flags           map[string]string
+		flagsInt        map[string]int
+		resolveUID      string
+		resolveErr      error
+		expectedError   string
+		validateRequest func(*testing.T, *megaport.BuyVXCRequest)
+	}{
+		{
+			name: "A-End Azure partner config resolves UID and is assigned",
+			flags: map[string]string{
+				"name":                 "Test VXC",
+				"b-end-uid":            "b-end-uid-123",
+				"a-end-partner-config": `{"connectType":"AZURE","serviceKey":"azure-svc-key"}`,
+			},
+			flagsInt:   map[string]int{"rate-limit": 100, "term": 1},
+			resolveUID: "resolved-a-uid",
+			validateRequest: func(t *testing.T, req *megaport.BuyVXCRequest) {
+				assert.Equal(t, "resolved-a-uid", req.PortUID)
+				assert.NotNil(t, req.AEndConfiguration.PartnerConfig)
+				azCfg, ok := req.AEndConfiguration.PartnerConfig.(*megaport.VXCPartnerConfigAzure)
+				require.True(t, ok)
+				assert.Equal(t, "azure-svc-key", azCfg.ServiceKey)
+			},
+		},
+		{
+			name: "A-End Google partner config resolves UID and is assigned",
+			flags: map[string]string{
+				"name":                 "Test VXC",
+				"b-end-uid":            "b-end-uid-123",
+				"a-end-partner-config": `{"connectType":"GOOGLE","pairingKey":"google-pairing-key"}`,
+			},
+			flagsInt:   map[string]int{"rate-limit": 100, "term": 1},
+			resolveUID: "resolved-a-uid",
+			validateRequest: func(t *testing.T, req *megaport.BuyVXCRequest) {
+				assert.Equal(t, "resolved-a-uid", req.PortUID)
+				assert.NotNil(t, req.AEndConfiguration.PartnerConfig)
+				_, ok := req.AEndConfiguration.PartnerConfig.(*megaport.VXCPartnerConfigGoogle)
+				require.True(t, ok)
+			},
+		},
+		{
+			name: "B-End Azure partner config resolves UID",
+			flags: map[string]string{
+				"name":                 "Test VXC",
+				"a-end-uid":            "a-end-uid-123",
+				"b-end-partner-config": `{"connectType":"AZURE","serviceKey":"azure-svc-key"}`,
+			},
+			flagsInt:   map[string]int{"rate-limit": 100, "term": 1},
+			resolveUID: "resolved-b-uid",
+			validateRequest: func(t *testing.T, req *megaport.BuyVXCRequest) {
+				assert.Equal(t, "resolved-b-uid", req.BEndConfiguration.ProductUID)
+				assert.NotNil(t, req.BEndConfiguration.PartnerConfig)
+			},
+		},
+		{
+			name: "A-End partner resolve error",
+			flags: map[string]string{
+				"name":                 "Test VXC",
+				"b-end-uid":            "b-end-uid-123",
+				"a-end-partner-config": `{"connectType":"AZURE","serviceKey":"bad-key"}`,
+			},
+			flagsInt:      map[string]int{"rate-limit": 100, "term": 1},
+			resolveErr:    fmt.Errorf("azure partner port: failed to look up partner port: API error"),
+			expectedError: "failed to look up A-End Partner Port",
+		},
+		{
+			name: "B-End partner resolve error",
+			flags: map[string]string{
+				"name":                 "Test VXC",
+				"a-end-uid":            "a-end-uid-123",
+				"b-end-partner-config": `{"connectType":"GOOGLE","pairingKey":"bad-key"}`,
+			},
+			flagsInt:      map[string]int{"rate-limit": 100, "term": 1},
+			resolveErr:    fmt.Errorf("google partner port: failed to look up partner port: API error"),
+			expectedError: "failed to look up B-End Partner Port",
+		},
+		{
+			name: "A-End UID provided skips resolution but keeps partner config",
+			flags: map[string]string{
+				"name":                 "Test VXC",
+				"a-end-uid":            "explicit-a-uid",
+				"b-end-uid":            "b-end-uid-123",
+				"a-end-partner-config": `{"connectType":"AZURE","serviceKey":"azure-svc-key"}`,
+			},
+			flagsInt: map[string]int{"rate-limit": 100, "term": 1},
+			validateRequest: func(t *testing.T, req *megaport.BuyVXCRequest) {
+				assert.Equal(t, "explicit-a-uid", req.PortUID)
+				assert.NotNil(t, req.AEndConfiguration.PartnerConfig)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolvePartnerPortUID = func(_ context.Context, _ megaport.VXCService, _ megaport.VXCPartnerConfiguration) (string, error) {
+				return tt.resolveUID, tt.resolveErr
+			}
+
+			cmd := newBuyCmd()
+			for k, v := range tt.flags {
+				require.NoError(t, cmd.Flags().Set(k, v))
+			}
+			for k, v := range tt.flagsInt {
+				require.NoError(t, cmd.Flags().Set(k, fmt.Sprintf("%d", v)))
+			}
+
+			ctx := context.Background()
+			mockSvc := &MockVXCService{}
+
+			req, err := buildVXCRequestFromFlags(cmd, ctx, mockSvc)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+				if tt.validateRequest != nil {
+					tt.validateRequest(t, req)
 				}
 			}
 		})

--- a/internal/commands/vxc/vxc_utils.go
+++ b/internal/commands/vxc/vxc_utils.go
@@ -55,20 +55,32 @@ var getPartnerPortUID = func(ctx context.Context, svc megaport.VXCService, key, 
 var resolvePartnerPortUID = func(ctx context.Context, svc megaport.VXCService, partnerConfig megaport.VXCPartnerConfiguration) (string, error) {
 	switch pc := partnerConfig.(type) {
 	case *megaport.VXCPartnerConfigAzure:
-		if pc.ServiceKey == "" {
+		if pc == nil || pc.ServiceKey == "" {
 			return "", fmt.Errorf("serviceKey is required for Azure configuration")
 		}
-		return getPartnerPortUID(ctx, svc, pc.ServiceKey, "AZURE")
+		uid, err := getPartnerPortUID(ctx, svc, pc.ServiceKey, "AZURE")
+		if err != nil {
+			return "", fmt.Errorf("azure partner port: %w", err)
+		}
+		return uid, nil
 	case *megaport.VXCPartnerConfigGoogle:
-		if pc.PairingKey == "" {
+		if pc == nil || pc.PairingKey == "" {
 			return "", fmt.Errorf("pairingKey is required for Google configuration")
 		}
-		return getPartnerPortUID(ctx, svc, pc.PairingKey, "GOOGLE")
+		uid, err := getPartnerPortUID(ctx, svc, pc.PairingKey, "GOOGLE")
+		if err != nil {
+			return "", fmt.Errorf("google partner port: %w", err)
+		}
+		return uid, nil
 	case *megaport.VXCPartnerConfigOracle:
-		if pc.VirtualCircuitId == "" {
+		if pc == nil || pc.VirtualCircuitId == "" {
 			return "", fmt.Errorf("virtualCircuitId is required for Oracle configuration")
 		}
-		return getPartnerPortUID(ctx, svc, pc.VirtualCircuitId, "ORACLE")
+		uid, err := getPartnerPortUID(ctx, svc, pc.VirtualCircuitId, "ORACLE")
+		if err != nil {
+			return "", fmt.Errorf("oracle partner port: %w", err)
+		}
+		return uid, nil
 	default:
 		return "", nil
 	}

--- a/internal/commands/vxc/vxc_utils.go
+++ b/internal/commands/vxc/vxc_utils.go
@@ -49,6 +49,31 @@ var getPartnerPortUID = func(ctx context.Context, svc megaport.VXCService, key, 
 	return res.ProductUID, nil
 }
 
+// resolvePartnerPortUID extracts the lookup key from a partner config and
+// resolves it to a product UID. Returns ("", nil) if the config type does
+// not support UID lookup.
+var resolvePartnerPortUID = func(ctx context.Context, svc megaport.VXCService, partnerConfig megaport.VXCPartnerConfiguration) (string, error) {
+	switch pc := partnerConfig.(type) {
+	case *megaport.VXCPartnerConfigAzure:
+		if pc.ServiceKey == "" {
+			return "", fmt.Errorf("serviceKey is required for Azure configuration")
+		}
+		return getPartnerPortUID(ctx, svc, pc.ServiceKey, "AZURE")
+	case *megaport.VXCPartnerConfigGoogle:
+		if pc.PairingKey == "" {
+			return "", fmt.Errorf("pairingKey is required for Google configuration")
+		}
+		return getPartnerPortUID(ctx, svc, pc.PairingKey, "GOOGLE")
+	case *megaport.VXCPartnerConfigOracle:
+		if pc.VirtualCircuitId == "" {
+			return "", fmt.Errorf("virtualCircuitId is required for Oracle configuration")
+		}
+		return getPartnerPortUID(ctx, svc, pc.VirtualCircuitId, "ORACLE")
+	default:
+		return "", nil
+	}
+}
+
 var listVXCResourceTagsFunc = func(ctx context.Context, client *megaport.Client, vxcUID string) (map[string]string, error) {
 	return client.VXCService.ListVXCResourceTags(ctx, vxcUID)
 }


### PR DESCRIPTION
Extracts a shared `resolvePartnerPortUID` helper in `vxc_utils.go` to eliminate the near-identical Azure/Google/Oracle type-switch blocks that were duplicated in both the A-End and B-End partner port UID resolution paths of `buildVXCRequestFromFlags`.

Also fixes a bug where A-End Azure and Google partner configs were parsed from JSON but never assigned to `aEndConfig.PartnerConfig` — only the Oracle case included the assignment. The B-End path correctly assigned the partner config unconditionally. Both paths now behave consistently.

## Changes
- **`vxc_utils.go`**: Add `resolvePartnerPortUID(ctx, svc, partnerConfig)` that extracts the lookup key from a typed partner config and calls `getPartnerPortUID`
- **`vxc_inputs.go`**: Replace both A-End and B-End inline switch blocks with calls to the shared helper; assign `aEndConfig.PartnerConfig` unconditionally (bug fix)

## Test plan
- [x] `go test -v ./internal/commands/vxc/` — all 125 tests pass
- [x] `golangci-lint run ./internal/commands/vxc/` — 0 issues
- [x] `go build -v ./...` — clean build