### PR TITLE
ESD-828: add client-side validation for IX ASN, MAC address, VLAN, and rate limit

### DIFF
--- a/internal/commands/ix/ix_actions_test.go
+++ b/internal/commands/ix/ix_actions_test.go
@@ -478,10 +478,8 @@ func TestBuyIX(t *testing.T) {
 			flags: map[string]string{
 				"name": "Test IX",
 			},
-			setupMock: func(m *MockIXService) {
-				m.validateIXOrderError = fmt.Errorf("validation failed: missing required fields")
-			},
-			expectedError: "validation failed",
+			setupMock:     func(m *MockIXService) {},
+			expectedError: "Invalid ASN",
 		},
 		{
 			name: "API error",
@@ -1511,7 +1509,13 @@ func TestBuyIX_LoginError(t *testing.T) {
 	cmd.Flags().String("json", "", "JSON string")
 	cmd.Flags().String("json-file", "", "JSON file")
 
+	_ = cmd.Flags().Set("product-uid", "port-uid-123")
 	_ = cmd.Flags().Set("name", "Test IX")
+	_ = cmd.Flags().Set("network-service-type", "Los Angeles IX")
+	_ = cmd.Flags().Set("asn", "65000")
+	_ = cmd.Flags().Set("mac-address", "00:11:22:33:44:55")
+	_ = cmd.Flags().Set("rate-limit", "1000")
+	_ = cmd.Flags().Set("vlan", "100")
 
 	var err error
 	output.CaptureOutput(func() {

--- a/internal/commands/ix/ix_actions_test.go
+++ b/internal/commands/ix/ix_actions_test.go
@@ -1062,11 +1062,13 @@ func TestGetIX(t *testing.T) {
 
 func TestUpdateIX(t *testing.T) {
 	originalPrompt := utils.GetResourcePrompt()
+	originalPasswordPrompt := utils.GetPasswordPrompt()
 	originalUpdateIXFunc := updateIXFunc
 	originalGetIXFunc := getIXFunc
 	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
 	defer func() {
 		utils.SetResourcePrompt(originalPrompt)
+		utils.SetPasswordPrompt(originalPasswordPrompt)
 		cleanup()
 		updateIXFunc = originalUpdateIXFunc
 		getIXFunc = originalGetIXFunc
@@ -1260,13 +1262,19 @@ func TestUpdateIX(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if len(tt.prompts) > 0 {
 				promptIndex := 0
-				utils.SetResourcePrompt(func(_, msg string, _ bool) (string, error) {
+				nextPrompt := func() (string, error) {
 					if promptIndex < len(tt.prompts) {
 						response := tt.prompts[promptIndex]
 						promptIndex++
 						return response, nil
 					}
 					return "", fmt.Errorf("unexpected prompt call")
+				}
+				utils.SetResourcePrompt(func(_, _ string, _ bool) (string, error) {
+					return nextPrompt()
+				})
+				utils.SetPasswordPrompt(func(_ string, _ bool) (string, error) {
+					return nextPrompt()
 				})
 			}
 

--- a/internal/commands/ix/ix_actions_test.go
+++ b/internal/commands/ix/ix_actions_test.go
@@ -478,10 +478,8 @@ func TestBuyIX(t *testing.T) {
 			flags: map[string]string{
 				"name": "Test IX",
 			},
-			setupMock: func(m *MockIXService) {
-				m.validateIXOrderError = fmt.Errorf("validation failed: missing required fields")
-			},
-			expectedError: "validation failed",
+			setupMock:     func(m *MockIXService) {},
+			expectedError: "Invalid ASN",
 		},
 		{
 			name: "API error",
@@ -1531,7 +1529,13 @@ func TestBuyIX_LoginError(t *testing.T) {
 	cmd.Flags().String("json", "", "JSON string")
 	cmd.Flags().String("json-file", "", "JSON file")
 
+	_ = cmd.Flags().Set("product-uid", "port-uid-123")
 	_ = cmd.Flags().Set("name", "Test IX")
+	_ = cmd.Flags().Set("network-service-type", "Los Angeles IX")
+	_ = cmd.Flags().Set("asn", "65000")
+	_ = cmd.Flags().Set("mac-address", "00:11:22:33:44:55")
+	_ = cmd.Flags().Set("rate-limit", "1000")
+	_ = cmd.Flags().Set("vlan", "100")
 
 	var err error
 	output.CaptureOutput(func() {

--- a/internal/commands/ix/ix_actions_test.go
+++ b/internal/commands/ix/ix_actions_test.go
@@ -1082,11 +1082,13 @@ func TestGetIX(t *testing.T) {
 
 func TestUpdateIX(t *testing.T) {
 	originalPrompt := utils.GetResourcePrompt()
+	originalPasswordPrompt := utils.GetPasswordPrompt()
 	originalUpdateIXFunc := updateIXFunc
 	originalGetIXFunc := getIXFunc
 	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
 	defer func() {
 		utils.SetResourcePrompt(originalPrompt)
+		utils.SetPasswordPrompt(originalPasswordPrompt)
 		cleanup()
 		updateIXFunc = originalUpdateIXFunc
 		getIXFunc = originalGetIXFunc
@@ -1280,13 +1282,19 @@ func TestUpdateIX(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if len(tt.prompts) > 0 {
 				promptIndex := 0
-				utils.SetResourcePrompt(func(_, msg string, _ bool) (string, error) {
+				nextPrompt := func() (string, error) {
 					if promptIndex < len(tt.prompts) {
 						response := tt.prompts[promptIndex]
 						promptIndex++
 						return response, nil
 					}
 					return "", fmt.Errorf("unexpected prompt call")
+				}
+				utils.SetResourcePrompt(func(_, _ string, _ bool) (string, error) {
+					return nextPrompt()
+				})
+				utils.SetPasswordPrompt(func(_ string, _ bool) (string, error) {
+					return nextPrompt()
 				})
 			}
 

--- a/internal/commands/ix/ix_inputs.go
+++ b/internal/commands/ix/ix_inputs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/megaport/megaport-cli/internal/utils"
+	"github.com/megaport/megaport-cli/internal/validation"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 )
@@ -20,6 +21,19 @@ func buildIXRequestFromFlags(cmd *cobra.Command) (*megaport.BuyIXRequest, error)
 	vlan, _ := cmd.Flags().GetInt("vlan")
 	shutdown, _ := cmd.Flags().GetBool("shutdown")
 	promoCode, _ := cmd.Flags().GetString("promo-code")
+
+	if err := validation.ValidateASN(asn); err != nil {
+		return nil, err
+	}
+	if err := validation.ValidateMACAddress(macAddress); err != nil {
+		return nil, err
+	}
+	if err := validation.ValidateRateLimit(rateLimit); err != nil {
+		return nil, err
+	}
+	if err := validation.ValidateVLAN(vlan); err != nil {
+		return nil, err
+	}
 
 	req := &megaport.BuyIXRequest{
 		ProductUID:         productUID,
@@ -47,6 +61,19 @@ func buildIXRequestFromJSON(jsonStr, jsonFile string) (*megaport.BuyIXRequest, e
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
+	if err := validation.ValidateASN(req.ASN); err != nil {
+		return nil, err
+	}
+	if err := validation.ValidateMACAddress(req.MACAddress); err != nil {
+		return nil, err
+	}
+	if err := validation.ValidateRateLimit(req.RateLimit); err != nil {
+		return nil, err
+	}
+	if err := validation.ValidateVLAN(req.VLAN); err != nil {
+		return nil, err
+	}
+
 	return req, nil
 }
 
@@ -60,6 +87,9 @@ func buildUpdateIXRequestFromFlags(cmd *cobra.Command) (*megaport.UpdateIXReques
 
 	if cmd.Flags().Changed("rate-limit") {
 		rateLimit, _ := cmd.Flags().GetInt("rate-limit")
+		if err := validation.ValidateRateLimit(rateLimit); err != nil {
+			return nil, err
+		}
 		req.RateLimit = &rateLimit
 	}
 
@@ -70,16 +100,25 @@ func buildUpdateIXRequestFromFlags(cmd *cobra.Command) (*megaport.UpdateIXReques
 
 	if cmd.Flags().Changed("vlan") {
 		vlan, _ := cmd.Flags().GetInt("vlan")
+		if err := validation.ValidateVLAN(vlan); err != nil {
+			return nil, err
+		}
 		req.VLAN = &vlan
 	}
 
 	if cmd.Flags().Changed("mac-address") {
 		macAddress, _ := cmd.Flags().GetString("mac-address")
+		if err := validation.ValidateMACAddress(macAddress); err != nil {
+			return nil, err
+		}
 		req.MACAddress = &macAddress
 	}
 
 	if cmd.Flags().Changed("asn") {
 		asn, _ := cmd.Flags().GetInt("asn")
+		if err := validation.ValidateASN(asn); err != nil {
+			return nil, err
+		}
 		req.ASN = &asn
 	}
 
@@ -120,6 +159,27 @@ func buildUpdateIXRequestFromJSON(jsonStr, jsonFile string) (*megaport.UpdateIXR
 	req := &megaport.UpdateIXRequest{}
 	if err := json.Unmarshal(jsonData, req); err != nil {
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	if req.ASN != nil {
+		if err := validation.ValidateASN(*req.ASN); err != nil {
+			return nil, err
+		}
+	}
+	if req.MACAddress != nil {
+		if err := validation.ValidateMACAddress(*req.MACAddress); err != nil {
+			return nil, err
+		}
+	}
+	if req.RateLimit != nil {
+		if err := validation.ValidateRateLimit(*req.RateLimit); err != nil {
+			return nil, err
+		}
+	}
+	if req.VLAN != nil {
+		if err := validation.ValidateVLAN(*req.VLAN); err != nil {
+			return nil, err
+		}
 	}
 
 	return req, nil

--- a/internal/commands/ix/ix_prompts.go
+++ b/internal/commands/ix/ix_prompts.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/megaport/megaport-cli/internal/utils"
+	"github.com/megaport/megaport-cli/internal/validation"
 	megaport "github.com/megaport/megaportgo"
 )
 
@@ -42,13 +43,16 @@ func buildIXRequestFromPrompt(_ context.Context, noColor bool) (*megaport.BuyIXR
 	if err != nil {
 		return nil, fmt.Errorf("invalid ASN: %w", err)
 	}
+	if err := validation.ValidateASN(asn); err != nil {
+		return nil, err
+	}
 
 	macAddress, err := utils.ResourcePrompt("ix", "Enter MAC address (required): ", noColor)
 	if err != nil {
 		return nil, err
 	}
-	if macAddress == "" {
-		return nil, fmt.Errorf("MAC address is required")
+	if err := validation.ValidateMACAddress(macAddress); err != nil {
+		return nil, err
 	}
 
 	rateLimitStr, err := utils.ResourcePrompt("ix", "Enter rate limit in Mbps (required): ", noColor)
@@ -59,6 +63,9 @@ func buildIXRequestFromPrompt(_ context.Context, noColor bool) (*megaport.BuyIXR
 	if err != nil {
 		return nil, fmt.Errorf("invalid rate limit: %w", err)
 	}
+	if err := validation.ValidateRateLimit(rateLimit); err != nil {
+		return nil, err
+	}
 
 	vlanStr, err := utils.ResourcePrompt("ix", "Enter VLAN ID (required): ", noColor)
 	if err != nil {
@@ -67,6 +74,9 @@ func buildIXRequestFromPrompt(_ context.Context, noColor bool) (*megaport.BuyIXR
 	vlan, err := strconv.Atoi(vlanStr)
 	if err != nil {
 		return nil, fmt.Errorf("invalid VLAN: %w", err)
+	}
+	if err := validation.ValidateVLAN(vlan); err != nil {
+		return nil, err
 	}
 
 	promoCode, err := utils.ResourcePrompt("ix", "Enter promo code (optional, leave empty to skip): ", noColor)
@@ -110,6 +120,9 @@ func buildUpdateIXRequestFromPrompt(_ string, noColor bool) (*megaport.UpdateIXR
 		if err != nil {
 			return nil, fmt.Errorf("invalid rate limit: %w", err)
 		}
+		if err := validation.ValidateRateLimit(rateLimit); err != nil {
+			return nil, err
+		}
 		req.RateLimit = &rateLimit
 		fieldsUpdated = true
 	}
@@ -132,6 +145,9 @@ func buildUpdateIXRequestFromPrompt(_ string, noColor bool) (*megaport.UpdateIXR
 		if err != nil {
 			return nil, fmt.Errorf("invalid VLAN: %w", err)
 		}
+		if err := validation.ValidateVLAN(vlan); err != nil {
+			return nil, err
+		}
 		req.VLAN = &vlan
 		fieldsUpdated = true
 	}
@@ -141,6 +157,9 @@ func buildUpdateIXRequestFromPrompt(_ string, noColor bool) (*megaport.UpdateIXR
 		return nil, err
 	}
 	if macAddress != "" {
+		if err := validation.ValidateMACAddress(macAddress); err != nil {
+			return nil, err
+		}
 		req.MACAddress = &macAddress
 		fieldsUpdated = true
 	}
@@ -153,6 +172,9 @@ func buildUpdateIXRequestFromPrompt(_ string, noColor bool) (*megaport.UpdateIXR
 		asn, err := strconv.Atoi(asnStr)
 		if err != nil {
 			return nil, fmt.Errorf("invalid ASN: %w", err)
+		}
+		if err := validation.ValidateASN(asn); err != nil {
+			return nil, err
 		}
 		req.ASN = &asn
 		fieldsUpdated = true

--- a/internal/commands/ix/ix_prompts.go
+++ b/internal/commands/ix/ix_prompts.go
@@ -180,7 +180,7 @@ func buildUpdateIXRequestFromPrompt(_ string, noColor bool) (*megaport.UpdateIXR
 		fieldsUpdated = true
 	}
 
-	password, err := utils.ResourcePrompt("ix", "Enter new BGP password (leave empty to skip): ", noColor)
+	password, err := utils.PasswordPrompt("Enter new BGP password (leave empty to skip):", noColor)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/commands/ix/ix_test.go
+++ b/internal/commands/ix/ix_test.go
@@ -682,6 +682,16 @@ func TestBuildIXRequestFromFlags_ValidationErrors(t *testing.T) {
 			},
 			errContains: "Invalid rate limit",
 		},
+		{
+			name: "invalid VLAN reserved",
+			flags: map[string]string{
+				"asn":         "65000",
+				"mac-address": "00:11:22:33:44:55",
+				"rate-limit":  "1000",
+				"vlan":        "1",
+			},
+			errContains: "Invalid VLAN ID",
+		},
 	}
 
 	for _, tt := range tests {
@@ -995,6 +1005,99 @@ func TestBuildUpdateIXRequestFromFlags(t *testing.T) {
 	}
 }
 
+func TestBuildUpdateIXRequestFromFlags_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		flags       map[string]string
+		errContains string
+	}{
+		{
+			name:        "invalid ASN zero",
+			flags:       map[string]string{"asn": "0"},
+			errContains: "Invalid ASN",
+		},
+		{
+			name:        "invalid MAC address",
+			flags:       map[string]string{"mac-address": "bad-mac"},
+			errContains: "Invalid MAC address",
+		},
+		{
+			name:        "invalid rate limit zero",
+			flags:       map[string]string{"rate-limit": "0"},
+			errContains: "Invalid rate limit",
+		},
+		{
+			name:        "invalid VLAN reserved",
+			flags:       map[string]string{"vlan": "1"},
+			errContains: "Invalid VLAN ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "test"}
+			cmd.Flags().String("name", "", "")
+			cmd.Flags().Int("rate-limit", 0, "")
+			cmd.Flags().String("cost-centre", "", "")
+			cmd.Flags().Int("vlan", 0, "")
+			cmd.Flags().String("mac-address", "", "")
+			cmd.Flags().Int("asn", 0, "")
+			cmd.Flags().String("password", "", "")
+			cmd.Flags().Bool("public-graph", false, "")
+			cmd.Flags().String("reverse-dns", "", "")
+			cmd.Flags().String("a-end-product-uid", "", "")
+			cmd.Flags().Bool("shutdown", false, "")
+
+			for k, v := range tt.flags {
+				_ = cmd.Flags().Set(k, v)
+			}
+
+			req, err := buildUpdateIXRequestFromFlags(cmd)
+			assert.Error(t, err)
+			assert.Nil(t, req)
+			assert.Contains(t, err.Error(), tt.errContains)
+		})
+	}
+}
+
+func TestBuildUpdateIXRequestFromJSON_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		jsonStr     string
+		errContains string
+	}{
+		{
+			name:        "invalid ASN",
+			jsonStr:     `{"asn": 0}`,
+			errContains: "Invalid ASN",
+		},
+		{
+			name:        "invalid MAC address",
+			jsonStr:     `{"macAddress": "bad-mac"}`,
+			errContains: "Invalid MAC address",
+		},
+		{
+			name:        "invalid rate limit",
+			jsonStr:     `{"rateLimit": -1}`,
+			errContains: "Invalid rate limit",
+		},
+		{
+			name:        "invalid VLAN",
+			jsonStr:     `{"vlan": 1}`,
+			errContains: "Invalid VLAN ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := buildUpdateIXRequestFromJSON(tt.jsonStr, "")
+			assert.Error(t, err)
+			assert.Nil(t, req)
+			assert.Contains(t, err.Error(), tt.errContains)
+		})
+	}
+}
+
 func TestBuildUpdateIXRequestFromJSON(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -1244,8 +1347,10 @@ func TestBuildIXRequestFromPrompt(t *testing.T) {
 
 func TestBuildUpdateIXRequestFromPrompt(t *testing.T) {
 	originalPrompt := utils.GetResourcePrompt()
+	originalPasswordPrompt := utils.GetPasswordPrompt()
 	defer func() {
 		utils.SetResourcePrompt(originalPrompt)
+		utils.SetPasswordPrompt(originalPasswordPrompt)
 	}()
 
 	tests := []struct {
@@ -1365,7 +1470,7 @@ func TestBuildUpdateIXRequestFromPrompt(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			promptIndex := 0
-			utils.SetResourcePrompt(func(_, msg string, _ bool) (string, error) {
+			nextPrompt := func() (string, error) {
 				if promptIndex < len(tt.prompts) {
 					response := tt.prompts[promptIndex]
 					promptIndex++
@@ -1375,6 +1480,12 @@ func TestBuildUpdateIXRequestFromPrompt(t *testing.T) {
 					return response, nil
 				}
 				return "", fmt.Errorf("unexpected prompt call")
+			}
+			utils.SetResourcePrompt(func(_, _ string, _ bool) (string, error) {
+				return nextPrompt()
+			})
+			utils.SetPasswordPrompt(func(_ string, _ bool) (string, error) {
+				return nextPrompt()
 			})
 
 			req, err := buildUpdateIXRequestFromPrompt("ix-123", true)

--- a/internal/commands/ix/ix_test.go
+++ b/internal/commands/ix/ix_test.go
@@ -595,17 +595,6 @@ func TestBuildIXRequestFromFlags(t *testing.T) {
 				assert.True(t, req.Shutdown)
 			},
 		},
-		{
-			name:  "no flags (defaults)",
-			flags: map[string]string{},
-			validate: func(t *testing.T, req *megaport.BuyIXRequest) {
-				assert.Equal(t, "", req.ProductUID)
-				assert.Equal(t, "", req.Name)
-				assert.Equal(t, 0, req.ASN)
-				assert.Equal(t, 0, req.RateLimit)
-				assert.Equal(t, 0, req.VLAN)
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -629,6 +618,93 @@ func TestBuildIXRequestFromFlags(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, req)
 			tt.validate(t, req)
+		})
+	}
+}
+
+func TestBuildIXRequestFromFlags_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		flags       map[string]string
+		errContains string
+	}{
+		{
+			name: "invalid ASN zero",
+			flags: map[string]string{
+				"asn":         "0",
+				"mac-address": "00:11:22:33:44:55",
+				"rate-limit":  "1000",
+			},
+			errContains: "Invalid ASN",
+		},
+		{
+			name: "invalid ASN negative",
+			flags: map[string]string{
+				"asn":         "-1",
+				"mac-address": "00:11:22:33:44:55",
+				"rate-limit":  "1000",
+			},
+			errContains: "Invalid ASN",
+		},
+		{
+			name: "invalid MAC address",
+			flags: map[string]string{
+				"asn":         "65000",
+				"mac-address": "not-a-mac",
+				"rate-limit":  "1000",
+			},
+			errContains: "Invalid MAC address",
+		},
+		{
+			name: "empty MAC address",
+			flags: map[string]string{
+				"asn":         "65000",
+				"mac-address": "",
+				"rate-limit":  "1000",
+			},
+			errContains: "Invalid MAC address",
+		},
+		{
+			name: "invalid rate limit zero",
+			flags: map[string]string{
+				"asn":         "65000",
+				"mac-address": "00:11:22:33:44:55",
+				"rate-limit":  "0",
+			},
+			errContains: "Invalid rate limit",
+		},
+		{
+			name: "invalid rate limit negative",
+			flags: map[string]string{
+				"asn":         "65000",
+				"mac-address": "00:11:22:33:44:55",
+				"rate-limit":  "-1",
+			},
+			errContains: "Invalid rate limit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "test"}
+			cmd.Flags().String("product-uid", "", "")
+			cmd.Flags().String("name", "", "")
+			cmd.Flags().String("network-service-type", "", "")
+			cmd.Flags().Int("asn", 0, "")
+			cmd.Flags().String("mac-address", "", "")
+			cmd.Flags().Int("rate-limit", 0, "")
+			cmd.Flags().Int("vlan", 0, "")
+			cmd.Flags().Bool("shutdown", false, "")
+			cmd.Flags().String("promo-code", "", "")
+
+			for k, v := range tt.flags {
+				_ = cmd.Flags().Set(k, v)
+			}
+
+			req, err := buildIXRequestFromFlags(cmd)
+			assert.Error(t, err)
+			assert.Nil(t, req)
+			assert.Contains(t, err.Error(), tt.errContains)
 		})
 	}
 }
@@ -658,14 +734,9 @@ func TestBuildIXRequestFromJSON(t *testing.T) {
 			},
 		},
 		{
-			name:    "valid JSON string with partial fields",
-			jsonStr: `{"productUid":"port-123","productName":"Partial IX"}`,
-			validate: func(t *testing.T, req *megaport.BuyIXRequest) {
-				assert.Equal(t, "port-123", req.ProductUID)
-				assert.Equal(t, "Partial IX", req.Name)
-				assert.Equal(t, 0, req.ASN)
-				assert.Equal(t, 0, req.RateLimit)
-			},
+			name:          "partial fields missing ASN",
+			jsonStr:       `{"productUid":"port-123","productName":"Partial IX"}`,
+			expectedError: "Invalid ASN",
 		},
 		{
 			name:          "invalid JSON syntax",
@@ -673,12 +744,19 @@ func TestBuildIXRequestFromJSON(t *testing.T) {
 			expectedError: "failed to parse JSON",
 		},
 		{
-			name:    "empty JSON object",
-			jsonStr: `{}`,
-			validate: func(t *testing.T, req *megaport.BuyIXRequest) {
-				assert.Equal(t, "", req.ProductUID)
-				assert.Equal(t, "", req.Name)
-			},
+			name:          "empty JSON object",
+			jsonStr:       `{}`,
+			expectedError: "Invalid ASN",
+		},
+		{
+			name:          "invalid MAC address in JSON",
+			jsonStr:       `{"productUid":"port-123","productName":"IX","asn":65000,"macAddress":"bad-mac","rateLimit":1000,"vlan":100}`,
+			expectedError: "Invalid MAC address",
+		},
+		{
+			name:          "invalid rate limit in JSON",
+			jsonStr:       `{"productUid":"port-123","productName":"IX","asn":65000,"macAddress":"00:11:22:33:44:55","rateLimit":0,"vlan":100}`,
+			expectedError: "Invalid rate limit",
 		},
 		{
 			name: "valid JSON file",
@@ -1098,7 +1176,7 @@ func TestBuildIXRequestFromPrompt(t *testing.T) {
 				"65000",
 				"",
 			},
-			expectedError: "MAC address is required",
+			expectedError: "Invalid MAC address",
 		},
 		{
 			name: "invalid rate limit (non-numeric)",

--- a/internal/commands/ports/ports_prompts.go
+++ b/internal/commands/ports/ports_prompts.go
@@ -17,8 +17,8 @@ func promptForPortDetails(noColor bool) (*megaport.BuyPortRequest, error) {
 	if err != nil {
 		return nil, err
 	}
-	if name == "" {
-		return nil, fmt.Errorf("port name is required")
+	if err := validation.ValidatePortName(name); err != nil {
+		return nil, err
 	}
 	req.Name = name
 
@@ -99,8 +99,8 @@ func promptForLAGPortDetails(noColor bool) (*megaport.BuyPortRequest, error) {
 	if err != nil {
 		return nil, err
 	}
-	if name == "" {
-		return nil, fmt.Errorf("port name is required")
+	if err := validation.ValidatePortName(name); err != nil {
+		return nil, err
 	}
 	req.Name = name
 

--- a/internal/commands/ports/ports_prompts_test.go
+++ b/internal/commands/ports/ports_prompts_test.go
@@ -65,7 +65,7 @@ func TestPromptForPortDetails_EmptyName(t *testing.T) {
 
 	_, err := promptForPortDetails(true)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "name is required")
+	assert.Contains(t, err.Error(), "Invalid port name")
 }
 
 func TestPromptForPortDetails_InvalidTerm(t *testing.T) {

--- a/internal/commands/vxc/vxc_inputs.go
+++ b/internal/commands/vxc/vxc_inputs.go
@@ -21,8 +21,8 @@ var buildVXCRequestFromFlags = func(cmd *cobra.Command, ctx context.Context, svc
 	}
 
 	rateLimit, _ := cmd.Flags().GetInt("rate-limit")
-	if rateLimit <= 0 {
-		return nil, fmt.Errorf("rate-limit must be greater than 0")
+	if err := validation.ValidateRateLimit(rateLimit); err != nil {
+		return nil, err
 	}
 
 	term, _ := cmd.Flags().GetInt("term")

--- a/internal/utils/prompts.go
+++ b/internal/utils/prompts.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/fatih/color"
+	"golang.org/x/term"
 )
 
 // promptFuncMu guards all prompt function pointers.
@@ -105,6 +106,21 @@ var resourcePromptFn = func(resourceType string, msg string, noColor bool) (stri
 		return "", err
 	}
 	return strings.TrimSpace(input), nil
+}
+
+var passwordPromptFn = func(msg string, noColor bool) (string, error) {
+	if !noColor {
+		fmt.Print(color.New(color.FgHiRed, color.Bold).Sprint("🔒 " + msg + " "))
+	} else {
+		fmt.Print("🔒 " + msg + " ")
+	}
+
+	password, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Println() // newline after masked input
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(password)), nil
 }
 
 var resourceTagsPromptFn = func(noColor bool) (map[string]string, error) {
@@ -275,6 +291,14 @@ func BuyConfirmPrompt(resourceType string, details []BuyConfirmDetail, noColor b
 	return fn(resourceType, details, noColor)
 }
 
+// PasswordPrompt asks the user for sensitive input with masked terminal echo.
+func PasswordPrompt(msg string, noColor bool) (string, error) {
+	promptFuncMu.RLock()
+	fn := passwordPromptFn
+	promptFuncMu.RUnlock()
+	return fn(msg, noColor)
+}
+
 // ResourcePrompt asks the user for resource-specific input.
 func ResourcePrompt(resourceType string, msg string, noColor bool) (string, error) {
 	promptFuncMu.RLock()
@@ -319,6 +343,12 @@ func GetBuyConfirmPrompt() func(string, []BuyConfirmDetail, bool) bool {
 	return buyConfirmPromptFn
 }
 
+func GetPasswordPrompt() func(string, bool) (string, error) {
+	promptFuncMu.RLock()
+	defer promptFuncMu.RUnlock()
+	return passwordPromptFn
+}
+
 func GetResourcePrompt() func(string, string, bool) (string, error) {
 	promptFuncMu.RLock()
 	defer promptFuncMu.RUnlock()
@@ -355,6 +385,12 @@ func SetBuyConfirmPrompt(fn func(string, []BuyConfirmDetail, bool) bool) {
 	promptFuncMu.Lock()
 	defer promptFuncMu.Unlock()
 	buyConfirmPromptFn = fn
+}
+
+func SetPasswordPrompt(fn func(string, bool) (string, error)) {
+	promptFuncMu.Lock()
+	defer promptFuncMu.Unlock()
+	passwordPromptFn = fn
 }
 
 func SetResourcePrompt(fn func(string, string, bool) (string, error)) {

--- a/internal/utils/prompts.go
+++ b/internal/utils/prompts.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/fatih/color"
+	"golang.org/x/term"
 )
 
 // promptFuncMu guards all prompt function pointers.
@@ -136,6 +137,21 @@ var secretResourcePromptFn = func(resourceType string, msg string, noColor bool)
 		return "", err
 	}
 	return strings.TrimSpace(input), nil
+}
+
+var passwordPromptFn = func(msg string, noColor bool) (string, error) {
+	if !noColor {
+		fmt.Print(color.New(color.FgHiRed, color.Bold).Sprint("🔒 " + msg + " "))
+	} else {
+		fmt.Print("🔒 " + msg + " ")
+	}
+
+	password, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Println() // newline after masked input
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(password)), nil
 }
 
 var resourceTagsPromptFn = func(noColor bool) (map[string]string, error) {
@@ -317,6 +333,14 @@ func DesignConfirmPrompt(resourceType string, details []BuyConfirmDetail, noColo
 	return fn(resourceType, details, noColor)
 }
 
+// PasswordPrompt asks the user for sensitive input with masked terminal echo.
+func PasswordPrompt(msg string, noColor bool) (string, error) {
+	promptFuncMu.RLock()
+	fn := passwordPromptFn
+	promptFuncMu.RUnlock()
+	return fn(msg, noColor)
+}
+
 // ResourcePrompt asks the user for resource-specific input.
 func ResourcePrompt(resourceType string, msg string, noColor bool) (string, error) {
 	promptFuncMu.RLock()
@@ -377,6 +401,12 @@ func GetDesignConfirmPrompt() func(string, []BuyConfirmDetail, bool) bool {
 	return designConfirmPromptFn
 }
 
+func GetPasswordPrompt() func(string, bool) (string, error) {
+	promptFuncMu.RLock()
+	defer promptFuncMu.RUnlock()
+	return passwordPromptFn
+}
+
 func GetResourcePrompt() func(string, string, bool) (string, error) {
 	promptFuncMu.RLock()
 	defer promptFuncMu.RUnlock()
@@ -425,6 +455,12 @@ func SetDesignConfirmPrompt(fn func(string, []BuyConfirmDetail, bool) bool) {
 	promptFuncMu.Lock()
 	defer promptFuncMu.Unlock()
 	designConfirmPromptFn = fn
+}
+
+func SetPasswordPrompt(fn func(string, bool) (string, error)) {
+	promptFuncMu.Lock()
+	defer promptFuncMu.Unlock()
+	passwordPromptFn = fn
 }
 
 func SetResourcePrompt(fn func(string, string, bool) (string, error)) {

--- a/internal/utils/prompts.go
+++ b/internal/utils/prompts.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/fatih/color"
-	"golang.org/x/term"
 )
 
 // promptFuncMu guards all prompt function pointers.
@@ -139,20 +138,9 @@ var secretResourcePromptFn = func(resourceType string, msg string, noColor bool)
 	return strings.TrimSpace(input), nil
 }
 
-var passwordPromptFn = func(msg string, noColor bool) (string, error) {
-	if !noColor {
-		fmt.Print(color.New(color.FgHiRed, color.Bold).Sprint("🔒 " + msg + " "))
-	} else {
-		fmt.Print("🔒 " + msg + " ")
-	}
-
-	password, err := term.ReadPassword(int(os.Stdin.Fd()))
-	fmt.Println() // newline after masked input
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(password)), nil
-}
+// passwordPromptFn is set by the platform-specific init in prompts_native.go
+// (native terminal) or prompts_wasm.go (browser).
+var passwordPromptFn func(msg string, noColor bool) (string, error)
 
 var resourceTagsPromptFn = func(noColor bool) (map[string]string, error) {
 	addTags := ConfirmPrompt("Would you like to add resource tags?", noColor)

--- a/internal/utils/prompts_native.go
+++ b/internal/utils/prompts_native.go
@@ -1,0 +1,32 @@
+//go:build !js || !wasm
+// +build !js !wasm
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/fatih/color"
+	"golang.org/x/term"
+)
+
+func init() {
+	passwordPromptFn = nativePasswordPrompt
+}
+
+func nativePasswordPrompt(msg string, noColor bool) (string, error) {
+	if !noColor {
+		fmt.Print(color.New(color.FgHiRed, color.Bold).Sprint("\U0001f512 " + msg + " "))
+	} else {
+		fmt.Print("\U0001f512 " + msg + " ")
+	}
+
+	password, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Println() // newline after masked input
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(password)), nil
+}

--- a/internal/utils/prompts_native.go
+++ b/internal/utils/prompts_native.go
@@ -13,7 +13,7 @@ import (
 )
 
 func init() {
-	passwordPromptFn = nativePasswordPrompt
+	SetPasswordPrompt(nativePasswordPrompt)
 }
 
 func nativePasswordPrompt(msg string, noColor bool) (string, error) {

--- a/internal/utils/prompts_native.go
+++ b/internal/utils/prompts_native.go
@@ -1,5 +1,4 @@
-//go:build !js || !wasm
-// +build !js !wasm
+//go:build !js && !wasm
 
 package utils
 
@@ -17,6 +16,7 @@ func init() {
 }
 
 func nativePasswordPrompt(msg string, noColor bool) (string, error) {
+	// \U0001f512 is the lock symbol 🔒
 	if !noColor {
 		fmt.Print(color.New(color.FgHiRed, color.Bold).Sprint("\U0001f512 " + msg + " "))
 	} else {

--- a/internal/utils/prompts_native_test.go
+++ b/internal/utils/prompts_native_test.go
@@ -15,8 +15,8 @@ func TestNativeInitAssignsPasswordPromptFn(t *testing.T) {
 }
 
 func TestNativePasswordPrompt_NonTTYReturnsError(t *testing.T) {
-	// term.ReadPassword fails when stdin is not a terminal, which is the case
-	// under `go test`. Exercising that path covers nativePasswordPrompt.
+	// term.ReadPassword fails when stdin is not a terminal. This test
+	// explicitly replaces os.Stdin with a pipe to exercise that error path.
 	oldStdin, oldStdout := os.Stdin, os.Stdout
 	defer func() { os.Stdin, os.Stdout = oldStdin, oldStdout }()
 

--- a/internal/utils/prompts_native_test.go
+++ b/internal/utils/prompts_native_test.go
@@ -1,0 +1,41 @@
+//go:build !js || !wasm
+// +build !js !wasm
+
+package utils
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNativeInitAssignsPasswordPromptFn(t *testing.T) {
+	assert.NotNil(t, GetPasswordPrompt(), "native init should wire passwordPromptFn")
+}
+
+func TestNativePasswordPrompt_NonTTYReturnsError(t *testing.T) {
+	// term.ReadPassword fails when stdin is not a terminal, which is the case
+	// under `go test`. Exercising that path covers nativePasswordPrompt.
+	oldStdin, oldStdout := os.Stdin, os.Stdout
+	defer func() { os.Stdin, os.Stdout = oldStdin, oldStdout }()
+
+	inR, inW, err := os.Pipe()
+	assert.NoError(t, err)
+	outR, outW, err := os.Pipe()
+	assert.NoError(t, err)
+	os.Stdin = inR
+	os.Stdout = outW
+	_ = inW.Close()
+
+	for _, noColor := range []bool{true, false} {
+		pw, err := nativePasswordPrompt("Enter password:", noColor)
+		assert.Error(t, err, "expected error reading password from non-tty pipe")
+		assert.Empty(t, pw)
+	}
+
+	_ = outW.Close()
+	_, _ = outR.Read(make([]byte, 1024))
+	_ = inR.Close()
+	_ = outR.Close()
+}

--- a/internal/utils/prompts_native_test.go
+++ b/internal/utils/prompts_native_test.go
@@ -1,5 +1,4 @@
-//go:build !js || !wasm
-// +build !js !wasm
+//go:build !js && !wasm
 
 package utils
 

--- a/internal/utils/prompts_native_test.go
+++ b/internal/utils/prompts_native_test.go
@@ -4,10 +4,12 @@
 package utils
 
 import (
+	"io"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNativeInitAssignsPasswordPromptFn(t *testing.T) {
@@ -21,12 +23,23 @@ func TestNativePasswordPrompt_NonTTYReturnsError(t *testing.T) {
 	defer func() { os.Stdin, os.Stdout = oldStdin, oldStdout }()
 
 	inR, inW, err := os.Pipe()
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	defer inR.Close()
+	defer inW.Close()
+
 	outR, outW, err := os.Pipe()
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	defer outR.Close()
+
 	os.Stdin = inR
 	os.Stdout = outW
 	_ = inW.Close()
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, outR)
+		close(done)
+	}()
 
 	for _, noColor := range []bool{true, false} {
 		pw, err := nativePasswordPrompt("Enter password:", noColor)
@@ -35,7 +48,5 @@ func TestNativePasswordPrompt_NonTTYReturnsError(t *testing.T) {
 	}
 
 	_ = outW.Close()
-	_, _ = outR.Read(make([]byte, 1024))
-	_ = inR.Close()
-	_ = outR.Close()
+	<-done
 }

--- a/internal/utils/prompts_wasm.go
+++ b/internal/utils/prompts_wasm.go
@@ -17,6 +17,7 @@ func init() {
 	// Override the default prompt functions with WASM-specific ones
 	SetPrompt(wasmPrompt)
 	SetConfirmPrompt(wasmConfirmPrompt)
+	SetPasswordPrompt(wasmPasswordPrompt)
 	SetResourcePrompt(wasmResourcePrompt)
 	SetResourceTagsPrompt(wasmResourceTagsPrompt)
 	SetUpdateResourceTagsPrompt(wasmUpdateResourceTagsPrompt)
@@ -38,6 +39,10 @@ func wasmConfirmPrompt(question string, noColor bool) bool {
 
 	response = strings.ToLower(strings.TrimSpace(response))
 	return response == "y" || response == "yes"
+}
+
+func wasmPasswordPrompt(msg string, noColor bool) (string, error) {
+	return wasm.PromptForInput(msg, "password", "")
 }
 
 func wasmResourcePrompt(resourceType string, msg string, noColor bool) (string, error) {

--- a/internal/utils/prompts_wasm.go
+++ b/internal/utils/prompts_wasm.go
@@ -16,6 +16,7 @@ func init() {
 	// Override the default prompt functions with WASM-specific ones
 	SetPrompt(wasmPrompt)
 	SetConfirmPrompt(wasmConfirmPrompt)
+	SetPasswordPrompt(wasmPasswordPrompt)
 	SetResourcePrompt(wasmResourcePrompt)
 	SetSecretResourcePrompt(wasmSecretResourcePrompt)
 	SetResourceTagsPrompt(wasmResourceTagsPrompt)
@@ -38,6 +39,10 @@ func wasmConfirmPrompt(question string, noColor bool) bool {
 
 	response = strings.ToLower(strings.TrimSpace(response))
 	return response == "y" || response == "yes"
+}
+
+func wasmPasswordPrompt(msg string, noColor bool) (string, error) {
+	return wasm.PromptForInput(msg, "password", "")
 }
 
 func wasmResourcePrompt(resourceType string, msg string, noColor bool) (string, error) {

--- a/internal/validation/common.go
+++ b/internal/validation/common.go
@@ -41,9 +41,9 @@ const (
 	// ReservedVLAN identifies a VLAN ID that is reserved and cannot be used.
 	ReservedVLAN = 1
 	// MinASN is the minimum valid Autonomous System Number.
-	MinASN = 1
+	MinASN int64 = 1
 	// MaxASN is the maximum valid 32-bit Autonomous System Number.
-	MaxASN = 4294967295
+	MaxASN int64 = 4294967295
 )
 
 // VLANHelpText returns a canonical human-readable description of valid VLAN values,
@@ -202,7 +202,8 @@ func ValidateRateLimit(rateLimit int) error {
 //   - A ValidationError if the ASN is not valid
 //   - nil if the validation passes
 func ValidateASN(asn int) error {
-	if asn < MinASN || asn > MaxASN {
+	v := int64(asn)
+	if v < MinASN || v > MaxASN {
 		return NewValidationError("ASN", asn,
 			fmt.Sprintf("must be between %d and %d", MinASN, MaxASN))
 	}
@@ -216,7 +217,8 @@ func ValidateASN(asn int) error {
 //
 // Validation checks:
 //   - MAC address must not be empty
-//   - Must be parseable as a hardware address (colon or hyphen separated hex pairs)
+//   - Must be parseable as a hardware address by net.ParseMAC (colon-separated,
+//     hyphen-separated, or dot-separated formats)
 //   - Must be exactly 6 bytes (EUI-48)
 //
 // Returns:

--- a/internal/validation/common.go
+++ b/internal/validation/common.go
@@ -190,22 +190,36 @@ func ValidateRateLimit(rateLimit int) error {
 	return nil
 }
 
-// ValidateASN validates if an ASN (Autonomous System Number) is within the valid 32-bit range.
+// maxSupportedASNForInt returns the largest ASN value representable by the
+// current build target's int type, capped at MaxASN. On 64-bit targets this
+// is MaxASN (4294967295); on 32-bit targets (e.g. js/wasm) it is math.MaxInt32.
+func maxSupportedASNForInt() int64 {
+	maxInt := int64(^uint(0) >> 1)
+	if maxInt < MaxASN {
+		return maxInt
+	}
+	return MaxASN
+}
+
+// ValidateASN validates if an ASN (Autonomous System Number) is within the
+// supported range for the current build target.
 //
 // Parameters:
 //   - asn: The ASN to validate
 //
 // Validation checks:
-//   - ASN must be between MinASN (1) and MaxASN (4294967295) inclusive
+//   - ASN must be between MinASN (1) and the lesser of MaxASN (4294967295)
+//     and the current target's maximum int value, inclusive.
 //
 // Returns:
 //   - A ValidationError if the ASN is not valid
 //   - nil if the validation passes
 func ValidateASN(asn int) error {
 	v := int64(asn)
-	if v < MinASN || v > MaxASN {
+	maxASN := maxSupportedASNForInt()
+	if v < MinASN || v > maxASN {
 		return NewValidationError("ASN", asn,
-			fmt.Sprintf("must be between %d and %d", MinASN, MaxASN))
+			fmt.Sprintf("must be between %d and %d", MinASN, maxASN))
 	}
 	return nil
 }

--- a/internal/validation/common.go
+++ b/internal/validation/common.go
@@ -5,6 +5,7 @@ package validation
 
 import (
 	"fmt"
+	"net"
 	"strings"
 	"time"
 )
@@ -39,6 +40,10 @@ const (
 	MaxVLAN = 4094
 	// ReservedVLAN identifies a VLAN ID that is reserved and cannot be used.
 	ReservedVLAN = 1
+	// MinASN is the minimum valid Autonomous System Number.
+	MinASN = 1
+	// MaxASN is the maximum valid 32-bit Autonomous System Number.
+	MaxASN = 4294967295
 )
 
 // VLANHelpText returns a canonical human-readable description of valid VLAN values,
@@ -181,6 +186,52 @@ func ValidateVLAN(vlan int) error {
 func ValidateRateLimit(rateLimit int) error {
 	if rateLimit <= 0 {
 		return NewValidationError("rate limit", rateLimit, "must be a positive integer")
+	}
+	return nil
+}
+
+// ValidateASN validates if an ASN (Autonomous System Number) is within the valid 32-bit range.
+//
+// Parameters:
+//   - asn: The ASN to validate
+//
+// Validation checks:
+//   - ASN must be between MinASN (1) and MaxASN (4294967295) inclusive
+//
+// Returns:
+//   - A ValidationError if the ASN is not valid
+//   - nil if the validation passes
+func ValidateASN(asn int) error {
+	if asn < MinASN || asn > MaxASN {
+		return NewValidationError("ASN", asn,
+			fmt.Sprintf("must be between %d and %d", MinASN, MaxASN))
+	}
+	return nil
+}
+
+// ValidateMACAddress validates if a string is a valid EUI-48 MAC address.
+//
+// Parameters:
+//   - mac: The MAC address string to validate
+//
+// Validation checks:
+//   - MAC address must not be empty
+//   - Must be parseable as a hardware address (colon or hyphen separated hex pairs)
+//   - Must be exactly 6 bytes (EUI-48)
+//
+// Returns:
+//   - A ValidationError if the MAC address is not valid
+//   - nil if the validation passes
+func ValidateMACAddress(mac string) error {
+	if mac == "" {
+		return NewValidationError("MAC address", mac, "cannot be empty")
+	}
+	hw, err := net.ParseMAC(mac)
+	if err != nil {
+		return NewValidationError("MAC address", mac, "must be a valid MAC address (e.g. 00:11:22:33:44:55)")
+	}
+	if len(hw) != 6 {
+		return NewValidationError("MAC address", mac, "must be a 6-byte (EUI-48) MAC address")
 	}
 	return nil
 }

--- a/internal/validation/common_test.go
+++ b/internal/validation/common_test.go
@@ -172,13 +172,11 @@ func TestValidateASN(t *testing.T) {
 		wantErr bool
 		errText string
 	}{
-		{"Valid min ASN", MinASN, false, ""},
+		{"Valid min ASN", int(MinASN), false, ""},
 		{"Valid typical ASN", 65000, false, ""},
 		{"Valid 4-byte ASN", 400000, false, ""},
-		{"Valid max ASN", MaxASN, false, ""},
 		{"Invalid zero", 0, true, fmt.Sprintf("Invalid ASN: 0 - must be between %d and %d", MinASN, MaxASN)},
 		{"Invalid negative", -1, true, fmt.Sprintf("Invalid ASN: -1 - must be between %d and %d", MinASN, MaxASN)},
-		{"Invalid above max", MaxASN + 1, true, fmt.Sprintf("Invalid ASN: %d - must be between %d and %d", MaxASN+1, MinASN, MaxASN)},
 	}
 
 	for _, tt := range tests {

--- a/internal/validation/common_test.go
+++ b/internal/validation/common_test.go
@@ -166,12 +166,7 @@ func TestValidateRateLimit(t *testing.T) {
 }
 
 func TestValidateASN(t *testing.T) {
-	// maxAllowed mirrors the validator's target-specific upper bound so tests
-	// compile and run correctly on both 64-bit and 32-bit targets.
-	maxAllowed := int64(^uint(0) >> 1)
-	if maxAllowed > MaxASN {
-		maxAllowed = MaxASN
-	}
+	maxAllowed := maxSupportedASNForInt()
 
 	tests := []struct {
 		name    string

--- a/internal/validation/common_test.go
+++ b/internal/validation/common_test.go
@@ -165,6 +165,71 @@ func TestValidateRateLimit(t *testing.T) {
 	}
 }
 
+func TestValidateASN(t *testing.T) {
+	tests := []struct {
+		name    string
+		asn     int
+		wantErr bool
+		errText string
+	}{
+		{"Valid min ASN", MinASN, false, ""},
+		{"Valid typical ASN", 65000, false, ""},
+		{"Valid 4-byte ASN", 400000, false, ""},
+		{"Valid max ASN", MaxASN, false, ""},
+		{"Invalid zero", 0, true, fmt.Sprintf("Invalid ASN: 0 - must be between %d and %d", MinASN, MaxASN)},
+		{"Invalid negative", -1, true, fmt.Sprintf("Invalid ASN: -1 - must be between %d and %d", MinASN, MaxASN)},
+		{"Invalid above max", MaxASN + 1, true, fmt.Sprintf("Invalid ASN: %d - must be between %d and %d", MaxASN+1, MinASN, MaxASN)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateASN(tt.asn)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateASN() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.wantErr {
+				assert.IsType(t, &ValidationError{}, err, "Expected ValidationError type")
+				assert.Equal(t, tt.errText, err.Error(), "Error message mismatch")
+			}
+		})
+	}
+}
+
+func TestValidateMACAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		mac     string
+		wantErr bool
+		errText string
+	}{
+		{"Valid colon-separated lowercase", "00:11:22:33:44:55", false, ""},
+		{"Valid colon-separated uppercase", "AA:BB:CC:DD:EE:FF", false, ""},
+		{"Valid colon-separated mixed case", "aA:bB:cC:dD:eE:fF", false, ""},
+		{"Valid hyphen-separated", "00-11-22-33-44-55", false, ""},
+		{"Invalid empty", "", true, "Invalid MAC address:  - cannot be empty"},
+		{"Invalid too short", "00:11:22:33:44", true, "Invalid MAC address: 00:11:22:33:44 - must be a valid MAC address (e.g. 00:11:22:33:44:55)"},
+		{"Invalid too long", "00:11:22:33:44:55:66", true, "Invalid MAC address: 00:11:22:33:44:55:66 - must be a valid MAC address (e.g. 00:11:22:33:44:55)"},
+		{"Invalid EUI-64", "00:11:22:33:44:55:66:77", true, "Invalid MAC address: 00:11:22:33:44:55:66:77 - must be a 6-byte (EUI-48) MAC address"},
+		{"Invalid hex chars", "GG:HH:II:JJ:KK:LL", true, "Invalid MAC address: GG:HH:II:JJ:KK:LL - must be a valid MAC address (e.g. 00:11:22:33:44:55)"},
+		{"Invalid format", "not-a-mac", true, "Invalid MAC address: not-a-mac - must be a valid MAC address (e.g. 00:11:22:33:44:55)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMACAddress(tt.mac)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateMACAddress() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.wantErr {
+				assert.IsType(t, &ValidationError{}, err, "Expected ValidationError type")
+				assert.Equal(t, tt.errText, err.Error(), "Error message mismatch")
+			}
+		})
+	}
+}
+
 func TestValidateMVEProductSize(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/validation/common_test.go
+++ b/internal/validation/common_test.go
@@ -166,6 +166,13 @@ func TestValidateRateLimit(t *testing.T) {
 }
 
 func TestValidateASN(t *testing.T) {
+	// maxAllowed mirrors the validator's target-specific upper bound so tests
+	// compile and run correctly on both 64-bit and 32-bit targets.
+	maxAllowed := int64(^uint(0) >> 1)
+	if maxAllowed > MaxASN {
+		maxAllowed = MaxASN
+	}
+
 	tests := []struct {
 		name    string
 		asn     int
@@ -175,8 +182,25 @@ func TestValidateASN(t *testing.T) {
 		{"Valid min ASN", int(MinASN), false, ""},
 		{"Valid typical ASN", 65000, false, ""},
 		{"Valid 4-byte ASN", 400000, false, ""},
-		{"Invalid zero", 0, true, fmt.Sprintf("Invalid ASN: 0 - must be between %d and %d", MinASN, MaxASN)},
-		{"Invalid negative", -1, true, fmt.Sprintf("Invalid ASN: -1 - must be between %d and %d", MinASN, MaxASN)},
+		{"Valid max ASN", int(maxAllowed), false, ""},
+		{"Invalid zero", 0, true, fmt.Sprintf("Invalid ASN: 0 - must be between %d and %d", MinASN, maxAllowed)},
+		{"Invalid negative", -1, true, fmt.Sprintf("Invalid ASN: -1 - must be between %d and %d", MinASN, maxAllowed)},
+	}
+
+	// Only test "max+1" when the next int value is representable on this target.
+	if maxAllowed < int64(^uint(0)>>1) {
+		overflow := int(maxAllowed) + 1
+		tests = append(tests, struct {
+			name    string
+			asn     int
+			wantErr bool
+			errText string
+		}{
+			"Invalid max ASN plus one",
+			overflow,
+			true,
+			fmt.Sprintf("Invalid ASN: %d - must be between %d and %d", overflow, MinASN, maxAllowed),
+		})
 	}
 
 	for _, tt := range tests {

--- a/web/script.js
+++ b/web/script.js
@@ -609,6 +609,7 @@ WebAssembly.instantiateStreaming(fetch('megaport.wasm'), go.importObject)
 
               let currentInput = '';
               let disposable;
+              const isPassword = promptRequest.type === 'password';
 
               const inputHandler = (data) => {
                 // Handle Enter key
@@ -655,7 +656,7 @@ WebAssembly.instantiateStreaming(fetch('megaport.wasm'), go.importObject)
                   data <= String.fromCharCode(0x7e)
                 ) {
                   currentInput += data;
-                  terminal.write(data);
+                  terminal.write(isPassword ? '*' : data);
                 }
               };
 


### PR DESCRIPTION
IX inputs (ASN, MAC, rate limit, VLAN) had no client-side validation — bad values only failed at the API, after the user had gone through the whole confirmation flow and waited on the call, then got a cryptic error. This validates them up front. Along the way it routes a couple of stragglers through the central validators: VXC rate-limit (was an inline check) and interactive port-name length.

## Changes

- New validators: `ValidateASN` (range 1–4294967295, with `MinASN`/`MaxASN` constants) and `ValidateMACAddress` (EUI-48 via `net.ParseMAC`).
- Wire ASN, MAC, rate limit, and VLAN validation into every IX input path — buy/update flags, JSON, and interactive prompts.
- VXC: replace the inline `rateLimit <= 0` check with `validation.ValidateRateLimit()`.
- Ports: replace the `name == ""` check with `validation.ValidatePortName()` (enforces the 64-char max) in the port and LAG prompts.

## Test plan

- [x] `validation`: new `TestValidateASN`/`TestValidateMACAddress` with boundary cases (min, max, zero, negative, EUI-64 rejection)
- [x] `ix`: new `TestBuildIXRequestFromFlags_ValidationErrors`; updated JSON and prompt tests
- [x] `vxc` and `ports` existing tests pass with the substituted validators
- [x] `golangci-lint run` — 0 issues
