### PR TITLE
ESD-863: split native password prompt into build-tagged file

### DIFF
--- a/internal/utils/prompts.go
+++ b/internal/utils/prompts.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/fatih/color"
-	"golang.org/x/term"
 )
 
 // promptFuncMu guards all prompt function pointers.
@@ -108,20 +107,9 @@ var resourcePromptFn = func(resourceType string, msg string, noColor bool) (stri
 	return strings.TrimSpace(input), nil
 }
 
-var passwordPromptFn = func(msg string, noColor bool) (string, error) {
-	if !noColor {
-		fmt.Print(color.New(color.FgHiRed, color.Bold).Sprint("🔒 " + msg + " "))
-	} else {
-		fmt.Print("🔒 " + msg + " ")
-	}
-
-	password, err := term.ReadPassword(int(os.Stdin.Fd()))
-	fmt.Println() // newline after masked input
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(password)), nil
-}
+// passwordPromptFn is set by the platform-specific init in prompts_native.go
+// (native terminal) or prompts_wasm.go (browser).
+var passwordPromptFn func(msg string, noColor bool) (string, error)
 
 var resourceTagsPromptFn = func(noColor bool) (map[string]string, error) {
 	addTags := ConfirmPrompt("Would you like to add resource tags?", noColor)

--- a/internal/utils/prompts_native.go
+++ b/internal/utils/prompts_native.go
@@ -1,0 +1,32 @@
+//go:build !js || !wasm
+// +build !js !wasm
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/fatih/color"
+	"golang.org/x/term"
+)
+
+func init() {
+	passwordPromptFn = nativePasswordPrompt
+}
+
+func nativePasswordPrompt(msg string, noColor bool) (string, error) {
+	if !noColor {
+		fmt.Print(color.New(color.FgHiRed, color.Bold).Sprint("\U0001f512 " + msg + " "))
+	} else {
+		fmt.Print("\U0001f512 " + msg + " ")
+	}
+
+	password, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Println() // newline after masked input
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(password)), nil
+}

--- a/internal/utils/prompts_native.go
+++ b/internal/utils/prompts_native.go
@@ -13,7 +13,7 @@ import (
 )
 
 func init() {
-	passwordPromptFn = nativePasswordPrompt
+	SetPasswordPrompt(nativePasswordPrompt)
 }
 
 func nativePasswordPrompt(msg string, noColor bool) (string, error) {

--- a/internal/utils/prompts_native.go
+++ b/internal/utils/prompts_native.go
@@ -1,5 +1,4 @@
-//go:build !js || !wasm
-// +build !js !wasm
+//go:build !js && !wasm
 
 package utils
 
@@ -17,6 +16,7 @@ func init() {
 }
 
 func nativePasswordPrompt(msg string, noColor bool) (string, error) {
+	// \U0001f512 is the lock symbol 🔒
 	if !noColor {
 		fmt.Print(color.New(color.FgHiRed, color.Bold).Sprint("\U0001f512 " + msg + " "))
 	} else {

--- a/internal/utils/prompts_native_test.go
+++ b/internal/utils/prompts_native_test.go
@@ -15,8 +15,8 @@ func TestNativeInitAssignsPasswordPromptFn(t *testing.T) {
 }
 
 func TestNativePasswordPrompt_NonTTYReturnsError(t *testing.T) {
-	// term.ReadPassword fails when stdin is not a terminal, which is the case
-	// under `go test`. Exercising that path covers nativePasswordPrompt.
+	// term.ReadPassword fails when stdin is not a terminal. This test
+	// explicitly replaces os.Stdin with a pipe to exercise that error path.
 	oldStdin, oldStdout := os.Stdin, os.Stdout
 	defer func() { os.Stdin, os.Stdout = oldStdin, oldStdout }()
 

--- a/internal/utils/prompts_native_test.go
+++ b/internal/utils/prompts_native_test.go
@@ -1,0 +1,41 @@
+//go:build !js || !wasm
+// +build !js !wasm
+
+package utils
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNativeInitAssignsPasswordPromptFn(t *testing.T) {
+	assert.NotNil(t, GetPasswordPrompt(), "native init should wire passwordPromptFn")
+}
+
+func TestNativePasswordPrompt_NonTTYReturnsError(t *testing.T) {
+	// term.ReadPassword fails when stdin is not a terminal, which is the case
+	// under `go test`. Exercising that path covers nativePasswordPrompt.
+	oldStdin, oldStdout := os.Stdin, os.Stdout
+	defer func() { os.Stdin, os.Stdout = oldStdin, oldStdout }()
+
+	inR, inW, err := os.Pipe()
+	assert.NoError(t, err)
+	outR, outW, err := os.Pipe()
+	assert.NoError(t, err)
+	os.Stdin = inR
+	os.Stdout = outW
+	_ = inW.Close()
+
+	for _, noColor := range []bool{true, false} {
+		pw, err := nativePasswordPrompt("Enter password:", noColor)
+		assert.Error(t, err, "expected error reading password from non-tty pipe")
+		assert.Empty(t, pw)
+	}
+
+	_ = outW.Close()
+	_, _ = outR.Read(make([]byte, 1024))
+	_ = inR.Close()
+	_ = outR.Close()
+}

--- a/internal/utils/prompts_native_test.go
+++ b/internal/utils/prompts_native_test.go
@@ -1,5 +1,4 @@
-//go:build !js || !wasm
-// +build !js !wasm
+//go:build !js && !wasm
 
 package utils
 

--- a/internal/utils/prompts_native_test.go
+++ b/internal/utils/prompts_native_test.go
@@ -4,10 +4,12 @@
 package utils
 
 import (
+	"io"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNativeInitAssignsPasswordPromptFn(t *testing.T) {
@@ -21,12 +23,23 @@ func TestNativePasswordPrompt_NonTTYReturnsError(t *testing.T) {
 	defer func() { os.Stdin, os.Stdout = oldStdin, oldStdout }()
 
 	inR, inW, err := os.Pipe()
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	defer inR.Close()
+	defer inW.Close()
+
 	outR, outW, err := os.Pipe()
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	defer outR.Close()
+
 	os.Stdin = inR
 	os.Stdout = outW
 	_ = inW.Close()
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, outR)
+		close(done)
+	}()
 
 	for _, noColor := range []bool{true, false} {
 		pw, err := nativePasswordPrompt("Enter password:", noColor)
@@ -35,7 +48,5 @@ func TestNativePasswordPrompt_NonTTYReturnsError(t *testing.T) {
 	}
 
 	_ = outW.Close()
-	_, _ = outR.Read(make([]byte, 1024))
-	_ = inR.Close()
-	_ = outR.Close()
+	<-done
 }


### PR DESCRIPTION
Moves the `term.ReadPassword`-based `passwordPromptFn` out of `prompts.go` and into a new `prompts_native.go` gated by `//go:build !js || !wasm`, leaving only the uninitialized function pointer in the shared file. This mirrors the existing native/wasm split pattern — `prompts_wasm.go` already wires its implementation via `SetPasswordPrompt` in `init()`, so the native side was the odd one out.

The practical benefit is that `golang.org/x/term` no longer gets pulled into the wasm build, and the platform-specific prompt wiring is consistent across all three prompt functions.

## Notes
- Stacked on top of #329 (depends on the `PasswordPrompt` infrastructure added there). Merge #329 first, then rebase this onto main.
- No behaviour change on native builds — same `term.ReadPassword` path, just relocated.

## Test plan
- [x] `go build ./...`
- [x] `GOOS=js GOARCH=wasm go build -tags js,wasm .`
- [x] `go test ./internal/utils/`
- [x] `golangci-lint run ./internal/utils/`