### PR TITLE
chore: bump megaportgo to 1.7.2 and add mock interface methods 

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  ignore:
+    - "**/*_mock.go"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/jedib0t/go-pretty/v6 v6.7.9
 	github.com/jmespath/go-jmespath v0.4.0
-	github.com/megaport/megaportgo v1.7.0
+	github.com/megaport/megaportgo v1.7.2
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.17 h1:78v8ZlW0bP43XfmAfPsdXcoNCelfMHsDmd/pkENfrjQ=
 github.com/mattn/go-runewidth v0.0.17/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/megaport/megaportgo v1.7.0 h1:TUvFsMnSKX2ALl5WthXxiqJsUFPOpi1ueeY2xfs6XkA=
-github.com/megaport/megaportgo v1.7.0/go.mod h1:KgHDAyT1uVg93qBaW/z0M63sQlPvipB04vab4F88dGA=
+github.com/megaport/megaportgo v1.7.2 h1:JvmjXVIA9ter/QT+YTVR/dbhPDIuxtMTKk9g79EBx5o=
+github.com/megaport/megaportgo v1.7.2/go.mod h1:Ee2mHySrxQo3bkpib2TILCtYOL8KfhDXAD1xEVA3aeE=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=

--- a/internal/commands/locations/locations_mock.go
+++ b/internal/commands/locations/locations_mock.go
@@ -28,6 +28,8 @@ type MockLocationsService struct {
 
 	FilterLocationsByMetroV3Result []*megaport.LocationV3
 
+	FilterLocationsByNATGatewaySpeedV3Result []*megaport.LocationV3
+
 	// V2 methods
 	ListLocationsResult []*megaport.Location
 	ListLocationsErr    error
@@ -114,6 +116,10 @@ func (m *MockLocationsService) FilterLocationsByMcrAvailabilityV3(ctx context.Co
 
 func (m *MockLocationsService) FilterLocationsByMetroV3(ctx context.Context, metro string, locations []*megaport.LocationV3) []*megaport.LocationV3 {
 	return m.FilterLocationsByMetroV3Result
+}
+
+func (m *MockLocationsService) FilterLocationsByNATGatewaySpeedV3(ctx context.Context, speedMbps int, locations []*megaport.LocationV3) []*megaport.LocationV3 {
+	return m.FilterLocationsByNATGatewaySpeedV3Result
 }
 
 // Shared methods

--- a/internal/commands/nat_gateway/nat_gateway_mock.go
+++ b/internal/commands/nat_gateway/nat_gateway_mock.go
@@ -21,12 +21,18 @@ type MockNATGatewayService struct {
 	SessionsErr     error
 	TelemetryResult *megaport.ServiceTelemetryResponse
 	TelemetryErr    error
+	BuyResult      *megaport.NATGatewayBuyResult
+	BuyErr         error
+	ValidateResult *megaport.NATGatewayValidateResult
+	ValidateErr    error
 
 	CapturedCreateReq    *megaport.CreateNATGatewayRequest
 	CapturedUpdateReq    *megaport.UpdateNATGatewayRequest
 	CapturedDeleteUID    string
 	CapturedGetUID       string
 	CapturedTelemetryReq *megaport.GetNATGatewayTelemetryRequest
+	CapturedBuyUID      string
+	CapturedValidateUID string
 }
 
 func (m *MockNATGatewayService) CreateNATGateway(ctx context.Context, req *megaport.CreateNATGatewayRequest) (*megaport.NATGateway, error) {
@@ -92,6 +98,28 @@ func (m *MockNATGatewayService) GetNATGatewayTelemetry(ctx context.Context, req 
 	return &megaport.ServiceTelemetryResponse{}, nil
 }
 
+func (m *MockNATGatewayService) ValidateNATGatewayOrder(ctx context.Context, productUID string) (*megaport.NATGatewayValidateResult, error) {
+	m.CapturedValidateUID = productUID
+	if m.ValidateErr != nil {
+		return nil, m.ValidateErr
+	}
+	if m.ValidateResult != nil {
+		return m.ValidateResult, nil
+	}
+	return &megaport.NATGatewayValidateResult{ProductUID: productUID}, nil
+}
+
+func (m *MockNATGatewayService) BuyNATGateway(ctx context.Context, productUID string) (*megaport.NATGatewayBuyResult, error) {
+	m.CapturedBuyUID = productUID
+	if m.BuyErr != nil {
+		return nil, m.BuyErr
+	}
+	if m.BuyResult != nil {
+		return m.BuyResult, nil
+	}
+	return &megaport.NATGatewayBuyResult{ProductUID: productUID}, nil
+}
+
 func (m *MockNATGatewayService) Reset() {
 	m.CreateResult = nil
 	m.CreateErr = nil
@@ -106,6 +134,12 @@ func (m *MockNATGatewayService) Reset() {
 	m.SessionsErr = nil
 	m.TelemetryResult = nil
 	m.TelemetryErr = nil
+	m.BuyResult = nil
+	m.BuyErr = nil
+	m.ValidateResult = nil
+	m.ValidateErr = nil
+	m.CapturedBuyUID = ""
+	m.CapturedValidateUID = ""
 	m.CapturedCreateReq = nil
 	m.CapturedUpdateReq = nil
 	m.CapturedDeleteUID = ""

--- a/internal/commands/partners/partners_mock.go
+++ b/internal/commands/partners/partners_mock.go
@@ -33,7 +33,7 @@ func (m *MockPartnerService) FilterPartnerMegaportByLocationId(ctx context.Conte
 	return m.filterResponse, m.filterErr
 }
 
-func (m *MockPartnerService) FilterPartnerMegaportByDiversityZone(ctx context.Context, partners []*megaport.PartnerMegaport, diversityZone string, exactMatch bool) ([]*megaport.PartnerMegaport, error) {
+func (m *MockPartnerService) FilterPartnerMegaportByDiversityZone(ctx context.Context, partners []*megaport.PartnerMegaport, diversityZone string) ([]*megaport.PartnerMegaport, error) {
 	return m.filterResponse, m.filterErr
 }
 


### PR DESCRIPTION
Picks up [megaportgo#136](https://github.com/megaport/megaportgo/pull/136), which dropped the `exactMatch bool` parameter from `FilterPartnerMegaportByDiversityZone`. Diversity zones are a bounded enum (`red`/`blue`) so fuzzy matching was unnecessary.

Updates `MockPartnerService.FilterPartnerMegaportByDiversityZone` in `partners_mock.go` to match the updated interface, and bumps the `megaportgo` dependency from v1.7.0 to v1.7.2.