### PR TITLE
ESD-830: Reduce global state in output package

### DIFF
--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -5,6 +5,7 @@ package megaport
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/base/registry"
@@ -104,6 +105,7 @@ func InitializeCommon() {
 		cfg.NoHeader = noHeader
 		cfg.NoPager = noPager // no-op in WASM pager; keeps flag wiring symmetric with native
 		cfg.Verbosity = verbosity
+		cfg.Format = strings.ToLower(outputFormat)
 		output.ApplyOutputConfig(cfg)
 		if utils.MaxRetries < 0 {
 			return fmt.Errorf("--max-retries must be >= 0, got %d", utils.MaxRetries)

--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -102,6 +102,9 @@ func InitializeCommon() {
 			verbosity = "verbose"
 		}
 		format := strings.ToLower(outputFormat)
+		if format == utils.FormatGoTemplate {
+			return fmt.Errorf("invalid output format: go-template is not supported in the browser version")
+		}
 		validFmt := false
 		for _, vf := range utils.ValidFormats {
 			if format == vf {

--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -94,9 +94,16 @@ func InitializeCommon() {
 	// Validate retry flags in WASM builds too.
 	existingPreRunE := rootCmd.PersistentPreRunE
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		verbosity := "normal"
+		if quiet {
+			verbosity = "quiet"
+		} else if verbose {
+			verbosity = "verbose"
+		}
 		cfg := output.GetOutputConfig()
 		cfg.NoHeader = noHeader
 		cfg.NoPager = noPager // no-op in WASM pager; keeps flag wiring symmetric with native
+		cfg.Verbosity = verbosity
 		output.ApplyOutputConfig(cfg)
 		if utils.MaxRetries < 0 {
 			return fmt.Errorf("--max-retries must be >= 0, got %d", utils.MaxRetries)

--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -101,11 +101,23 @@ func InitializeCommon() {
 		} else if verbose {
 			verbosity = "verbose"
 		}
+		format := strings.ToLower(outputFormat)
+		validFmt := false
+		for _, vf := range utils.ValidFormats {
+			if format == vf {
+				validFmt = true
+				break
+			}
+		}
+		if !validFmt {
+			return fmt.Errorf("invalid output format: %s. Must be one of: %s",
+				outputFormat, strings.Join(utils.ValidFormats, ", "))
+		}
 		cfg := output.GetOutputConfig()
 		cfg.NoHeader = noHeader
 		cfg.NoPager = noPager // no-op in WASM pager; keeps flag wiring symmetric with native
 		cfg.Verbosity = verbosity
-		cfg.Format = strings.ToLower(outputFormat)
+		cfg.Format = format
 		output.ApplyOutputConfig(cfg)
 		if utils.MaxRetries < 0 {
 			return fmt.Errorf("--max-retries must be >= 0, got %d", utils.MaxRetries)

--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -94,8 +94,10 @@ func InitializeCommon() {
 	// Validate retry flags in WASM builds too.
 	existingPreRunE := rootCmd.PersistentPreRunE
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		output.SetNoHeader(noHeader)
-		output.SetNoPager(noPager) // no-op in WASM; keeps flag wiring symmetric with native
+		cfg := output.GetOutputConfig()
+		cfg.NoHeader = noHeader
+		cfg.NoPager = noPager // no-op in WASM pager; keeps flag wiring symmetric with native
+		output.ApplyOutputConfig(cfg)
 		if utils.MaxRetries < 0 {
 			return fmt.Errorf("--max-retries must be >= 0, got %d", utils.MaxRetries)
 		}

--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -102,11 +102,8 @@ func InitializeCommon() {
 			verbosity = "verbose"
 		}
 		format := strings.ToLower(outputFormat)
-		if format == utils.FormatGoTemplate {
-			return fmt.Errorf("invalid output format: go-template is not supported in the browser version")
-		}
 		validFmt := false
-		for _, vf := range utils.ValidFormats {
+		for _, vf := range utils.ValidFormatsWASM {
 			if format == vf {
 				validFmt = true
 				break
@@ -114,7 +111,7 @@ func InitializeCommon() {
 		}
 		if !validFmt {
 			return fmt.Errorf("invalid output format: %s. Must be one of: %s",
-				outputFormat, strings.Join(utils.ValidFormats, ", "))
+				outputFormat, strings.Join(utils.ValidFormatsWASM, ", "))
 		}
 		cfg := output.GetOutputConfig()
 		cfg.NoHeader = noHeader

--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -101,6 +101,9 @@ func InitializeCommon() {
 			verbosity = "verbose"
 		}
 		format := strings.ToLower(outputFormat)
+		if format == utils.FormatGoTemplate {
+			return fmt.Errorf("invalid output format: go-template is not supported in the browser version")
+		}
 		validFmt := false
 		for _, vf := range utils.ValidFormats {
 			if format == vf {

--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -4,6 +4,7 @@ package megaport
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/base/registry"
@@ -103,6 +104,7 @@ func InitializeCommon() {
 		cfg.NoHeader = noHeader
 		cfg.NoPager = noPager // no-op in WASM pager; keeps flag wiring symmetric with native
 		cfg.Verbosity = verbosity
+		cfg.Format = strings.ToLower(outputFormat)
 		output.ApplyOutputConfig(cfg)
 		if utils.MaxRetries < 0 {
 			return fmt.Errorf("--max-retries must be >= 0, got %d", utils.MaxRetries)

--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -93,8 +93,10 @@ func InitializeCommon() {
 	// Validate retry flags in WASM builds too.
 	existingPreRunE := rootCmd.PersistentPreRunE
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		output.SetNoHeader(noHeader)
-		output.SetNoPager(noPager) // no-op in WASM; keeps flag wiring symmetric with native
+		cfg := output.GetOutputConfig()
+		cfg.NoHeader = noHeader
+		cfg.NoPager = noPager // no-op in WASM pager; keeps flag wiring symmetric with native
+		output.ApplyOutputConfig(cfg)
 		if utils.MaxRetries < 0 {
 			return fmt.Errorf("--max-retries must be >= 0, got %d", utils.MaxRetries)
 		}

--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -101,11 +101,8 @@ func InitializeCommon() {
 			verbosity = "verbose"
 		}
 		format := strings.ToLower(outputFormat)
-		if format == utils.FormatGoTemplate {
-			return fmt.Errorf("invalid output format: go-template is not supported in the browser version")
-		}
 		validFmt := false
-		for _, vf := range utils.ValidFormats {
+		for _, vf := range utils.ValidFormatsWASM {
 			if format == vf {
 				validFmt = true
 				break
@@ -113,7 +110,7 @@ func InitializeCommon() {
 		}
 		if !validFmt {
 			return fmt.Errorf("invalid output format: %s. Must be one of: %s",
-				outputFormat, strings.Join(utils.ValidFormats, ", "))
+				outputFormat, strings.Join(utils.ValidFormatsWASM, ", "))
 		}
 		cfg := output.GetOutputConfig()
 		cfg.NoHeader = noHeader

--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -93,9 +93,16 @@ func InitializeCommon() {
 	// Validate retry flags in WASM builds too.
 	existingPreRunE := rootCmd.PersistentPreRunE
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		verbosity := "normal"
+		if quiet {
+			verbosity = "quiet"
+		} else if verbose {
+			verbosity = "verbose"
+		}
 		cfg := output.GetOutputConfig()
 		cfg.NoHeader = noHeader
 		cfg.NoPager = noPager // no-op in WASM pager; keeps flag wiring symmetric with native
+		cfg.Verbosity = verbosity
 		output.ApplyOutputConfig(cfg)
 		if utils.MaxRetries < 0 {
 			return fmt.Errorf("--max-retries must be >= 0, got %d", utils.MaxRetries)

--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -100,11 +100,23 @@ func InitializeCommon() {
 		} else if verbose {
 			verbosity = "verbose"
 		}
+		format := strings.ToLower(outputFormat)
+		validFmt := false
+		for _, vf := range utils.ValidFormats {
+			if format == vf {
+				validFmt = true
+				break
+			}
+		}
+		if !validFmt {
+			return fmt.Errorf("invalid output format: %s. Must be one of: %s",
+				outputFormat, strings.Join(utils.ValidFormats, ", "))
+		}
 		cfg := output.GetOutputConfig()
 		cfg.NoHeader = noHeader
 		cfg.NoPager = noPager // no-op in WASM pager; keeps flag wiring symmetric with native
 		cfg.Verbosity = verbosity
-		cfg.Format = strings.ToLower(outputFormat)
+		cfg.Format = format
 		output.ApplyOutputConfig(cfg)
 		if utils.MaxRetries < 0 {
 			return fmt.Errorf("--max-retries must be >= 0, got %d", utils.MaxRetries)

--- a/cmd/megaport/megaport.go
+++ b/cmd/megaport/megaport.go
@@ -33,9 +33,6 @@ func init() {
 			noColor = true
 			_ = cmd.Flags().Set("no-color", "true")
 		}
-		output.SetNoHeader(noHeader)
-		output.SetNoPager(noPager)
-
 		format := strings.ToLower(outputFormat)
 		validFmt := false
 		for _, vf := range utils.ValidFormats {
@@ -49,14 +46,17 @@ func init() {
 				outputFormat, strings.Join(utils.ValidFormats, ", "))
 		}
 
-		// Set verbosity level based on flags
+		verbosity := "normal"
 		if quiet {
-			output.SetVerbosity("quiet")
+			verbosity = "quiet"
 		} else if verbose {
-			output.SetVerbosity("verbose")
-		} else {
-			output.SetVerbosity("normal")
+			verbosity = "verbose"
 		}
+		cfg := output.GetOutputConfig()
+		cfg.NoHeader = noHeader
+		cfg.NoPager = noPager
+		cfg.Verbosity = verbosity
+		output.ApplyOutputConfig(cfg)
 
 		// Validate retry flags
 		if utils.MaxRetries < 0 {

--- a/cmd/megaport/megaport.go
+++ b/cmd/megaport/megaport.go
@@ -56,6 +56,7 @@ func init() {
 		cfg.NoHeader = noHeader
 		cfg.NoPager = noPager
 		cfg.Verbosity = verbosity
+		cfg.Format = format // normalized to lower-case above
 		output.ApplyOutputConfig(cfg)
 
 		// Validate retry flags

--- a/cmd/megaport/megaport.go
+++ b/cmd/megaport/megaport.go
@@ -55,6 +55,7 @@ func init() {
 		cfg.NoHeader = noHeader
 		cfg.NoPager = noPager
 		cfg.Verbosity = verbosity
+		cfg.Format = format // normalized to lower-case above
 		output.ApplyOutputConfig(cfg)
 
 		// Emit config-default warnings now that output format and verbosity are

--- a/cmd/megaport/megaport.go
+++ b/cmd/megaport/megaport.go
@@ -31,9 +31,6 @@ func init() {
 			noColor = true
 			_ = cmd.Flags().Set("no-color", "true")
 		}
-		output.SetNoHeader(noHeader)
-		output.SetNoPager(noPager)
-
 		format := strings.ToLower(outputFormat)
 		validFmt := false
 		for _, vf := range utils.ValidFormats {
@@ -48,14 +45,17 @@ func init() {
 		}
 		output.SetOutputFormat(format)
 
-		// Set verbosity level based on flags
+		verbosity := "normal"
 		if quiet {
-			output.SetVerbosity("quiet")
+			verbosity = "quiet"
 		} else if verbose {
-			output.SetVerbosity("verbose")
-		} else {
-			output.SetVerbosity("normal")
+			verbosity = "verbose"
 		}
+		cfg := output.GetOutputConfig()
+		cfg.NoHeader = noHeader
+		cfg.NoPager = noPager
+		cfg.Verbosity = verbosity
+		output.ApplyOutputConfig(cfg)
 
 		// Emit config-default warnings now that output format and verbosity are
 		// configured, so PrintWarning routes to stderr under --output json and

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -49,8 +49,8 @@ func TestNoHeaderFlagWiredThroughPersistentPreRunE(t *testing.T) {
 
 // TestNoPagerDefaultApplied verifies that a "no-pager" default persisted in
 // the config file is read by applyDefaultSettings AND forwarded to the output
-// package via output.SetNoPager in PersistentPreRunE. Both sides of the
-// wiring are asserted so that removing either call causes the test to fail.
+// package via output.ApplyOutputConfig in PersistentPreRunE. Both sides of
+// the wiring are asserted so that removing either call causes the test to fail.
 func TestNoPagerDefaultApplied(t *testing.T) {
 	// Use an isolated config directory so this test doesn't touch the real one.
 	dir := t.TempDir()
@@ -77,8 +77,8 @@ func TestNoPagerDefaultApplied(t *testing.T) {
 
 	// Assert the flag var was set (applyDefaultSettings path).
 	assert.True(t, noPager, "noPager package var should be true after config default is applied")
-	// Assert the output package was notified (output.SetNoPager wiring path).
-	assert.True(t, output.GetNoPager(), "output.GetNoPager() should be true after PersistentPreRunE wires SetNoPager")
+	// Assert the output package was notified (output.ApplyOutputConfig wiring path).
+	assert.True(t, output.GetNoPager(), "output.GetNoPager() should be true after PersistentPreRunE wires NoPager via ApplyOutputConfig")
 }
 
 func TestExitCodeFromError(t *testing.T) {

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -84,11 +84,12 @@ func TestNoPagerDefaultApplied(t *testing.T) {
 // resetVerbosityFlags resets the quiet/verbose package vars, their cobra flag
 // values, and — critically — their Changed state so the mutually-exclusive
 // group check does not fire on subsequent tests that share the global rootCmd.
-func resetVerbosityFlags() {
+func resetVerbosityFlags(t *testing.T) {
+	t.Helper()
 	quiet = false
 	verbose = false
 	for _, name := range []string{"quiet", "verbose"} {
-		_ = rootCmd.PersistentFlags().Set(name, "false")
+		require.NoError(t, rootCmd.PersistentFlags().Set(name, "false"))
 		if f := rootCmd.PersistentFlags().Lookup(name); f != nil {
 			f.Changed = false
 		}
@@ -100,7 +101,7 @@ func resetVerbosityFlags() {
 func TestQuietFlagWiredThroughPersistentPreRunE(t *testing.T) {
 	defer func() {
 		output.ResetState()
-		resetVerbosityFlags()
+		resetVerbosityFlags(t)
 	}()
 	rootCmd.SetArgs([]string{"version", "--quiet"})
 	_ = output.CaptureOutput(func() {
@@ -115,7 +116,7 @@ func TestQuietFlagWiredThroughPersistentPreRunE(t *testing.T) {
 func TestVerboseFlagWiredThroughPersistentPreRunE(t *testing.T) {
 	defer func() {
 		output.ResetState()
-		resetVerbosityFlags()
+		resetVerbosityFlags(t)
 	}()
 	rootCmd.SetArgs([]string{"version", "--verbose"})
 	_ = output.CaptureOutput(func() {

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -81,6 +81,50 @@ func TestNoPagerDefaultApplied(t *testing.T) {
 	assert.True(t, output.GetNoPager(), "output.GetNoPager() should be true after PersistentPreRunE wires NoPager via ApplyOutputConfig")
 }
 
+// resetVerbosityFlags resets the quiet/verbose package vars, their cobra flag
+// values, and — critically — their Changed state so the mutually-exclusive
+// group check does not fire on subsequent tests that share the global rootCmd.
+func resetVerbosityFlags() {
+	quiet = false
+	verbose = false
+	for _, name := range []string{"quiet", "verbose"} {
+		_ = rootCmd.PersistentFlags().Set(name, "false")
+		if f := rootCmd.PersistentFlags().Lookup(name); f != nil {
+			f.Changed = false
+		}
+	}
+}
+
+// TestQuietFlagWiredThroughPersistentPreRunE verifies that --quiet sets
+// Verbosity to "quiet" in the output config via ApplyOutputConfig.
+func TestQuietFlagWiredThroughPersistentPreRunE(t *testing.T) {
+	defer func() {
+		output.ResetState()
+		resetVerbosityFlags()
+	}()
+	rootCmd.SetArgs([]string{"version", "--quiet"})
+	_ = output.CaptureOutput(func() {
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+	})
+	assert.True(t, output.IsQuiet(), "IsQuiet should be true after --quiet flag wired via ApplyOutputConfig")
+}
+
+// TestVerboseFlagWiredThroughPersistentPreRunE verifies that --verbose sets
+// Verbosity to "verbose" in the output config via ApplyOutputConfig.
+func TestVerboseFlagWiredThroughPersistentPreRunE(t *testing.T) {
+	defer func() {
+		output.ResetState()
+		resetVerbosityFlags()
+	}()
+	rootCmd.SetArgs([]string{"version", "--verbose"})
+	_ = output.CaptureOutput(func() {
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+	})
+	assert.True(t, output.IsVerbose(), "IsVerbose should be true after --verbose flag wired via ApplyOutputConfig")
+}
+
 func TestExitCodeFromError(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -170,6 +170,48 @@ func TestApplyDefaultSettings_CLIVerboseOverridesConfigQuiet(t *testing.T) {
 
 	assert.True(t, verbose, "CLI-set --verbose should win over config quiet")
 	assert.False(t, quiet, "config-sourced quiet should be dropped when CLI set verbose")
+// resetVerbosityFlags resets the quiet/verbose package vars, their cobra flag
+// values, and — critically — their Changed state so the mutually-exclusive
+// group check does not fire on subsequent tests that share the global rootCmd.
+func resetVerbosityFlags() {
+	quiet = false
+	verbose = false
+	for _, name := range []string{"quiet", "verbose"} {
+		_ = rootCmd.PersistentFlags().Set(name, "false")
+		if f := rootCmd.PersistentFlags().Lookup(name); f != nil {
+			f.Changed = false
+		}
+	}
+}
+
+// TestQuietFlagWiredThroughPersistentPreRunE verifies that --quiet sets
+// Verbosity to "quiet" in the output config via ApplyOutputConfig.
+func TestQuietFlagWiredThroughPersistentPreRunE(t *testing.T) {
+	defer func() {
+		output.ResetState()
+		resetVerbosityFlags()
+	}()
+	rootCmd.SetArgs([]string{"version", "--quiet"})
+	_ = output.CaptureOutput(func() {
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+	})
+	assert.True(t, output.IsQuiet(), "IsQuiet should be true after --quiet flag wired via ApplyOutputConfig")
+}
+
+// TestVerboseFlagWiredThroughPersistentPreRunE verifies that --verbose sets
+// Verbosity to "verbose" in the output config via ApplyOutputConfig.
+func TestVerboseFlagWiredThroughPersistentPreRunE(t *testing.T) {
+	defer func() {
+		output.ResetState()
+		resetVerbosityFlags()
+	}()
+	rootCmd.SetArgs([]string{"version", "--verbose"})
+	_ = output.CaptureOutput(func() {
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+	})
+	assert.True(t, output.IsVerbose(), "IsVerbose should be true after --verbose flag wired via ApplyOutputConfig")
 }
 
 func TestExitCodeFromError(t *testing.T) {

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -156,10 +156,7 @@ func TestApplyDefaultSettings_CLIVerboseOverridesConfigQuiet(t *testing.T) {
 
 	defer func() {
 		output.ResetState()
-		quiet = false
-		verbose = false
-		_ = rootCmd.PersistentFlags().Set("quiet", "false")
-		_ = rootCmd.PersistentFlags().Set("verbose", "false")
+		resetVerbosityFlags(t)
 	}()
 
 	// Simulate the user passing --verbose on the CLI.
@@ -170,6 +167,8 @@ func TestApplyDefaultSettings_CLIVerboseOverridesConfigQuiet(t *testing.T) {
 
 	assert.True(t, verbose, "CLI-set --verbose should win over config quiet")
 	assert.False(t, quiet, "config-sourced quiet should be dropped when CLI set verbose")
+}
+
 // resetVerbosityFlags resets the quiet/verbose package vars, their cobra flag
 // values, and — critically — their Changed state so the mutually-exclusive
 // group check does not fire on subsequent tests that share the global rootCmd.

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -173,11 +173,12 @@ func TestApplyDefaultSettings_CLIVerboseOverridesConfigQuiet(t *testing.T) {
 // resetVerbosityFlags resets the quiet/verbose package vars, their cobra flag
 // values, and — critically — their Changed state so the mutually-exclusive
 // group check does not fire on subsequent tests that share the global rootCmd.
-func resetVerbosityFlags() {
+func resetVerbosityFlags(t *testing.T) {
+	t.Helper()
 	quiet = false
 	verbose = false
 	for _, name := range []string{"quiet", "verbose"} {
-		_ = rootCmd.PersistentFlags().Set(name, "false")
+		require.NoError(t, rootCmd.PersistentFlags().Set(name, "false"))
 		if f := rootCmd.PersistentFlags().Lookup(name); f != nil {
 			f.Changed = false
 		}
@@ -189,7 +190,7 @@ func resetVerbosityFlags() {
 func TestQuietFlagWiredThroughPersistentPreRunE(t *testing.T) {
 	defer func() {
 		output.ResetState()
-		resetVerbosityFlags()
+		resetVerbosityFlags(t)
 	}()
 	rootCmd.SetArgs([]string{"version", "--quiet"})
 	_ = output.CaptureOutput(func() {
@@ -204,7 +205,7 @@ func TestQuietFlagWiredThroughPersistentPreRunE(t *testing.T) {
 func TestVerboseFlagWiredThroughPersistentPreRunE(t *testing.T) {
 	defer func() {
 		output.ResetState()
-		resetVerbosityFlags()
+		resetVerbosityFlags(t)
 	}()
 	rootCmd.SetArgs([]string{"version", "--verbose"})
 	_ = output.CaptureOutput(func() {

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -50,8 +50,8 @@ func TestNoHeaderFlagWiredThroughPersistentPreRunE(t *testing.T) {
 
 // TestNoPagerDefaultApplied verifies that a "no-pager" default persisted in
 // the config file is read by applyDefaultSettings AND forwarded to the output
-// package via output.SetNoPager in PersistentPreRunE. Both sides of the
-// wiring are asserted so that removing either call causes the test to fail.
+// package via output.ApplyOutputConfig in PersistentPreRunE. Both sides of
+// the wiring are asserted so that removing either call causes the test to fail.
 func TestNoPagerDefaultApplied(t *testing.T) {
 	// Use an isolated config directory so this test doesn't touch the real one.
 	dir := t.TempDir()
@@ -78,8 +78,8 @@ func TestNoPagerDefaultApplied(t *testing.T) {
 
 	// Assert the flag var was set (applyDefaultSettings path).
 	assert.True(t, noPager, "noPager package var should be true after config default is applied")
-	// Assert the output package was notified (output.SetNoPager wiring path).
-	assert.True(t, output.GetNoPager(), "output.GetNoPager() should be true after PersistentPreRunE wires SetNoPager")
+	// Assert the output package was notified (output.ApplyOutputConfig wiring path).
+	assert.True(t, output.GetNoPager(), "output.GetNoPager() should be true after PersistentPreRunE wires NoPager via ApplyOutputConfig")
 }
 
 // TestApplyDefaultSettings_WarnsOnConfigLoadFailure verifies that when

--- a/internal/base/output/common.go
+++ b/internal/base/output/common.go
@@ -93,14 +93,22 @@ func SetOutputQuery(query string) {
 	updateOutputConfig(func(c *OutputConfig) { c.Query = query })
 }
 
-func getOutputQuery() string { return GetOutputConfig().Query }
+func getOutputQuery() string {
+	outputCfgMu.RLock()
+	defer outputCfgMu.RUnlock()
+	return outputCfg.Query
+}
 
 // SetNoHeader sets whether table and CSV output should suppress column headers.
 func SetNoHeader(v bool) {
 	updateOutputConfig(func(c *OutputConfig) { c.NoHeader = v })
 }
 
-func getNoHeader() bool { return GetOutputConfig().NoHeader }
+func getNoHeader() bool {
+	outputCfgMu.RLock()
+	defer outputCfgMu.RUnlock()
+	return outputCfg.NoHeader
+}
 
 // SetTemplateString sets the Go template string applied by printGoTemplate.
 // Pass "" to disable.
@@ -109,7 +117,11 @@ func SetTemplateString(s string) {
 }
 
 // GetTemplateString returns the current Go template string.
-func GetTemplateString() string { return GetOutputConfig().Template }
+func GetTemplateString() string {
+	outputCfgMu.RLock()
+	defer outputCfgMu.RUnlock()
+	return outputCfg.Template
+}
 
 // errorBody and errorEnvelope are the JSON error envelope types shared by
 // PrintErrorJSON across native and WASM builds.

--- a/internal/base/output/common.go
+++ b/internal/base/output/common.go
@@ -15,72 +15,84 @@ import (
 // Both native and WASM builds use this mutex.
 var stdoutMu sync.Mutex
 
-// outputFields holds the user-selected fields from --fields flag.
-// nil means all fields are shown. Protected by outputFieldsMu.
-var (
-	outputFields   []string
-	outputFieldsMu sync.RWMutex
-)
-
-// SetOutputFields sets the field filter applied by all PrintOutput calls.
-// Only fields whose json tag name or header display name (case-insensitive) appears
-// in fields will be included in output. Pass nil to restore full output (all fields).
-// This function is goroutine-safe. Tests should call defer SetOutputFields(nil) to
-// reset state between test cases.
-func SetOutputFields(fields []string) {
-	outputFieldsMu.Lock()
-	defer outputFieldsMu.Unlock()
-	outputFields = fields
+// OutputConfig holds all user-facing output configuration as a single struct.
+// Use ApplyOutputConfig to write and GetOutputConfig to read atomically.
+type OutputConfig struct {
+	Fields    []string // nil = show all
+	Query     string   // JMESPath; "" = disabled
+	NoHeader  bool
+	Template  string // Go template; "" = disabled
+	NoPager   bool
+	Format    string // "table"|"json"|"csv"|"xml"|"go-template"
+	Verbosity string // "normal"|"quiet"|"verbose"
 }
 
-// getOutputFields returns a copy of the current field filter under a read lock.
-func getOutputFields() []string {
-	outputFieldsMu.RLock()
-	defer outputFieldsMu.RUnlock()
-	if outputFields == nil {
-		return nil
+func defaultOutputConfig() OutputConfig {
+	return OutputConfig{Format: "table", Verbosity: "normal"}
+}
+
+var (
+	outputCfg   = defaultOutputConfig()
+	outputCfgMu sync.RWMutex
+)
+
+// ApplyOutputConfig atomically replaces the entire output configuration.
+func ApplyOutputConfig(cfg OutputConfig) {
+	outputCfgMu.Lock()
+	defer outputCfgMu.Unlock()
+	outputCfg = cfg
+}
+
+// GetOutputConfig returns a snapshot of the current output configuration.
+func GetOutputConfig() OutputConfig {
+	outputCfgMu.RLock()
+	defer outputCfgMu.RUnlock()
+	cp := outputCfg
+	if outputCfg.Fields != nil {
+		cp.Fields = make([]string, len(outputCfg.Fields))
+		copy(cp.Fields, outputCfg.Fields)
 	}
-	cp := make([]string, len(outputFields))
-	copy(cp, outputFields)
 	return cp
 }
 
-// outputQuery holds the JMESPath expression from --query flag.
-// Empty string means no query. Protected by outputQueryMu.
-var (
-	outputQuery   string
-	outputQueryMu sync.RWMutex
-)
+// SetOutputFields sets the field filter applied by all PrintOutput calls.
+// Pass nil to restore full output (all fields). Goroutine-safe.
+func SetOutputFields(fields []string) {
+	cfg := GetOutputConfig()
+	cfg.Fields = fields
+	ApplyOutputConfig(cfg)
+}
 
-// SetOutputQuery sets the JMESPath query applied by printJSON.
-// Pass "" to disable. This function is goroutine-safe.
-// Tests should call defer SetOutputQuery("") to reset state between test cases.
+func getOutputFields() []string { return GetOutputConfig().Fields }
+
+// SetOutputQuery sets the JMESPath query applied by printJSON. Pass "" to disable.
 func SetOutputQuery(query string) {
-	outputQueryMu.Lock()
-	defer outputQueryMu.Unlock()
-	outputQuery = query
+	cfg := GetOutputConfig()
+	cfg.Query = query
+	ApplyOutputConfig(cfg)
 }
 
-// getOutputQuery returns the current JMESPath query under a read lock.
-func getOutputQuery() string {
-	outputQueryMu.RLock()
-	defer outputQueryMu.RUnlock()
-	return outputQuery
+func getOutputQuery() string { return GetOutputConfig().Query }
+
+// SetNoHeader sets whether table and CSV output should suppress column headers.
+func SetNoHeader(v bool) {
+	cfg := GetOutputConfig()
+	cfg.NoHeader = v
+	ApplyOutputConfig(cfg)
 }
 
-// noHeader controls whether table and CSV output suppresses the header row.
-// Set via --no-header flag. Protected by noHeaderMu.
-var (
-	noHeader   bool
-	noHeaderMu sync.RWMutex
-)
+func getNoHeader() bool { return GetOutputConfig().NoHeader }
 
-// templateStr holds the Go template string from --template flag.
-// Empty string means no template. Protected by templateStrMu.
-var (
-	templateStr   string
-	templateStrMu sync.RWMutex
-)
+// SetTemplateString sets the Go template string applied by printGoTemplate.
+// Pass "" to disable.
+func SetTemplateString(s string) {
+	cfg := GetOutputConfig()
+	cfg.Template = s
+	ApplyOutputConfig(cfg)
+}
+
+// GetTemplateString returns the current Go template string.
+func GetTemplateString() string { return GetOutputConfig().Template }
 
 // errorBody and errorEnvelope are the JSON error envelope types shared by
 // PrintErrorJSON across native and WASM builds.
@@ -94,49 +106,9 @@ type errorEnvelope struct {
 	Error errorBody `json:"error"`
 }
 
-// SetTemplateString sets the Go template string applied by printGoTemplate.
-// Pass "" to disable. This function is goroutine-safe.
-func SetTemplateString(s string) {
-	templateStrMu.Lock()
-	defer templateStrMu.Unlock()
-	templateStr = s
-}
-
-// GetTemplateString returns the current Go template string under a read lock.
-func GetTemplateString() string {
-	templateStrMu.RLock()
-	defer templateStrMu.RUnlock()
-	return templateStr
-}
-
-// SetNoHeader sets whether table and CSV output should suppress column headers.
-// This function is goroutine-safe. Tests should call defer SetNoHeader(false) to
-// reset state between test cases.
-func SetNoHeader(v bool) {
-	noHeaderMu.Lock()
-	defer noHeaderMu.Unlock()
-	noHeader = v
-}
-
-// getNoHeader returns whether header suppression is active under a read lock.
-func getNoHeader() bool {
-	noHeaderMu.RLock()
-	defer noHeaderMu.RUnlock()
-	return noHeader
-}
-
-// ResetState clears all package-level output configuration back to defaults.
-// Intended for callers such as the WASM entry point that must ensure all
-// output-related global state does not bleed between invocations.
-func ResetState() {
-	SetOutputFields(nil)
-	SetOutputQuery("")
-	SetNoHeader(false)
-	SetNoPager(false)
-	SetTemplateString("")
-	SetOutputFormat("table")
-	SetVerbosity("normal")
-}
+// ResetState clears all output configuration back to defaults.
+// Intended for the WASM entry point to prevent state bleed between invocations.
+func ResetState() { ApplyOutputConfig(defaultOutputConfig()) }
 
 // applyJMESPath applies a JMESPath query to v and returns the result.
 // v must be a JSON-compatible value (e.g. []T or []map[string]interface{}).

--- a/internal/base/output/common.go
+++ b/internal/base/output/common.go
@@ -38,13 +38,22 @@ var (
 )
 
 // ApplyOutputConfig atomically replaces the entire output configuration.
+// Fields is deep-copied before storing so that mutations to the caller's slice
+// cannot affect the stored configuration after this call returns.
 func ApplyOutputConfig(cfg OutputConfig) {
+	if cfg.Fields != nil {
+		cp := make([]string, len(cfg.Fields))
+		copy(cp, cfg.Fields)
+		cfg.Fields = cp
+	}
 	outputCfgMu.Lock()
 	defer outputCfgMu.Unlock()
 	outputCfg = cfg
 }
 
 // GetOutputConfig returns a snapshot of the current output configuration.
+// Fields is deep-copied so that mutations to the returned slice cannot affect
+// the stored configuration.
 func GetOutputConfig() OutputConfig {
 	outputCfgMu.RLock()
 	defer outputCfgMu.RUnlock()
@@ -56,30 +65,39 @@ func GetOutputConfig() OutputConfig {
 	return cp
 }
 
+// updateOutputConfig holds the write lock and calls fn to mutate the stored
+// config in place. Use this in single-field Set* shims to avoid the
+// read-modify-write window that snapshot+replace creates.
+func updateOutputConfig(fn func(*OutputConfig)) {
+	outputCfgMu.Lock()
+	defer outputCfgMu.Unlock()
+	fn(&outputCfg)
+}
+
 // SetOutputFields sets the field filter applied by all PrintOutput calls.
-// Pass nil to restore full output (all fields).
+// Pass nil to restore full output (all fields). The slice is deep-copied so
+// subsequent mutations to fields do not affect the stored config.
 func SetOutputFields(fields []string) {
-	cfg := GetOutputConfig()
-	cfg.Fields = fields
-	ApplyOutputConfig(cfg)
+	var cp []string
+	if fields != nil {
+		cp = make([]string, len(fields))
+		copy(cp, fields)
+	}
+	updateOutputConfig(func(c *OutputConfig) { c.Fields = cp })
 }
 
 func getOutputFields() []string { return GetOutputConfig().Fields }
 
 // SetOutputQuery sets the JMESPath query applied by printJSON. Pass "" to disable.
 func SetOutputQuery(query string) {
-	cfg := GetOutputConfig()
-	cfg.Query = query
-	ApplyOutputConfig(cfg)
+	updateOutputConfig(func(c *OutputConfig) { c.Query = query })
 }
 
 func getOutputQuery() string { return GetOutputConfig().Query }
 
 // SetNoHeader sets whether table and CSV output should suppress column headers.
 func SetNoHeader(v bool) {
-	cfg := GetOutputConfig()
-	cfg.NoHeader = v
-	ApplyOutputConfig(cfg)
+	updateOutputConfig(func(c *OutputConfig) { c.NoHeader = v })
 }
 
 func getNoHeader() bool { return GetOutputConfig().NoHeader }
@@ -87,9 +105,7 @@ func getNoHeader() bool { return GetOutputConfig().NoHeader }
 // SetTemplateString sets the Go template string applied by printGoTemplate.
 // Pass "" to disable.
 func SetTemplateString(s string) {
-	cfg := GetOutputConfig()
-	cfg.Template = s
-	ApplyOutputConfig(cfg)
+	updateOutputConfig(func(c *OutputConfig) { c.Template = s })
 }
 
 // GetTemplateString returns the current Go template string.

--- a/internal/base/output/common.go
+++ b/internal/base/output/common.go
@@ -27,6 +27,7 @@ type OutputConfig struct {
 	Verbosity string // "normal"|"quiet"|"verbose"
 }
 
+// defaultOutputConfig returns the baseline configuration used at startup and by ResetState.
 func defaultOutputConfig() OutputConfig {
 	return OutputConfig{Format: "table", Verbosity: "normal"}
 }
@@ -56,7 +57,7 @@ func GetOutputConfig() OutputConfig {
 }
 
 // SetOutputFields sets the field filter applied by all PrintOutput calls.
-// Pass nil to restore full output (all fields). Goroutine-safe.
+// Pass nil to restore full output (all fields).
 func SetOutputFields(fields []string) {
 	cfg := GetOutputConfig()
 	cfg.Fields = fields

--- a/internal/base/output/common.go
+++ b/internal/base/output/common.go
@@ -180,7 +180,7 @@ func prepareJSONData[T OutputFields](data []T) (interface{}, error) {
 		rows := make([]interface{}, 0, len(data))
 		for _, item := range data {
 			v := reflect.ValueOf(item)
-			if v.Kind() == reflect.Ptr {
+			if v.Kind() == reflect.Pointer {
 				if v.IsNil() {
 					rows = append(rows, nil)
 					continue
@@ -272,7 +272,7 @@ func getStructTypeInfo[T OutputFields](data []T) (headers, jsonNames []string, f
 		return nil, nil, nil, nil
 	}
 	itemType := sampleVal.Type()
-	if itemType.Kind() == reflect.Ptr {
+	if itemType.Kind() == reflect.Pointer {
 		if sampleVal.IsNil() {
 			if itemType.Elem().Kind() != reflect.Struct {
 				return nil, nil, nil, nil
@@ -304,7 +304,7 @@ func extractCSVFieldInfo[T OutputFields](data []T) (headers, jsonNames []string,
 		return nil, nil, nil, nil
 	}
 	t := sampleVal.Type()
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		if sampleVal.IsNil() {
 			if t.Elem().Kind() != reflect.Struct {
 				return nil, nil, nil, nil
@@ -459,7 +459,7 @@ func filterByFields(headers, jsonNames []string, indices []int, selected []strin
 // isOutputCompatibleType checks if a type can be output
 func isOutputCompatibleType(t reflect.Type) bool {
 	// Handle pointer types by checking the element type
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		return isOutputCompatibleType(t.Elem())
 	}
 
@@ -490,13 +490,13 @@ func isOutputCompatibleType(t reflect.Type) bool {
 // isNilOrInvalid returns true if item is a nil pointer or an invalid reflect value.
 func isNilOrInvalid(item interface{}) bool {
 	v := reflect.ValueOf(item)
-	return !v.IsValid() || (v.Kind() == reflect.Ptr && v.IsNil())
+	return !v.IsValid() || (v.Kind() == reflect.Pointer && v.IsNil())
 }
 
 // extractRowData extracts field values from a struct for table/CSV output
 func extractRowData(item interface{}, fieldIndices []int) []string {
 	itemVal := reflect.ValueOf(item)
-	if itemVal.Kind() == reflect.Ptr {
+	if itemVal.Kind() == reflect.Pointer {
 		if itemVal.IsNil() {
 			return make([]string, len(fieldIndices))
 		}
@@ -518,7 +518,7 @@ func formatFieldValue(fieldVal reflect.Value) string {
 	if !fieldVal.IsValid() {
 		return ""
 	}
-	if fieldVal.Kind() == reflect.Ptr {
+	if fieldVal.Kind() == reflect.Pointer {
 		if fieldVal.IsNil() {
 			return ""
 		}

--- a/internal/base/output/common.go
+++ b/internal/base/output/common.go
@@ -86,28 +86,14 @@ func SetOutputFields(fields []string) {
 	updateOutputConfig(func(c *OutputConfig) { c.Fields = cp })
 }
 
-func getOutputFields() []string { return GetOutputConfig().Fields }
-
 // SetOutputQuery sets the JMESPath query applied by printJSON. Pass "" to disable.
 func SetOutputQuery(query string) {
 	updateOutputConfig(func(c *OutputConfig) { c.Query = query })
 }
 
-func getOutputQuery() string {
-	outputCfgMu.RLock()
-	defer outputCfgMu.RUnlock()
-	return outputCfg.Query
-}
-
 // SetNoHeader sets whether table and CSV output should suppress column headers.
 func SetNoHeader(v bool) {
 	updateOutputConfig(func(c *OutputConfig) { c.NoHeader = v })
-}
-
-func getNoHeader() bool {
-	outputCfgMu.RLock()
-	defer outputCfgMu.RUnlock()
-	return outputCfg.NoHeader
 }
 
 // SetTemplateString sets the Go template string applied by printGoTemplate.
@@ -139,6 +125,31 @@ type errorEnvelope struct {
 // Intended for the WASM entry point to prevent state bleed between invocations.
 func ResetState() { ApplyOutputConfig(defaultOutputConfig()) }
 
+// printOptions is the per-call snapshot of the field/query/header/template
+// settings that the data-output path consults. PrintOutput reads the config
+// once into a printOptions and threads it down through the formatters, so the
+// individual formatters never reach into global state (and never take a lock)
+// mid-render.
+type printOptions struct {
+	fields   []string
+	query    string
+	noHeader bool
+	template string
+}
+
+// currentPrintOptions snapshots the output config into a printOptions with a
+// single locked read. Called once per PrintOutput invocation on the calling
+// goroutine.
+func currentPrintOptions() printOptions {
+	cfg := GetOutputConfig()
+	return printOptions{
+		fields:   cfg.Fields,
+		query:    cfg.Query,
+		noHeader: cfg.NoHeader,
+		template: cfg.Template,
+	}
+}
+
 // applyJMESPath applies a JMESPath query to v and returns the result.
 // v must be a JSON-compatible value (e.g. []T or []map[string]interface{}).
 // The marshal→unmarshal round-trip is intentional: go-jmespath operates on an
@@ -163,9 +174,9 @@ func applyJMESPath(query string, v interface{}) (interface{}, error) {
 // prepareJSONData applies --fields filtering and --query (JMESPath) to data,
 // returning the value ready for JSON encoding. This shared logic is used by
 // both native and WASM printJSON implementations.
-func prepareJSONData[T OutputFields](data []T) (interface{}, error) {
-	fields := getOutputFields()
-	query := getOutputQuery()
+func prepareJSONData[T OutputFields](data []T, opts printOptions) (interface{}, error) {
+	fields := opts.fields
+	query := opts.query
 
 	var toEncode interface{}
 	if len(fields) > 0 {
@@ -244,18 +255,19 @@ func PrintOutput[T OutputFields](data []T, format string, noColor bool) error {
 	if !validFormats[format] {
 		return fmt.Errorf("invalid output format: %s", format)
 	}
+	opts := currentPrintOptions()
 	switch format {
 	case "json":
-		return printJSON(data)
+		return printJSON(data, opts)
 	case "csv":
-		return printCSV(data)
+		return printCSV(data, opts)
 	case "xml":
-		return printXML(data)
+		return printXML(data, opts)
 	case "go-template":
-		return printGoTemplate(data)
+		return printGoTemplate(data, opts)
 	default:
 		return RunWithPager(func() error {
-			return printTable(data, noColor)
+			return printTable(data, noColor, opts)
 		})
 	}
 }

--- a/internal/base/output/common.go
+++ b/internal/base/output/common.go
@@ -15,80 +15,84 @@ import (
 // Both native and WASM builds use this mutex.
 var stdoutMu sync.Mutex
 
-// outputFields holds the user-selected fields from --fields flag.
-// nil means all fields are shown. Protected by outputFieldsMu.
-var (
-	outputFields   []string
-	outputFieldsMu sync.RWMutex
-)
-
-// SetOutputFields sets the field filter applied by all PrintOutput calls.
-// Only fields whose json tag name or header display name (case-insensitive)
-// appears in fields will be included in output. Passing nil or an empty
-// slice restores full output (all fields). This function is goroutine-safe.
-// Tests should call defer SetOutputFields(nil) to reset state between
-// test cases.
-//
-// The slice is copied before being stored, so callers may mutate or reuse
-// the backing array after the call returns without affecting the filter.
-func SetOutputFields(fields []string) {
-	outputFieldsMu.Lock()
-	defer outputFieldsMu.Unlock()
-	if fields == nil {
-		outputFields = nil
-		return
-	}
-	outputFields = append([]string(nil), fields...)
+// OutputConfig holds all user-facing output configuration as a single struct.
+// Use ApplyOutputConfig to write and GetOutputConfig to read atomically.
+type OutputConfig struct {
+	Fields    []string // nil = show all
+	Query     string   // JMESPath; "" = disabled
+	NoHeader  bool
+	Template  string // Go template; "" = disabled
+	NoPager   bool
+	Format    string // "table"|"json"|"csv"|"xml"|"go-template"
+	Verbosity string // "normal"|"quiet"|"verbose"
 }
 
-// getOutputFields returns a copy of the current field filter under a read lock.
-func getOutputFields() []string {
-	outputFieldsMu.RLock()
-	defer outputFieldsMu.RUnlock()
-	if outputFields == nil {
-		return nil
+func defaultOutputConfig() OutputConfig {
+	return OutputConfig{Format: "table", Verbosity: "normal"}
+}
+
+var (
+	outputCfg   = defaultOutputConfig()
+	outputCfgMu sync.RWMutex
+)
+
+// ApplyOutputConfig atomically replaces the entire output configuration.
+func ApplyOutputConfig(cfg OutputConfig) {
+	outputCfgMu.Lock()
+	defer outputCfgMu.Unlock()
+	outputCfg = cfg
+}
+
+// GetOutputConfig returns a snapshot of the current output configuration.
+func GetOutputConfig() OutputConfig {
+	outputCfgMu.RLock()
+	defer outputCfgMu.RUnlock()
+	cp := outputCfg
+	if outputCfg.Fields != nil {
+		cp.Fields = make([]string, len(outputCfg.Fields))
+		copy(cp.Fields, outputCfg.Fields)
 	}
-	cp := make([]string, len(outputFields))
-	copy(cp, outputFields)
 	return cp
 }
 
-// outputQuery holds the JMESPath expression from --query flag.
-// Empty string means no query. Protected by outputQueryMu.
-var (
-	outputQuery   string
-	outputQueryMu sync.RWMutex
-)
+// SetOutputFields sets the field filter applied by all PrintOutput calls.
+// Pass nil to restore full output (all fields). Goroutine-safe.
+func SetOutputFields(fields []string) {
+	cfg := GetOutputConfig()
+	cfg.Fields = fields
+	ApplyOutputConfig(cfg)
+}
 
-// SetOutputQuery sets the JMESPath query applied by printJSON.
-// Pass "" to disable. This function is goroutine-safe.
-// Tests should call defer SetOutputQuery("") to reset state between test cases.
+func getOutputFields() []string { return GetOutputConfig().Fields }
+
+// SetOutputQuery sets the JMESPath query applied by printJSON. Pass "" to disable.
 func SetOutputQuery(query string) {
-	outputQueryMu.Lock()
-	defer outputQueryMu.Unlock()
-	outputQuery = query
+	cfg := GetOutputConfig()
+	cfg.Query = query
+	ApplyOutputConfig(cfg)
 }
 
-// getOutputQuery returns the current JMESPath query under a read lock.
-func getOutputQuery() string {
-	outputQueryMu.RLock()
-	defer outputQueryMu.RUnlock()
-	return outputQuery
+func getOutputQuery() string { return GetOutputConfig().Query }
+
+// SetNoHeader sets whether table and CSV output should suppress column headers.
+func SetNoHeader(v bool) {
+	cfg := GetOutputConfig()
+	cfg.NoHeader = v
+	ApplyOutputConfig(cfg)
 }
 
-// noHeader controls whether table and CSV output suppresses the header row.
-// Set via --no-header flag. Protected by noHeaderMu.
-var (
-	noHeader   bool
-	noHeaderMu sync.RWMutex
-)
+func getNoHeader() bool { return GetOutputConfig().NoHeader }
 
-// templateStr holds the Go template string from --template flag.
-// Empty string means no template. Protected by templateStrMu.
-var (
-	templateStr   string
-	templateStrMu sync.RWMutex
-)
+// SetTemplateString sets the Go template string applied by printGoTemplate.
+// Pass "" to disable.
+func SetTemplateString(s string) {
+	cfg := GetOutputConfig()
+	cfg.Template = s
+	ApplyOutputConfig(cfg)
+}
+
+// GetTemplateString returns the current Go template string.
+func GetTemplateString() string { return GetOutputConfig().Template }
 
 // errorBody and errorEnvelope are the JSON error envelope types shared by
 // PrintErrorJSON across native and WASM builds.
@@ -102,90 +106,9 @@ type errorEnvelope struct {
 	Error errorBody `json:"error"`
 }
 
-// SetTemplateString sets the Go template string applied by printGoTemplate.
-// Pass "" to disable. This function is goroutine-safe.
-func SetTemplateString(s string) {
-	templateStrMu.Lock()
-	defer templateStrMu.Unlock()
-	templateStr = s
-}
-
-// GetTemplateString returns the current Go template string under a read lock.
-func GetTemplateString() string {
-	templateStrMu.RLock()
-	defer templateStrMu.RUnlock()
-	return templateStr
-}
-
-// SetNoHeader sets whether table and CSV output should suppress column headers.
-// This function is goroutine-safe. Tests should call defer SetNoHeader(false) to
-// reset state between test cases.
-func SetNoHeader(v bool) {
-	noHeaderMu.Lock()
-	defer noHeaderMu.Unlock()
-	noHeader = v
-}
-
-// getNoHeader returns whether header suppression is active under a read lock.
-func getNoHeader() bool {
-	noHeaderMu.RLock()
-	defer noHeaderMu.RUnlock()
-	return noHeader
-}
-
-// OutputConfig bundles every field that the package-level setters accept.
-// Callers that need to apply several settings at once (most notably the
-// WASM entry point on re-invocation and test cleanup helpers) can assemble
-// an OutputConfig and pass it to SetConfig rather than calling each setter
-// by hand. The individual setters remain the primary API; SetConfig is a
-// convenience on top of them.
-//
-// SetConfig writes every field verbatim — there is no "leave unchanged"
-// sentinel. Callers that want defaults should start from
-// DefaultOutputConfig() and override the fields they care about.
-type OutputConfig struct {
-	// Fields is the list of field names (json tag or header display name,
-	// case-insensitive) to include in output. Nil or empty means all fields.
-	// The slice is copied by SetOutputFields, so callers may reuse the
-	// backing array after SetConfig returns.
-	Fields   []string
-	Query    string
-	NoHeader bool
-	NoPager  bool
-	Template string
-	Format   string
-	// Verbosity is one of "normal", "quiet", or "verbose".
-	Verbosity string
-}
-
-// DefaultOutputConfig returns the defaults that ResetState applies.
-func DefaultOutputConfig() OutputConfig {
-	return OutputConfig{Format: "table", Verbosity: "normal"}
-}
-
-// SetConfig applies every field of c by delegating to the individual
-// setters. Those setters use a mix of per-field mutexes (Fields, Query,
-// NoHeader, NoPager, Template) and atomic.Value (Format, Verbosity), so
-// SetConfig is not atomic across fields — concurrent readers may observe
-// a partial update. Callers should invoke SetConfig from the main
-// goroutine before spawning work, which matches how the flag-driven RunE
-// wrappers already use the individual setters.
-func SetConfig(c OutputConfig) {
-	SetOutputFields(c.Fields)
-	SetOutputQuery(c.Query)
-	SetNoHeader(c.NoHeader)
-	SetNoPager(c.NoPager)
-	SetTemplateString(c.Template)
-	SetOutputFormat(c.Format)
-	SetVerbosity(c.Verbosity)
-}
-
-// ResetState clears all package-level output configuration back to defaults.
-// Intended for callers such as the WASM entry point that must ensure all
-// output-related global state does not bleed between invocations.
-func ResetState() {
-	SetConfig(DefaultOutputConfig())
-}
+// ResetState clears all output configuration back to defaults.
+// Intended for the WASM entry point to prevent state bleed between invocations.
+func ResetState() { ApplyOutputConfig(defaultOutputConfig()) }
 
 // applyJMESPath applies a JMESPath query to v and returns the result.
 // v must be a JSON-compatible value (e.g. []T or []map[string]interface{}).
@@ -228,7 +151,7 @@ func prepareJSONData[T OutputFields](data []T) (interface{}, error) {
 		rows := make([]interface{}, 0, len(data))
 		for _, item := range data {
 			v := reflect.ValueOf(item)
-			if v.Kind() == reflect.Pointer {
+			if v.Kind() == reflect.Ptr {
 				if v.IsNil() {
 					rows = append(rows, nil)
 					continue
@@ -320,7 +243,7 @@ func getStructTypeInfo[T OutputFields](data []T) (headers, jsonNames []string, f
 		return nil, nil, nil, nil
 	}
 	itemType := sampleVal.Type()
-	if itemType.Kind() == reflect.Pointer {
+	if itemType.Kind() == reflect.Ptr {
 		if sampleVal.IsNil() {
 			if itemType.Elem().Kind() != reflect.Struct {
 				return nil, nil, nil, nil
@@ -352,7 +275,7 @@ func extractCSVFieldInfo[T OutputFields](data []T) (headers, jsonNames []string,
 		return nil, nil, nil, nil
 	}
 	t := sampleVal.Type()
-	if t.Kind() == reflect.Pointer {
+	if t.Kind() == reflect.Ptr {
 		if sampleVal.IsNil() {
 			if t.Elem().Kind() != reflect.Struct {
 				return nil, nil, nil, nil
@@ -507,7 +430,7 @@ func filterByFields(headers, jsonNames []string, indices []int, selected []strin
 // isOutputCompatibleType checks if a type can be output
 func isOutputCompatibleType(t reflect.Type) bool {
 	// Handle pointer types by checking the element type
-	if t.Kind() == reflect.Pointer {
+	if t.Kind() == reflect.Ptr {
 		return isOutputCompatibleType(t.Elem())
 	}
 
@@ -538,13 +461,13 @@ func isOutputCompatibleType(t reflect.Type) bool {
 // isNilOrInvalid returns true if item is a nil pointer or an invalid reflect value.
 func isNilOrInvalid(item interface{}) bool {
 	v := reflect.ValueOf(item)
-	return !v.IsValid() || (v.Kind() == reflect.Pointer && v.IsNil())
+	return !v.IsValid() || (v.Kind() == reflect.Ptr && v.IsNil())
 }
 
 // extractRowData extracts field values from a struct for table/CSV output
 func extractRowData(item interface{}, fieldIndices []int) []string {
 	itemVal := reflect.ValueOf(item)
-	if itemVal.Kind() == reflect.Pointer {
+	if itemVal.Kind() == reflect.Ptr {
 		if itemVal.IsNil() {
 			return make([]string, len(fieldIndices))
 		}
@@ -566,7 +489,7 @@ func formatFieldValue(fieldVal reflect.Value) string {
 	if !fieldVal.IsValid() {
 		return ""
 	}
-	if fieldVal.Kind() == reflect.Pointer {
+	if fieldVal.Kind() == reflect.Ptr {
 		if fieldVal.IsNil() {
 			return ""
 		}

--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -32,9 +32,7 @@ var spinnerColors = []func(...interface{}) string{
 
 // SetVerbosity sets the global verbosity level ("normal", "quiet", or "verbose").
 func SetVerbosity(level string) {
-	cfg := GetOutputConfig()
-	cfg.Verbosity = level
-	ApplyOutputConfig(cfg)
+	updateOutputConfig(func(c *OutputConfig) { c.Verbosity = level })
 }
 
 // IsQuiet returns true when quiet mode is active.
@@ -57,9 +55,7 @@ func newNoOpSpinner(noColor bool) *Spinner {
 }
 
 func SetOutputFormat(format string) {
-	cfg := GetOutputConfig()
-	cfg.Format = format
-	ApplyOutputConfig(cfg)
+	updateOutputConfig(func(c *OutputConfig) { c.Format = format })
 }
 
 // GetOutputFormat returns the currently active output format (e.g. "table", "json").

--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -51,7 +51,7 @@ func newNoOpSpinner(noColor bool) *Spinner {
 	return &Spinner{
 		stop:         make(chan bool, 1),
 		stopped:      true,
-		outputFormat: getOutputFormat(),
+		outputFormat: GetOutputFormat(),
 		noColor:      noColor,
 	}
 }
@@ -62,15 +62,13 @@ func SetOutputFormat(format string) {
 	ApplyOutputConfig(cfg)
 }
 
-func getOutputFormat() string { return GetOutputConfig().Format }
-
 // GetOutputFormat returns the currently active output format (e.g. "table", "json").
 func GetOutputFormat() string { return GetOutputConfig().Format }
 
 // shouldSuppressSpinner returns true when spinner output should be suppressed
 // to avoid corrupting machine-readable output formats (csv, xml, json, yaml, etc.).
 func shouldSuppressSpinner() bool {
-	return shouldSuppressSpinnerForFormat(getOutputFormat())
+	return shouldSuppressSpinnerForFormat(GetOutputFormat())
 }
 
 // shouldSuppressSpinnerForFormat checks a specific format string. Spinners are
@@ -337,7 +335,7 @@ func PrintResourceCreating(resourceType, uid string, noColor bool) *Spinner {
 	}
 	uidFormatted := FormatUID(uid, noColor)
 	msg := fmt.Sprintf("Creating %s %s...", resourceType, uidFormatted)
-	spinner := NewSpinnerWithOutput(noColor, getOutputFormat())
+	spinner := NewSpinnerWithOutput(noColor, GetOutputFormat())
 	spinner.Start(msg)
 	return spinner
 }
@@ -348,7 +346,7 @@ func PrintResourceProvisioning(resourceType, uid string, noColor bool) *Spinner 
 	}
 	uidFormatted := FormatUID(uid, noColor)
 	msg := fmt.Sprintf("Provisioning %s %s...", resourceType, uidFormatted)
-	spinner := NewSpinnerWithOutput(noColor, getOutputFormat())
+	spinner := NewSpinnerWithOutput(noColor, GetOutputFormat())
 	spinner.StartWithElapsed(msg)
 	return spinner
 }
@@ -359,7 +357,7 @@ func PrintResourceUpdating(resourceType, uid string, noColor bool) *Spinner {
 	}
 	uidFormatted := FormatUID(uid, noColor)
 	msg := fmt.Sprintf("Updating %s %s...", resourceType, uidFormatted)
-	spinner := NewSpinnerWithOutput(noColor, getOutputFormat())
+	spinner := NewSpinnerWithOutput(noColor, GetOutputFormat())
 	spinner.Start(msg)
 	return spinner
 }
@@ -370,7 +368,7 @@ func PrintResourceDeleting(resourceType, uid string, noColor bool) *Spinner {
 	}
 	uidFormatted := FormatUID(uid, noColor)
 	msg := fmt.Sprintf("Deleting %s %s...", resourceType, uidFormatted)
-	spinner := NewSpinnerWithOutput(noColor, getOutputFormat())
+	spinner := NewSpinnerWithOutput(noColor, GetOutputFormat())
 	spinner.Start(msg)
 	return spinner
 }
@@ -380,7 +378,7 @@ func PrintResourceListing(resourceType string, noColor bool) *Spinner {
 		return newNoOpSpinner(noColor)
 	}
 	msg := fmt.Sprintf("Listing %ss...", resourceType)
-	spinner := NewSpinnerWithOutput(noColor, getOutputFormat())
+	spinner := NewSpinnerWithOutput(noColor, GetOutputFormat())
 	spinner.Start(msg)
 	return spinner
 }
@@ -391,14 +389,14 @@ func PrintResourceGetting(resourceType, uid string, noColor bool) *Spinner {
 	}
 	uidFormatted := FormatUID(uid, noColor)
 	msg := fmt.Sprintf("Getting %s %s details...", resourceType, uidFormatted)
-	spinner := NewSpinnerWithOutput(noColor, getOutputFormat())
+	spinner := NewSpinnerWithOutput(noColor, GetOutputFormat())
 	spinner.Start(msg)
 	return spinner
 }
 
 func PrintResourceGettingWithOutput(resourceType, uid string, noColor bool, outputFormat string) *Spinner {
 	if outputFormat == "" {
-		outputFormat = getOutputFormat()
+		outputFormat = GetOutputFormat()
 	}
 	if shouldSuppressSpinnerForFormat(outputFormat) {
 		s := newNoOpSpinner(noColor)
@@ -418,7 +416,7 @@ func PrintListingResourceTags(resourceType, uid string, noColor bool) *Spinner {
 	}
 	uidFormatted := FormatUID(uid, noColor)
 	msg := fmt.Sprintf("Listing resource tags for %s %s...", resourceType, uidFormatted)
-	spinner := NewSpinnerWithOutput(noColor, getOutputFormat())
+	spinner := NewSpinnerWithOutput(noColor, GetOutputFormat())
 	spinner.Start(msg)
 	return spinner
 }
@@ -428,7 +426,7 @@ func PrintResourceValidating(resourceType string, noColor bool) *Spinner {
 		return newNoOpSpinner(noColor)
 	}
 	msg := fmt.Sprintf("Validating %s order...", resourceType)
-	spinner := NewSpinnerWithOutput(noColor, getOutputFormat())
+	spinner := NewSpinnerWithOutput(noColor, GetOutputFormat())
 	spinner.Start(msg)
 	return spinner
 }
@@ -438,7 +436,7 @@ func PrintLoggingIn(noColor bool) *Spinner {
 		return newNoOpSpinner(noColor)
 	}
 	msg := "Logging in to Megaport..."
-	spinner := NewSpinnerWithOutput(noColor, getOutputFormat())
+	spinner := NewSpinnerWithOutput(noColor, GetOutputFormat())
 	spinner.Start(msg)
 	return spinner
 }
@@ -448,7 +446,7 @@ func PrintLoggingInWithOutput(noColor bool, outputFormat string) *Spinner {
 		return newNoOpSpinner(noColor)
 	}
 	if outputFormat == "" {
-		outputFormat = getOutputFormat()
+		outputFormat = GetOutputFormat()
 	}
 	msg := "Logging in to Megaport..."
 	spinner := NewSpinnerWithOutput(noColor, outputFormat)
@@ -462,7 +460,7 @@ func PrintCustomSpinner(action, resourceId string, noColor bool) *Spinner {
 	}
 	uidFormatted := FormatUID(resourceId, noColor)
 	msg := fmt.Sprintf("%s %s...", action, uidFormatted)
-	spinner := NewSpinnerWithOutput(noColor, getOutputFormat())
+	spinner := NewSpinnerWithOutput(noColor, GetOutputFormat())
 	spinner.Start(msg)
 	return spinner
 }
@@ -473,7 +471,7 @@ func PrintVerbose(format string, noColor bool, args ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf(format, args...)
-	if getOutputFormat() == "json" {
+	if GetOutputFormat() == "json" {
 		if noColor {
 			fmt.Fprintf(os.Stderr, "[DEBUG] %s\n", msg)
 		} else {

--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -37,10 +37,18 @@ func SetVerbosity(level string) {
 
 // IsQuiet returns true when quiet mode is active.
 // In quiet mode, informational messages and spinners are suppressed.
-func IsQuiet() bool { return GetOutputConfig().Verbosity == "quiet" }
+func IsQuiet() bool {
+	outputCfgMu.RLock()
+	defer outputCfgMu.RUnlock()
+	return outputCfg.Verbosity == "quiet"
+}
 
 // IsVerbose returns true when verbose mode is active.
-func IsVerbose() bool { return GetOutputConfig().Verbosity == "verbose" }
+func IsVerbose() bool {
+	outputCfgMu.RLock()
+	defer outputCfgMu.RUnlock()
+	return outputCfg.Verbosity == "verbose"
+}
 
 // newNoOpSpinner returns a spinner that is already stopped.
 // Safe to call Start(), Stop(), and StopWithSuccess() on.
@@ -59,7 +67,11 @@ func SetOutputFormat(format string) {
 }
 
 // GetOutputFormat returns the currently active output format (e.g. "table", "json").
-func GetOutputFormat() string { return GetOutputConfig().Format }
+func GetOutputFormat() string {
+	outputCfgMu.RLock()
+	defer outputCfgMu.RUnlock()
+	return outputCfg.Format
+}
 
 // shouldSuppressSpinner returns true when spinner output should be suppressed
 // to avoid corrupting machine-readable output formats (csv, xml, json, yaml, etc.).

--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/fatih/color"
@@ -31,40 +30,19 @@ var spinnerColors = []func(...interface{}) string{
 	color.New(color.FgHiGreen, color.Bold).SprintFunc(),
 }
 
-// currentOutputFormat stores the output format atomically to avoid data races
-// between spinner goroutines and Print* calls on the main goroutine.
-var currentOutputFormat atomic.Value
-
-// currentVerbosity stores the verbosity level atomically.
-// Valid values: "normal", "quiet", "verbose".
-var currentVerbosity atomic.Value
-
-func init() {
-	currentOutputFormat.Store("table")
-	currentVerbosity.Store("normal")
-}
-
 // SetVerbosity sets the global verbosity level ("normal", "quiet", or "verbose").
 func SetVerbosity(level string) {
-	currentVerbosity.Store(level)
+	cfg := GetOutputConfig()
+	cfg.Verbosity = level
+	ApplyOutputConfig(cfg)
 }
 
 // IsQuiet returns true when quiet mode is active.
 // In quiet mode, informational messages and spinners are suppressed.
-func IsQuiet() bool {
-	if v, ok := currentVerbosity.Load().(string); ok {
-		return v == "quiet"
-	}
-	return false
-}
+func IsQuiet() bool { return GetOutputConfig().Verbosity == "quiet" }
 
 // IsVerbose returns true when verbose mode is active.
-func IsVerbose() bool {
-	if v, ok := currentVerbosity.Load().(string); ok {
-		return v == "verbose"
-	}
-	return false
-}
+func IsVerbose() bool { return GetOutputConfig().Verbosity == "verbose" }
 
 // newNoOpSpinner returns a spinner that is already stopped.
 // Safe to call Start(), Stop(), and StopWithSuccess() on.
@@ -79,19 +57,15 @@ func newNoOpSpinner(noColor bool) *Spinner {
 }
 
 func SetOutputFormat(format string) {
-	currentOutputFormat.Store(format)
+	cfg := GetOutputConfig()
+	cfg.Format = format
+	ApplyOutputConfig(cfg)
 }
 
-func getOutputFormat() string {
-	if v, ok := currentOutputFormat.Load().(string); ok {
-		return v
-	}
-	return "table"
-}
+func getOutputFormat() string { return GetOutputConfig().Format }
 
 // GetOutputFormat returns the currently active output format (e.g. "table", "json").
-// Exported so other packages can read the current output format without relying on an unexported helper.
-func GetOutputFormat() string { return getOutputFormat() }
+func GetOutputFormat() string { return GetOutputConfig().Format }
 
 // shouldSuppressSpinner returns true when spinner output should be suppressed
 // to avoid corrupting machine-readable output formats (csv, xml, json, yaml, etc.).

--- a/internal/base/output/messages_native.go
+++ b/internal/base/output/messages_native.go
@@ -35,7 +35,7 @@ func PrintSuccess(format string, noColor bool, args ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf(format, args...)
-	if getOutputFormat() == "json" {
+	if GetOutputFormat() == "json" {
 		if noColor {
 			fmt.Fprintf(os.Stderr, "✓ %s\n", msg)
 		} else {
@@ -54,7 +54,7 @@ func PrintSuccess(format string, noColor bool, args ...interface{}) {
 
 func PrintError(format string, noColor bool, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	if getOutputFormat() == "json" {
+	if GetOutputFormat() == "json" {
 		if noColor {
 			fmt.Fprintf(os.Stderr, "✗ %s\n", msg)
 		} else {
@@ -76,7 +76,7 @@ func PrintWarning(format string, noColor bool, args ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf(format, args...)
-	if getOutputFormat() == "json" {
+	if GetOutputFormat() == "json" {
 		if noColor {
 			fmt.Fprintf(os.Stderr, "⚠ %s\n", msg)
 		} else {
@@ -98,7 +98,7 @@ func PrintInfo(format string, noColor bool, args ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf(format, args...)
-	if getOutputFormat() == "json" {
+	if GetOutputFormat() == "json" {
 		if noColor {
 			fmt.Fprintf(os.Stderr, "ℹ %s\n", msg)
 		} else {

--- a/internal/base/output/messages_native.go
+++ b/internal/base/output/messages_native.go
@@ -34,7 +34,7 @@ func PrintSuccess(format string, noColor bool, args ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf(format, args...)
-	if getOutputFormat() == "json" {
+	if GetOutputFormat() == "json" {
 		if noColor {
 			fmt.Fprintf(os.Stderr, "✓ %s\n", msg)
 		} else {
@@ -53,7 +53,7 @@ func PrintSuccess(format string, noColor bool, args ...interface{}) {
 
 func PrintError(format string, noColor bool, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	if getOutputFormat() == "json" {
+	if GetOutputFormat() == "json" {
 		if noColor {
 			fmt.Fprintf(os.Stderr, "✗ %s\n", msg)
 		} else {
@@ -75,7 +75,7 @@ func PrintWarning(format string, noColor bool, args ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf(format, args...)
-	if getOutputFormat() == "json" {
+	if GetOutputFormat() == "json" {
 		if noColor {
 			fmt.Fprintf(os.Stderr, "⚠ %s\n", msg)
 		} else {
@@ -97,7 +97,7 @@ func PrintInfo(format string, noColor bool, args ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf(format, args...)
-	if getOutputFormat() == "json" {
+	if GetOutputFormat() == "json" {
 		if noColor {
 			fmt.Fprintf(os.Stderr, "ℹ %s\n", msg)
 		} else {

--- a/internal/base/output/messages_native.go
+++ b/internal/base/output/messages_native.go
@@ -121,7 +121,7 @@ func PrintPlain(format string, _ bool, args ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf(format, args...)
-	if getOutputFormat() == "json" {
+	if GetOutputFormat() == "json" {
 		fmt.Fprintln(os.Stderr, msg)
 	} else {
 		fmt.Println(msg)
@@ -134,7 +134,7 @@ func PrintNewline() {
 	if IsQuiet() {
 		return
 	}
-	if getOutputFormat() == "json" {
+	if GetOutputFormat() == "json" {
 		fmt.Fprintln(os.Stderr)
 		return
 	}

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -170,8 +170,9 @@ func TestSpinner(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping timing-sensitive spinner test")
 	}
+	orig := isTerminalCached.Load()
+	t.Cleanup(func() { SetIsTerminal(orig) })
 	SetIsTerminal(true)
-	defer SetIsTerminal(false)
 
 	spinner := NewSpinner(true)
 	assert.NotNil(t, spinner)
@@ -190,8 +191,9 @@ func TestPrintResourceSpinners(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping timing-sensitive resource spinner test")
 	}
+	orig := isTerminalCached.Load()
+	t.Cleanup(func() { SetIsTerminal(orig) })
 	SetIsTerminal(true)
-	defer SetIsTerminal(false)
 
 	tests := []struct {
 		name         string
@@ -251,8 +253,9 @@ func TestPrintResourceListing(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping timing-sensitive resource listing test")
 	}
+	orig := isTerminalCached.Load()
+	t.Cleanup(func() { SetIsTerminal(orig) })
 	SetIsTerminal(true)
-	defer SetIsTerminal(false)
 
 	output := captureOutput(func() {
 		spinner := PrintResourceListing("Port", true)
@@ -503,8 +506,9 @@ func TestPrintResourceProvisioning(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping timing-sensitive provisioning test")
 	}
+	orig := isTerminalCached.Load()
+	t.Cleanup(func() { SetIsTerminal(orig) })
 	SetIsTerminal(true)
-	defer SetIsTerminal(false)
 
 	t.Run("shows provisioning message with elapsed time", func(t *testing.T) {
 		output := captureOutput(func() {
@@ -529,8 +533,9 @@ func TestStartWithElapsed(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping timing-sensitive elapsed timer test")
 	}
+	orig := isTerminalCached.Load()
+	t.Cleanup(func() { SetIsTerminal(orig) })
 	SetIsTerminal(true)
-	defer SetIsTerminal(false)
 
 	t.Run("appends elapsed time to message", func(t *testing.T) {
 		spinner := NewSpinner(true)
@@ -588,8 +593,9 @@ func TestSpinnerStopWithSuccess(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping timing-sensitive spinner stop test")
 	}
+	orig := isTerminalCached.Load()
+	t.Cleanup(func() { SetIsTerminal(orig) })
 	SetIsTerminal(true)
-	defer SetIsTerminal(false)
 
 	output := captureOutput(func() {
 		spinner := NewSpinner(true)
@@ -682,8 +688,9 @@ func TestSpinnerActiveForTable(t *testing.T) {
 	}
 	saveOutputFormat(t)
 	SetOutputFormat("table")
+	orig := isTerminalCached.Load()
+	t.Cleanup(func() { SetIsTerminal(orig) })
 	SetIsTerminal(true)
-	defer SetIsTerminal(false)
 
 	spinner := PrintResourceListing("test", true)
 	assert.False(t, spinner.stopped, "spinner should be active for table format")
@@ -722,8 +729,9 @@ func TestSpinnersNotSuppressedForTable(t *testing.T) {
 	}
 	t.Cleanup(func() { ResetState() })
 	SetOutputFormat("table")
+	orig := isTerminalCached.Load()
+	t.Cleanup(func() { SetIsTerminal(orig) })
 	SetIsTerminal(true)
-	defer SetIsTerminal(false)
 
 	s1 := PrintListingResourceTags("Port", "uid-1", true)
 	assert.False(t, s1.stopped, "PrintListingResourceTags should not be suppressed for table format")
@@ -757,8 +765,9 @@ func TestPrintLoggingInWithOutput_EmptyFormatFallback(t *testing.T) {
 	}
 	t.Cleanup(func() { ResetState() })
 	SetOutputFormat("table")
+	orig := isTerminalCached.Load()
+	t.Cleanup(func() { SetIsTerminal(orig) })
 	SetIsTerminal(true)
-	defer SetIsTerminal(false)
 
 	s := PrintLoggingInWithOutput(true, "")
 	assert.False(t, s.stopped, "login spinner should not be suppressed when format falls back to table")
@@ -771,8 +780,9 @@ func TestLoginSpinnersNotSuppressedForCSV(t *testing.T) {
 	}
 	saveOutputFormat(t)
 	SetOutputFormat("csv")
+	orig := isTerminalCached.Load()
+	t.Cleanup(func() { SetIsTerminal(orig) })
 	SetIsTerminal(true)
-	defer SetIsTerminal(false)
 
 	// Login spinners should still show regardless of output format
 	spinner := PrintLoggingIn(true)
@@ -787,8 +797,9 @@ func TestLoginSpinnersNotSuppressedForCSV(t *testing.T) {
 func TestStopWithSuccessDoesNotWriteToStdoutForCSV(t *testing.T) {
 	saveOutputFormat(t)
 	SetOutputFormat("csv")
+	orig := isTerminalCached.Load()
+	t.Cleanup(func() { SetIsTerminal(orig) })
 	SetIsTerminal(true)
-	defer SetIsTerminal(false)
 
 	spinner := PrintResourceListing("test", true)
 
@@ -809,8 +820,9 @@ func TestStopWithSuccessDoesNotWriteToStdoutForCSV(t *testing.T) {
 func TestStopWithSuccessDoesNotWriteToStdoutForXML(t *testing.T) {
 	saveOutputFormat(t)
 	SetOutputFormat("xml")
+	orig := isTerminalCached.Load()
+	t.Cleanup(func() { SetIsTerminal(orig) })
 	SetIsTerminal(true)
-	defer SetIsTerminal(false)
 
 	spinner := PrintResourceGetting("test", "uid", true)
 

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -707,6 +707,59 @@ func TestAllSpinnerFunctionsSuppressedForCSV(t *testing.T) {
 	}
 }
 
+// TestSpinnersNotSuppressedForTable covers the non-suppressed code paths in
+// PrintListingResourceTags, PrintResourceValidating, and PrintCustomSpinner —
+// specifically the GetOutputFormat() call and spinner creation that are only
+// reached when the output format is "table" and a terminal is active.
+func TestSpinnersNotSuppressedForTable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping spinner test in short mode")
+	}
+	t.Cleanup(func() { ResetState() })
+	SetOutputFormat("table")
+	SetIsTerminal(true)
+	defer SetIsTerminal(false)
+
+	s1 := PrintListingResourceTags("Port", "uid-1", true)
+	assert.False(t, s1.stopped, "PrintListingResourceTags should not be suppressed for table format")
+	s1.Stop()
+
+	s2 := PrintResourceValidating("VXC", true)
+	assert.False(t, s2.stopped, "PrintResourceValidating should not be suppressed for table format")
+	s2.Stop()
+
+	s3 := PrintCustomSpinner("Syncing", "uid-2", true)
+	assert.False(t, s3.stopped, "PrintCustomSpinner should not be suppressed for table format")
+	s3.Stop()
+}
+
+// TestPrintResourceGettingWithOutput_EmptyFormatFallback covers the
+// outputFormat = GetOutputFormat() fallback when an empty string is passed.
+func TestPrintResourceGettingWithOutput_EmptyFormatFallback(t *testing.T) {
+	t.Cleanup(func() { ResetState() })
+	SetOutputFormat("csv") // suppresses spinner so the test is fast
+
+	s := PrintResourceGettingWithOutput("Port", "uid-1", true, "")
+	assert.True(t, s.stopped, "spinner should be suppressed when format falls back to csv")
+	assert.Equal(t, "csv", s.outputFormat)
+}
+
+// TestPrintLoggingInWithOutput_EmptyFormatFallback covers the
+// outputFormat = GetOutputFormat() fallback when an empty string is passed.
+func TestPrintLoggingInWithOutput_EmptyFormatFallback(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping spinner test in short mode")
+	}
+	t.Cleanup(func() { ResetState() })
+	SetOutputFormat("table")
+	SetIsTerminal(true)
+	defer SetIsTerminal(false)
+
+	s := PrintLoggingInWithOutput(true, "")
+	assert.False(t, s.stopped, "login spinner should not be suppressed when format falls back to table")
+	s.Stop()
+}
+
 func TestLoginSpinnersNotSuppressedForCSV(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping spinner test in short mode")

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -443,9 +443,8 @@ func TestOutputFormatConcurrency(t *testing.T) {
 	const goroutines = 10
 	const iterations = 50
 
-	// Restore original format after the test.
-	origFormat := getOutputFormat()
-	defer SetOutputFormat(origFormat)
+	orig := GetOutputConfig()
+	t.Cleanup(func() { ApplyOutputConfig(orig) })
 
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
@@ -500,7 +499,7 @@ func TestPrintResourceProvisioning(t *testing.T) {
 
 	t.Run("quiet mode returns no-op spinner", func(t *testing.T) {
 		SetVerbosity("quiet")
-		defer SetVerbosity("normal")
+		t.Cleanup(func() { ResetState() })
 		spinner := PrintResourceProvisioning("Port", "port-123", true)
 		assert.NotNil(t, spinner)
 		assert.True(t, spinner.stopped)
@@ -583,9 +582,7 @@ func TestSpinnerStopWithSuccess(t *testing.T) {
 }
 
 func TestShouldSuppressSpinner(t *testing.T) {
-	origFormat := getOutputFormat()
-	defer SetOutputFormat(origFormat)
-	defer SetVerbosity("normal")
+	t.Cleanup(func() { ResetState() })
 
 	tests := []struct {
 		name     string
@@ -617,7 +614,7 @@ func TestShouldSuppressSpinner(t *testing.T) {
 
 func TestShouldSuppressSpinnerForFormat(t *testing.T) {
 	// Ensure normal verbosity so IsQuiet() doesn't interfere.
-	defer SetVerbosity("normal")
+	t.Cleanup(func() { ResetState() })
 	SetVerbosity("normal")
 
 	assert.False(t, shouldSuppressSpinnerForFormat("table"))

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -449,6 +449,11 @@ func TestOutputFormatConcurrency(t *testing.T) {
 	orig := GetOutputConfig()
 	t.Cleanup(func() { ApplyOutputConfig(orig) })
 
+	// Seed both fields that goroutines will cycle through so assertions
+	// cannot observe a value from a previous test.
+	SetOutputFormat("table")
+	SetVerbosity("normal")
+
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
 

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -436,9 +436,12 @@ func TestFormatNewValue(t *testing.T) {
 	assert.Contains(t, StripANSIColors(result), "new-value")
 }
 
-// TestOutputFormatConcurrency verifies that SetOutputFormat, getOutputFormat,
-// Print* helpers, and spinner creation can be called concurrently without a
-// data race. Run with: go test -race ./internal/base/output/...
+// TestOutputFormatConcurrency verifies that concurrent reads and writes to the
+// output config via GetOutputFormat, SetVerbosity, and the Print* helpers do
+// not cause data races. Unlike tests that only vary a single field, this one
+// has odd-numbered goroutines write Format while even-numbered goroutines write
+// Verbosity — exercising concurrent writes to different fields simultaneously.
+// Run with: go test -race ./internal/base/output/...
 func TestOutputFormatConcurrency(t *testing.T) {
 	const goroutines = 10
 	const iterations = 50
@@ -453,24 +456,35 @@ func TestOutputFormatConcurrency(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 			for j := 0; j < iterations; j++ {
-				// Alternate between formats to maximize contention.
-				if j%2 == 0 {
-					SetOutputFormat("json")
+				if id%2 == 0 {
+					// Even goroutines write Format.
+					if j%2 == 0 {
+						SetOutputFormat("json")
+					} else {
+						SetOutputFormat("table")
+					}
 				} else {
-					SetOutputFormat("table")
+					// Odd goroutines write Verbosity — different field, same mutex.
+					if j%2 == 0 {
+						SetVerbosity("quiet")
+					} else {
+						SetVerbosity("normal")
+					}
 				}
 
-				// Read the format (the main thing under test).
-				f := getOutputFormat()
-				assert.Contains(t, []string{"json", "table"}, f)
+				// All goroutines read back through the struct — any lost write
+				// or torn read will be caught by the race detector.
+				cfg := GetOutputConfig()
+				assert.Contains(t, []string{"json", "table"}, cfg.Format)
+				assert.Contains(t, []string{"quiet", "normal"}, cfg.Verbosity)
 
-				// Exercise Print* helpers that read the atomic value.
+				// Exercise Print* helpers that read the config.
 				PrintSuccess("concurrent %d", true, id)
 				PrintError("concurrent %d", true, id)
 				PrintWarning("concurrent %d", true, id)
 				PrintInfo("concurrent %d", true, id)
 
-				// Exercise spinner creation which also reads the format.
+				// Exercise spinner creation which also reads the config.
 				s := PrintResourceListing("Port", true)
 				s.Stop()
 			}
@@ -628,7 +642,7 @@ func TestShouldSuppressSpinnerForFormat(t *testing.T) {
 // to restore it, avoiding hard-coded assumptions about initial state.
 func saveOutputFormat(t *testing.T) {
 	t.Helper()
-	orig := getOutputFormat()
+	orig := GetOutputFormat()
 	t.Cleanup(func() { SetOutputFormat(orig) })
 }
 

--- a/internal/base/output/output.go
+++ b/internal/base/output/output.go
@@ -13,8 +13,8 @@ import (
 	"text/template"
 )
 
-func printGoTemplate[T OutputFields](data []T) error {
-	tmplStr := GetTemplateString()
+func printGoTemplate[T OutputFields](data []T, opts printOptions) error {
+	tmplStr := opts.template
 	funcMap := template.FuncMap{
 		"join":  strings.Join,
 		"upper": strings.ToUpper,
@@ -32,12 +32,12 @@ func printGoTemplate[T OutputFields](data []T) error {
 	return tmpl.Execute(os.Stdout, data)
 }
 
-func printJSON[T OutputFields](data []T) error {
+func printJSON[T OutputFields](data []T, opts printOptions) error {
 	if data == nil {
 		data = []T{}
 	}
 
-	toEncode, err := prepareJSONData(data)
+	toEncode, err := prepareJSONData(data, opts)
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func calculateColumnWidths(rows [][]string) []int {
 	return colWidths
 }
 
-func printCSV[T OutputFields](data []T) error {
+func printCSV[T OutputFields](data []T, opts printOptions) error {
 	w := csv.NewWriter(os.Stdout)
 	defer w.Flush()
 
@@ -71,7 +71,7 @@ func printCSV[T OutputFields](data []T) error {
 	if err != nil {
 		return err
 	}
-	if csvFields := getOutputFields(); len(csvFields) > 0 {
+	if csvFields := opts.fields; len(csvFields) > 0 {
 		headers, _, fieldIndices, err = filterByFields(headers, jsonNames, fieldIndices, csvFields)
 		if err != nil {
 			return err
@@ -80,7 +80,7 @@ func printCSV[T OutputFields](data []T) error {
 	if len(headers) == 0 {
 		return nil
 	}
-	if !getNoHeader() {
+	if !opts.noHeader {
 		if err := w.Write(headers); err != nil {
 			return err
 		}
@@ -97,7 +97,7 @@ func printCSV[T OutputFields](data []T) error {
 	return nil
 }
 
-func printXML[T OutputFields](data []T) error {
+func printXML[T OutputFields](data []T, opts printOptions) error {
 	if data == nil {
 		data = []T{}
 	}
@@ -113,7 +113,7 @@ func printXML[T OutputFields](data []T) error {
 		return nil
 	}
 
-	if xmlFields := getOutputFields(); len(xmlFields) > 0 {
+	if xmlFields := opts.fields; len(xmlFields) > 0 {
 		_, jsonNames, fieldIndices, err = filterByFields(headers, jsonNames, fieldIndices, xmlFields)
 		if err != nil {
 			return err

--- a/internal/base/output/output_bench_test.go
+++ b/internal/base/output/output_bench_test.go
@@ -49,7 +49,7 @@ func BenchmarkPrintTable(b *testing.B) {
 	defer cleanup()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := printTable(data, true); err != nil {
+		if err := printTable(data, true, currentPrintOptions()); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -61,7 +61,7 @@ func BenchmarkPrintJSON(b *testing.B) {
 	defer cleanup()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := printJSON(data); err != nil {
+		if err := printJSON(data, currentPrintOptions()); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -73,7 +73,7 @@ func BenchmarkPrintCSV(b *testing.B) {
 	defer cleanup()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := printCSV(data); err != nil {
+		if err := printCSV(data, currentPrintOptions()); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -85,7 +85,7 @@ func BenchmarkPrintXML(b *testing.B) {
 	defer cleanup()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := printXML(data); err != nil {
+		if err := printXML(data, currentPrintOptions()); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/internal/base/output/output_test.go
+++ b/internal/base/output/output_test.go
@@ -1051,7 +1051,8 @@ func fieldsTestData() []fieldsTestStruct {
 }
 
 func TestSetOutputFields_Table(t *testing.T) {
-	t.Cleanup(func() { ResetState() })
+	origIsTerminal := isTerminalCached.Load()
+	t.Cleanup(func() { ResetState(); SetIsTerminal(origIsTerminal) })
 	SetOutputFields([]string{"uid", "name"})
 	SetIsTerminal(false)
 
@@ -1119,7 +1120,8 @@ func TestSetOutputFields_XML(t *testing.T) {
 }
 
 func TestSetOutputFields_CaseInsensitive(t *testing.T) {
-	t.Cleanup(func() { ResetState() })
+	origIsTerminal := isTerminalCached.Load()
+	t.Cleanup(func() { ResetState(); SetIsTerminal(origIsTerminal) })
 	SetOutputFields([]string{"UID", "NAME"}) // uppercase
 	SetIsTerminal(false)
 
@@ -1134,7 +1136,8 @@ func TestSetOutputFields_CaseInsensitive(t *testing.T) {
 }
 
 func TestSetOutputFields_HeaderNameAlias(t *testing.T) {
-	t.Cleanup(func() { ResetState() })
+	origIsTerminal := isTerminalCached.Load()
+	t.Cleanup(func() { ResetState(); SetIsTerminal(origIsTerminal) })
 	// Match by header name "Port Speed" (has a space)
 	SetOutputFields([]string{"Port Speed"})
 	SetIsTerminal(false)
@@ -1150,7 +1153,8 @@ func TestSetOutputFields_HeaderNameAlias(t *testing.T) {
 }
 
 func TestSetOutputFields_UnknownField(t *testing.T) {
-	t.Cleanup(func() { ResetState() })
+	origIsTerminal := isTerminalCached.Load()
+	t.Cleanup(func() { ResetState(); SetIsTerminal(origIsTerminal) })
 	SetOutputFields([]string{"uid", "nonexistent"})
 	SetIsTerminal(false)
 
@@ -1162,6 +1166,8 @@ func TestSetOutputFields_UnknownField(t *testing.T) {
 }
 
 func TestSetOutputFields_Nil_RestoresAll(t *testing.T) {
+	origIsTerminal := isTerminalCached.Load()
+	t.Cleanup(func() { ResetState(); SetIsTerminal(origIsTerminal) })
 	SetIsTerminal(false)
 
 	SetOutputFields([]string{"uid"})

--- a/internal/base/output/output_test.go
+++ b/internal/base/output/output_test.go
@@ -1212,7 +1212,6 @@ func TestSetOutputQuery_ExtractField(t *testing.T) {
 
 func TestSetOutputQuery_WithFields(t *testing.T) {
 	t.Cleanup(func() { ResetState() })
-	t.Cleanup(func() { ResetState() })
 	SetOutputFields([]string{"uid", "name"})
 	SetOutputQuery("[*].uid")
 

--- a/internal/base/output/output_test.go
+++ b/internal/base/output/output_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1050,7 +1051,7 @@ func fieldsTestData() []fieldsTestStruct {
 }
 
 func TestSetOutputFields_Table(t *testing.T) {
-	defer SetOutputFields(nil)
+	t.Cleanup(func() { ResetState() })
 	SetOutputFields([]string{"uid", "name"})
 	SetIsTerminal(false)
 
@@ -1068,7 +1069,7 @@ func TestSetOutputFields_Table(t *testing.T) {
 }
 
 func TestSetOutputFields_CSV(t *testing.T) {
-	defer SetOutputFields(nil)
+	t.Cleanup(func() { ResetState() })
 	SetOutputFields([]string{"uid", "status"})
 
 	out := CaptureOutput(func() {
@@ -1085,7 +1086,7 @@ func TestSetOutputFields_CSV(t *testing.T) {
 }
 
 func TestSetOutputFields_JSON(t *testing.T) {
-	defer SetOutputFields(nil)
+	t.Cleanup(func() { ResetState() })
 	SetOutputFields([]string{"uid", "name"})
 
 	out := CaptureOutput(func() {
@@ -1103,7 +1104,7 @@ func TestSetOutputFields_JSON(t *testing.T) {
 }
 
 func TestSetOutputFields_XML(t *testing.T) {
-	defer SetOutputFields(nil)
+	t.Cleanup(func() { ResetState() })
 	SetOutputFields([]string{"uid", "name"})
 
 	out := CaptureOutput(func() {
@@ -1118,7 +1119,7 @@ func TestSetOutputFields_XML(t *testing.T) {
 }
 
 func TestSetOutputFields_CaseInsensitive(t *testing.T) {
-	defer SetOutputFields(nil)
+	t.Cleanup(func() { ResetState() })
 	SetOutputFields([]string{"UID", "NAME"}) // uppercase
 	SetIsTerminal(false)
 
@@ -1133,7 +1134,7 @@ func TestSetOutputFields_CaseInsensitive(t *testing.T) {
 }
 
 func TestSetOutputFields_HeaderNameAlias(t *testing.T) {
-	defer SetOutputFields(nil)
+	t.Cleanup(func() { ResetState() })
 	// Match by header name "Port Speed" (has a space)
 	SetOutputFields([]string{"Port Speed"})
 	SetIsTerminal(false)
@@ -1149,7 +1150,7 @@ func TestSetOutputFields_HeaderNameAlias(t *testing.T) {
 }
 
 func TestSetOutputFields_UnknownField(t *testing.T) {
-	defer SetOutputFields(nil)
+	t.Cleanup(func() { ResetState() })
 	SetOutputFields([]string{"uid", "nonexistent"})
 	SetIsTerminal(false)
 
@@ -1180,7 +1181,7 @@ func TestSetOutputFields_Nil_RestoresAll(t *testing.T) {
 // ---- --query flag tests ----
 
 func TestSetOutputQuery_FilterArray(t *testing.T) {
-	defer SetOutputQuery("")
+	t.Cleanup(func() { ResetState() })
 	SetOutputQuery("[?status=='LIVE']")
 
 	out, err := CaptureOutputErr(func() error {
@@ -1196,7 +1197,7 @@ func TestSetOutputQuery_FilterArray(t *testing.T) {
 }
 
 func TestSetOutputQuery_ExtractField(t *testing.T) {
-	defer SetOutputQuery("")
+	t.Cleanup(func() { ResetState() })
 	SetOutputQuery("[*].name")
 
 	out, err := CaptureOutputErr(func() error {
@@ -1210,8 +1211,8 @@ func TestSetOutputQuery_ExtractField(t *testing.T) {
 }
 
 func TestSetOutputQuery_WithFields(t *testing.T) {
-	defer SetOutputFields(nil)
-	defer SetOutputQuery("")
+	t.Cleanup(func() { ResetState() })
+	t.Cleanup(func() { ResetState() })
 	SetOutputFields([]string{"uid", "name"})
 	SetOutputQuery("[*].uid")
 
@@ -1226,7 +1227,7 @@ func TestSetOutputQuery_WithFields(t *testing.T) {
 }
 
 func TestSetOutputQuery_InvalidQuery(t *testing.T) {
-	defer SetOutputQuery("")
+	t.Cleanup(func() { ResetState() })
 	SetOutputQuery("INVALID[[")
 
 	err := PrintOutput(fieldsTestData(), "json", true)
@@ -1235,7 +1236,7 @@ func TestSetOutputQuery_InvalidQuery(t *testing.T) {
 }
 
 func TestSetOutputQuery_EmptyData(t *testing.T) {
-	defer SetOutputQuery("")
+	t.Cleanup(func() { ResetState() })
 	SetOutputQuery("[*].uid")
 
 	out, err := CaptureOutputErr(func() error {
@@ -1275,7 +1276,7 @@ func TestApplyJMESPath_MarshalError(t *testing.T) {
 
 func TestNoHeaderTableSuppressesHeader(t *testing.T) {
 	SetNoHeader(true)
-	defer SetNoHeader(false)
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 1, Name: "alpha", Active: true}}
 	out := CaptureOutput(func() {
@@ -1289,7 +1290,7 @@ func TestNoHeaderTableSuppressesHeader(t *testing.T) {
 
 func TestNoHeaderTableWithHeaderEnabled(t *testing.T) {
 	SetNoHeader(false)
-	defer SetNoHeader(false)
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 1, Name: "beta", Active: false}}
 	out := CaptureOutput(func() {
@@ -1302,7 +1303,7 @@ func TestNoHeaderTableWithHeaderEnabled(t *testing.T) {
 
 func TestNoHeaderCSVSuppressesHeader(t *testing.T) {
 	SetNoHeader(true)
-	defer SetNoHeader(false)
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 42, Name: "gamma", Active: true}}
 	out := CaptureOutput(func() {
@@ -1317,7 +1318,7 @@ func TestNoHeaderCSVSuppressesHeader(t *testing.T) {
 
 func TestNoHeaderCSVWithHeaderEnabled(t *testing.T) {
 	SetNoHeader(false)
-	defer SetNoHeader(false)
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 7, Name: "delta", Active: false}}
 	out := CaptureOutput(func() {
@@ -1332,7 +1333,7 @@ func TestNoHeaderCSVWithHeaderEnabled(t *testing.T) {
 
 func TestNoHeaderDoesNotAffectJSON(t *testing.T) {
 	SetNoHeader(true)
-	defer SetNoHeader(false)
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 3, Name: "epsilon", Active: true}}
 	out := CaptureOutput(func() {
@@ -1346,7 +1347,7 @@ func TestNoHeaderDoesNotAffectJSON(t *testing.T) {
 
 func TestPrintGoTemplate_FieldExtraction(t *testing.T) {
 	SetTemplateString(`{{range .}}{{.Name}}{{"\n"}}{{end}}`)
-	defer SetTemplateString("")
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 1, Name: "alpha", Active: true}, {ID: 2, Name: "beta", Active: false}}
 	out := CaptureOutput(func() {
@@ -1360,7 +1361,7 @@ func TestPrintGoTemplate_FieldExtraction(t *testing.T) {
 
 func TestPrintGoTemplate_SingleItem(t *testing.T) {
 	SetTemplateString(`{{(index . 0).Name}}`)
-	defer SetTemplateString("")
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 1, Name: "gamma", Active: true}}
 	out := CaptureOutput(func() {
@@ -1373,7 +1374,7 @@ func TestPrintGoTemplate_SingleItem(t *testing.T) {
 
 func TestPrintGoTemplate_FuncMap(t *testing.T) {
 	SetTemplateString(`{{range .}}{{upper .Name}}{{"\n"}}{{end}}`)
-	defer SetTemplateString("")
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 1, Name: "delta"}}
 	out := CaptureOutput(func() {
@@ -1386,7 +1387,7 @@ func TestPrintGoTemplate_FuncMap(t *testing.T) {
 
 func TestPrintGoTemplate_InvalidTemplate(t *testing.T) {
 	SetTemplateString(`{{invalid`)
-	defer SetTemplateString("")
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 1, Name: "test"}}
 	var err error
@@ -1400,7 +1401,7 @@ func TestPrintGoTemplate_InvalidTemplate(t *testing.T) {
 
 func TestPrintGoTemplate_Count(t *testing.T) {
 	SetTemplateString(`{{len .}}`)
-	defer SetTemplateString("")
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 1, Name: "a"}, {ID: 2, Name: "b"}, {ID: 3, Name: "c"}}
 	out := CaptureOutput(func() {
@@ -1413,7 +1414,7 @@ func TestPrintGoTemplate_Count(t *testing.T) {
 
 func TestPrintGoTemplate_JSONFuncMap(t *testing.T) {
 	SetTemplateString(`{{range .}}{{json .}}{{"\n"}}{{end}}`)
-	defer SetTemplateString("")
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 1, Name: "epsilon", Active: true}}
 	out := CaptureOutput(func() {
@@ -1435,4 +1436,22 @@ func TestGetOutputFormat(t *testing.T) {
 	t.Cleanup(func() { SetOutputFormat(orig) })
 	SetOutputFormat("json")
 	assert.Equal(t, "json", GetOutputFormat())
+}
+
+func TestApplyOutputConfigConcurrent(t *testing.T) {
+	orig := GetOutputConfig()
+	t.Cleanup(func() { ApplyOutputConfig(orig) })
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cfg := GetOutputConfig()
+			cfg.Format = "json"
+			ApplyOutputConfig(cfg)
+			_ = GetOutputConfig()
+		}()
+	}
+	wg.Wait()
 }

--- a/internal/base/output/output_test.go
+++ b/internal/base/output/output_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1050,7 +1051,7 @@ func fieldsTestData() []fieldsTestStruct {
 }
 
 func TestSetOutputFields_Table(t *testing.T) {
-	defer SetOutputFields(nil)
+	t.Cleanup(func() { ResetState() })
 	SetOutputFields([]string{"uid", "name"})
 	SetIsTerminal(false)
 
@@ -1068,7 +1069,7 @@ func TestSetOutputFields_Table(t *testing.T) {
 }
 
 func TestSetOutputFields_CSV(t *testing.T) {
-	defer SetOutputFields(nil)
+	t.Cleanup(func() { ResetState() })
 	SetOutputFields([]string{"uid", "status"})
 
 	out := CaptureOutput(func() {
@@ -1085,7 +1086,7 @@ func TestSetOutputFields_CSV(t *testing.T) {
 }
 
 func TestSetOutputFields_JSON(t *testing.T) {
-	defer SetOutputFields(nil)
+	t.Cleanup(func() { ResetState() })
 	SetOutputFields([]string{"uid", "name"})
 
 	out := CaptureOutput(func() {
@@ -1103,7 +1104,7 @@ func TestSetOutputFields_JSON(t *testing.T) {
 }
 
 func TestSetOutputFields_XML(t *testing.T) {
-	defer SetOutputFields(nil)
+	t.Cleanup(func() { ResetState() })
 	SetOutputFields([]string{"uid", "name"})
 
 	out := CaptureOutput(func() {
@@ -1118,7 +1119,7 @@ func TestSetOutputFields_XML(t *testing.T) {
 }
 
 func TestSetOutputFields_CaseInsensitive(t *testing.T) {
-	defer SetOutputFields(nil)
+	t.Cleanup(func() { ResetState() })
 	SetOutputFields([]string{"UID", "NAME"}) // uppercase
 	SetIsTerminal(false)
 
@@ -1133,7 +1134,7 @@ func TestSetOutputFields_CaseInsensitive(t *testing.T) {
 }
 
 func TestSetOutputFields_HeaderNameAlias(t *testing.T) {
-	defer SetOutputFields(nil)
+	t.Cleanup(func() { ResetState() })
 	// Match by header name "Port Speed" (has a space)
 	SetOutputFields([]string{"Port Speed"})
 	SetIsTerminal(false)
@@ -1149,7 +1150,7 @@ func TestSetOutputFields_HeaderNameAlias(t *testing.T) {
 }
 
 func TestSetOutputFields_UnknownField(t *testing.T) {
-	defer SetOutputFields(nil)
+	t.Cleanup(func() { ResetState() })
 	SetOutputFields([]string{"uid", "nonexistent"})
 	SetIsTerminal(false)
 
@@ -1180,7 +1181,7 @@ func TestSetOutputFields_Nil_RestoresAll(t *testing.T) {
 // ---- --query flag tests ----
 
 func TestSetOutputQuery_FilterArray(t *testing.T) {
-	defer SetOutputQuery("")
+	t.Cleanup(func() { ResetState() })
 	SetOutputQuery("[?status=='LIVE']")
 
 	out, err := CaptureOutputErr(func() error {
@@ -1196,7 +1197,7 @@ func TestSetOutputQuery_FilterArray(t *testing.T) {
 }
 
 func TestSetOutputQuery_ExtractField(t *testing.T) {
-	defer SetOutputQuery("")
+	t.Cleanup(func() { ResetState() })
 	SetOutputQuery("[*].name")
 
 	out, err := CaptureOutputErr(func() error {
@@ -1210,8 +1211,8 @@ func TestSetOutputQuery_ExtractField(t *testing.T) {
 }
 
 func TestSetOutputQuery_WithFields(t *testing.T) {
-	defer SetOutputFields(nil)
-	defer SetOutputQuery("")
+	t.Cleanup(func() { ResetState() })
+	t.Cleanup(func() { ResetState() })
 	SetOutputFields([]string{"uid", "name"})
 	SetOutputQuery("[*].uid")
 
@@ -1226,7 +1227,7 @@ func TestSetOutputQuery_WithFields(t *testing.T) {
 }
 
 func TestSetOutputQuery_InvalidQuery(t *testing.T) {
-	defer SetOutputQuery("")
+	t.Cleanup(func() { ResetState() })
 	SetOutputQuery("INVALID[[")
 
 	err := PrintOutput(fieldsTestData(), "json", true)
@@ -1235,7 +1236,7 @@ func TestSetOutputQuery_InvalidQuery(t *testing.T) {
 }
 
 func TestSetOutputQuery_EmptyData(t *testing.T) {
-	defer SetOutputQuery("")
+	t.Cleanup(func() { ResetState() })
 	SetOutputQuery("[*].uid")
 
 	out, err := CaptureOutputErr(func() error {
@@ -1275,7 +1276,7 @@ func TestApplyJMESPath_MarshalError(t *testing.T) {
 
 func TestNoHeaderTableSuppressesHeader(t *testing.T) {
 	SetNoHeader(true)
-	defer SetNoHeader(false)
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 1, Name: "alpha", Active: true}}
 	out := CaptureOutput(func() {
@@ -1289,7 +1290,7 @@ func TestNoHeaderTableSuppressesHeader(t *testing.T) {
 
 func TestNoHeaderTableWithHeaderEnabled(t *testing.T) {
 	SetNoHeader(false)
-	defer SetNoHeader(false)
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 1, Name: "beta", Active: false}}
 	out := CaptureOutput(func() {
@@ -1302,7 +1303,7 @@ func TestNoHeaderTableWithHeaderEnabled(t *testing.T) {
 
 func TestNoHeaderCSVSuppressesHeader(t *testing.T) {
 	SetNoHeader(true)
-	defer SetNoHeader(false)
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 42, Name: "gamma", Active: true}}
 	out := CaptureOutput(func() {
@@ -1317,7 +1318,7 @@ func TestNoHeaderCSVSuppressesHeader(t *testing.T) {
 
 func TestNoHeaderCSVWithHeaderEnabled(t *testing.T) {
 	SetNoHeader(false)
-	defer SetNoHeader(false)
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 7, Name: "delta", Active: false}}
 	out := CaptureOutput(func() {
@@ -1332,7 +1333,7 @@ func TestNoHeaderCSVWithHeaderEnabled(t *testing.T) {
 
 func TestNoHeaderDoesNotAffectJSON(t *testing.T) {
 	SetNoHeader(true)
-	defer SetNoHeader(false)
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 3, Name: "epsilon", Active: true}}
 	out := CaptureOutput(func() {
@@ -1346,7 +1347,7 @@ func TestNoHeaderDoesNotAffectJSON(t *testing.T) {
 
 func TestPrintGoTemplate_FieldExtraction(t *testing.T) {
 	SetTemplateString(`{{range .}}{{.Name}}{{"\n"}}{{end}}`)
-	defer SetTemplateString("")
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 1, Name: "alpha", Active: true}, {ID: 2, Name: "beta", Active: false}}
 	out := CaptureOutput(func() {
@@ -1360,7 +1361,7 @@ func TestPrintGoTemplate_FieldExtraction(t *testing.T) {
 
 func TestPrintGoTemplate_SingleItem(t *testing.T) {
 	SetTemplateString(`{{(index . 0).Name}}`)
-	defer SetTemplateString("")
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 1, Name: "gamma", Active: true}}
 	out := CaptureOutput(func() {
@@ -1373,7 +1374,7 @@ func TestPrintGoTemplate_SingleItem(t *testing.T) {
 
 func TestPrintGoTemplate_FuncMap(t *testing.T) {
 	SetTemplateString(`{{range .}}{{upper .Name}}{{"\n"}}{{end}}`)
-	defer SetTemplateString("")
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 1, Name: "delta"}}
 	out := CaptureOutput(func() {
@@ -1386,7 +1387,7 @@ func TestPrintGoTemplate_FuncMap(t *testing.T) {
 
 func TestPrintGoTemplate_InvalidTemplate(t *testing.T) {
 	SetTemplateString(`{{invalid`)
-	defer SetTemplateString("")
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 1, Name: "test"}}
 	var err error
@@ -1400,7 +1401,7 @@ func TestPrintGoTemplate_InvalidTemplate(t *testing.T) {
 
 func TestPrintGoTemplate_Count(t *testing.T) {
 	SetTemplateString(`{{len .}}`)
-	defer SetTemplateString("")
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 1, Name: "a"}, {ID: 2, Name: "b"}, {ID: 3, Name: "c"}}
 	out := CaptureOutput(func() {
@@ -1413,7 +1414,7 @@ func TestPrintGoTemplate_Count(t *testing.T) {
 
 func TestPrintGoTemplate_JSONFuncMap(t *testing.T) {
 	SetTemplateString(`{{range .}}{{json .}}{{"\n"}}{{end}}`)
-	defer SetTemplateString("")
+	t.Cleanup(func() { ResetState() })
 
 	data := []SimpleStruct{{ID: 1, Name: "epsilon", Active: true}}
 	out := CaptureOutput(func() {
@@ -1437,120 +1438,20 @@ func TestGetOutputFormat(t *testing.T) {
 	assert.Equal(t, "json", GetOutputFormat())
 }
 
-func TestDefaultOutputConfig_Values(t *testing.T) {
-	cfg := DefaultOutputConfig()
-	assert.Equal(t, OutputConfig{Format: "table", Verbosity: "normal"}, cfg)
-}
+func TestApplyOutputConfigConcurrent(t *testing.T) {
+	orig := GetOutputConfig()
+	t.Cleanup(func() { ApplyOutputConfig(orig) })
 
-// TestSetConfig_AppliesAllFields verifies that SetConfig writes every field
-// of the struct to the backing package-level state. NoPager is covered in
-// pager_test.go because pager state is native-only — the WASM build
-// provides stub SetNoPager (no-op) and GetNoPager (always false)
-// implementations, so a round-trip assertion is only meaningful on native.
-func TestSetConfig_AppliesAllFields(t *testing.T) {
-	t.Cleanup(ResetState)
-
-	fields := []string{"uid", "name"}
-	SetConfig(OutputConfig{
-		Fields:    fields,
-		Query:     "[].uid",
-		NoHeader:  true,
-		Template:  "{{.UID}}",
-		Format:    "json",
-		Verbosity: "verbose",
-	})
-
-	assert.Equal(t, fields, getOutputFields())
-	assert.Equal(t, "[].uid", getOutputQuery())
-	assert.True(t, getNoHeader())
-	assert.Equal(t, "{{.UID}}", GetTemplateString())
-	assert.Equal(t, "json", GetOutputFormat())
-	assert.True(t, IsVerbose())
-	assert.False(t, IsQuiet())
-}
-
-// TestSetConfig_ZeroValueClearsState verifies that passing a zero-value
-// OutputConfig writes empty/false to every field. This documents that
-// SetConfig does not have a "leave unchanged" sentinel — callers that want
-// to preserve existing state must read it first.
-func TestSetConfig_ZeroValueClearsState(t *testing.T) {
-	t.Cleanup(ResetState)
-
-	SetConfig(OutputConfig{
-		Fields:    []string{"uid"},
-		Query:     "[]",
-		NoHeader:  true,
-		Template:  "{{.}}",
-		Format:    "json",
-		Verbosity: "verbose",
-	})
-
-	SetConfig(OutputConfig{})
-
-	assert.Nil(t, getOutputFields())
-	assert.Equal(t, "", getOutputQuery())
-	assert.False(t, getNoHeader())
-	assert.Equal(t, "", GetTemplateString())
-	assert.Equal(t, "", GetOutputFormat())
-	assert.False(t, IsVerbose())
-	assert.False(t, IsQuiet())
-}
-
-// TestSetOutputFields_CopiesInputSlice verifies that SetOutputFields does
-// not retain the caller's slice header. Mutating the original slice after
-// the call must not affect the stored filter, otherwise concurrent readers
-// of getOutputFields could observe a torn update.
-func TestSetOutputFields_CopiesInputSlice(t *testing.T) {
-	t.Cleanup(ResetState)
-
-	original := []string{"uid", "name"}
-	SetOutputFields(original)
-
-	original[0] = "mutated"
-	original[1] = "also-mutated"
-
-	assert.Equal(t, []string{"uid", "name"}, getOutputFields())
-}
-
-// TestSetConfig_CopiesFieldsSlice is the SetConfig equivalent of the above
-// — the defensive copy must also apply when Fields is passed via
-// OutputConfig, since the SetConfig godoc promises callers can reuse the
-// backing array after the call returns.
-func TestSetConfig_CopiesFieldsSlice(t *testing.T) {
-	t.Cleanup(ResetState)
-
-	original := []string{"uid", "name"}
-	SetConfig(OutputConfig{Fields: original})
-
-	original[0] = "mutated"
-	original[1] = "also-mutated"
-
-	assert.Equal(t, []string{"uid", "name"}, getOutputFields())
-}
-
-// TestResetState_ViaDefaultOutputConfig verifies that ResetState restores
-// the documented defaults after every field has been set to a non-default
-// value. This protects against a future SetConfig change that forgets to
-// apply one of the defaults.
-func TestResetState_ViaDefaultOutputConfig(t *testing.T) {
-	t.Cleanup(ResetState)
-
-	SetConfig(OutputConfig{
-		Fields:    []string{"uid"},
-		Query:     "[]",
-		NoHeader:  true,
-		Template:  "{{.}}",
-		Format:    "json",
-		Verbosity: "quiet",
-	})
-
-	ResetState()
-
-	assert.Nil(t, getOutputFields())
-	assert.Equal(t, "", getOutputQuery())
-	assert.False(t, getNoHeader())
-	assert.Equal(t, "", GetTemplateString())
-	assert.Equal(t, "table", GetOutputFormat())
-	assert.False(t, IsQuiet())
-	assert.False(t, IsVerbose())
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cfg := GetOutputConfig()
+			cfg.Format = "json"
+			ApplyOutputConfig(cfg)
+			_ = GetOutputConfig()
+		}()
+	}
+	wg.Wait()
 }

--- a/internal/base/output/output_test.go
+++ b/internal/base/output/output_test.go
@@ -73,7 +73,7 @@ func TestPrintCSV_SimpleStruct(t *testing.T) {
 	}
 
 	output := CaptureOutput(func() {
-		err := printCSV(data)
+		err := printCSV(data, currentPrintOptions())
 		assert.NoError(t, err)
 	})
 
@@ -101,7 +101,7 @@ func TestPrintCSV_ComplexStruct(t *testing.T) {
 	}
 
 	output := CaptureOutput(func() {
-		err := printCSV(data)
+		err := printCSV(data, currentPrintOptions())
 		assert.NoError(t, err)
 	})
 
@@ -113,7 +113,7 @@ func TestPrintCSV_EmptySlice(t *testing.T) {
 	data := []SimpleStruct{}
 
 	output := CaptureOutput(func() {
-		err := printCSV(data)
+		err := printCSV(data, currentPrintOptions())
 		assert.NoError(t, err)
 	})
 
@@ -125,12 +125,12 @@ func TestPrintCSV_NilSlice(t *testing.T) {
 	var data []SimpleStruct = nil
 
 	_ = CaptureOutput(func() {
-		err := printCSV(data)
+		err := printCSV(data, currentPrintOptions())
 		assert.NoError(t, err)
 	})
 
 	assert.NotPanics(t, func() {
-		_ = printCSV(data)
+		_ = printCSV(data, currentPrintOptions())
 	})
 }
 
@@ -142,7 +142,7 @@ func TestPrintCSV_PointerStruct(t *testing.T) {
 	data := []*SimpleStruct{s1, s2, s3}
 
 	output := CaptureOutput(func() {
-		err := printCSV(data)
+		err := printCSV(data, currentPrintOptions())
 		assert.NoError(t, err)
 	})
 
@@ -158,7 +158,7 @@ func TestPrintCSV_NoTagStruct(t *testing.T) {
 	data := []NoTagStruct{{ID: 1, Name: "Test"}}
 
 	output := CaptureOutput(func() {
-		err := printCSV(data)
+		err := printCSV(data, currentPrintOptions())
 		assert.NoError(t, err)
 	})
 
@@ -173,7 +173,7 @@ func TestPrintJSON(t *testing.T) {
 	}
 
 	output := CaptureOutput(func() {
-		err := printJSON(data)
+		err := printJSON(data, currentPrintOptions())
 		assert.NoError(t, err)
 	})
 
@@ -824,7 +824,7 @@ func TestPrintXML_SimpleStruct(t *testing.T) {
 	}
 
 	output := CaptureOutput(func() {
-		err := printXML(data)
+		err := printXML(data, currentPrintOptions())
 		assert.NoError(t, err)
 	})
 
@@ -844,7 +844,7 @@ func TestPrintXML_EmptySlice(t *testing.T) {
 	data := []SimpleStruct{}
 
 	output := CaptureOutput(func() {
-		err := printXML(data)
+		err := printXML(data, currentPrintOptions())
 		assert.NoError(t, err)
 	})
 
@@ -859,7 +859,7 @@ func TestPrintXML_NilSlice(t *testing.T) {
 
 	assert.NotPanics(t, func() {
 		output := CaptureOutput(func() {
-			err := printXML(data)
+			err := printXML(data, currentPrintOptions())
 			assert.NoError(t, err)
 		})
 		assert.Contains(t, output, "<items>")
@@ -882,7 +882,7 @@ func TestPrintXML_ComplexStruct(t *testing.T) {
 	}
 
 	output := CaptureOutput(func() {
-		err := printXML(data)
+		err := printXML(data, currentPrintOptions())
 		assert.NoError(t, err)
 	})
 
@@ -911,7 +911,7 @@ func TestPrintXML_PointerStruct(t *testing.T) {
 	data := []*SimpleStruct{s1, s2, s3}
 
 	output := CaptureOutput(func() {
-		err := printXML(data)
+		err := printXML(data, currentPrintOptions())
 		assert.NoError(t, err)
 	})
 
@@ -930,7 +930,7 @@ func TestPrintXML_CustomTagStruct(t *testing.T) {
 	}
 
 	output := CaptureOutput(func() {
-		err := printXML(data)
+		err := printXML(data, currentPrintOptions())
 		assert.NoError(t, err)
 	})
 
@@ -945,7 +945,7 @@ func TestPrintXML_NoTagStruct(t *testing.T) {
 	}
 
 	output := CaptureOutput(func() {
-		err := printXML(data)
+		err := printXML(data, currentPrintOptions())
 		assert.NoError(t, err)
 	})
 
@@ -960,7 +960,7 @@ func TestPrintXML_SpecialCharacters(t *testing.T) {
 	}
 
 	output := CaptureOutput(func() {
-		err := printXML(data)
+		err := printXML(data, currentPrintOptions())
 		assert.NoError(t, err)
 	})
 
@@ -1013,7 +1013,7 @@ func TestPrintXML_Parseable(t *testing.T) {
 	}
 
 	output := CaptureOutput(func() {
-		err := printXML(data)
+		err := printXML(data, currentPrintOptions())
 		assert.NoError(t, err)
 	})
 

--- a/internal/base/output/output_wasm.go
+++ b/internal/base/output/output_wasm.go
@@ -29,7 +29,7 @@ var WasmCSVWriter = &bytes.Buffer{}
 var WasmXMLWriter = &bytes.Buffer{}
 
 // printJSON is the WASM-specific implementation that properly captures JSON output
-func printJSON[T OutputFields](data []T) error {
+func printJSON[T OutputFields](data []T, opts printOptions) error {
 	wasmBufMu.Lock()
 	defer wasmBufMu.Unlock()
 	WasmJSONWriter.Reset()
@@ -38,7 +38,7 @@ func printJSON[T OutputFields](data []T) error {
 		data = []T{}
 	}
 
-	toEncode, err := prepareJSONData(data)
+	toEncode, err := prepareJSONData(data, opts)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func printJSON[T OutputFields](data []T) error {
 }
 
 // printCSV is the WASM-specific implementation that properly captures CSV output
-func printCSV[T OutputFields](data []T) error {
+func printCSV[T OutputFields](data []T, opts printOptions) error {
 	wasmBufMu.Lock()
 	defer wasmBufMu.Unlock()
 	WasmCSVWriter.Reset()
@@ -126,7 +126,7 @@ func printCSV[T OutputFields](data []T) error {
 	}
 
 	// Apply --fields filter if set.
-	if csvFields := getOutputFields(); len(csvFields) > 0 {
+	if csvFields := opts.fields; len(csvFields) > 0 {
 		var err error
 		headers, _, fieldIndices, err = filterByFields(headers, jsonNames, fieldIndices, csvFields)
 		if err != nil {
@@ -137,7 +137,7 @@ func printCSV[T OutputFields](data []T) error {
 		return nil
 	}
 
-	if !getNoHeader() {
+	if !opts.noHeader {
 		if err := w.Write(headers); err != nil {
 			return err
 		}
@@ -184,7 +184,7 @@ func printCSV[T OutputFields](data []T) error {
 }
 
 // printXML is the WASM-specific implementation that properly captures XML output
-func printXML[T OutputFields](data []T) error {
+func printXML[T OutputFields](data []T, opts printOptions) error {
 	wasmBufMu.Lock()
 	defer wasmBufMu.Unlock()
 	WasmXMLWriter.Reset()
@@ -263,7 +263,7 @@ func printXML[T OutputFields](data []T) error {
 	}
 
 	// Apply --fields filter if set.
-	if xmlFields := getOutputFields(); len(xmlFields) > 0 {
+	if xmlFields := opts.fields; len(xmlFields) > 0 {
 		xmlHeaders := make([]string, len(fields))
 		xmlJSONNames := make([]string, len(fields))
 		xmlIndices := make([]int, len(fields))
@@ -353,7 +353,7 @@ func printXML[T OutputFields](data []T) error {
 
 // printGoTemplate is not supported in the WASM build.
 // The error message begins with "invalid output format" so classifyError maps it to exitcodes.Usage.
-func printGoTemplate[T OutputFields](_ []T) error {
+func printGoTemplate[T OutputFields](_ []T, _ printOptions) error {
 	return fmt.Errorf("invalid output format: go-template is not supported in the browser version")
 }
 

--- a/internal/base/output/output_wasm_test.go
+++ b/internal/base/output/output_wasm_test.go
@@ -46,7 +46,7 @@ func TestPrintJSON_WASM(t *testing.T) {
 	js.Global().Delete("wasmJSONOutput")
 
 	// Print JSON
-	err := printJSON(data)
+	err := printJSON(data, currentPrintOptions())
 	assert.NoError(t, err)
 
 	// Verify buffer has content
@@ -74,7 +74,7 @@ func TestPrintJSON_WASM_EmptyData(t *testing.T) {
 
 	WasmJSONWriter.Reset()
 
-	err := printJSON(data)
+	err := printJSON(data, currentPrintOptions())
 	assert.NoError(t, err)
 
 	output := WasmJSONWriter.String()
@@ -96,7 +96,7 @@ func TestPrintJSON_WASM_ComplexData(t *testing.T) {
 
 	WasmJSONWriter.Reset()
 
-	err := printJSON(data)
+	err := printJSON(data, currentPrintOptions())
 	assert.NoError(t, err)
 
 	output := WasmJSONWriter.String()
@@ -118,7 +118,7 @@ func TestPrintCSV_WASM(t *testing.T) {
 	js.Global().Delete("wasmCSVOutput")
 
 	// Print CSV
-	err := printCSV(data)
+	err := printCSV(data, currentPrintOptions())
 	assert.NoError(t, err)
 
 	// Verify buffer has content
@@ -139,7 +139,7 @@ func TestPrintCSV_WASM_EmptyData(t *testing.T) {
 
 	WasmCSVWriter.Reset()
 
-	err := printCSV(data)
+	err := printCSV(data, currentPrintOptions())
 	assert.NoError(t, err)
 
 	output := WasmCSVWriter.String()
@@ -155,7 +155,7 @@ func TestPrintCSV_WASM_SpecialCharacters(t *testing.T) {
 
 	WasmCSVWriter.Reset()
 
-	err := printCSV(data)
+	err := printCSV(data, currentPrintOptions())
 	assert.NoError(t, err)
 
 	output := WasmCSVWriter.String()
@@ -334,16 +334,16 @@ func TestConsoleLogging(t *testing.T) {
 	// All print functions should handle console.log gracefully
 	assert.NotPanics(t, func() {
 		WasmJSONWriter.Reset()
-		_ = printJSON(data)
+		_ = printJSON(data, currentPrintOptions())
 	})
 
 	assert.NotPanics(t, func() {
 		WasmCSVWriter.Reset()
-		_ = printCSV(data)
+		_ = printCSV(data, currentPrintOptions())
 	})
 
 	assert.NotPanics(t, func() {
 		WasmTableWriter.Reset()
-		_ = printTable(data, false)
+		_ = printTable(data, false, currentPrintOptions())
 	})
 }

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -18,9 +18,7 @@ import (
 // SetNoPager disables or enables the pager. When true, output is always written
 // directly to stdout even if it exceeds the terminal height.
 func SetNoPager(v bool) {
-	cfg := GetOutputConfig()
-	cfg.NoPager = v
-	ApplyOutputConfig(cfg)
+	updateOutputConfig(func(c *OutputConfig) { c.NoPager = v })
 }
 
 func getNoPager() bool { return GetOutputConfig().NoPager }

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -21,11 +21,19 @@ func SetNoPager(v bool) {
 	updateOutputConfig(func(c *OutputConfig) { c.NoPager = v })
 }
 
-func getNoPager() bool { return GetOutputConfig().NoPager }
+func getNoPager() bool {
+	outputCfgMu.RLock()
+	defer outputCfgMu.RUnlock()
+	return outputCfg.NoPager
+}
 
 // GetNoPager returns the current no-pager setting. Intended for tests that
 // need to assert the output package was correctly wired by PersistentPreRunE.
-func GetNoPager() bool { return GetOutputConfig().NoPager }
+func GetNoPager() bool {
+	outputCfgMu.RLock()
+	defer outputCfgMu.RUnlock()
+	return outputCfg.NoPager
+}
 
 // resolvePager returns the pager command to use.
 // Precedence: MEGAPORT_PAGER > PAGER > "less -R".

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -29,11 +29,7 @@ func getNoPager() bool {
 
 // GetNoPager returns the current no-pager setting. Intended for tests that
 // need to assert the output package was correctly wired by PersistentPreRunE.
-func GetNoPager() bool {
-	outputCfgMu.RLock()
-	defer outputCfgMu.RUnlock()
-	return outputCfg.NoPager
-}
+func GetNoPager() bool { return getNoPager() }
 
 // resolvePager returns the pager command to use.
 // Precedence: MEGAPORT_PAGER > PAGER > "less -R".

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -15,30 +15,19 @@ import (
 	"golang.org/x/term"
 )
 
-var (
-	noPagerMu  sync.RWMutex
-	noPagerVal bool
-)
-
 // SetNoPager disables or enables the pager. When true, output is always written
 // directly to stdout even if it exceeds the terminal height.
 func SetNoPager(v bool) {
-	noPagerMu.Lock()
-	defer noPagerMu.Unlock()
-	noPagerVal = v
+	cfg := GetOutputConfig()
+	cfg.NoPager = v
+	ApplyOutputConfig(cfg)
 }
 
-func getNoPager() bool {
-	noPagerMu.RLock()
-	defer noPagerMu.RUnlock()
-	return noPagerVal
-}
+func getNoPager() bool { return GetOutputConfig().NoPager }
 
 // GetNoPager returns the current no-pager setting. Intended for tests that
 // need to assert the output package was correctly wired by PersistentPreRunE.
-func GetNoPager() bool {
-	return getNoPager()
-}
+func GetNoPager() bool { return GetOutputConfig().NoPager }
 
 // resolvePager returns the pager command to use.
 // Precedence: MEGAPORT_PAGER > PAGER > "less -R".

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -17,9 +17,7 @@ import (
 // SetNoPager disables or enables the pager. When true, output is always written
 // directly to stdout even if it exceeds the terminal height.
 func SetNoPager(v bool) {
-	cfg := GetOutputConfig()
-	cfg.NoPager = v
-	ApplyOutputConfig(cfg)
+	updateOutputConfig(func(c *OutputConfig) { c.NoPager = v })
 }
 
 func getNoPager() bool { return GetOutputConfig().NoPager }

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -28,11 +28,7 @@ func getNoPager() bool {
 
 // GetNoPager returns the current no-pager setting. Intended for tests that
 // need to assert the output package was correctly wired by PersistentPreRunE.
-func GetNoPager() bool {
-	outputCfgMu.RLock()
-	defer outputCfgMu.RUnlock()
-	return outputCfg.NoPager
-}
+func GetNoPager() bool { return getNoPager() }
 
 // resolvePager returns the pager command to use.
 // Precedence: MEGAPORT_PAGER > PAGER > "less -R".

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -14,30 +14,19 @@ import (
 	"golang.org/x/term"
 )
 
-var (
-	noPagerMu  sync.RWMutex
-	noPagerVal bool
-)
-
 // SetNoPager disables or enables the pager. When true, output is always written
 // directly to stdout even if it exceeds the terminal height.
 func SetNoPager(v bool) {
-	noPagerMu.Lock()
-	defer noPagerMu.Unlock()
-	noPagerVal = v
+	cfg := GetOutputConfig()
+	cfg.NoPager = v
+	ApplyOutputConfig(cfg)
 }
 
-func getNoPager() bool {
-	noPagerMu.RLock()
-	defer noPagerMu.RUnlock()
-	return noPagerVal
-}
+func getNoPager() bool { return GetOutputConfig().NoPager }
 
 // GetNoPager returns the current no-pager setting. Intended for tests that
 // need to assert the output package was correctly wired by PersistentPreRunE.
-func GetNoPager() bool {
-	return getNoPager()
-}
+func GetNoPager() bool { return GetOutputConfig().NoPager }
 
 // resolvePager returns the pager command to use.
 // Precedence: MEGAPORT_PAGER > PAGER > "less -R".

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -20,11 +20,19 @@ func SetNoPager(v bool) {
 	updateOutputConfig(func(c *OutputConfig) { c.NoPager = v })
 }
 
-func getNoPager() bool { return GetOutputConfig().NoPager }
+func getNoPager() bool {
+	outputCfgMu.RLock()
+	defer outputCfgMu.RUnlock()
+	return outputCfg.NoPager
+}
 
 // GetNoPager returns the current no-pager setting. Intended for tests that
 // need to assert the output package was correctly wired by PersistentPreRunE.
-func GetNoPager() bool { return GetOutputConfig().NoPager }
+func GetNoPager() bool {
+	outputCfgMu.RLock()
+	defer outputCfgMu.RUnlock()
+	return outputCfg.NoPager
+}
 
 // resolvePager returns the pager command to use.
 // Precedence: MEGAPORT_PAGER > PAGER > "less -R".

--- a/internal/base/output/pager_test.go
+++ b/internal/base/output/pager_test.go
@@ -138,8 +138,10 @@ func TestRunWithPager_PropagatesFnError(t *testing.T) {
 func TestSetNoPager_RoundTrip(t *testing.T) {
 	SetNoPager(true)
 	assert.True(t, getNoPager())
+	assert.True(t, GetNoPager())
 	SetNoPager(false)
 	assert.False(t, getNoPager())
+	assert.False(t, GetNoPager())
 }
 
 // TestRunWithPager_NoTrailingNewline verifies that output without a trailing

--- a/internal/base/output/pager_test.go
+++ b/internal/base/output/pager_test.go
@@ -151,10 +151,10 @@ func TestSetNoPager_RoundTrip(t *testing.T) {
 func TestSetConfig_NoPager(t *testing.T) {
 	t.Cleanup(ResetState)
 
-	SetConfig(OutputConfig{NoPager: true})
+	ApplyOutputConfig(OutputConfig{NoPager: true})
 	assert.True(t, GetNoPager())
 
-	SetConfig(OutputConfig{NoPager: false})
+	ApplyOutputConfig(OutputConfig{NoPager: false})
 	assert.False(t, GetNoPager())
 }
 

--- a/internal/base/output/pager_test.go
+++ b/internal/base/output/pager_test.go
@@ -137,8 +137,10 @@ func TestRunWithPager_PropagatesFnError(t *testing.T) {
 func TestSetNoPager_RoundTrip(t *testing.T) {
 	SetNoPager(true)
 	assert.True(t, getNoPager())
+	assert.True(t, GetNoPager())
 	SetNoPager(false)
 	assert.False(t, getNoPager())
+	assert.False(t, GetNoPager())
 }
 
 // TestSetConfig_NoPager covers the NoPager field of SetConfig on native

--- a/internal/base/output/pager_wasm.go
+++ b/internal/base/output/pager_wasm.go
@@ -12,7 +12,11 @@ func SetNoPager(v bool) {
 
 // GetNoPager returns the stored no-pager setting. It may be true if the
 // --no-pager flag was passed, but RunWithPager ignores it in WASM builds.
-func GetNoPager() bool { return GetOutputConfig().NoPager }
+func GetNoPager() bool {
+	outputCfgMu.RLock()
+	defer outputCfgMu.RUnlock()
+	return outputCfg.NoPager
+}
 
 // RunWithPager in the WASM build simply calls fn directly. There is no
 // terminal to detect and no process to spawn.

--- a/internal/base/output/pager_wasm.go
+++ b/internal/base/output/pager_wasm.go
@@ -7,9 +7,7 @@ package output
 // value has no effect in the WASM build because RunWithPager always calls fn
 // directly — there is no terminal and no pager process to spawn.
 func SetNoPager(v bool) {
-	cfg := GetOutputConfig()
-	cfg.NoPager = v
-	ApplyOutputConfig(cfg)
+	updateOutputConfig(func(c *OutputConfig) { c.NoPager = v })
 }
 
 // GetNoPager returns the stored no-pager setting. It may be true if the

--- a/internal/base/output/pager_wasm.go
+++ b/internal/base/output/pager_wasm.go
@@ -3,12 +3,18 @@
 
 package output
 
-// SetNoPager is a no-op in the WASM build. The browser environment has no
-// terminal and cannot spawn pager processes.
-func SetNoPager(_ bool) {}
+// SetNoPager stores the no-pager flag in the shared OutputConfig. The stored
+// value has no effect in the WASM build because RunWithPager always calls fn
+// directly — there is no terminal and no pager process to spawn.
+func SetNoPager(v bool) {
+	cfg := GetOutputConfig()
+	cfg.NoPager = v
+	ApplyOutputConfig(cfg)
+}
 
-// GetNoPager always returns false in the WASM build; paging is never active.
-func GetNoPager() bool { return false }
+// GetNoPager returns the stored no-pager setting. It may be true if the
+// --no-pager flag was passed, but RunWithPager ignores it in WASM builds.
+func GetNoPager() bool { return GetOutputConfig().NoPager }
 
 // RunWithPager in the WASM build simply calls fn directly. There is no
 // terminal to detect and no process to spawn.

--- a/internal/base/output/pager_wasm.go
+++ b/internal/base/output/pager_wasm.go
@@ -6,9 +6,7 @@ package output
 // value has no effect in the WASM build because RunWithPager always calls fn
 // directly — there is no terminal and no pager process to spawn.
 func SetNoPager(v bool) {
-	cfg := GetOutputConfig()
-	cfg.NoPager = v
-	ApplyOutputConfig(cfg)
+	updateOutputConfig(func(c *OutputConfig) { c.NoPager = v })
 }
 
 // GetNoPager returns the stored no-pager setting. It may be true if the

--- a/internal/base/output/pager_wasm.go
+++ b/internal/base/output/pager_wasm.go
@@ -2,12 +2,18 @@
 
 package output
 
-// SetNoPager is a no-op in the WASM build. The browser environment has no
-// terminal and cannot spawn pager processes.
-func SetNoPager(_ bool) {}
+// SetNoPager stores the no-pager flag in the shared OutputConfig. The stored
+// value has no effect in the WASM build because RunWithPager always calls fn
+// directly — there is no terminal and no pager process to spawn.
+func SetNoPager(v bool) {
+	cfg := GetOutputConfig()
+	cfg.NoPager = v
+	ApplyOutputConfig(cfg)
+}
 
-// GetNoPager always returns false in the WASM build; paging is never active.
-func GetNoPager() bool { return false }
+// GetNoPager returns the stored no-pager setting. It may be true if the
+// --no-pager flag was passed, but RunWithPager ignores it in WASM builds.
+func GetNoPager() bool { return GetOutputConfig().NoPager }
 
 // RunWithPager in the WASM build simply calls fn directly. There is no
 // terminal to detect and no process to spawn.

--- a/internal/base/output/pager_wasm.go
+++ b/internal/base/output/pager_wasm.go
@@ -11,7 +11,11 @@ func SetNoPager(v bool) {
 
 // GetNoPager returns the stored no-pager setting. It may be true if the
 // --no-pager flag was passed, but RunWithPager ignores it in WASM builds.
-func GetNoPager() bool { return GetOutputConfig().NoPager }
+func GetNoPager() bool {
+	outputCfgMu.RLock()
+	defer outputCfgMu.RUnlock()
+	return outputCfg.NoPager
+}
 
 // RunWithPager in the WASM build simply calls fn directly. There is no
 // terminal to detect and no process to spawn.

--- a/internal/base/output/table.go
+++ b/internal/base/output/table.go
@@ -63,12 +63,12 @@ func calculateDynamicWidth(termWidth int, minWidth, maxPercentage int) int {
 	return maxWidth
 }
 
-func printTable[T OutputFields](data []T, noColor bool) error {
+func printTable[T OutputFields](data []T, noColor bool, opts printOptions) error {
 	headers, jsonNames, fieldIndices, err := getStructTypeInfo(data)
 	if err != nil {
 		return err
 	}
-	if tableFields := getOutputFields(); len(tableFields) > 0 {
+	if tableFields := opts.fields; len(tableFields) > 0 {
 		headers, _, fieldIndices, err = filterByFields(headers, jsonNames, fieldIndices, tableFields)
 		if err != nil {
 			return err
@@ -141,7 +141,7 @@ func printTable[T OutputFields](data []T, noColor bool) error {
 	for _, header := range headers {
 		headerRow = append(headerRow, strings.ToUpper(header))
 	}
-	if !getNoHeader() {
+	if !opts.noHeader {
 		t.AppendHeader(headerRow)
 	}
 	for _, item := range data {

--- a/internal/base/output/table_wasm.go
+++ b/internal/base/output/table_wasm.go
@@ -44,14 +44,14 @@ func calculateDynamicWidth(termWidth int, minWidth, maxPercentage int) int {
 }
 
 // printTable is the WASM-specific implementation that properly captures table output
-func printTable[T OutputFields](data []T, noColor bool) error {
+func printTable[T OutputFields](data []T, noColor bool, opts printOptions) error {
 	wasmBufMu.Lock()
 	defer wasmBufMu.Unlock()
 	headers, jsonNames, fieldIndices, err := getStructTypeInfo(data)
 	if err != nil {
 		return err
 	}
-	if wasmFields := getOutputFields(); len(wasmFields) > 0 {
+	if wasmFields := opts.fields; len(wasmFields) > 0 {
 		headers, _, fieldIndices, err = filterByFields(headers, jsonNames, fieldIndices, wasmFields)
 		if err != nil {
 			return err
@@ -171,7 +171,7 @@ func printTable[T OutputFields](data []T, noColor bool) error {
 	for _, header := range headers {
 		headerRow = append(headerRow, strings.ToUpper(header))
 	}
-	if !getNoHeader() {
+	if !opts.noHeader {
 		t.AppendHeader(headerRow)
 	}
 

--- a/internal/base/output/table_wasm_test.go
+++ b/internal/base/output/table_wasm_test.go
@@ -45,7 +45,7 @@ func TestPrintTable_WASM(t *testing.T) {
 	js.Global().Delete("wasmTableOutput")
 
 	// Print table
-	err := printTable(data, false)
+	err := printTable(data, false, currentPrintOptions())
 	assert.NoError(t, err)
 
 	// Verify buffer has content
@@ -72,7 +72,7 @@ func TestPrintTable_WASM_NoColor(t *testing.T) {
 	WasmTableWriter.Reset()
 
 	// Print with noColor=true
-	err := printTable(data, true)
+	err := printTable(data, true, currentPrintOptions())
 	assert.NoError(t, err)
 
 	output := WasmTableWriter.String()
@@ -93,7 +93,7 @@ func TestPrintTable_WASM_WithColor(t *testing.T) {
 	WasmTableWriter.Reset()
 
 	// Print with noColor=false (colors enabled)
-	err := printTable(data, false)
+	err := printTable(data, false, currentPrintOptions())
 	assert.NoError(t, err)
 
 	output := WasmTableWriter.String()
@@ -110,7 +110,7 @@ func TestPrintTable_WASM_EmptyData(t *testing.T) {
 
 	WasmTableWriter.Reset()
 
-	err := printTable(data, false)
+	err := printTable(data, false, currentPrintOptions())
 	assert.NoError(t, err)
 
 	output := WasmTableWriter.String()
@@ -135,7 +135,7 @@ func TestPrintTable_WASM_ComplexData(t *testing.T) {
 
 	WasmTableWriter.Reset()
 
-	err := printTable(data, false)
+	err := printTable(data, false, currentPrintOptions())
 	assert.NoError(t, err)
 
 	output := WasmTableWriter.String()
@@ -205,7 +205,7 @@ func TestPrintTable_WASM_ColumnWidths(t *testing.T) {
 
 	WasmTableWriter.Reset()
 
-	err := printTable(data, false)
+	err := printTable(data, false, currentPrintOptions())
 	assert.NoError(t, err)
 
 	output := WasmTableWriter.String()
@@ -228,7 +228,7 @@ func TestPrintTable_WASM_BoxDrawing(t *testing.T) {
 
 	WasmTableWriter.Reset()
 
-	err := printTable(data, false)
+	err := printTable(data, false, currentPrintOptions())
 	assert.NoError(t, err)
 
 	output := WasmTableWriter.String()
@@ -253,7 +253,7 @@ func TestPrintTable_WASM_HeaderFormatting(t *testing.T) {
 
 	WasmTableWriter.Reset()
 
-	err := printTable(data, false)
+	err := printTable(data, false, currentPrintOptions())
 	assert.NoError(t, err)
 
 	output := WasmTableWriter.String()
@@ -286,7 +286,7 @@ func TestPrintTable_WASM_GlobalVariable(t *testing.T) {
 	WasmTableWriter.Reset()
 
 	// Print table
-	err := printTable(data, false)
+	err := printTable(data, false, currentPrintOptions())
 	assert.NoError(t, err)
 
 	// Verify global is set
@@ -310,7 +310,7 @@ func TestPrintTable_WASM_ConsoleLogging(t *testing.T) {
 
 	// This should not panic or error even with console.log calls
 	assert.NotPanics(t, func() {
-		err := printTable(data, false)
+		err := printTable(data, false, currentPrintOptions())
 		assert.NoError(t, err)
 	})
 }
@@ -324,7 +324,7 @@ func TestPrintTable_WASM_MegaportStyle(t *testing.T) {
 
 	WasmTableWriter.Reset()
 
-	err := printTable(data, false)
+	err := printTable(data, false, currentPrintOptions())
 	assert.NoError(t, err)
 
 	output := WasmTableWriter.String()

--- a/internal/base/output/verbosity_test.go
+++ b/internal/base/output/verbosity_test.go
@@ -231,7 +231,7 @@ func TestVerbosePrintVerboseWithJSONFormat(t *testing.T) {
 	resetVerbosity(t)
 	SetVerbosity("verbose")
 
-	oldFormat := getOutputFormat()
+	oldFormat := GetOutputFormat()
 	SetOutputFormat("json")
 	defer SetOutputFormat(oldFormat)
 

--- a/internal/base/output/verbosity_test.go
+++ b/internal/base/output/verbosity_test.go
@@ -263,7 +263,7 @@ func TestPrintNewlineWritesToStdout(t *testing.T) {
 func TestPrintNewlineWithJSONFormat(t *testing.T) {
 	resetVerbosity(t)
 
-	oldFormat := getOutputFormat()
+	oldFormat := GetOutputFormat()
 	SetOutputFormat("json")
 	defer SetOutputFormat(oldFormat)
 
@@ -299,7 +299,7 @@ func TestPrintPlainWritesToStdout(t *testing.T) {
 func TestPrintPlainWithJSONFormat(t *testing.T) {
 	resetVerbosity(t)
 
-	oldFormat := getOutputFormat()
+	oldFormat := GetOutputFormat()
 	SetOutputFormat("json")
 	defer SetOutputFormat(oldFormat)
 

--- a/internal/base/output/verbosity_test.go
+++ b/internal/base/output/verbosity_test.go
@@ -230,7 +230,7 @@ func TestVerbosePrintVerboseWithJSONFormat(t *testing.T) {
 	resetVerbosity(t)
 	SetVerbosity("verbose")
 
-	oldFormat := getOutputFormat()
+	oldFormat := GetOutputFormat()
 	SetOutputFormat("json")
 	defer SetOutputFormat(oldFormat)
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -43,7 +43,8 @@ var (
 	// LogHTTP enables raw HTTP request/response logging to stderr. Set via --log-http flag.
 	LogHTTP bool
 
-	ValidFormats = []string{FormatTable, FormatJSON, FormatCSV, FormatXML, FormatGoTemplate}
+	ValidFormats     = []string{FormatTable, FormatJSON, FormatCSV, FormatXML, FormatGoTemplate}
+	ValidFormatsWASM = []string{FormatTable, FormatJSON, FormatCSV, FormatXML}
 )
 
 func ShouldDisableColors() bool {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -70,7 +70,8 @@ var (
 	// BaseURL overrides the API base URL (e.g. http://localhost:8080). Set via --base-url flag.
 	BaseURL string
 
-	ValidFormats = []string{FormatTable, FormatJSON, FormatCSV, FormatXML, FormatGoTemplate}
+	ValidFormats     = []string{FormatTable, FormatJSON, FormatCSV, FormatXML, FormatGoTemplate}
+	ValidFormatsWASM = []string{FormatTable, FormatJSON, FormatCSV, FormatXML}
 )
 
 func ShouldDisableColors() bool {


### PR DESCRIPTION
Replaces seven package-level globals in the `output` package — each with its own mutex — with a single `OutputConfig` struct behind one `sync.RWMutex`. `ResetState()` becomes a single atomic write, the per-field mutex sprawl is gone, and test teardown simplifies.

The full public `Set*`/`Get*` API is preserved as thin shims, so nothing outside the `output` package changes.

## Notable details

- `PersistentPreRunE` collapses three sequential `Set*` calls into one `ApplyOutputConfig`, so output config is applied atomically.
- The WASM entry point (`common_wasm.go`) now wires `--quiet`/`--verbose`, which were previously parsed but silently ignored in browser builds.
- `pager_wasm.go` keeps consistent shims — `NoPager` is stored but `RunWithPager` ignores it in WASM (documented inline).
- Tests swap 26 `defer SetXxx(zero)` patterns for `t.Cleanup(ResetState)`, and add concurrency coverage (`TestApplyOutputConfigConcurrent`, plus a rewritten `TestOutputFormatConcurrency` exercising simultaneous writes to different fields).
