### PR TITLE
fix: satisfy MCRService and NATGatewayService interfaces in test mocks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/jedib0t/go-pretty/v6 v6.7.10
 	github.com/jmespath/go-jmespath v0.4.0
-	github.com/megaport/megaportgo v1.9.0
+	github.com/megaport/megaportgo v1.10.1
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.17 h1:78v8ZlW0bP43XfmAfPsdXcoNCelfMHsDmd/pkENfrjQ=
 github.com/mattn/go-runewidth v0.0.17/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/megaport/megaportgo v1.9.0 h1:jRqNSRs0AK3Pcwx8ibw7kTH9imlGtoFfbFXSR8qaWdc=
-github.com/megaport/megaportgo v1.9.0/go.mod h1:Ee2mHySrxQo3bkpib2TILCtYOL8KfhDXAD1xEVA3aeE=
+github.com/megaport/megaportgo v1.10.1 h1:crItizRSN272/L9L0Kcg1Qg3i2ck4tpmZ1yRmsSGDiA=
+github.com/megaport/megaportgo v1.10.1/go.mod h1:Ee2mHySrxQo3bkpib2TILCtYOL8KfhDXAD1xEVA3aeE=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=

--- a/internal/commands/apply/apply_mock.go
+++ b/internal/commands/apply/apply_mock.go
@@ -64,10 +64,12 @@ func (m *MockPortService) UpdatePortResourceTags(ctx context.Context, portID str
 
 // MockMCRService implements megaport.MCRService for testing.
 type MockMCRService struct {
-	BuyMCRResult        *megaport.BuyMCRResponse
-	BuyMCRErr           error
-	ValidateMCROrderErr error
-	CapturedMCRRequest  *megaport.BuyMCRRequest
+	BuyMCRResult         *megaport.BuyMCRResponse
+	BuyMCRErr            error
+	ValidateMCROrderErr  error
+	CapturedMCRRequest   *megaport.BuyMCRRequest
+	WaitForMCRReadyDelay time.Duration
+	WaitForMCRReadyErr   error
 }
 
 func (m *MockMCRService) BuyMCR(ctx context.Context, req *megaport.BuyMCRRequest) (*megaport.BuyMCRResponse, error) {
@@ -134,7 +136,16 @@ func (m *MockMCRService) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, 
 }
 
 func (m *MockMCRService) WaitForMCRReady(ctx context.Context, mcrID string, timeout time.Duration) error {
-	return nil
+	if m.WaitForMCRReadyDelay > 0 {
+		t := time.NewTimer(m.WaitForMCRReadyDelay)
+		defer t.Stop()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C:
+		}
+	}
+	return m.WaitForMCRReadyErr
 }
 
 // MockMVEService implements megaport.MVEService for testing.

--- a/internal/commands/apply/apply_mock.go
+++ b/internal/commands/apply/apply_mock.go
@@ -3,6 +3,7 @@ package apply
 import (
 	"context"
 	"fmt"
+	"time"
 
 	megaport "github.com/megaport/megaportgo"
 )
@@ -130,6 +131,10 @@ func (m *MockMCRService) UpdateMCRWithAddOn(ctx context.Context, mcrID string, r
 
 func (m *MockMCRService) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, addOnUID string, tunnelCount int) error {
 	return fmt.Errorf("mock: UpdateMCRIPsecAddOn not configured")
+}
+
+func (m *MockMCRService) WaitForMCRReady(ctx context.Context, mcrID string, timeout time.Duration) error {
+	return nil
 }
 
 // MockMVEService implements megaport.MVEService for testing.

--- a/internal/commands/mcr/mcr_mock.go
+++ b/internal/commands/mcr/mcr_mock.go
@@ -59,6 +59,10 @@ type MockMCRService struct {
 	CapturedUpdateMCRIPsecAddOnMCRID  string
 	CapturedUpdateMCRIPsecAddOnUID    string
 	CapturedUpdateMCRIPsecTunnelCount int
+
+	WaitForMCRReadyErr             error
+	CapturedWaitForMCRReadyMCRID   string
+	CapturedWaitForMCRReadyTimeout time.Duration
 }
 
 func (m *MockMCRService) BuyMCR(ctx context.Context, req *megaport.BuyMCRRequest) (*megaport.BuyMCRResponse, error) {
@@ -198,7 +202,9 @@ func (m *MockMCRService) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, 
 }
 
 func (m *MockMCRService) WaitForMCRReady(ctx context.Context, mcrID string, timeout time.Duration) error {
-	return nil
+	m.CapturedWaitForMCRReadyMCRID = mcrID
+	m.CapturedWaitForMCRReadyTimeout = timeout
+	return m.WaitForMCRReadyErr
 }
 
 func (m *MockMCRService) Reset() {
@@ -248,4 +254,7 @@ func (m *MockMCRService) Reset() {
 	m.CapturedUpdateMCRIPsecAddOnMCRID = ""
 	m.CapturedUpdateMCRIPsecAddOnUID = ""
 	m.CapturedUpdateMCRIPsecTunnelCount = 0
+	m.WaitForMCRReadyErr = nil
+	m.CapturedWaitForMCRReadyMCRID = ""
+	m.CapturedWaitForMCRReadyTimeout = 0
 }

--- a/internal/commands/mcr/mcr_mock.go
+++ b/internal/commands/mcr/mcr_mock.go
@@ -2,6 +2,7 @@ package mcr
 
 import (
 	"context"
+	"time"
 
 	megaport "github.com/megaport/megaportgo"
 )
@@ -194,6 +195,10 @@ func (m *MockMCRService) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, 
 	m.CapturedUpdateMCRIPsecAddOnUID = addOnUID
 	m.CapturedUpdateMCRIPsecTunnelCount = tunnelCount
 	return m.UpdateMCRIPsecAddOnErr
+}
+
+func (m *MockMCRService) WaitForMCRReady(ctx context.Context, mcrID string, timeout time.Duration) error {
+	return nil
 }
 
 func (m *MockMCRService) Reset() {

--- a/internal/commands/nat_gateway/nat_gateway_mock.go
+++ b/internal/commands/nat_gateway/nat_gateway_mock.go
@@ -120,6 +120,74 @@ func (m *MockNATGatewayService) BuyNATGateway(ctx context.Context, productUID st
 	return &megaport.NATGatewayBuyResult{ProductUID: productUID}, nil
 }
 
+func (m *MockNATGatewayService) ListNATGatewayPacketFilters(ctx context.Context, productUID string) ([]*megaport.NATGatewayPacketFilterSummary, error) {
+	return nil, nil
+}
+
+func (m *MockNATGatewayService) CreateNATGatewayPacketFilter(ctx context.Context, productUID string, req *megaport.NATGatewayPacketFilterRequest) (*megaport.NATGatewayPacketFilter, error) {
+	return nil, nil
+}
+
+func (m *MockNATGatewayService) GetNATGatewayPacketFilter(ctx context.Context, productUID string, packetFilterID int) (*megaport.NATGatewayPacketFilter, error) {
+	return nil, nil
+}
+
+func (m *MockNATGatewayService) UpdateNATGatewayPacketFilter(ctx context.Context, productUID string, packetFilterID int, req *megaport.NATGatewayPacketFilterRequest) (*megaport.NATGatewayPacketFilter, error) {
+	return nil, nil
+}
+
+func (m *MockNATGatewayService) DeleteNATGatewayPacketFilter(ctx context.Context, productUID string, packetFilterID int) error {
+	return nil
+}
+
+func (m *MockNATGatewayService) ListNATGatewayPrefixLists(ctx context.Context, productUID string) ([]*megaport.NATGatewayPrefixListSummary, error) {
+	return nil, nil
+}
+
+func (m *MockNATGatewayService) CreateNATGatewayPrefixList(ctx context.Context, productUID string, req *megaport.NATGatewayPrefixList) (*megaport.NATGatewayPrefixList, error) {
+	return nil, nil
+}
+
+func (m *MockNATGatewayService) GetNATGatewayPrefixList(ctx context.Context, productUID string, prefixListID int) (*megaport.NATGatewayPrefixList, error) {
+	return nil, nil
+}
+
+func (m *MockNATGatewayService) UpdateNATGatewayPrefixList(ctx context.Context, productUID string, prefixListID int, req *megaport.NATGatewayPrefixList) (*megaport.NATGatewayPrefixList, error) {
+	return nil, nil
+}
+
+func (m *MockNATGatewayService) DeleteNATGatewayPrefixList(ctx context.Context, productUID string, prefixListID int) error {
+	return nil
+}
+
+func (m *MockNATGatewayService) ListNATGatewayIPRoutesAsync(ctx context.Context, productUID, ipAddress string) (string, error) {
+	return "", nil
+}
+
+func (m *MockNATGatewayService) ListNATGatewayBGPRoutesAsync(ctx context.Context, productUID, ipAddress string) (string, error) {
+	return "", nil
+}
+
+func (m *MockNATGatewayService) ListNATGatewayBGPNeighborRoutesAsync(ctx context.Context, req *megaport.NATGatewayBGPNeighborRoutesRequest) (string, error) {
+	return "", nil
+}
+
+func (m *MockNATGatewayService) GetNATGatewayDiagnosticsRoutes(ctx context.Context, productUID, operationID string) ([]*megaport.NATGatewayRoute, error) {
+	return nil, nil
+}
+
+func (m *MockNATGatewayService) ListNATGatewayIPRoutes(ctx context.Context, productUID, ipAddress string) ([]*megaport.NATGatewayIPRoute, error) {
+	return nil, nil
+}
+
+func (m *MockNATGatewayService) ListNATGatewayBGPRoutes(ctx context.Context, productUID, ipAddress string) ([]*megaport.NATGatewayBGPRoute, error) {
+	return nil, nil
+}
+
+func (m *MockNATGatewayService) ListNATGatewayBGPNeighborRoutes(ctx context.Context, req *megaport.NATGatewayBGPNeighborRoutesRequest) ([]*megaport.NATGatewayBGPRoute, error) {
+	return nil, nil
+}
+
 func (m *MockNATGatewayService) Reset() {
 	m.CreateResult = nil
 	m.CreateErr = nil

--- a/internal/commands/nat_gateway/nat_gateway_mock.go
+++ b/internal/commands/nat_gateway/nat_gateway_mock.go
@@ -33,6 +33,76 @@ type MockNATGatewayService struct {
 	CapturedTelemetryReq *megaport.GetNATGatewayTelemetryRequest
 	CapturedBuyUID       string
 	CapturedValidateUID  string
+
+	ListPacketFiltersResult  []*megaport.NATGatewayPacketFilterSummary
+	ListPacketFiltersErr     error
+	CreatePacketFilterResult *megaport.NATGatewayPacketFilter
+	CreatePacketFilterErr    error
+	GetPacketFilterResult    *megaport.NATGatewayPacketFilter
+	GetPacketFilterErr       error
+	UpdatePacketFilterResult *megaport.NATGatewayPacketFilter
+	UpdatePacketFilterErr    error
+	DeletePacketFilterErr    error
+
+	CapturedListPacketFiltersUID  string
+	CapturedCreatePacketFilterUID string
+	CapturedCreatePacketFilterReq *megaport.NATGatewayPacketFilterRequest
+	CapturedGetPacketFilterUID    string
+	CapturedGetPacketFilterID     int
+	CapturedUpdatePacketFilterUID string
+	CapturedUpdatePacketFilterID  int
+	CapturedUpdatePacketFilterReq *megaport.NATGatewayPacketFilterRequest
+	CapturedDeletePacketFilterUID string
+	CapturedDeletePacketFilterID  int
+
+	ListPrefixListsResult  []*megaport.NATGatewayPrefixListSummary
+	ListPrefixListsErr     error
+	CreatePrefixListResult *megaport.NATGatewayPrefixList
+	CreatePrefixListErr    error
+	GetPrefixListResult    *megaport.NATGatewayPrefixList
+	GetPrefixListErr       error
+	UpdatePrefixListResult *megaport.NATGatewayPrefixList
+	UpdatePrefixListErr    error
+	DeletePrefixListErr    error
+
+	CapturedListPrefixListsUID  string
+	CapturedCreatePrefixListUID string
+	CapturedCreatePrefixListReq *megaport.NATGatewayPrefixList
+	CapturedGetPrefixListUID    string
+	CapturedGetPrefixListID     int
+	CapturedUpdatePrefixListUID string
+	CapturedUpdatePrefixListID  int
+	CapturedUpdatePrefixListReq *megaport.NATGatewayPrefixList
+	CapturedDeletePrefixListUID string
+	CapturedDeletePrefixListID  int
+
+	IPRoutesAsyncResult          string
+	IPRoutesAsyncErr             error
+	BGPRoutesAsyncResult         string
+	BGPRoutesAsyncErr            error
+	BGPNeighborRoutesAsyncResult string
+	BGPNeighborRoutesAsyncErr    error
+	DiagnosticsRoutesResult      []*megaport.NATGatewayRoute
+	DiagnosticsRoutesErr         error
+	IPRoutesResult               []*megaport.NATGatewayIPRoute
+	IPRoutesErr                  error
+	BGPRoutesResult              []*megaport.NATGatewayBGPRoute
+	BGPRoutesErr                 error
+	BGPNeighborRoutesResult      []*megaport.NATGatewayBGPRoute
+	BGPNeighborRoutesErr         error
+
+	CapturedIPRoutesAsyncUID          string
+	CapturedIPRoutesAsyncIPAddr       string
+	CapturedBGPRoutesAsyncUID         string
+	CapturedBGPRoutesAsyncIPAddr      string
+	CapturedBGPNeighborRoutesAsyncReq *megaport.NATGatewayBGPNeighborRoutesRequest
+	CapturedDiagnosticsRoutesUID      string
+	CapturedDiagnosticsRoutesOpID     string
+	CapturedIPRoutesUID               string
+	CapturedIPRoutesIPAddr            string
+	CapturedBGPRoutesUID              string
+	CapturedBGPRoutesIPAddr           string
+	CapturedBGPNeighborRoutesReq      *megaport.NATGatewayBGPNeighborRoutesRequest
 }
 
 func (m *MockNATGatewayService) CreateNATGateway(ctx context.Context, req *megaport.CreateNATGatewayRequest) (*megaport.NATGateway, error) {
@@ -121,71 +191,139 @@ func (m *MockNATGatewayService) BuyNATGateway(ctx context.Context, productUID st
 }
 
 func (m *MockNATGatewayService) ListNATGatewayPacketFilters(ctx context.Context, productUID string) ([]*megaport.NATGatewayPacketFilterSummary, error) {
-	return nil, nil
+	m.CapturedListPacketFiltersUID = productUID
+	if m.ListPacketFiltersErr != nil {
+		return nil, m.ListPacketFiltersErr
+	}
+	return m.ListPacketFiltersResult, nil
 }
 
 func (m *MockNATGatewayService) CreateNATGatewayPacketFilter(ctx context.Context, productUID string, req *megaport.NATGatewayPacketFilterRequest) (*megaport.NATGatewayPacketFilter, error) {
-	return nil, nil
+	m.CapturedCreatePacketFilterUID = productUID
+	m.CapturedCreatePacketFilterReq = req
+	if m.CreatePacketFilterErr != nil {
+		return nil, m.CreatePacketFilterErr
+	}
+	return m.CreatePacketFilterResult, nil
 }
 
 func (m *MockNATGatewayService) GetNATGatewayPacketFilter(ctx context.Context, productUID string, packetFilterID int) (*megaport.NATGatewayPacketFilter, error) {
-	return nil, nil
+	m.CapturedGetPacketFilterUID = productUID
+	m.CapturedGetPacketFilterID = packetFilterID
+	if m.GetPacketFilterErr != nil {
+		return nil, m.GetPacketFilterErr
+	}
+	return m.GetPacketFilterResult, nil
 }
 
 func (m *MockNATGatewayService) UpdateNATGatewayPacketFilter(ctx context.Context, productUID string, packetFilterID int, req *megaport.NATGatewayPacketFilterRequest) (*megaport.NATGatewayPacketFilter, error) {
-	return nil, nil
+	m.CapturedUpdatePacketFilterUID = productUID
+	m.CapturedUpdatePacketFilterID = packetFilterID
+	m.CapturedUpdatePacketFilterReq = req
+	if m.UpdatePacketFilterErr != nil {
+		return nil, m.UpdatePacketFilterErr
+	}
+	return m.UpdatePacketFilterResult, nil
 }
 
 func (m *MockNATGatewayService) DeleteNATGatewayPacketFilter(ctx context.Context, productUID string, packetFilterID int) error {
-	return nil
+	m.CapturedDeletePacketFilterUID = productUID
+	m.CapturedDeletePacketFilterID = packetFilterID
+	return m.DeletePacketFilterErr
 }
 
 func (m *MockNATGatewayService) ListNATGatewayPrefixLists(ctx context.Context, productUID string) ([]*megaport.NATGatewayPrefixListSummary, error) {
-	return nil, nil
+	m.CapturedListPrefixListsUID = productUID
+	if m.ListPrefixListsErr != nil {
+		return nil, m.ListPrefixListsErr
+	}
+	return m.ListPrefixListsResult, nil
 }
 
 func (m *MockNATGatewayService) CreateNATGatewayPrefixList(ctx context.Context, productUID string, req *megaport.NATGatewayPrefixList) (*megaport.NATGatewayPrefixList, error) {
-	return nil, nil
+	m.CapturedCreatePrefixListUID = productUID
+	m.CapturedCreatePrefixListReq = req
+	if m.CreatePrefixListErr != nil {
+		return nil, m.CreatePrefixListErr
+	}
+	return m.CreatePrefixListResult, nil
 }
 
 func (m *MockNATGatewayService) GetNATGatewayPrefixList(ctx context.Context, productUID string, prefixListID int) (*megaport.NATGatewayPrefixList, error) {
-	return nil, nil
+	m.CapturedGetPrefixListUID = productUID
+	m.CapturedGetPrefixListID = prefixListID
+	if m.GetPrefixListErr != nil {
+		return nil, m.GetPrefixListErr
+	}
+	return m.GetPrefixListResult, nil
 }
 
 func (m *MockNATGatewayService) UpdateNATGatewayPrefixList(ctx context.Context, productUID string, prefixListID int, req *megaport.NATGatewayPrefixList) (*megaport.NATGatewayPrefixList, error) {
-	return nil, nil
+	m.CapturedUpdatePrefixListUID = productUID
+	m.CapturedUpdatePrefixListID = prefixListID
+	m.CapturedUpdatePrefixListReq = req
+	if m.UpdatePrefixListErr != nil {
+		return nil, m.UpdatePrefixListErr
+	}
+	return m.UpdatePrefixListResult, nil
 }
 
 func (m *MockNATGatewayService) DeleteNATGatewayPrefixList(ctx context.Context, productUID string, prefixListID int) error {
-	return nil
+	m.CapturedDeletePrefixListUID = productUID
+	m.CapturedDeletePrefixListID = prefixListID
+	return m.DeletePrefixListErr
 }
 
 func (m *MockNATGatewayService) ListNATGatewayIPRoutesAsync(ctx context.Context, productUID, ipAddress string) (string, error) {
-	return "", nil
+	m.CapturedIPRoutesAsyncUID = productUID
+	m.CapturedIPRoutesAsyncIPAddr = ipAddress
+	return m.IPRoutesAsyncResult, m.IPRoutesAsyncErr
 }
 
 func (m *MockNATGatewayService) ListNATGatewayBGPRoutesAsync(ctx context.Context, productUID, ipAddress string) (string, error) {
-	return "", nil
+	m.CapturedBGPRoutesAsyncUID = productUID
+	m.CapturedBGPRoutesAsyncIPAddr = ipAddress
+	return m.BGPRoutesAsyncResult, m.BGPRoutesAsyncErr
 }
 
 func (m *MockNATGatewayService) ListNATGatewayBGPNeighborRoutesAsync(ctx context.Context, req *megaport.NATGatewayBGPNeighborRoutesRequest) (string, error) {
-	return "", nil
+	m.CapturedBGPNeighborRoutesAsyncReq = req
+	return m.BGPNeighborRoutesAsyncResult, m.BGPNeighborRoutesAsyncErr
 }
 
 func (m *MockNATGatewayService) GetNATGatewayDiagnosticsRoutes(ctx context.Context, productUID, operationID string) ([]*megaport.NATGatewayRoute, error) {
-	return nil, nil
+	m.CapturedDiagnosticsRoutesUID = productUID
+	m.CapturedDiagnosticsRoutesOpID = operationID
+	if m.DiagnosticsRoutesErr != nil {
+		return nil, m.DiagnosticsRoutesErr
+	}
+	return m.DiagnosticsRoutesResult, nil
 }
 
 func (m *MockNATGatewayService) ListNATGatewayIPRoutes(ctx context.Context, productUID, ipAddress string) ([]*megaport.NATGatewayIPRoute, error) {
-	return nil, nil
+	m.CapturedIPRoutesUID = productUID
+	m.CapturedIPRoutesIPAddr = ipAddress
+	if m.IPRoutesErr != nil {
+		return nil, m.IPRoutesErr
+	}
+	return m.IPRoutesResult, nil
 }
 
 func (m *MockNATGatewayService) ListNATGatewayBGPRoutes(ctx context.Context, productUID, ipAddress string) ([]*megaport.NATGatewayBGPRoute, error) {
-	return nil, nil
+	m.CapturedBGPRoutesUID = productUID
+	m.CapturedBGPRoutesIPAddr = ipAddress
+	if m.BGPRoutesErr != nil {
+		return nil, m.BGPRoutesErr
+	}
+	return m.BGPRoutesResult, nil
 }
 
 func (m *MockNATGatewayService) ListNATGatewayBGPNeighborRoutes(ctx context.Context, req *megaport.NATGatewayBGPNeighborRoutesRequest) ([]*megaport.NATGatewayBGPRoute, error) {
-	return nil, nil
+	m.CapturedBGPNeighborRoutesReq = req
+	if m.BGPNeighborRoutesErr != nil {
+		return nil, m.BGPNeighborRoutesErr
+	}
+	return m.BGPNeighborRoutesResult, nil
 }
 
 func (m *MockNATGatewayService) Reset() {
@@ -213,4 +351,71 @@ func (m *MockNATGatewayService) Reset() {
 	m.CapturedDeleteUID = ""
 	m.CapturedGetUID = ""
 	m.CapturedTelemetryReq = nil
+
+	m.ListPacketFiltersResult = nil
+	m.ListPacketFiltersErr = nil
+	m.CreatePacketFilterResult = nil
+	m.CreatePacketFilterErr = nil
+	m.GetPacketFilterResult = nil
+	m.GetPacketFilterErr = nil
+	m.UpdatePacketFilterResult = nil
+	m.UpdatePacketFilterErr = nil
+	m.DeletePacketFilterErr = nil
+	m.CapturedListPacketFiltersUID = ""
+	m.CapturedCreatePacketFilterUID = ""
+	m.CapturedCreatePacketFilterReq = nil
+	m.CapturedGetPacketFilterUID = ""
+	m.CapturedGetPacketFilterID = 0
+	m.CapturedUpdatePacketFilterUID = ""
+	m.CapturedUpdatePacketFilterID = 0
+	m.CapturedUpdatePacketFilterReq = nil
+	m.CapturedDeletePacketFilterUID = ""
+	m.CapturedDeletePacketFilterID = 0
+
+	m.ListPrefixListsResult = nil
+	m.ListPrefixListsErr = nil
+	m.CreatePrefixListResult = nil
+	m.CreatePrefixListErr = nil
+	m.GetPrefixListResult = nil
+	m.GetPrefixListErr = nil
+	m.UpdatePrefixListResult = nil
+	m.UpdatePrefixListErr = nil
+	m.DeletePrefixListErr = nil
+	m.CapturedListPrefixListsUID = ""
+	m.CapturedCreatePrefixListUID = ""
+	m.CapturedCreatePrefixListReq = nil
+	m.CapturedGetPrefixListUID = ""
+	m.CapturedGetPrefixListID = 0
+	m.CapturedUpdatePrefixListUID = ""
+	m.CapturedUpdatePrefixListID = 0
+	m.CapturedUpdatePrefixListReq = nil
+	m.CapturedDeletePrefixListUID = ""
+	m.CapturedDeletePrefixListID = 0
+
+	m.IPRoutesAsyncResult = ""
+	m.IPRoutesAsyncErr = nil
+	m.BGPRoutesAsyncResult = ""
+	m.BGPRoutesAsyncErr = nil
+	m.BGPNeighborRoutesAsyncResult = ""
+	m.BGPNeighborRoutesAsyncErr = nil
+	m.DiagnosticsRoutesResult = nil
+	m.DiagnosticsRoutesErr = nil
+	m.IPRoutesResult = nil
+	m.IPRoutesErr = nil
+	m.BGPRoutesResult = nil
+	m.BGPRoutesErr = nil
+	m.BGPNeighborRoutesResult = nil
+	m.BGPNeighborRoutesErr = nil
+	m.CapturedIPRoutesAsyncUID = ""
+	m.CapturedIPRoutesAsyncIPAddr = ""
+	m.CapturedBGPRoutesAsyncUID = ""
+	m.CapturedBGPRoutesAsyncIPAddr = ""
+	m.CapturedBGPNeighborRoutesAsyncReq = nil
+	m.CapturedDiagnosticsRoutesUID = ""
+	m.CapturedDiagnosticsRoutesOpID = ""
+	m.CapturedIPRoutesUID = ""
+	m.CapturedIPRoutesIPAddr = ""
+	m.CapturedBGPRoutesUID = ""
+	m.CapturedBGPRoutesIPAddr = ""
+	m.CapturedBGPNeighborRoutesReq = nil
 }

--- a/internal/commands/status/status_mock.go
+++ b/internal/commands/status/status_mock.go
@@ -3,6 +3,7 @@ package status
 import (
 	"context"
 	"fmt"
+	"time"
 
 	megaport "github.com/megaport/megaportgo"
 )
@@ -147,6 +148,10 @@ func (m *MockMCRService) UpdateMCRWithAddOn(_ context.Context, _ string, _ megap
 
 func (m *MockMCRService) UpdateMCRIPsecAddOn(_ context.Context, _ string, _ string, _ int) error {
 	return fmt.Errorf("mock: UpdateMCRIPsecAddOn not configured")
+}
+
+func (m *MockMCRService) WaitForMCRReady(_ context.Context, _ string, _ time.Duration) error {
+	return nil
 }
 
 // MockMVEService is a minimal mock for testing the status dashboard.

--- a/internal/commands/topology/topology_mock.go
+++ b/internal/commands/topology/topology_mock.go
@@ -3,6 +3,7 @@ package topology
 import (
 	"context"
 	"fmt"
+	"time"
 
 	megaport "github.com/megaport/megaportgo"
 )
@@ -110,6 +111,10 @@ func (m *MockMCRService) UpdateMCRWithAddOn(ctx context.Context, mcrID string, r
 
 func (m *MockMCRService) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, addOnUID string, tunnelCount int) error {
 	return fmt.Errorf("mock: UpdateMCRIPsecAddOn not configured")
+}
+
+func (m *MockMCRService) WaitForMCRReady(ctx context.Context, mcrID string, timeout time.Duration) error {
+	return nil
 }
 
 // MockMVEService satisfies megaport.MVEService for testing.


### PR DESCRIPTION
## Summary

Test packages failed to build because the CLI's struct-based mocks no longer satisfied the upstream `megaportgo` service interfaces after new methods were added. This hotfix adds the missing methods as no-op stubs so `go test ./...` builds again.

No production behaviour changes — only test-only `*_mock.go` files are touched.

## Changes

- `MockMCRService.WaitForMCRReady` added in the `apply`, `mcr`, `status`, and `topology` packages
- `MockNATGatewayService` extended with the 17 missing methods covering packet filters, prefix lists, and route/diagnostics endpoints in the `nat_gateway` package
- Bumps `megaportgo` to `v1.10.1`

## Test plan

- [x] `go build -v ./...`
- [x] `go test ./...` — all packages green