### PR TITLE
ci: route homebrew-tap update through mp1-cli-releaser App + PR mode

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,15 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
 
+      - name: Mint installation token for homebrew-tap
+        id: tap-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: megaport
+          repositories: homebrew-tap
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
@@ -53,7 +62,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          HOMEBREW_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
+          HOMEBREW_TOKEN: ${{ steps.tap-token.outputs.token }}
 
       - name: Attest build provenance for release archives
         uses: actions/attest-build-provenance@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -106,6 +106,8 @@ brews:
       owner: megaport
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TOKEN }}"
+      pull_request:
+        enabled: true
     directory: Formula
     homepage: "https://github.com/megaport/megaport-cli"
     description: "CLI tool for managing Megaport network infrastructure"


### PR DESCRIPTION
## Summary

Two coupled changes that together unblock the SLSA attestation step
in the release workflow (it has been silently skipped on every
release since v0.9.0 because GoReleaser exits non-zero before
\`actions/attest-build-provenance@v2\` runs):

1. **goreleaser PR-mode for homebrew-tap** — adds
   \`pull_request.enabled: true\` to the \`brews.repository\` block in
   \`.goreleaser.yml\` so GoReleaser opens a PR against
   \`megaport/homebrew-tap\` instead of pushing directly to its
   default branch. Direct push has been blocked since the
   \`Require PRs for commits\` ruleset's bypass list was tightened
   between v0.8.0 (2026-04-13, last successful direct push) and
   v0.9.1 (2026-04-28, first 409 \`Repository rule violations
   found\`). PR-mode satisfies the ruleset by going through CODEOWNERS
   + 1-approval like any other contributor.
2. **Use the \`mp1-cli-releaser\` GitHub App for tap auth** —
   \`release.yaml\` now mints a 1-hour-TTL installation token via
   \`actions/create-github-app-token@v1\`, scoped to
   \`megaport/homebrew-tap\`, and passes it to GoReleaser as
   \`HOMEBREW_TOKEN\`. The App is already installed on both
   \`megaport-cli\` and \`homebrew-tap\` and \`APP_ID\` /
   \`APP_PRIVATE_KEY\` were populated as secrets on 2026-04-14; this
   PR is the wiring step that finally uses them. Removes the
   user-owned PAT (\`HOMEBREW_TOKEN\`) from the auth path — homebrew-tap
   PRs will be authored by \`mp1-cli-releaser[bot]\` going forward,
   surviving the original PAT owner's offboarding and eliminating an
   annual rotation calendar item.

## Why it was failing

GoReleaser uploads release artifacts (zips, SHA256SUMS,
SHA256SUMS.sig) early in its pipeline, then runs the homebrew tap
update late. v0.9.1 and v0.9.2 logs show:

\`\`\`
• release created/updated url=…/releases/tag/v0.9.2
• homebrew tap formula
  • pushing repository=megaport/homebrew-tap
⨯ release failed after 4m37s
  error=1 error occurred:
    * homebrew tap formula: could not update \"Formula/megaport-cli.rb\":
      PUT …/contents/Formula/megaport-cli.rb: 409 Repository rule
      violations found — Changes must be made through a pull request.
\`\`\`

Goreleaser exit-code 1 prevents the next workflow step,
\`Attest build provenance for release archives\`, from running
(default \`if: success()\` semantics). Result: every release since
v0.9.1 ships zips + GPG-signed SHA256SUMS but **no SLSA
attestation** — \`gh attestation verify\` returns 404 on every
artifact. Switching to PR-mode lets goreleaser exit cleanly so the
attest step lands.

## Prerequisite for this PR to land cleanly

\`mp1-cli-releaser\` is currently configured with
\`Contents: read/write\` + \`Metadata: read\`. PR-mode also needs
**\`Pull requests: Read and write\`** added at
<https://github.com/organizations/megaport/settings/apps/mp1-cli-releaser/permissions>.
After saving, GitHub will prompt to **accept the new permission on
each installation** (\`megaport-cli\` AND \`homebrew-tap\`); both must
be accepted before the installation token will carry the new scope.
No private-key rotation needed.

If this lands before the permission update, the next tagged release
will fail with \`Resource not accessible by integration\` (403) at the
\`Mint installation token for homebrew-tap\` step (or at goreleaser's
PR-creation call — depending on which surface evaluates the scope
first). Sequence the permission change first, then merge here.

## Test plan

- [ ] Confirm \`mp1-cli-releaser\` has \`Pull requests: Read and write\`
  in App settings AND that both \`megaport-cli\` and \`homebrew-tap\`
  installations have **accepted** the new permission (each install's
  page should not show a pending \"new permissions requested\"
  banner).
- [ ] CI passes on this PR (no functional changes outside release.yaml
  + .goreleaser.yml; both only execute on tag push).
- [ ] After merge, cut a patch release tag (e.g. v0.9.3) — the
  workflow run reports **success** end-to-end (no 409, no skipped
  attest step).
- [ ] On the resulting release, run:
  \`\`\`sh
  gh attestation verify megaport-cli_<ver>_<os>_<arch>.zip \\
    --repo megaport/megaport-cli
  gh attestation verify megaport-cli_<ver>_<os>_<arch>.zip \\
    --repo megaport/megaport-cli \\
    --signer-workflow megaport/megaport-cli/.github/workflows/release.yaml@refs/tags/v<ver>
  \`\`\`
  Both print \`✓ Verification succeeded!\`.
- [ ] A PR appears on \`megaport/homebrew-tap\` updating
  \`Formula/megaport-cli.rb\`, **authored by \`mp1-cli-releaser[bot]\`**
  (not by \`MegaportPhilipBrowne\` or \`goreleaserbot\` as the
  authenticated push identity).
- [ ] Decide whether to auto-merge the tap PR via
  \`gh pr merge --auto --squash\` or merge manually each release.
- [ ] Once verified on a tag, delete the now-unused
  \`HOMEBREW_TOKEN\` secret from
  <https://github.com/megaport/megaport-cli/settings/secrets/actions>.

## Downstream impact

The \`megaport/megaport-agent-toolkit\` shim
(\`hosts/claude/bin/megaport-cli\`) currently only does SHA256
verification because no upstream release has carried an attestation.
Once a tag from this fix carries SLSA provenance, the toolkit can
land its companion change to add \`gh attestation verify
--signer-workflow …@refs/tags/vX.Y.Z\` to the shim, closing
megaport/megaport-cli#346 (now merged) and the corresponding toolkit
issue in lockstep.