### PR TITLE
ci: harden GitHub Actions workflows (permissions, SHA pins, Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    ignore:
+      # Major bumps land as deliberate human decisions; minor/patch only.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Wait 7 days after a release before opening an update PR, so any
+    # bad releases or supply-chain incidents have time to surface.
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       github-actions:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -4,12 +4,15 @@ on:
     - cron: '0 2 * * 1'  # Weekly, Monday 02:00 UTC
   workflow_dispatch:       # Allow manual trigger from GitHub UI
 
+permissions:
+  contents: read
+
 jobs:
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
           go-version-file: 'go.mod'
       - name: Run integration tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,37 +17,37 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
-      
-      - uses: actions/setup-go@v5
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
           go-version-file: 'go.mod'
           cache: true
-      
+
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec  # v6.3.0
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811  # v5.1.0
         with:
           args: release --clean
         env:
@@ -56,7 +56,7 @@ jobs:
           HOMEBREW_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
 
       - name: Attest build provenance for release archives
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2.4.0
         with:
           subject-path: |
             dist/megaport-cli_*.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,19 +6,22 @@ on:
       - 'main'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   unit-test:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
           go-version-file: 'go.mod'
       - name: Run Tests
         run: go test -v -coverprofile=coverage.out -covermode=atomic ./...
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238  # v4.6.0
         with:
           files: coverage.out
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary

Hardens the three CI workflows (`test.yml`, `integration-test.yml`, `release.yaml`) against the GitHub Actions script-injection / token-theft class actively exploited in 2025 (HackerBot Claw; same class discussed alongside CVE-2026-3854).

- **Add top-level `permissions: contents: read`** to `test.yml` and `integration-test.yml`. `test.yml` runs on `pull_request` from forks — the default `GITHUB_TOKEN` was over-scoped (write to most resources). Least-privilege is the right default. `release.yaml` already had its permissions explicitly scoped.
- **SHA-pin all third-party actions** (with version comment) instead of mutable major-version tags. Mutable `@v3` / `@v5` / `@v6` references can be silently re-pointed by a compromised maintainer — a high-value target on the **release workflow**, which holds `GPG_PRIVATE_KEY`, `PASSPHRASE`, and `HOMEBREW_TOKEN`.
  - `test.yml`: `actions/checkout` v4.3.1, `actions/setup-go` v5.6.0, `codecov/codecov-action` v4.6.0
  - `integration-test.yml`: `actions/checkout` v4.3.1, `actions/setup-go` v5.6.0
  - `release.yaml`: `actions/checkout` v4.3.1, `actions/setup-go` v5.6.0, `docker/setup-qemu-action` v3.7.0, `docker/setup-buildx-action` v3.12.0, `docker/login-action` v3.7.0, `crazy-max/ghaction-import-gpg` v6.3.0, `goreleaser/goreleaser-action` v5.1.0, `actions/attest-build-provenance` v2.4.0
- **Add `github-actions` ecosystem to Dependabot** so SHA bumps land as reviewable PRs (weekly, grouped, minor/patch only — major bumps stay human decisions).

## What this does *not* change

- No workflow logic, no scope changes to `release.yaml` permissions, no schedule changes to `integration-test.yml`.
- Same Go version, same goreleaser invocation, same Docker steps.

## Threat-model context

The repo's `pull_request` workflow does not use `pull_request_target` and does not unwrap PR-controlled strings (title/body/branch) into `run:` blocks, so there were no live injection findings. This PR closes the surrounding hardening gaps:

| Gap | Before | After |
|---|---|---|
| Token scope on PR runs | implicit (write-most) | `contents: read` |
| Action references (test) | `@v4`/`@v5` | `@<sha>  # v...` |
| Action references (release) | `@v3`/`@v5`/`@v6` | `@<sha>  # v...` |
| Action update visibility | none | weekly grouped Dependabot PRs |

## Test plan

- [ ] CI passes (unit tests + Codecov upload) on this PR
- [ ] Confirm `GITHUB_TOKEN` permissions in the Actions log show `contents: read` only
- [ ] After merge: confirm Dependabot opens the first `github-actions` group PR within a week
- [ ] Next tagged release runs cleanly (no behaviour change in pinned action versions)