### PR TITLE
fix(goreleaser): wire head branch + PR base so homebrew-tap update opens a PR

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -105,9 +105,12 @@ brews:
     repository:
       owner: megaport
       name: homebrew-tap
+      branch: "bump-megaport-cli-{{ .Version }}"
       token: "{{ .Env.HOMEBREW_TOKEN }}"
       pull_request:
         enabled: true
+        base:
+          branch: main
     directory: Formula
     homepage: "https://github.com/megaport/megaport-cli"
     description: "CLI tool for managing Megaport network infrastructure"


### PR DESCRIPTION
## Summary

Follow-up to #350. v0.9.3's release run still failed with the same `409 Repository rule violations found — Changes must be made through a pull request` at the homebrew tap step ([failed run](https://github.com/megaport/megaport-cli/actions/runs/25136781240)) because the `pull_request.enabled: true` flag added in #350 was **necessary but not sufficient** to engage PR mode in goreleaser v1.26.2.

## What was actually happening

Reading `internal/pipe/brew/brew.go::doPublish` in [goreleaser v1.26.2](https://github.com/goreleaser/goreleaser/blob/v1.26.2/internal/pipe/brew/brew.go#L135-L207), the publish flow is:

1. `SyncFork(head=repo, base=PullRequest.Base)` — best-effort. With `PullRequest.Base` empty in our config, this called `GET https://api.github.com/repos//` and emitted the `could not sync fork` warning we saw in the log. Non-fatal.
2. **`cl.CreateFile(ctx, ..., repo, ...)`** — writes `Formula/megaport-cli.rb` to `repo.Branch`. With `repository.branch` unset, [`CreateFile`](https://github.com/goreleaser/goreleaser/blob/v1.26.2/internal/client/github.go#L274-L356) defaults to the repo's default branch (`main`) and does `PUT /repos/megaport/homebrew-tap/contents/Formula/megaport-cli.rb`. **This is the 409** — a direct content write to `main`, blocked by the `Require PRs for commits` ruleset.
3. `OpenPullRequest` is never reached because step 2 returned non-nil.

That's why no PR has ever appeared on `megaport/homebrew-tap` for v0.9.1, v0.9.2, or v0.9.3 — PR mode never actually engaged. Goreleaser was still attempting the same direct push as before #350; the new flag just dangled with no effect because there was no head branch to push to and no PR base to open against.

## App permissions are fine

I ran a throwaway probe workflow on `ci/check-app-permissions` (now deleted) that minted an installation token with `permission-pull-requests: write` scoped to `homebrew-tap`. GitHub returns 422 when the App lacks a requested scope at token-creation time — the mint succeeded, [confirming](https://github.com/megaport/megaport-cli/actions/runs/25182632962) that `mp1-cli-releaser` has both `Contents: write` and `Pull requests: write` granted *and accepted* on the `homebrew-tap` installation. So the prerequisite called out in #350's description is in place; the failure was purely the missing config.

## The fix

Set the two fields the v1.26.2 PR-mode flow actually reads:

```yaml
brews:
  - repository:
      owner: megaport
      name: homebrew-tap
      branch: "bump-megaport-cli-{{ .Version }}"   # head — the feature branch goreleaser pushes to
      token: "{{ .Env.HOMEBREW_TOKEN }}"
      pull_request:
        enabled: true
        base:
          branch: main                              # base — the PR target on homebrew-tap
```

`base.owner` and `base.name` default to `repository.owner`/`repository.name`, so they don't need restating. With these two lines, goreleaser will:

1. Create `refs/heads/bump-megaport-cli-X.Y.Z` in `megaport/homebrew-tap` (allowed — the ruleset blocks direct writes to `main`, not feature-branch creation)
2. Write the updated `Formula/megaport-cli.rb` to that branch
3. Open a PR from that branch into `main` of `homebrew-tap` — authored by `mp1-cli-releaser[bot]`

…which is what #350 intended.

## Knock-on benefit

This also unblocks the SLSA `Attest build provenance for release archives` step in `release.yaml` for the first time. The attest step has `if: success()` semantics by default and has been silently skipped on every release since v0.9.0 because goreleaser exited non-zero before reaching it. Once goreleaser exits 0, the attest step lands and `gh attestation verify` will succeed against the release archives — finally closing the loop on the work tracked in #348.

## Test plan

- [ ] CI passes on this PR (no functional changes outside `.goreleaser.yml`; only takes effect on tag push).
- [ ] After merge, cut v0.9.4 — the workflow run reports **success** end-to-end.
- [ ] A PR appears on `megaport/homebrew-tap`:
  - branch `bump-megaport-cli-0.9.4`, base `main`
  - file changed: `Formula/megaport-cli.rb`
  - **authored by `mp1-cli-releaser[bot]`** (not `MegaportPhilipBrowne`, not `goreleaserbot`)
- [ ] `Attest build provenance for release archives` step runs (no longer skipped) and the resulting release artifacts pass:
  ```sh
  gh attestation verify megaport-cli_0.9.4_<os>_<arch>.zip --repo megaport/megaport-cli
  gh attestation verify megaport-cli_0.9.4_<os>_<arch>.zip \
    --repo megaport/megaport-cli \
    --signer-workflow megaport/megaport-cli/.github/workflows/release.yaml@refs/tags/v0.9.4
  ```
- [ ] Decide whether to auto-merge each release's tap PR via `gh pr merge --auto --squash`, or merge manually.
- [ ] Once verified, delete the now-unused `HOMEBREW_TOKEN` secret from <https://github.com/megaport/megaport-cli/settings/secrets/actions>.