### PR TITLE
chore: remove deprecated build tags

### DIFF
--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package megaport
 

--- a/cmd/megaport/megaport.go
+++ b/cmd/megaport/megaport.go
@@ -1,5 +1,4 @@
 //go:build !js && !wasm
-// +build !js,!wasm
 
 package megaport
 

--- a/cmd/megaport/megaport_common.go
+++ b/cmd/megaport/megaport_common.go
@@ -1,5 +1,4 @@
 //go:build !wasm
-// +build !wasm
 
 package megaport
 

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -1,5 +1,4 @@
 //go:build !js && !wasm
-// +build !js,!wasm
 
 package megaport
 

--- a/cmd/megaport/megaport_wasm.go
+++ b/cmd/megaport/megaport_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package megaport
 

--- a/cmd/megaport/modules_wasm.go
+++ b/cmd/megaport/modules_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package megaport
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -1,5 +1,4 @@
 //go:build !js && !wasm
-// +build !js,!wasm
 
 package main
 

--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -1,5 +1,4 @@
 //go:build !js && !wasm
-// +build !js,!wasm
 
 package main
 

--- a/docs/INTEGRATION_TESTING.md
+++ b/docs/INTEGRATION_TESTING.md
@@ -42,7 +42,6 @@ All integration test files use the `//go:build integration` build tag:
 
 ```go
 //go:build integration
-// +build integration
 
 package ports
 ```

--- a/internal/base/output/messages_native.go
+++ b/internal/base/output/messages_native.go
@@ -1,5 +1,4 @@
 //go:build !wasm
-// +build !wasm
 
 package output
 

--- a/internal/base/output/messages_native_test.go
+++ b/internal/base/output/messages_native_test.go
@@ -1,5 +1,4 @@
 //go:build !wasm
-// +build !wasm
 
 package output
 

--- a/internal/base/output/messages_wasm.go
+++ b/internal/base/output/messages_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package output
 

--- a/internal/base/output/output.go
+++ b/internal/base/output/output.go
@@ -1,5 +1,4 @@
 //go:build !wasm
-// +build !wasm
 
 package output
 

--- a/internal/base/output/output_wasm.go
+++ b/internal/base/output/output_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package output
 

--- a/internal/base/output/output_wasm_test.go
+++ b/internal/base/output/output_wasm_test.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package output
 

--- a/internal/base/output/pager.go
+++ b/internal/base/output/pager.go
@@ -1,5 +1,4 @@
 //go:build !wasm
-// +build !wasm
 
 package output
 

--- a/internal/base/output/pager_test.go
+++ b/internal/base/output/pager_test.go
@@ -1,5 +1,4 @@
 //go:build !wasm
-// +build !wasm
 
 package output
 

--- a/internal/base/output/pager_wasm.go
+++ b/internal/base/output/pager_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package output
 

--- a/internal/base/output/spinner_native.go
+++ b/internal/base/output/spinner_native.go
@@ -1,5 +1,4 @@
 //go:build !wasm
-// +build !wasm
 
 package output
 

--- a/internal/base/output/spinner_wasm.go
+++ b/internal/base/output/spinner_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package output
 

--- a/internal/base/output/table.go
+++ b/internal/base/output/table.go
@@ -1,5 +1,4 @@
 //go:build !wasm
-// +build !wasm
 
 package output
 

--- a/internal/base/output/table_wasm.go
+++ b/internal/base/output/table_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package output
 

--- a/internal/base/output/table_wasm_test.go
+++ b/internal/base/output/table_wasm_test.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package output
 

--- a/internal/base/output/verbosity_test.go
+++ b/internal/base/output/verbosity_test.go
@@ -1,5 +1,4 @@
 //go:build !wasm
-// +build !wasm
 
 package output
 

--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -1,5 +1,4 @@
 //go:build !js || !wasm
-// +build !js !wasm
 
 package config
 

--- a/internal/commands/config/config_actions_test.go
+++ b/internal/commands/config/config_actions_test.go
@@ -1,5 +1,4 @@
 //go:build !js && !wasm
-// +build !js,!wasm
 
 package config
 

--- a/internal/commands/config/config_module.go
+++ b/internal/commands/config/config_module.go
@@ -1,5 +1,4 @@
 //go:build !js || !wasm
-// +build !js !wasm
 
 package config
 

--- a/internal/commands/config/config_module_wasm.go
+++ b/internal/commands/config/config_module_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package config
 

--- a/internal/commands/config/config_wasm.go
+++ b/internal/commands/config/config_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package config
 

--- a/internal/commands/config/login.go
+++ b/internal/commands/config/login.go
@@ -1,5 +1,4 @@
 //go:build !js && !wasm
-// +build !js,!wasm
 
 package config
 

--- a/internal/commands/config/login_wasm.go
+++ b/internal/commands/config/login_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package config
 

--- a/internal/commands/config/manager_test.go
+++ b/internal/commands/config/manager_test.go
@@ -1,5 +1,4 @@
 //go:build !js && !wasm
-// +build !js,!wasm
 
 package config
 

--- a/internal/commands/config/manager_wasm.go
+++ b/internal/commands/config/manager_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package config
 

--- a/internal/commands/config/storage_wasm.go
+++ b/internal/commands/config/storage_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package config
 

--- a/internal/commands/locations/locations_actions_wasm.go
+++ b/internal/commands/locations/locations_actions_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package locations
 

--- a/internal/commands/locations/locations_integration_test.go
+++ b/internal/commands/locations/locations_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package locations
 

--- a/internal/commands/mcr/mcr_actions_wasm.go
+++ b/internal/commands/mcr/mcr_actions_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package mcr
 

--- a/internal/commands/mve/mve_actions_wasm.go
+++ b/internal/commands/mve/mve_actions_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package mve
 

--- a/internal/commands/ports/ports_actions_wasm.go
+++ b/internal/commands/ports/ports_actions_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package ports
 

--- a/internal/commands/vxc/vxc_actions_wasm.go
+++ b/internal/commands/vxc/vxc_actions_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package vxc
 

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -1,5 +1,4 @@
 //go:build !js && !wasm
-// +build !js,!wasm
 
 package server
 

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -1,5 +1,4 @@
 //go:build !js && !wasm
-// +build !js,!wasm
 
 package server
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,4 @@
 //go:build !js && !wasm
-// +build !js,!wasm
 
 package server
 

--- a/internal/server/session.go
+++ b/internal/server/session.go
@@ -1,5 +1,4 @@
 //go:build !js && !wasm
-// +build !js,!wasm
 
 package server
 

--- a/internal/server/session_test.go
+++ b/internal/server/session_test.go
@@ -1,5 +1,4 @@
 //go:build !js && !wasm
-// +build !js,!wasm
 
 package server
 

--- a/internal/testutil/integration.go
+++ b/internal/testutil/integration.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package testutil
 

--- a/internal/utils/prompts_wasm.go
+++ b/internal/utils/prompts_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package utils
 

--- a/internal/utils/prompts_wasm_test.go
+++ b/internal/utils/prompts_wasm_test.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package utils
 

--- a/internal/utils/watch_native.go
+++ b/internal/utils/watch_native.go
@@ -1,5 +1,4 @@
 //go:build !wasm
-// +build !wasm
 
 package utils
 

--- a/internal/utils/watch_test.go
+++ b/internal/utils/watch_test.go
@@ -1,5 +1,4 @@
 //go:build !wasm
-// +build !wasm
 
 package utils
 

--- a/internal/utils/watch_wasm.go
+++ b/internal/utils/watch_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package utils
 

--- a/internal/wasm/api/api.go
+++ b/internal/wasm/api/api.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package api
 

--- a/internal/wasm/prompts.go
+++ b/internal/wasm/prompts.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package wasm
 

--- a/internal/wasm/prompts_test.go
+++ b/internal/wasm/prompts_test.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package wasm
 

--- a/internal/wasm/stub.go
+++ b/internal/wasm/stub.go
@@ -1,5 +1,4 @@
 //go:build !js && !wasm
-// +build !js,!wasm
 
 package wasm
 

--- a/internal/wasm/stub_test.go
+++ b/internal/wasm/stub_test.go
@@ -1,5 +1,4 @@
 //go:build !js && !wasm
-// +build !js,!wasm
 
 package wasm
 

--- a/internal/wasm/wasm.go
+++ b/internal/wasm/wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package wasm
 

--- a/internal/wasm/wasm_test.go
+++ b/internal/wasm/wasm_test.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package wasm
 

--- a/internal/wasm/wasmhttp/transport.go
+++ b/internal/wasm/wasmhttp/transport.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package wasmhttp
 

--- a/main.go
+++ b/main.go
@@ -1,5 +1,4 @@
 //go:build !js || !wasm
-// +build !js !wasm
 
 package main
 

--- a/main_wasm.go
+++ b/main_wasm.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package main
 

--- a/main_wasm_test.go
+++ b/main_wasm_test.go
@@ -1,5 +1,4 @@
 //go:build js && wasm
-// +build js,wasm
 
 package main
 


### PR DESCRIPTION
## Contributions

Please read the (Contribution Guidelines)[https://github.com/megaport/megaportgo/wiki/Contributing.md]
prior to lodging Pull Requests (PR).

## Description

Old style build tag syntax `// +build` hasn't been needed since Go 1.17. Let's remove those.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Contributor Agreement

Lodging this Pull Request (PR) indicates agreement with the project's 
(Contributor License Agreement)[https://github.com/megaport/megaportgo/wiki/Megaport_Contributor_Licence_Agreement.md].

Please read the Contributor Licence Agreement (CLA) and affirm your acceptance here:

[I have read an accept the CLA]

**NOTE** If multiple authors have commited to this PR, each one will need to comment on this PR and 
agree to the CLA before this PR can be accepted.
