### PR TITLE
ESD-1184: Default all cancel commands to immediate, opt-in deferred via --later

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,8 +305,8 @@ megaport-cli ports update PORT_UID --name "Updated Port" --marketplace-visibilit
 megaport-cli ports update PORT_UID --json '{"name":"Updated Port","marketplaceVisibility":true}'
 megaport-cli ports update PORT_UID --json-file ./update-port-config.json
 
-# Delete a port
-megaport-cli ports delete PORT_UID --now
+# Delete a port (ports are always deleted immediately)
+megaport-cli ports delete PORT_UID
 
 # Restore a deleted port
 megaport-cli ports restore PORT_UID

--- a/README.md
+++ b/README.md
@@ -343,8 +343,8 @@ megaport-cli mcr update MCR_UID --name "Updated MCR" --cost-centre "IT-123"
 megaport-cli mcr update MCR_UID --json '{"name":"Updated MCR","costCentre":"IT-123"}'
 megaport-cli mcr update MCR_UID --json-file ./update-mcr-config.json
 
-# Delete an MCR
-megaport-cli mcr delete MCR_UID --now
+# Delete an MCR (immediate)
+megaport-cli mcr delete MCR_UID
 
 # Restore a deleted MCR
 megaport-cli mcr restore MCR_UID
@@ -397,8 +397,8 @@ megaport-cli mve update MVE_UID --interactive
 megaport-cli mve update MVE_UID --name "Updated MVE Name" --cost-centre "New Cost Centre" --contract-term 24
 megaport-cli mve update MVE_UID --json '{"name": "New MVE Name", "costCentre": "New Cost Centre", "contractTermMonths": 24}'
 
-# Delete an MVE
-megaport-cli mve delete MVE_UID --now
+# Delete an MVE (immediate)
+megaport-cli mve delete MVE_UID
 
 # List all available MVE images
 megaport-cli mve list-images

--- a/docs/guides/aws-direct-connect.md
+++ b/docs/guides/aws-direct-connect.md
@@ -156,9 +156,9 @@ To remove the connection when no longer needed:
 
 ```sh
 # Delete VXC first
-megaport-cli vxc delete vxc-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --now
+megaport-cli vxc delete vxc-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
-# Then delete the port (ports are always deleted immediately)
+# Then delete the port
 megaport-cli ports delete port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 

--- a/docs/guides/aws-direct-connect.md
+++ b/docs/guides/aws-direct-connect.md
@@ -158,8 +158,8 @@ To remove the connection when no longer needed:
 # Delete VXC first
 megaport-cli vxc delete vxc-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --now
 
-# Then delete the port
-megaport-cli ports delete port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --now
+# Then delete the port (ports are always deleted immediately)
+megaport-cli ports delete port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
 ## Related Commands

--- a/docs/guides/multi-cloud-connectivity.md
+++ b/docs/guides/multi-cloud-connectivity.md
@@ -275,13 +275,13 @@ Once all VXCs are LIVE, complete the setup in each cloud console:
 Delete VXCs before deleting the MCR:
 
 ```sh
-# Delete VXCs first
-megaport-cli vxc delete vxc-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --now  # AWS
-megaport-cli vxc delete vxc-yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy --now  # Azure
-megaport-cli vxc delete vxc-zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz --now  # GCP
+# Delete VXCs first (immediate by default; pass --later to defer to end of billing cycle)
+megaport-cli vxc delete vxc-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx  # AWS
+megaport-cli vxc delete vxc-yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy  # Azure
+megaport-cli vxc delete vxc-zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz  # GCP
 
 # Then delete the MCR
-megaport-cli mcr delete mcr-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --now
+megaport-cli mcr delete mcr-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
 ## Related Commands

--- a/docs/guides/portal-to-cli-migration.md
+++ b/docs/guides/portal-to-cli-migration.md
@@ -170,13 +170,13 @@ VXCs must be deleted before deleting their parent port or MCR:
 
 ```sh
 # Delete VXCs first
-megaport-cli vxc delete vxc-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --now
+megaport-cli vxc delete vxc-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
-# Then delete the port (ports are always deleted immediately)
+# Then delete the port
 megaport-cli ports delete port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
-> **Note:** For VXCs and other deferred-cancellation resources, omit `--now` to schedule deletion at the end of the current billing period. Ports no longer support deferred cancellation and are always deleted immediately.
+> **Note:** All `delete` commands now cancel resources immediately by default — billing stops right away. VXCs and IXs are the only resource types that still accept deferred cancellation; pass `--later` to schedule cancellation for the end of the current billing cycle instead.
 
 ### Manage billing contact
 
@@ -319,7 +319,7 @@ VXCS=$(megaport-cli vxc list --a-end-uid "$PORT_UID" --output json \
 
 for uid in $VXCS; do
   echo "Deleting VXC ${uid}..."
-  megaport-cli vxc delete "$uid" --now --force --quiet
+  megaport-cli vxc delete "$uid" --force --quiet
 done
 
 echo "Deleting port ${PORT_UID}..."

--- a/docs/guides/portal-to-cli-migration.md
+++ b/docs/guides/portal-to-cli-migration.md
@@ -172,11 +172,11 @@ VXCs must be deleted before deleting their parent port or MCR:
 # Delete VXCs first
 megaport-cli vxc delete vxc-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --now
 
-# Then delete the port
-megaport-cli ports delete port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --now
+# Then delete the port (ports are always deleted immediately)
+megaport-cli ports delete port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
-> **Note:** Omit `--now` to schedule deletion at the end of the current billing period instead of immediately.
+> **Note:** For VXCs and other deferred-cancellation resources, omit `--now` to schedule deletion at the end of the current billing period. Ports no longer support deferred cancellation and are always deleted immediately.
 
 ### Manage billing contact
 
@@ -226,10 +226,10 @@ megaport-cli ports get port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --export > my-p
 
 ### Skip confirmation prompts in scripts
 
-Use `--force` to suppress interactive prompts and `--now` for immediate deletion:
+Use `--force` to suppress interactive prompts (ports are always deleted immediately):
 
 ```sh
-megaport-cli ports delete port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --now --force
+megaport-cli ports delete port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --force
 ```
 
 ### Get machine-readable output
@@ -323,7 +323,7 @@ for uid in $VXCS; do
 done
 
 echo "Deleting port ${PORT_UID}..."
-megaport-cli ports delete "$PORT_UID" --now --force --quiet
+megaport-cli ports delete "$PORT_UID" --force --quiet
 echo "Done."
 ```
 

--- a/docs/megaport-cli_ix_delete.md
+++ b/docs/megaport-cli_ix_delete.md
@@ -6,14 +6,18 @@ Delete an IX from your account
 
 Delete an IX from your account.
 
-This command allows you to delete an IX from your account. By default, the IX will be scheduled for deletion at the end of the current billing period.
+Deletion is immediate by default; pass --later to schedule cancellation at the end of the current billing cycle instead.
+
+### Important Notes
+  - Deletion is immediate by default; billing stops right away
+  - Use --later to defer cancellation to the end of the current billing cycle
 
 ### Example Usage
 
 ```sh
   megaport-cli ix delete [ixUID]
-  megaport-cli ix delete [ixUID] --now
-  megaport-cli ix delete [ixUID] --now --force
+  megaport-cli ix delete [ixUID] --force
+  megaport-cli ix delete [ixUID] --later
 ```
 
 ## Usage
@@ -35,7 +39,7 @@ megaport-cli ix delete [flags]
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
 | `--force` | `-f` | `false` | Skip confirmation prompt | false |
-| `--now` |  | `false` | Delete resource immediately instead of at end of billing cycle | false |
+| `--later` |  | `false` | Schedule deletion at the end of the current billing cycle (default: delete immediately) | false |
 
 ## Subcommands
 * [docs](megaport-cli_ix_delete_docs.md)

--- a/docs/megaport-cli_mcr_delete.md
+++ b/docs/megaport-cli_mcr_delete.md
@@ -6,14 +6,18 @@ Delete an MCR from your account
 
 Delete an MCR from your account.
 
-This command allows you to delete an MCR from your account. By default, the MCR will be scheduled for deletion at the end of the current billing period.
+MCRs are deleted immediately; deferred end-of-term cancellation is not supported by the API.
+
+### Important Notes
+  - Deletion is immediate; billing stops right away
+  - Deletion is final and cannot be undone
 
 ### Example Usage
 
 ```sh
   megaport-cli mcr delete [mcrUID]
-  megaport-cli mcr delete [mcrUID] --now
-  megaport-cli mcr delete [mcrUID] --now --force
+  megaport-cli mcr delete [mcrUID] --force
+  megaport-cli mcr delete [mcrUID] --force --safe-delete
 ```
 
 ## Usage
@@ -35,7 +39,6 @@ megaport-cli mcr delete [flags]
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
 | `--force` | `-f` | `false` | Skip confirmation prompt | false |
-| `--now` |  | `false` | Delete resource immediately instead of at end of billing cycle | false |
 | `--safe-delete` |  | `false` | Fail if the resource has attached VXCs or other active services | false |
 
 ## Subcommands

--- a/docs/megaport-cli_mve_delete.md
+++ b/docs/megaport-cli_mve_delete.md
@@ -6,19 +6,19 @@ Delete an existing MVE
 
 Delete an existing Megaport Virtual Edge (MVE).
 
-This command allows you to delete an existing MVE by providing its UID.
+MVEs are deleted immediately; deferred end-of-term cancellation is not supported by the API.
 
 ### Important Notes
-  - Deletion is final and cannot be undone
-  - Billing for the MVE stops at the end of the current billing period unless --now is specified
+  - Deletion is immediate; billing stops right away
   - All associated VXCs will be automatically terminated
+  - Deletion is final and cannot be undone
 
 ### Example Usage
 
 ```sh
   megaport-cli mve delete 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p
   megaport-cli mve delete 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --force
-  megaport-cli mve delete 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --now
+  megaport-cli mve delete 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --force --safe-delete
 ```
 
 ## Usage
@@ -40,7 +40,6 @@ megaport-cli mve delete [flags]
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
 | `--force` | `-f` | `false` | Skip confirmation prompt | false |
-| `--now` |  | `false` | Delete resource immediately instead of at end of billing cycle | false |
 | `--safe-delete` |  | `false` | Fail if the resource has attached VXCs or other active services | false |
 
 ## Subcommands

--- a/docs/megaport-cli_ports_delete.md
+++ b/docs/megaport-cli_ports_delete.md
@@ -6,14 +6,15 @@ Delete a port from your account
 
 Delete a port from your account in the Megaport API.
 
-This command allows you to delete an existing port by providing the UID of the port as an argument. By default, the port will be scheduled for deletion at the end of the current billing period.
+This command deletes an existing port by providing the UID of the port as an argument. Ports are deleted immediately; deferred cancellation at the end of the billing period is no longer supported.
 
 ### Optional Fields
   - `force`: Skip the confirmation prompt and proceed with deletion
-  - `now`: Delete the port immediately instead of waiting until the end of the billing period
+  - `safe-delete`: Fail if the resource has attached VXCs or other active services
 
 ### Important Notes
   - All VXCs associated with the port must be deleted before the port can be deleted
+  - Ports are deleted immediately; the previous 'terminate later' option is no longer available
   - You can restore a deleted port before it's fully decommissioned using the 'restore' command
   - Once a port is fully decommissioned, restoration is not possible
 
@@ -21,8 +22,7 @@ This command allows you to delete an existing port by providing the UID of the p
 
 ```sh
   megaport-cli ports delete 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p
-  megaport-cli ports delete 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --now
-  megaport-cli ports delete 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --now --force
+  megaport-cli ports delete 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --force
 ```
 
 ## Usage
@@ -44,7 +44,6 @@ megaport-cli ports delete [flags]
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
 | `--force` | `-f` | `false` | Skip confirmation prompt | false |
-| `--now` |  | `false` | Delete resource immediately instead of at end of billing cycle | false |
 | `--safe-delete` |  | `false` | Fail if the resource has attached VXCs or other active services | false |
 
 ## Subcommands

--- a/docs/megaport-cli_vxc_delete.md
+++ b/docs/megaport-cli_vxc_delete.md
@@ -6,19 +6,19 @@ Delete an existing Virtual Cross Connect (VXC)
 
 Delete an existing Virtual Cross Connect (VXC) through the Megaport API.
 
-This command allows you to delete an existing VXC by providing its UID.
+This command allows you to delete an existing VXC by providing its UID. Deletion is immediate by default; pass --later to schedule cancellation at the end of the current billing cycle instead.
 
 ### Important Notes
+  - Deletion is immediate by default; the VXC is disconnected and billing stops right away
+  - Use --later to defer cancellation to the end of the current billing cycle (not supported for Transit VXCs)
   - Deletion is final and cannot be undone
-  - Billing for the VXC stops at the end of the current billing period
-  - The VXC is immediately disconnected upon deletion
 
 ### Example Usage
 
 ```sh
   megaport-cli vxc delete vxc-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   megaport-cli vxc delete vxc-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --force
-  megaport-cli vxc delete vxc-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --now
+  megaport-cli vxc delete vxc-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --later
 ```
 
 ## Usage
@@ -40,7 +40,7 @@ megaport-cli vxc delete [flags]
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
 | `--force` | `-f` | `false` | Skip confirmation prompt | false |
-| `--now` |  | `false` | Delete resource immediately instead of at end of billing cycle | false |
+| `--later` |  | `false` | Schedule deletion at the end of the current billing cycle (default: delete immediately) | false |
 
 ## Subcommands
 * [docs](megaport-cli_vxc_delete_docs.md)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/jedib0t/go-pretty/v6 v6.7.10
 	github.com/jmespath/go-jmespath v0.4.0
-	github.com/megaport/megaportgo v1.10.3
+	github.com/megaport/megaportgo v1.11.0
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.17 h1:78v8ZlW0bP43XfmAfPsdXcoNCelfMHsDmd/pkENfrjQ=
 github.com/mattn/go-runewidth v0.0.17/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/megaport/megaportgo v1.10.3 h1:/VfzT7faS4QQrGBqDF6+SxBYy4RNKBMcvTVokDRIHbo=
-github.com/megaport/megaportgo v1.10.3/go.mod h1:Ee2mHySrxQo3bkpib2TILCtYOL8KfhDXAD1xEVA3aeE=
+github.com/megaport/megaportgo v1.11.0 h1:cSfopzOQLs3yWlLmSPZYGDNE7IErZD7wWEb92IFccDs=
+github.com/megaport/megaportgo v1.11.0/go.mod h1:Ee2mHySrxQo3bkpib2TILCtYOL8KfhDXAD1xEVA3aeE=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=

--- a/internal/base/cmdbuilder/flagsets.go
+++ b/internal/base/cmdbuilder/flagsets.go
@@ -54,6 +54,14 @@ func (b *CommandBuilder) WithSafeDeleteFlags() *CommandBuilder {
 	return b
 }
 
+// WithImmediateSafeDeleteFlags adds delete flags for resources that only support
+// immediate deletion (no --now flag), with safe-delete support.
+func (b *CommandBuilder) WithImmediateSafeDeleteFlags() *CommandBuilder {
+	b.WithBoolFlagP("force", "f", false, "Skip confirmation prompt")
+	b.WithBoolFlag("safe-delete", false, "Fail if the resource has attached VXCs or other active services")
+	return b
+}
+
 // WithBuyConfirmFlags adds the --yes/-y flag to skip buy confirmation prompts
 func (b *CommandBuilder) WithBuyConfirmFlags() *CommandBuilder {
 	b.WithBoolFlagP("yes", "y", false, "Skip confirmation prompt for purchase")

--- a/internal/base/cmdbuilder/flagsets.go
+++ b/internal/base/cmdbuilder/flagsets.go
@@ -62,6 +62,23 @@ func (b *CommandBuilder) WithImmediateSafeDeleteFlags() *CommandBuilder {
 	return b
 }
 
+// WithImmediateDeleteFlags adds delete flags for resources that only support
+// immediate deletion (no --now flag), without safe-delete support.
+func (b *CommandBuilder) WithImmediateDeleteFlags() *CommandBuilder {
+	b.WithBoolFlagP("force", "f", false, "Skip confirmation prompt")
+	return b
+}
+
+// WithDeferredDeleteFlags adds delete flags for resources where immediate
+// deletion is the default and deferred end-of-term cancellation is opt-in
+// via --later. Used by VXC and IX, which are the only product types whose
+// API still accepts CANCEL (end-of-term).
+func (b *CommandBuilder) WithDeferredDeleteFlags() *CommandBuilder {
+	b.WithBoolFlagP("force", "f", false, "Skip confirmation prompt")
+	b.WithBoolFlag("later", false, "Schedule deletion at the end of the current billing cycle (default: delete immediately)")
+	return b
+}
+
 // WithBuyConfirmFlags adds the --yes/-y flag to skip buy confirmation prompts
 func (b *CommandBuilder) WithBuyConfirmFlags() *CommandBuilder {
 	b.WithBoolFlagP("yes", "y", false, "Skip confirmation prompt for purchase")

--- a/internal/base/cmdbuilder/flagsets_test.go
+++ b/internal/base/cmdbuilder/flagsets_test.go
@@ -76,6 +76,32 @@ func TestWithSafeDeleteFlags(t *testing.T) {
 	assertFlagType(t, cmd, "safe-delete", "bool")
 }
 
+func TestWithDeferredDeleteFlags(t *testing.T) {
+	cmd := NewCommand("test", "test").WithDeferredDeleteFlags().Build()
+
+	assertFlagExists(t, cmd, "force", "false")
+	assertFlagType(t, cmd, "force", "bool")
+	f := cmd.Flags().Lookup("force")
+	assert.Equal(t, "f", f.Shorthand)
+
+	assertFlagExists(t, cmd, "later", "false")
+	assertFlagType(t, cmd, "later", "bool")
+
+	// --now must not be present; that's the whole point of the new helper.
+	assert.Nil(t, cmd.Flags().Lookup("now"))
+}
+
+func TestWithImmediateDeleteFlags(t *testing.T) {
+	cmd := NewCommand("test", "test").WithImmediateDeleteFlags().Build()
+
+	assertFlagExists(t, cmd, "force", "false")
+	assertFlagType(t, cmd, "force", "bool")
+
+	// No --now and no --later for resources that only support immediate deletion.
+	assert.Nil(t, cmd.Flags().Lookup("now"))
+	assert.Nil(t, cmd.Flags().Lookup("later"))
+}
+
 func TestWithBuyConfirmFlags(t *testing.T) {
 	cmd := NewCommand("test", "test").WithBuyConfirmFlags().Build()
 

--- a/internal/commands/ix/ix.go
+++ b/internal/commands/ix/ix.go
@@ -97,11 +97,13 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 	deleteIXCmd := cmdbuilder.NewCommand("delete", "Delete an IX from your account").
 		WithArgs(cobra.ExactArgs(1)).
 		WithColorAwareRunFunc(DeleteIX).
-		WithDeleteFlags().
-		WithLongDesc("Delete an IX from your account.\n\nThis command allows you to delete an IX from your account. By default, the IX will be scheduled for deletion at the end of the current billing period.").
+		WithDeferredDeleteFlags().
+		WithLongDesc("Delete an IX from your account.\n\nDeletion is immediate by default; pass --later to schedule cancellation at the end of the current billing cycle instead.").
 		WithExample("megaport-cli ix delete [ixUID]").
-		WithExample("megaport-cli ix delete [ixUID] --now").
-		WithExample("megaport-cli ix delete [ixUID] --now --force").
+		WithExample("megaport-cli ix delete [ixUID] --force").
+		WithExample("megaport-cli ix delete [ixUID] --later").
+		WithImportantNote("Deletion is immediate by default; billing stops right away").
+		WithImportantNote("Use --later to defer cancellation to the end of the current billing cycle").
 		WithRootCmd(rootCmd).
 		WithAliases([]string{"rm"}).
 		Build()

--- a/internal/commands/ix/ix_actions.go
+++ b/internal/commands/ix/ix_actions.go
@@ -366,10 +366,11 @@ func DeleteIX(cmd *cobra.Command, args []string, noColor bool) error {
 
 	ixUID := args[0]
 
-	deleteNow, err := cmd.Flags().GetBool("now")
+	later, err := cmd.Flags().GetBool("later")
 	if err != nil {
 		return err
 	}
+	deleteNow := !later
 
 	force, err := cmd.Flags().GetBool("force")
 	if err != nil {

--- a/internal/commands/ix/ix_actions_test.go
+++ b/internal/commands/ix/ix_actions_test.go
@@ -821,23 +821,35 @@ func TestDeleteIX(t *testing.T) {
 	}()
 
 	tests := []struct {
-		name           string
-		ixUID          string
-		force          bool
-		deleteNow      bool
-		promptResponse string
-		setupMock      func(*MockIXService)
-		expectedError  string
-		expectedOutput string
-		expectDeleted  bool
+		name              string
+		ixUID             string
+		force             bool
+		later             bool
+		promptResponse    string
+		setupMock         func(*MockIXService)
+		expectedError     string
+		expectedOutput    string
+		expectDeleted     bool
+		expectedDeleteNow *bool
 	}{
 		{
-			name:           "confirm deletion with force",
-			ixUID:          "ix-to-delete",
-			force:          true,
-			setupMock:      func(m *MockIXService) {},
-			expectedOutput: "IX deleted",
-			expectDeleted:  true,
+			name:              "force delete defaults to immediate",
+			ixUID:             "ix-to-delete",
+			force:             true,
+			setupMock:         func(m *MockIXService) {},
+			expectedOutput:    "IX deleted",
+			expectDeleted:     true,
+			expectedDeleteNow: boolPtr(true),
+		},
+		{
+			name:              "force with --later defers cancellation",
+			ixUID:             "ix-to-delete-later",
+			force:             true,
+			later:             true,
+			setupMock:         func(m *MockIXService) {},
+			expectedOutput:    "IX deleted",
+			expectDeleted:     true,
+			expectedDeleteNow: boolPtr(false),
 		},
 		{
 			name:           "confirm deletion with prompt",
@@ -893,14 +905,14 @@ func TestDeleteIX(t *testing.T) {
 				},
 			}
 			cmd.Flags().BoolP("force", "f", false, "Force deletion without confirmation")
-			cmd.Flags().Bool("now", false, "Delete IX immediately")
+			cmd.Flags().Bool("later", false, "Defer deletion to end of billing cycle")
 			err := cmd.Flags().Set("force", fmt.Sprintf("%v", tt.force))
 			if err != nil {
 				t.Fatalf("Failed to set force flag: %v", err)
 			}
-			err = cmd.Flags().Set("now", fmt.Sprintf("%v", tt.deleteNow))
+			err = cmd.Flags().Set("later", fmt.Sprintf("%v", tt.later))
 			if err != nil {
-				t.Fatalf("Failed to set now flag: %v", err)
+				t.Fatalf("Failed to set later flag: %v", err)
 			}
 
 			capturedOutput := output.CaptureOutput(func() {
@@ -917,10 +929,18 @@ func TestDeleteIX(t *testing.T) {
 				if tt.expectDeleted {
 					assert.Equal(t, tt.ixUID, mockService.capturedDeleteIXUID)
 				}
+				if tt.expectedDeleteNow != nil {
+					if assert.NotNil(t, mockService.capturedDeleteIXReq, "expected DeleteIX to be called") {
+						assert.Equal(t, *tt.expectedDeleteNow, mockService.capturedDeleteIXReq.DeleteNow,
+							"DeleteNow value does not match expectation")
+					}
+				}
 			}
 		})
 	}
 }
+
+func boolPtr(b bool) *bool { return &b }
 
 func TestGetIX(t *testing.T) {
 	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})

--- a/internal/commands/mcr/mcr.go
+++ b/internal/commands/mcr/mcr.go
@@ -136,11 +136,13 @@ func buildMCRCommands(rootCmd *cobra.Command) (get, buy, update, del, restore, l
 	del = cmdbuilder.NewCommand("delete", "Delete an MCR from your account").
 		WithArgs(cobra.ExactArgs(1)).
 		WithColorAwareRunFunc(DeleteMCR).
-		WithSafeDeleteFlags().
-		WithLongDesc("Delete an MCR from your account.\n\nThis command allows you to delete an MCR from your account. By default, the MCR will be scheduled for deletion at the end of the current billing period.").
+		WithImmediateSafeDeleteFlags().
+		WithLongDesc("Delete an MCR from your account.\n\nMCRs are deleted immediately; deferred end-of-term cancellation is not supported by the API.").
 		WithExample("megaport-cli mcr delete [mcrUID]").
-		WithExample("megaport-cli mcr delete [mcrUID] --now").
-		WithExample("megaport-cli mcr delete [mcrUID] --now --force").
+		WithExample("megaport-cli mcr delete [mcrUID] --force").
+		WithExample("megaport-cli mcr delete [mcrUID] --force --safe-delete").
+		WithImportantNote("Deletion is immediate; billing stops right away").
+		WithImportantNote("Deletion is final and cannot be undone").
 		WithRootCmd(rootCmd).
 		WithAliases([]string{"rm"}).
 		Build()

--- a/internal/commands/mcr/mcr_actions_manage.go
+++ b/internal/commands/mcr/mcr_actions_manage.go
@@ -23,11 +23,6 @@ func DeleteMCR(cmd *cobra.Command, args []string, noColor bool) error {
 
 	mcrUID := args[0]
 
-	deleteNow, err := cmd.Flags().GetBool("now")
-	if err != nil {
-		return err
-	}
-
 	force, err := cmd.Flags().GetBool("force")
 	if err != nil {
 		return err
@@ -46,9 +41,11 @@ func DeleteMCR(cmd *cobra.Command, args []string, noColor bool) error {
 		return fmt.Errorf("failed to get safe-delete flag: %w", err)
 	}
 
+	// MCRs only support immediate deletion (CANCEL_NOW); the SDK rejects
+	// DeleteNow=false with ErrMCRCancelLaterNotAllowed.
 	deleteRequest := &megaport.DeleteMCRRequest{
 		MCRID:      mcrUID,
-		DeleteNow:  deleteNow,
+		DeleteNow:  true,
 		SafeDelete: safeDelete,
 	}
 
@@ -69,7 +66,7 @@ func DeleteMCR(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	if resp.IsDeleting {
-		output.PrintResourceDeleted("MCR", mcrUID, deleteNow, noColor)
+		output.PrintResourceDeleted("MCR", mcrUID, true, noColor)
 	} else {
 		output.PrintError("MCR deletion request was not successful", noColor)
 	}

--- a/internal/commands/mcr/mcr_actions_test.go
+++ b/internal/commands/mcr/mcr_actions_test.go
@@ -136,7 +136,6 @@ func TestDeleteMCRCmd_WithMockClient(t *testing.T) {
 		name           string
 		mcrID          string
 		force          bool
-		deleteNow      bool
 		safeDelete     bool
 		promptResponse string
 		setupMock      func(*MockMCRService)
@@ -148,7 +147,6 @@ func TestDeleteMCRCmd_WithMockClient(t *testing.T) {
 			name:           "confirm deletion",
 			mcrID:          "mcr-to-delete",
 			force:          false,
-			deleteNow:      false,
 			promptResponse: "y",
 			setupMock: func(m *MockMCRService) {
 				m.DeleteMCRResult = &megaport.DeleteMCRResponse{
@@ -162,7 +160,6 @@ func TestDeleteMCRCmd_WithMockClient(t *testing.T) {
 			name:           "safe delete flag passed to request",
 			mcrID:          "mcr-safe-delete",
 			force:          true,
-			deleteNow:      false,
 			safeDelete:     true,
 			promptResponse: "",
 			setupMock: func(m *MockMCRService) {
@@ -174,24 +171,9 @@ func TestDeleteMCRCmd_WithMockClient(t *testing.T) {
 			expectDeleted:  true,
 		},
 		{
-			name:           "confirm immediate deletion",
-			mcrID:          "mcr-to-delete-now",
-			force:          false,
-			deleteNow:      true,
-			promptResponse: "y",
-			setupMock: func(m *MockMCRService) {
-				m.DeleteMCRResult = &megaport.DeleteMCRResponse{
-					IsDeleting: true,
-				}
-			},
-			expectedOutput: "MCR deleted",
-			expectDeleted:  true,
-		},
-		{
-			name:      "force deletion",
-			mcrID:     "mcr-force-delete",
-			force:     true,
-			deleteNow: false,
+			name:  "force deletion",
+			mcrID: "mcr-force-delete",
+			force: true,
 			setupMock: func(m *MockMCRService) {
 				m.DeleteMCRResult = &megaport.DeleteMCRResponse{
 					IsDeleting: true,
@@ -250,11 +232,9 @@ func TestDeleteMCRCmd_WithMockClient(t *testing.T) {
 				},
 			}
 			cmd.Flags().BoolP("force", "f", false, "Force deletion without confirmation")
-			cmd.Flags().Bool("now", false, "Delete MCR immediately instead of at end of billing cycle")
 			cmd.Flags().Bool("safe-delete", false, "Fail if the resource has attached VXCs or other active services")
 			flags := map[string]string{
 				"force": fmt.Sprintf("%v", tt.force),
-				"now":   fmt.Sprintf("%v", tt.deleteNow),
 			}
 			if tt.safeDelete {
 				flags["safe-delete"] = "true"
@@ -276,6 +256,8 @@ func TestDeleteMCRCmd_WithMockClient(t *testing.T) {
 				if tt.expectDeleted {
 					assert.NotNil(t, mockMCRService.CapturedDeleteMCRUID)
 					assert.Equal(t, tt.mcrID, mockMCRService.CapturedDeleteMCRUID)
+					assert.True(t, mockMCRService.CapturedDeleteMCRRequest.DeleteNow,
+						"MCR delete must always send DeleteNow=true (SDK rejects deferred deletion)")
 					if tt.safeDelete {
 						assert.True(t, mockMCRService.CapturedDeleteMCRRequest.SafeDelete)
 					}

--- a/internal/commands/mve/mve.go
+++ b/internal/commands/mve/mve.go
@@ -120,14 +120,14 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 	deleteMVECmd := cmdbuilder.NewCommand("delete", "Delete an existing MVE").
 		WithArgs(cobra.ExactArgs(1)).
 		WithColorAwareRunFunc(DeleteMVE).
-		WithSafeDeleteFlags().
-		WithLongDesc("Delete an existing Megaport Virtual Edge (MVE).\n\nThis command allows you to delete an existing MVE by providing its UID.").
+		WithImmediateSafeDeleteFlags().
+		WithLongDesc("Delete an existing Megaport Virtual Edge (MVE).\n\nMVEs are deleted immediately; deferred end-of-term cancellation is not supported by the API.").
 		WithExample("megaport-cli mve delete 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p").
 		WithExample("megaport-cli mve delete 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --force").
-		WithExample("megaport-cli mve delete 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --now").
-		WithImportantNote("Deletion is final and cannot be undone").
-		WithImportantNote("Billing for the MVE stops at the end of the current billing period unless --now is specified").
+		WithExample("megaport-cli mve delete 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --force --safe-delete").
+		WithImportantNote("Deletion is immediate; billing stops right away").
 		WithImportantNote("All associated VXCs will be automatically terminated").
+		WithImportantNote("Deletion is final and cannot be undone").
 		WithRootCmd(rootCmd).
 		WithAliases([]string{"rm"}).
 		Build()

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -544,8 +544,7 @@ func DeleteMVE(cmd *cobra.Command, args []string, noColor bool) error {
 		return fmt.Errorf("failed to delete MVE: %w", err)
 	}
 
-	// MVEs always delete immediately (SDK hardcodes DeleteNow: true), so the
-	// --now flag has no API effect. Always report as immediate deletion.
+	// MVEs always delete immediately (SDK hardcodes DeleteNow: true).
 	if resp.IsDeleted {
 		output.PrintResourceDeleted("MVE", mveUID, true, noColor)
 	} else {

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -473,7 +473,6 @@ func TestDeleteMVE(t *testing.T) {
 		mockSetup      func(*MockMVEService)
 		confirmDelete  bool
 		forceFlag      bool
-		nowFlag        bool
 		safeDeleteFlag bool
 		expectedError  string
 		expectedOutput string
@@ -521,15 +520,6 @@ func TestDeleteMVE(t *testing.T) {
 			forceFlag:      true,
 			expectedOutput: "MVE deleted mve-uid",
 		},
-		{
-			name: "immediate deletion",
-			mockSetup: func(m *MockMVEService) {
-				m.DeleteMVEErr = nil
-			},
-			confirmDelete:  true,
-			nowFlag:        true,
-			expectedOutput: "MVE deleted mve-uid",
-		},
 	}
 
 	for _, tt := range tests {
@@ -556,7 +546,6 @@ func TestDeleteMVE(t *testing.T) {
 			}
 
 			cmd.Flags().Bool("force", tt.forceFlag, "")
-			cmd.Flags().Bool("now", tt.nowFlag, "")
 			cmd.Flags().Bool("safe-delete", false, "")
 			if tt.safeDeleteFlag {
 				_ = cmd.Flags().Set("safe-delete", "true")

--- a/internal/commands/ports/ports.go
+++ b/internal/commands/ports/ports.go
@@ -245,8 +245,7 @@ func buildPortManagementCommands(rootCmd *cobra.Command) (list, get, status, del
 	deleteCmd = cmdbuilder.NewCommand("delete", "Delete a port from your account").
 		WithArgs(cobra.ExactArgs(1)).
 		WithColorAwareRunFunc(DeletePort).
-		WithBoolFlagP("force", "f", false, "Skip confirmation prompt").
-		WithBoolFlag("safe-delete", false, "Fail if the resource has attached VXCs or other active services").
+		WithImmediateSafeDeleteFlags().
 		WithLongDesc("Delete a port from your account in the Megaport API.\n\nThis command deletes an existing port by providing the UID of the port as an argument. Ports are deleted immediately; deferred cancellation at the end of the billing period is no longer supported.").
 		WithOptionalFlag("force", "Skip the confirmation prompt and proceed with deletion").
 		WithOptionalFlag("safe-delete", "Fail if the resource has attached VXCs or other active services").

--- a/internal/commands/ports/ports.go
+++ b/internal/commands/ports/ports.go
@@ -245,16 +245,17 @@ func buildPortManagementCommands(rootCmd *cobra.Command) (list, get, status, del
 	deleteCmd = cmdbuilder.NewCommand("delete", "Delete a port from your account").
 		WithArgs(cobra.ExactArgs(1)).
 		WithColorAwareRunFunc(DeletePort).
-		WithSafeDeleteFlags().
-		WithLongDesc("Delete a port from your account in the Megaport API.\n\nThis command allows you to delete an existing port by providing the UID of the port as an argument. By default, the port will be scheduled for deletion at the end of the current billing period.").
-		WithOptionalFlag("now", "Delete the port immediately instead of waiting until the end of the billing period").
+		WithBoolFlagP("force", "f", false, "Skip confirmation prompt").
+		WithBoolFlag("safe-delete", false, "Fail if the resource has attached VXCs or other active services").
+		WithLongDesc("Delete a port from your account in the Megaport API.\n\nThis command deletes an existing port by providing the UID of the port as an argument. Ports are deleted immediately; deferred cancellation at the end of the billing period is no longer supported.").
 		WithOptionalFlag("force", "Skip the confirmation prompt and proceed with deletion").
+		WithOptionalFlag("safe-delete", "Fail if the resource has attached VXCs or other active services").
 		WithImportantNote("All VXCs associated with the port must be deleted before the port can be deleted").
+		WithImportantNote("Ports are deleted immediately; the previous 'terminate later' option is no longer available").
 		WithImportantNote("You can restore a deleted port before it's fully decommissioned using the 'restore' command").
 		WithImportantNote("Once a port is fully decommissioned, restoration is not possible").
 		WithExample("megaport-cli ports delete 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p").
-		WithExample("megaport-cli ports delete 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --now").
-		WithExample("megaport-cli ports delete 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --now --force").
+		WithExample("megaport-cli ports delete 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --force").
 		WithRootCmd(rootCmd).
 		WithAliases([]string{"rm"}).
 		Build()

--- a/internal/commands/ports/ports_actions_manage.go
+++ b/internal/commands/ports/ports_actions_manage.go
@@ -114,12 +114,6 @@ func DeletePort(cmd *cobra.Command, args []string, noColor bool) error {
 
 	portUID := args[0]
 
-	deleteNow, err := cmd.Flags().GetBool("now")
-	if err != nil {
-		output.PrintError("Failed to get delete now flag: %v", noColor, err)
-		return err
-	}
-
 	force, err := cmd.Flags().GetBool("force")
 	if err != nil {
 		output.PrintError("Failed to get force flag: %v", noColor, err)
@@ -140,9 +134,13 @@ func DeletePort(cmd *cobra.Command, args []string, noColor bool) error {
 		return err
 	}
 
+	// Ports only support immediate deletion (CANCEL_NOW). The previous
+	// "terminate later" option is no longer offered by the Megaport API,
+	// and DeletePort requests with DeleteNow=false are rejected by the SDK
+	// with ErrPortCancelLaterNotAllowed.
 	deleteRequest := &megaport.DeletePortRequest{
 		PortID:     portUID,
-		DeleteNow:  deleteNow,
+		DeleteNow:  true,
 		SafeDelete: safeDelete,
 	}
 
@@ -170,7 +168,7 @@ func DeletePort(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	if resp.IsDeleting {
-		output.PrintResourceDeleted("Port", portUID, deleteNow, noColor)
+		output.PrintResourceDeleted("Port", portUID, true, noColor)
 	} else {
 		output.PrintWarning("Port deletion request was not successful", noColor)
 	}

--- a/internal/commands/ports/ports_actions_test.go
+++ b/internal/commands/ports/ports_actions_test.go
@@ -2063,7 +2063,6 @@ func TestDeletePort_Comprehensive(t *testing.T) {
 	tests := []struct {
 		name             string
 		force            bool
-		deleteNow        bool
 		confirmResult    bool
 		deleteErr        error
 		isDeleting       bool
@@ -2101,13 +2100,6 @@ func TestDeletePort_Comprehensive(t *testing.T) {
 			isDeleting:       false,
 			expectedContains: "not successful",
 		},
-		{
-			name:             "delete now flag",
-			force:            true,
-			deleteNow:        true,
-			isDeleting:       true,
-			expectedContains: "port-123",
-		},
 	}
 
 	for _, tt := range tests {
@@ -2123,7 +2115,9 @@ func TestDeletePort_Comprehensive(t *testing.T) {
 				return tt.confirmResult
 			})
 
+			var capturedReq *megaport.DeletePortRequest
 			deletePortFunc = func(ctx context.Context, client *megaport.Client, req *megaport.DeletePortRequest) (*megaport.DeletePortResponse, error) {
+				capturedReq = req
 				if tt.deleteErr != nil {
 					return nil, tt.deleteErr
 				}
@@ -2132,20 +2126,22 @@ func TestDeletePort_Comprehensive(t *testing.T) {
 
 			cmd := &cobra.Command{Use: "delete"}
 			cmd.Flags().Bool("force", false, "")
-			cmd.Flags().Bool("now", false, "")
 			cmd.Flags().Bool("safe-delete", false, "")
 
 			if tt.force {
 				require.NoError(t, cmd.Flags().Set("force", "true"))
-			}
-			if tt.deleteNow {
-				require.NoError(t, cmd.Flags().Set("now", "true"))
 			}
 
 			var err error
 			capturedOutput := output.CaptureOutput(func() {
 				err = DeletePort(cmd, []string{"port-123"}, true)
 			})
+
+			// Ports must always be deleted immediately — the previous
+			// "terminate later" option is no longer supported.
+			if capturedReq != nil {
+				assert.True(t, capturedReq.DeleteNow, "DeletePort must always set DeleteNow=true")
+			}
 
 			if tt.expectedError != "" {
 				assert.Error(t, err)

--- a/internal/commands/vxc/vxc.go
+++ b/internal/commands/vxc/vxc.go
@@ -164,14 +164,14 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 	deleteVXCCmd := cmdbuilder.NewCommand("delete", "Delete an existing Virtual Cross Connect (VXC)").
 		WithArgs(cobra.ExactArgs(1)).
 		WithColorAwareRunFunc(DeleteVXC).
-		WithDeleteFlags().
-		WithLongDesc("Delete an existing Virtual Cross Connect (VXC) through the Megaport API.\n\nThis command allows you to delete an existing VXC by providing its UID.").
+		WithDeferredDeleteFlags().
+		WithLongDesc("Delete an existing Virtual Cross Connect (VXC) through the Megaport API.\n\nThis command allows you to delete an existing VXC by providing its UID. Deletion is immediate by default; pass --later to schedule cancellation at the end of the current billing cycle instead.").
 		WithExample("megaport-cli vxc delete vxc-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx").
 		WithExample("megaport-cli vxc delete vxc-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --force").
-		WithExample("megaport-cli vxc delete vxc-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --now").
+		WithExample("megaport-cli vxc delete vxc-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --later").
+		WithImportantNote("Deletion is immediate by default; the VXC is disconnected and billing stops right away").
+		WithImportantNote("Use --later to defer cancellation to the end of the current billing cycle (not supported for Transit VXCs)").
 		WithImportantNote("Deletion is final and cannot be undone").
-		WithImportantNote("Billing for the VXC stops at the end of the current billing period").
-		WithImportantNote("The VXC is immediately disconnected upon deletion").
 		WithRootCmd(rootCmd).
 		WithAliases([]string{"rm"}).
 		Build()

--- a/internal/commands/vxc/vxc_actions.go
+++ b/internal/commands/vxc/vxc_actions.go
@@ -441,7 +441,8 @@ func DeleteVXC(cmd *cobra.Command, args []string, noColor bool) error {
 	formattedUID := output.FormatUID(vxcUID, noColor)
 
 	force, _ := cmd.Flags().GetBool("force")
-	deleteNow, _ := cmd.Flags().GetBool("now")
+	later, _ := cmd.Flags().GetBool("later")
+	deleteNow := !later
 
 	if !force {
 		message := fmt.Sprintf("Are you sure you want to delete VXC %s?", formattedUID)

--- a/internal/commands/vxc/vxc_actions_test.go
+++ b/internal/commands/vxc/vxc_actions_test.go
@@ -1895,28 +1895,29 @@ func TestDeleteVXC(t *testing.T) {
 		expectedOutput string
 	}{
 		{
-			name:   "force delete success",
+			name:   "force delete defaults to immediate",
 			vxcUID: "vxc-del-1",
 			flags: map[string]string{
 				"force": "true",
 			},
 			setupMock: func() {
 				deleteVXCFunc = func(ctx context.Context, client *megaport.Client, vxcUID string, req *megaport.DeleteVXCRequest) error {
+					assert.True(t, req.DeleteNow, "default delete must be immediate")
 					return nil
 				}
 			},
 			expectedOutput: "deleted",
 		},
 		{
-			name:   "force and now delete success",
+			name:   "force with --later defers cancellation",
 			vxcUID: "vxc-del-2",
 			flags: map[string]string{
 				"force": "true",
-				"now":   "true",
+				"later": "true",
 			},
 			setupMock: func() {
 				deleteVXCFunc = func(ctx context.Context, client *megaport.Client, vxcUID string, req *megaport.DeleteVXCRequest) error {
-					assert.True(t, req.DeleteNow)
+					assert.False(t, req.DeleteNow, "--later must defer cancellation")
 					return nil
 				}
 			},
@@ -1981,7 +1982,7 @@ func TestDeleteVXC(t *testing.T) {
 
 			cmd := &cobra.Command{Use: "delete [vxcUID]"}
 			cmd.Flags().Bool("force", false, "")
-			cmd.Flags().Bool("now", false, "")
+			cmd.Flags().Bool("later", false, "")
 
 			testutil.SetFlags(t, cmd, tt.flags)
 


### PR DESCRIPTION
Cancellation behavior was inconsistent: `ports delete` cancelled immediately, but `vxc`/`ix delete` defaulted to deferred (end-of-billing-cycle), and `mcr`/`mve delete` carried a `--now` flag the SDK ignored. This makes every delete command immediate by default, with deferred as an explicit opt-in only where the API actually supports it.

| Command | API supports deferred? | Default | Opt-in flag |
|---|---|---|---|
| `ports delete` | No | now | — |
| `mcr delete` | No | now | — |
| `mve delete` | No | now | — |
| `vxc delete` | Yes | now | `--later` |
| `ix delete` | Yes | now | `--later` |

- Original ESD-1184 scope: the API/SDK no longer accept `DeleteNow=false` for ports, so `DeletePort` hardcodes immediate and the `--now` flag is gone.
- `mcr`/`mve delete` drop their no-op `--now` flag and hardcode immediate too.
- `vxc`/`ix delete` now default to immediate and take `--later` for end-of-cycle cancellation.
- New cmdbuilder helpers `WithImmediateDeleteFlags`/`WithDeferredDeleteFlags` declare each command's intent at the flagset level.
- Bumps `megaport/megaportgo` v1.10.3 → v1.11.0 (ports cancellation change + `DeletePort` nil-guard).

## Breaking changes

- `--now` is gone from `ports`/`mcr`/`mve delete` and now errors with `unknown flag: --now`. Behavior is unchanged — those commands were already immediate.
- `vxc delete` / `ix delete` now cancel **immediately** by default instead of at end-of-cycle. Scripts relying on the old default must add `--later`.

## Test plan

- [x] Build, vet, `go test ./...`, `golangci-lint` all clean
- [x] `--help` confirms `--now` gone from ports/mcr/mve and `--later` present on vxc/ix
- [x] Unit tests assert `DeleteNow=true` by default on VXC/IX and that `--later` flips it
- [ ] Staging: each `delete --force` sends CANCEL_NOW; `vxc delete --later --force` schedules end-of-term
