### PR TITLE
test(ports): migrate integration tests to direct-action pattern

### DIFF
--- a/docs/INTEGRATION_TESTING.md
+++ b/docs/INTEGRATION_TESTING.md
@@ -59,9 +59,35 @@ Integration tests run in CI via `.github/workflows/integration-test.yml`:
 
 1. Create `internal/commands/<resource>/<resource>_integration_test.go`
 2. Set `//go:build integration` at the top and use `package <resource>` (not `package <resource>_test`)
-3. Use `testutil.SetupIntegrationClient(t)` and `defer testutil.LoginWithClient(t, client)()` to authenticate
+3. Authenticate using one of the helpers below (see "Authentication helpers")
 4. Call action functions directly and capture output with `output.CaptureOutput`
 5. Use `t.Cleanup()` for resource deletion (e.g. deleting staging ports/VXCs) so cleanup runs even on test failure; `defer` is fine for non-resource cleanup like restoring login state
 6. Add the package to the provisioning job in `.github/workflows/integration-test.yml`
 
-See `internal/commands/locations/locations_integration_test.go` for a complete read-only example. Provisioning lifecycle examples (ports, VXC, MCR, MVE) will be available once those integration tests are written.
+See `internal/commands/locations/locations_integration_test.go` for a serial read-only example and `internal/commands/ports/ports_integration_test.go` for a parallel provisioning-lifecycle example.
+
+### Authentication helpers
+
+Two helpers in `internal/testutil` handle staging authentication. Pick based on whether your tests use `t.Parallel()`.
+
+**Serial tests** (no `t.Parallel()`): use `testutil.SetupIntegrationClient` plus `testutil.LoginWithClient`. The login override is saved on entry and restored on cleanup:
+
+```go
+func TestIntegration_Foo(t *testing.T) {
+    client := testutil.SetupIntegrationClient(t)
+    defer testutil.LoginWithClient(t, client)()
+    // ...
+}
+```
+
+**Parallel tests** (`t.Parallel()`): use `testutil.RequireSharedIntegrationClient`. It authorises once per process via `sync.Once` and installs the login override exactly once; it never restores. All callers share a single authorised `*megaport.Client`, which is safe because they all target the same staging environment.
+
+```go
+func TestIntegration_Foo(t *testing.T) {
+    t.Parallel()
+    testutil.RequireSharedIntegrationClient(t)
+    // ...
+}
+```
+
+Do not combine `LoginWithClient` with `t.Parallel()`: its save/restore pattern races when concurrent tests each capture and restore `config.LoginFunc`, leaving the global pointing at a stale closure.

--- a/docs/INTEGRATION_TESTING.md
+++ b/docs/INTEGRATION_TESTING.md
@@ -60,7 +60,7 @@ Integration tests run in CI via `.github/workflows/integration-test.yml`:
 1. Create `internal/commands/<resource>/<resource>_integration_test.go`
 2. Set `//go:build integration` at the top and use `package <resource>` (not `package <resource>_test`)
 3. Authenticate using one of the helpers below (see "Authentication helpers")
-4. Call action functions directly and capture output with `output.CaptureOutput`
+4. Call action functions directly. For parallel tests, read state via `testutil.SharedIntegrationClient(t)` rather than `output.CaptureOutput` (see "Output capture and parallelism")
 5. Use `t.Cleanup()` for resource deletion (e.g. deleting staging ports/VXCs) so cleanup runs even on test failure; `defer` is fine for non-resource cleanup like restoring login state
 6. Add the package to the provisioning job in `.github/workflows/integration-test.yml`
 
@@ -91,3 +91,18 @@ func TestIntegration_Foo(t *testing.T) {
 ```
 
 Do not combine `LoginWithClient` with `t.Parallel()`: its save/restore pattern races when concurrent tests each capture and restore `config.LoginFunc`, leaving the global pointing at a stale closure.
+
+### Output capture and parallelism
+
+`output.CaptureOutput` swaps the process-wide `os.Stdout` for a tmpfile and holds a mutex for the duration of the wrapped function. Combined with `t.Parallel()`, that has two failure modes:
+
+1. **Serialisation**: the lock serialises every captured call, so parallel goroutines block whenever any one of them is inside `CaptureOutput`. Long blocking actions (e.g. `BuyPort` with `WaitForProvision=true`) erase the wall-time benefit of `t.Parallel()`.
+2. **Stdout races**: action code uses spinner goroutines that write to `os.Stdout` asynchronously. While goroutine A holds the capture mutex with `os.Stdout = tmpA`, goroutine B's spinner can write into `tmpA` or into a just-closed file descriptor after A's defer runs. Captures come back polluted or empty.
+
+For parallel lifecycle tests, prefer this pattern:
+
+- Drive the side-effecting action (`BuyPort`, `UpdatePort`, `DeletePort`, …) without wrapping it in `CaptureOutput`. Its real stdout output interleaves with other tests' output on the terminal, which is harmless.
+- If the action returns data via the SDK response (e.g. `BuyPortResponse.TechnicalServiceUIDs`), hook the underlying package-level function variable (`buyPortFunc` etc.) in an `init()` and store the response in a `sync.Map` keyed by something the test controls (request name, UID). See `internal/commands/ports/ports_integration_test.go` for an example.
+- Read state for assertions via `testutil.SharedIntegrationClient(t)` rather than scraping `GetPort`/`ListPorts` stdout. This bypasses `CaptureOutput` entirely and is parallel-safe.
+
+Serial read-only tests (e.g. `locations`) can continue to use `output.CaptureOutput` directly because there is no concurrent goroutine to race with.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/jedib0t/go-pretty/v6 v6.7.10
 	github.com/jmespath/go-jmespath v0.4.0
-	github.com/megaport/megaportgo v1.12.0
+	github.com/megaport/megaportgo v1.12.1
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/jedib0t/go-pretty/v6 v6.7.10
 	github.com/jmespath/go-jmespath v0.4.0
-	github.com/megaport/megaportgo v1.11.0
+	github.com/megaport/megaportgo v1.12.0
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.17 h1:78v8ZlW0bP43XfmAfPsdXcoNCelfMHsDmd/pkENfrjQ=
 github.com/mattn/go-runewidth v0.0.17/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/megaport/megaportgo v1.12.0 h1:s0pK3z9xybmT6lMcqbOqGKfIbCZ9cdTlGrb6wBwLeFE=
-github.com/megaport/megaportgo v1.12.0/go.mod h1:Ee2mHySrxQo3bkpib2TILCtYOL8KfhDXAD1xEVA3aeE=
+github.com/megaport/megaportgo v1.12.1 h1:I2pwAFlMspiN0NW2mJB275lZkUOrwsG9Gu7r3YxKDnw=
+github.com/megaport/megaportgo v1.12.1/go.mod h1:Ee2mHySrxQo3bkpib2TILCtYOL8KfhDXAD1xEVA3aeE=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.17 h1:78v8ZlW0bP43XfmAfPsdXcoNCelfMHsDmd/pkENfrjQ=
 github.com/mattn/go-runewidth v0.0.17/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/megaport/megaportgo v1.11.0 h1:cSfopzOQLs3yWlLmSPZYGDNE7IErZD7wWEb92IFccDs=
-github.com/megaport/megaportgo v1.11.0/go.mod h1:Ee2mHySrxQo3bkpib2TILCtYOL8KfhDXAD1xEVA3aeE=
+github.com/megaport/megaportgo v1.12.0 h1:s0pK3z9xybmT6lMcqbOqGKfIbCZ9cdTlGrb6wBwLeFE=
+github.com/megaport/megaportgo v1.12.0/go.mod h1:Ee2mHySrxQo3bkpib2TILCtYOL8KfhDXAD1xEVA3aeE=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=

--- a/internal/commands/ix/ix_mock.go
+++ b/internal/commands/ix/ix_mock.go
@@ -81,6 +81,10 @@ func (m *MockIXService) ListIXs(ctx context.Context, req *megaport.ListIXsReques
 	return []*megaport.IX{}, nil
 }
 
+func (m *MockIXService) ListIXPs(ctx context.Context, req *megaport.ListIXPsRequest) ([]*megaport.IXP, error) {
+	return []*megaport.IXP{}, nil
+}
+
 // Reset clears all configured results, errors, and captured requests.
 func (m *MockIXService) Reset() {
 	m.buyIXResponse = nil

--- a/internal/commands/locations/locations_mock.go
+++ b/internal/commands/locations/locations_mock.go
@@ -94,6 +94,10 @@ func (m *MockLocationsService) ListLocationsV3(ctx context.Context) ([]*megaport
 	return m.ListLocationsV3Result, m.ListLocationsV3Err
 }
 
+func (m *MockLocationsService) ListLocationsV3WithOptions(ctx context.Context, opts *megaport.ListLocationsV3Options) ([]*megaport.LocationV3, error) {
+	return m.ListLocationsV3Result, m.ListLocationsV3Err
+}
+
 func (m *MockLocationsService) GetLocationByIDV3(ctx context.Context, locationID int) (*megaport.LocationV3, error) {
 	return m.GetLocationByIDV3Result, m.GetLocationByIDV3Err
 }

--- a/internal/commands/partners/partners_mock.go
+++ b/internal/commands/partners/partners_mock.go
@@ -37,6 +37,6 @@ func (m *MockPartnerService) FilterPartnerMegaportByDiversityZone(ctx context.Co
 	return m.filterResponse, m.filterErr
 }
 
-func (m *MockPartnerService) FilterPartnerMegaportByMetro(ctx context.Context, partners []*megaport.PartnerMegaport, locationService megaport.LocationService, metro string) ([]*megaport.PartnerMegaport, error) {
+func (m *MockPartnerService) FilterPartnerMegaportByMetro(ctx context.Context, partners []*megaport.PartnerMegaport, metro string) ([]*megaport.PartnerMegaport, error) {
 	return m.filterResponse, m.filterErr
 }

--- a/internal/commands/ports/ports_integration_test.go
+++ b/internal/commands/ports/ports_integration_test.go
@@ -136,11 +136,14 @@ func registerPortCleanup(t *testing.T, client *megaport.Client, uid string) {
 		require.NoError(t, delCmd.Flags().Set("now", "true"))
 		require.NoError(t, delCmd.Flags().Set("force", "true"))
 
+		var deleteErr error
 		_ = captureWithFormat("table", func() {
-			if err := DeletePort(delCmd, []string{uid}, true); err != nil {
-				t.Errorf("cleanup: failed to delete port %s: %v", uid, err)
-			}
+			deleteErr = DeletePort(delCmd, []string{uid}, true)
 		})
+		if deleteErr != nil {
+			t.Errorf("cleanup: failed to delete port %s: %v", uid, deleteErr)
+			return
+		}
 
 		getCmd := newGetPortCmd()
 		var getErr error
@@ -151,12 +154,16 @@ func registerPortCleanup(t *testing.T, client *megaport.Client, uid string) {
 			t.Logf("cleanup: GetPort after delete returned %v (port may already be gone)", getErr)
 			return
 		}
-		var ports []map[string]interface{}
+		var ports []map[string]any
 		if err := json.Unmarshal([]byte(getOut), &ports); err != nil || len(ports) == 0 {
-			t.Logf("cleanup: could not parse GetPort JSON: %v, output: %s", err, getOut)
+			t.Errorf("cleanup: GetPort returned success but body could not be parsed: %v, output: %s", err, getOut)
 			return
 		}
-		status, _ := ports[0]["provisioning_status"].(string)
+		status, ok := ports[0]["provisioning_status"].(string)
+		if !ok {
+			t.Errorf("cleanup: provisioning_status missing or not a string in GetPort response: %v", ports[0]["provisioning_status"])
+			return
+		}
 		if !strings.Contains(status, "DECOMMISSIONING") && !strings.Contains(status, "DECOMMISSIONED") {
 			t.Errorf("expected port %s to be DECOMMISSIONING or DECOMMISSIONED, got %q", uid, status)
 		}
@@ -165,7 +172,7 @@ func registerPortCleanup(t *testing.T, client *megaport.Client, uid string) {
 
 // portFromGet runs GetPort with JSON output and returns the first port record.
 // Fails the test if the response is empty or malformed.
-func portFromGet(t *testing.T, uid string) map[string]interface{} {
+func portFromGet(t *testing.T, uid string) map[string]any {
 	t.Helper()
 	cmd := newGetPortCmd()
 	var err error
@@ -173,7 +180,7 @@ func portFromGet(t *testing.T, uid string) map[string]interface{} {
 		err = GetPort(cmd, []string{uid}, true, "json")
 	})
 	require.NoError(t, err)
-	var ports []map[string]interface{}
+	var ports []map[string]any
 	require.NoErrorf(t, json.Unmarshal([]byte(captured), &ports), "GetPort output should be valid JSON: %s", captured)
 	require.NotEmptyf(t, ports, "GetPort returned empty array: %s", captured)
 	return ports[0]
@@ -215,22 +222,10 @@ func runUpdatePortName(t *testing.T, uid, newName string) {
 	require.NoErrorf(t, err, "UpdatePort failed: %s", captured)
 }
 
-func runUpdatePortJSON(t *testing.T, uid, jsonPayload string) {
+func runUpdatePortWithFlag(t *testing.T, uid, flagName, flagValue string) {
 	t.Helper()
 	cmd := newUpdatePortCmd()
-	require.NoError(t, cmd.Flags().Set("json", jsonPayload))
-
-	var err error
-	captured := captureWithFormat("table", func() {
-		err = UpdatePort(cmd, []string{uid}, true)
-	})
-	require.NoErrorf(t, err, "UpdatePort failed: %s", captured)
-}
-
-func runUpdatePortJSONFile(t *testing.T, uid, jsonFile string) {
-	t.Helper()
-	cmd := newUpdatePortCmd()
-	require.NoError(t, cmd.Flags().Set("json-file", jsonFile))
+	require.NoError(t, cmd.Flags().Set(flagName, flagValue))
 
 	var err error
 	captured := captureWithFormat("table", func() {
@@ -338,7 +333,7 @@ func TestIntegration_PortJSONInputLifecycle(t *testing.T) {
 	updatePayload, err := json.Marshal(map[string]string{"name": newName})
 	require.NoError(t, err)
 
-	runUpdatePortJSON(t, uid, string(updatePayload))
+	runUpdatePortWithFlag(t, uid, "json", string(updatePayload))
 
 	updated := portFromGet(t, uid)
 	assert.Equal(t, newName, updated["name"])
@@ -387,7 +382,7 @@ func TestIntegration_PortJSONFileLifecycle(t *testing.T) {
 	updateFile := filepath.Join(t.TempDir(), "port-update.json")
 	require.NoError(t, os.WriteFile(updateFile, updatePayload, 0o600))
 
-	runUpdatePortJSONFile(t, uid, updateFile)
+	runUpdatePortWithFlag(t, uid, "json-file", updateFile)
 
 	updated := portFromGet(t, uid)
 	assert.Equal(t, newName, updated["name"])

--- a/internal/commands/ports/ports_integration_test.go
+++ b/internal/commands/ports/ports_integration_test.go
@@ -1,0 +1,394 @@
+//go:build integration
+
+package ports
+
+import (
+	crypto_rand "crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/testutil"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// integrationLocationID is the staging data center used for port lifecycle
+// tests. ID 67 is the canonical example location across the CLI's README,
+// example flag strings, and the previous binary-invocation integration suite.
+// It is stable on staging and supports the 1G/10G port speeds these tests
+// exercise.
+const integrationLocationID = 67
+
+func generateUniqueID() string {
+	buf := make([]byte, 4)
+	if _, err := crypto_rand.Read(buf); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(buf)
+}
+
+// extractCreatedUID parses "<resource> created <uid>" from captured output and
+// returns the UID. PrintResourceCreated writes "<resource> created <uid>" via
+// PrintSuccess; with noColor=true the UID is unstyled, so the next whitespace
+// character terminates it.
+func extractCreatedUID(t *testing.T, captured, resourceLabel string) string {
+	t.Helper()
+	marker := resourceLabel + " created "
+	idx := strings.Index(captured, marker)
+	require.GreaterOrEqualf(t, idx, 0, "expected %q in output, got: %q", marker, captured)
+	rest := captured[idx+len(marker):]
+	end := strings.IndexAny(rest, " \n\r\t")
+	if end < 0 {
+		return strings.TrimSpace(rest)
+	}
+	return strings.TrimSpace(rest[:end])
+}
+
+func newBuyPortCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "buy"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().Bool("no-wait", false, "")
+	cmd.Flags().Bool("yes", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().Int("term", 0, "")
+	cmd.Flags().Int("port-speed", 0, "")
+	cmd.Flags().Int("location-id", 0, "")
+	cmd.Flags().Bool("marketplace-visibility", false, "")
+	cmd.Flags().String("diversity-zone", "", "")
+	cmd.Flags().String("cost-centre", "", "")
+	cmd.Flags().String("promo-code", "", "")
+	cmd.Flags().String("resource-tags", "", "")
+	cmd.Flags().Bool("cost-confirm", true, "")
+	return cmd
+}
+
+func newBuyLAGPortCmd() *cobra.Command {
+	cmd := newBuyPortCmd()
+	cmd.Flags().Int("lag-count", 0, "")
+	return cmd
+}
+
+func newUpdatePortCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().Bool("marketplace-visibility", false, "")
+	cmd.Flags().String("cost-centre", "", "")
+	cmd.Flags().Int("term", 0, "")
+	return cmd
+}
+
+func newDeletePortCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "delete"}
+	cmd.Flags().BoolP("force", "f", false, "")
+	cmd.Flags().Bool("now", false, "")
+	cmd.Flags().Bool("safe-delete", false, "")
+	return cmd
+}
+
+func newGetPortCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "get"}
+	cmd.Flags().Bool("watch", false, "")
+	cmd.Flags().Bool("export", false, "")
+	return cmd
+}
+
+// captureWithFormat sets the global output format and runs f under
+// output.CaptureOutput. Both happen while CaptureOutput's stdoutMu is held, so
+// parallel tests cannot race on the global format or on stdout swapping.
+func captureWithFormat(format string, f func()) string {
+	return output.CaptureOutput(func() {
+		output.SetOutputFormat(format)
+		f()
+	})
+}
+
+// registerPortCleanup schedules a best-effort delete of the given port. The
+// cleanup runs even when the test fails, ensuring no orphaned resources on
+// staging. After deletion it asserts the port is reported as
+// DECOMMISSIONING / DECOMMISSIONED.
+//
+// The cleanup re-installs the staging client into config.LoginFunc for the
+// duration of its run. This is necessary because the outer
+// `defer testutil.LoginWithClient(t, client)()` in the test body runs (and
+// restores the original loginFunc) before any t.Cleanup callback, so cleanup
+// would otherwise hit the real loginFunc — which may resolve to a different
+// environment than staging.
+func registerPortCleanup(t *testing.T, client *megaport.Client, uid string) {
+	t.Helper()
+	t.Cleanup(func() {
+		restore := testutil.LoginWithClient(t, client)
+		defer restore()
+
+		delCmd := newDeletePortCmd()
+		require.NoError(t, delCmd.Flags().Set("now", "true"))
+		require.NoError(t, delCmd.Flags().Set("force", "true"))
+
+		_ = captureWithFormat("table", func() {
+			if err := DeletePort(delCmd, []string{uid}, true); err != nil {
+				t.Errorf("cleanup: failed to delete port %s: %v", uid, err)
+			}
+		})
+
+		getCmd := newGetPortCmd()
+		var getErr error
+		getOut := captureWithFormat("json", func() {
+			getErr = GetPort(getCmd, []string{uid}, true, "json")
+		})
+		if getErr != nil {
+			t.Logf("cleanup: GetPort after delete returned %v (port may already be gone)", getErr)
+			return
+		}
+		var ports []map[string]interface{}
+		if err := json.Unmarshal([]byte(getOut), &ports); err != nil || len(ports) == 0 {
+			t.Logf("cleanup: could not parse GetPort JSON: %v, output: %s", err, getOut)
+			return
+		}
+		status, _ := ports[0]["provisioning_status"].(string)
+		if !strings.Contains(status, "DECOMMISSIONING") && !strings.Contains(status, "DECOMMISSIONED") {
+			t.Errorf("expected port %s to be DECOMMISSIONING or DECOMMISSIONED, got %q", uid, status)
+		}
+	})
+}
+
+// portFromGet runs GetPort with JSON output and returns the first port record.
+// Fails the test if the response is empty or malformed.
+func portFromGet(t *testing.T, uid string) map[string]interface{} {
+	t.Helper()
+	cmd := newGetPortCmd()
+	var err error
+	captured := captureWithFormat("json", func() {
+		err = GetPort(cmd, []string{uid}, true, "json")
+	})
+	require.NoError(t, err)
+	var ports []map[string]interface{}
+	require.NoErrorf(t, json.Unmarshal([]byte(captured), &ports), "GetPort output should be valid JSON: %s", captured)
+	require.NotEmptyf(t, ports, "GetPort returned empty array: %s", captured)
+	return ports[0]
+}
+
+func runBuyPort(t *testing.T, cmd *cobra.Command, resourceLabel string) string {
+	t.Helper()
+	var err error
+	captured := captureWithFormat("table", func() {
+		err = BuyPort(cmd, nil, true)
+	})
+	require.NoErrorf(t, err, "BuyPort failed: %s", captured)
+	uid := extractCreatedUID(t, captured, resourceLabel)
+	require.NotEmpty(t, uid, "extracted UID is empty")
+	return uid
+}
+
+func runBuyLAGPort(t *testing.T, cmd *cobra.Command) string {
+	t.Helper()
+	var err error
+	captured := captureWithFormat("table", func() {
+		err = BuyLAGPort(cmd, nil, true)
+	})
+	require.NoErrorf(t, err, "BuyLAGPort failed: %s", captured)
+	uid := extractCreatedUID(t, captured, "LAG Port")
+	require.NotEmpty(t, uid, "extracted LAG UID is empty")
+	return uid
+}
+
+func runUpdatePortName(t *testing.T, uid, newName string) {
+	t.Helper()
+	cmd := newUpdatePortCmd()
+	require.NoError(t, cmd.Flags().Set("name", newName))
+
+	var err error
+	captured := captureWithFormat("table", func() {
+		err = UpdatePort(cmd, []string{uid}, true)
+	})
+	require.NoErrorf(t, err, "UpdatePort failed: %s", captured)
+}
+
+func runUpdatePortJSON(t *testing.T, uid, jsonPayload string) {
+	t.Helper()
+	cmd := newUpdatePortCmd()
+	require.NoError(t, cmd.Flags().Set("json", jsonPayload))
+
+	var err error
+	captured := captureWithFormat("table", func() {
+		err = UpdatePort(cmd, []string{uid}, true)
+	})
+	require.NoErrorf(t, err, "UpdatePort failed: %s", captured)
+}
+
+func runUpdatePortJSONFile(t *testing.T, uid, jsonFile string) {
+	t.Helper()
+	cmd := newUpdatePortCmd()
+	require.NoError(t, cmd.Flags().Set("json-file", jsonFile))
+
+	var err error
+	captured := captureWithFormat("table", func() {
+		err = UpdatePort(cmd, []string{uid}, true)
+	})
+	require.NoErrorf(t, err, "UpdatePort failed: %s", captured)
+}
+
+func TestIntegration_PortLifecycle(t *testing.T) {
+	t.Parallel()
+
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	portName := fmt.Sprintf("CLI-Test-Port-%s", generateUniqueID())
+
+	buyCmd := newBuyPortCmd()
+	require.NoError(t, buyCmd.Flags().Set("name", portName))
+	require.NoError(t, buyCmd.Flags().Set("term", "1"))
+	require.NoError(t, buyCmd.Flags().Set("port-speed", "1000"))
+	require.NoError(t, buyCmd.Flags().Set("location-id", fmt.Sprintf("%d", integrationLocationID)))
+	require.NoError(t, buyCmd.Flags().Set("marketplace-visibility", "false"))
+	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
+
+	uid := runBuyPort(t, buyCmd, "Port")
+	registerPortCleanup(t, client, uid)
+	t.Logf("Created port with UID: %s", uid)
+
+	port := portFromGet(t, uid)
+	assert.Equal(t, uid, port["uid"])
+	assert.Equal(t, portName, port["name"])
+	assert.NotEmpty(t, port["provisioning_status"], "provisioning_status should be populated")
+
+	newName := portName + "-Updated"
+	runUpdatePortName(t, uid, newName)
+
+	updated := portFromGet(t, uid)
+	assert.Equal(t, newName, updated["name"])
+}
+
+func TestIntegration_LAGPortLifecycle(t *testing.T) {
+	t.Parallel()
+
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	portName := fmt.Sprintf("CLI-Test-LAG-%s", generateUniqueID())
+
+	buyCmd := newBuyLAGPortCmd()
+	require.NoError(t, buyCmd.Flags().Set("name", portName))
+	require.NoError(t, buyCmd.Flags().Set("term", "1"))
+	require.NoError(t, buyCmd.Flags().Set("port-speed", "10000"))
+	require.NoError(t, buyCmd.Flags().Set("location-id", fmt.Sprintf("%d", integrationLocationID)))
+	require.NoError(t, buyCmd.Flags().Set("lag-count", "1"))
+	require.NoError(t, buyCmd.Flags().Set("marketplace-visibility", "false"))
+	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
+
+	uid := runBuyLAGPort(t, buyCmd)
+	registerPortCleanup(t, client, uid)
+	t.Logf("Created LAG port with UID: %s", uid)
+
+	port := portFromGet(t, uid)
+	assert.Equal(t, uid, port["uid"])
+	assert.Equal(t, portName, port["name"])
+	assert.NotEmpty(t, port["provisioning_status"])
+
+	newName := portName + "-Updated"
+	runUpdatePortName(t, uid, newName)
+
+	updated := portFromGet(t, uid)
+	assert.Equal(t, newName, updated["name"])
+}
+
+func TestIntegration_PortJSONInputLifecycle(t *testing.T) {
+	t.Parallel()
+
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	portName := fmt.Sprintf("CLI-Test-Port-JSON-%s", generateUniqueID())
+
+	buyPayload := map[string]interface{}{
+		"name":                  portName,
+		"term":                  1,
+		"portSpeed":             1000,
+		"locationId":            integrationLocationID,
+		"marketPlaceVisibility": false,
+	}
+	buyJSON, err := json.Marshal(buyPayload)
+	require.NoError(t, err)
+
+	buyCmd := newBuyPortCmd()
+	require.NoError(t, buyCmd.Flags().Set("json", string(buyJSON)))
+
+	uid := runBuyPort(t, buyCmd, "Port")
+	registerPortCleanup(t, client, uid)
+	t.Logf("Created port (JSON input) with UID: %s", uid)
+
+	port := portFromGet(t, uid)
+	assert.Equal(t, uid, port["uid"])
+	assert.Equal(t, portName, port["name"])
+	assert.NotEmpty(t, port["provisioning_status"])
+
+	newName := portName + "-Updated-JSON"
+	updatePayload, err := json.Marshal(map[string]string{"name": newName})
+	require.NoError(t, err)
+
+	runUpdatePortJSON(t, uid, string(updatePayload))
+
+	updated := portFromGet(t, uid)
+	assert.Equal(t, newName, updated["name"])
+}
+
+func TestIntegration_PortJSONFileLifecycle(t *testing.T) {
+	t.Parallel()
+
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	portName := fmt.Sprintf("CLI-Test-Port-JSONFile-%s", generateUniqueID())
+
+	buyPayload := map[string]interface{}{
+		"name":                  portName,
+		"term":                  1,
+		"portSpeed":             1000,
+		"locationId":            integrationLocationID,
+		"marketPlaceVisibility": false,
+	}
+	buyJSON, err := json.MarshalIndent(buyPayload, "", "  ")
+	require.NoError(t, err)
+
+	buyFile := filepath.Join(t.TempDir(), "port-buy.json")
+	require.NoError(t, os.WriteFile(buyFile, buyJSON, 0o600))
+
+	buyCmd := newBuyPortCmd()
+	require.NoError(t, buyCmd.Flags().Set("json-file", buyFile))
+
+	uid := runBuyPort(t, buyCmd, "Port")
+	registerPortCleanup(t, client, uid)
+	t.Logf("Created port (JSON file) with UID: %s", uid)
+
+	port := portFromGet(t, uid)
+	assert.Equal(t, uid, port["uid"])
+	assert.Equal(t, portName, port["name"])
+	assert.NotEmpty(t, port["provisioning_status"])
+
+	newName := portName + "-Updated-TempJSON"
+	updatePayload, err := json.MarshalIndent(map[string]interface{}{
+		"name":                  newName,
+		"marketPlaceVisibility": true,
+	}, "", "  ")
+	require.NoError(t, err)
+
+	updateFile := filepath.Join(t.TempDir(), "port-update.json")
+	require.NoError(t, os.WriteFile(updateFile, updatePayload, 0o600))
+
+	runUpdatePortJSONFile(t, uid, updateFile)
+
+	updated := portFromGet(t, uid)
+	assert.Equal(t, newName, updated["name"])
+}

--- a/internal/commands/ports/ports_integration_test.go
+++ b/internal/commands/ports/ports_integration_test.go
@@ -219,10 +219,15 @@ func portsBySDKNameFilter(t *testing.T, nameSubstring string) []*megaport.Port {
 // buys, which encode the name inside the payload rather than on a cobra
 // flag, work the same way as flag-driven buys. It must match the Name in
 // the final BuyPortRequest the action sends to the SDK.
+//
+// Cleanup is registered here — immediately after the buy succeeds and before
+// uidFromBuyResponse asserts on the response — so that any created resources
+// are deleted even if UID extraction subsequently fails.
 func runBuyPort(t *testing.T, cmd *cobra.Command, portName string) string {
 	t.Helper()
 	require.NotEmpty(t, portName, "portName must be provided to runBuyPort")
 	require.NoErrorf(t, BuyPort(cmd, nil, true), "BuyPort failed for %q", portName)
+	registerBuyCleanups(t, portName)
 	return uidFromBuyResponse(t, portName)
 }
 
@@ -230,7 +235,29 @@ func runBuyLAGPort(t *testing.T, cmd *cobra.Command, portName string) string {
 	t.Helper()
 	require.NotEmpty(t, portName, "portName must be provided to runBuyLAGPort")
 	require.NoErrorf(t, BuyLAGPort(cmd, nil, true), "BuyLAGPort failed for %q", portName)
+	registerBuyCleanups(t, portName)
 	return uidFromBuyResponse(t, portName)
+}
+
+// registerBuyCleanups registers a cleanup for every UID in the buy response
+// stored under portName. It is called immediately after BuyPort/BuyLAGPort
+// returns so that created resources are cleaned up even if uidFromBuyResponse
+// subsequently fails (e.g. TechnicalServiceUIDs is unexpectedly empty).
+func registerBuyCleanups(t *testing.T, portName string) {
+	t.Helper()
+	v, ok := integrationBuyResponses.Load(portName)
+	if !ok {
+		return
+	}
+	resp, ok := v.(*megaport.BuyPortResponse)
+	if !ok {
+		return
+	}
+	for _, uid := range resp.TechnicalServiceUIDs {
+		if uid != "" {
+			registerPortCleanup(t, uid)
+		}
+	}
 }
 
 // uidFromBuyResponse returns the first technical service UID recorded for the
@@ -278,7 +305,6 @@ func TestIntegration_PortLifecycle(t *testing.T) {
 	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
 
 	uid := runBuyPort(t, buyCmd, portName)
-	registerPortCleanup(t, uid)
 	t.Logf("Created port with UID: %s", uid)
 
 	port := portFromSDK(t, uid)
@@ -320,7 +346,6 @@ func TestIntegration_LAGPortLifecycle(t *testing.T) {
 	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
 
 	uid := runBuyLAGPort(t, buyCmd, portName)
-	registerPortCleanup(t, uid)
 	t.Logf("Created LAG port with UID: %s", uid)
 
 	port := portFromSDK(t, uid)
@@ -355,7 +380,6 @@ func TestIntegration_PortJSONInputLifecycle(t *testing.T) {
 	require.NoError(t, buyCmd.Flags().Set("json", string(buyJSON)))
 
 	uid := runBuyPort(t, buyCmd, portName)
-	registerPortCleanup(t, uid)
 	t.Logf("Created port (JSON input) with UID: %s", uid)
 
 	port := portFromSDK(t, uid)
@@ -396,7 +420,6 @@ func TestIntegration_PortJSONFileLifecycle(t *testing.T) {
 	require.NoError(t, buyCmd.Flags().Set("json-file", buyFile))
 
 	uid := runBuyPort(t, buyCmd, portName)
-	registerPortCleanup(t, uid)
 	t.Logf("Created port (JSON file) with UID: %s", uid)
 
 	port := portFromSDK(t, uid)

--- a/internal/commands/ports/ports_integration_test.go
+++ b/internal/commands/ports/ports_integration_test.go
@@ -105,6 +105,17 @@ func newGetPortCmd() *cobra.Command {
 	return cmd
 }
 
+func newListPortsCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "list"}
+	cmd.Flags().Int("location-id", 0, "")
+	cmd.Flags().Int("port-speed", 0, "")
+	cmd.Flags().String("port-name", "", "")
+	cmd.Flags().Bool("include-inactive", false, "")
+	cmd.Flags().Int("limit", 0, "")
+	cmd.Flags().StringArray("tag", nil, "")
+	return cmd
+}
+
 // captureWithFormat sets the global output format and runs f under
 // output.CaptureOutput. Both happen while CaptureOutput's stdoutMu is held, so
 // parallel tests cannot race on the global format or on stdout swapping.
@@ -168,6 +179,25 @@ func registerPortCleanup(t *testing.T, client *megaport.Client, uid string) {
 			t.Errorf("expected port %s to be DECOMMISSIONING or DECOMMISSIONED, got %q", uid, status)
 		}
 	})
+}
+
+// listPortsByName runs ListPorts with --port-name set and returns the parsed
+// records. The port-name filter is a substring match server-side-equivalent on
+// the client; passing the unique generated name keeps results scoped to the
+// caller's port even when other parallel tests are running.
+func listPortsByName(t *testing.T, name string) []map[string]any {
+	t.Helper()
+	cmd := newListPortsCmd()
+	require.NoError(t, cmd.Flags().Set("port-name", name))
+
+	var err error
+	captured := captureWithFormat("json", func() {
+		err = ListPorts(cmd, nil, true, "json")
+	})
+	require.NoErrorf(t, err, "ListPorts failed: %s", captured)
+	var ports []map[string]any
+	require.NoErrorf(t, json.Unmarshal([]byte(captured), &ports), "ListPorts output should be valid JSON: %s", captured)
+	return ports
 }
 
 // portFromGet runs GetPort with JSON output and returns the first port record.
@@ -258,6 +288,17 @@ func TestIntegration_PortLifecycle(t *testing.T) {
 	assert.Equal(t, uid, port["uid"])
 	assert.Equal(t, portName, port["name"])
 	assert.NotEmpty(t, port["provisioning_status"], "provisioning_status should be populated")
+
+	listed := listPortsByName(t, portName)
+	require.NotEmpty(t, listed, "newly created port should appear in list filtered by name %q", portName)
+	found := false
+	for _, p := range listed {
+		if p["uid"] == uid {
+			found = true
+			break
+		}
+	}
+	assert.Truef(t, found, "uid %s not found in list filtered by name %q; got %d port(s)", uid, portName, len(listed))
 
 	newName := portName + "-Updated"
 	runUpdatePortName(t, uid, newName)

--- a/internal/commands/ports/ports_integration_test.go
+++ b/internal/commands/ports/ports_integration_test.go
@@ -3,6 +3,7 @@
 package ports
 
 import (
+	"context"
 	crypto_rand "crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -10,11 +11,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
-	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/testutil"
+	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,6 +32,33 @@ const integrationLocationID = 67
 // These tests use t.Parallel(); see testutil.RequireSharedIntegrationClient
 // for why a process-wide sync.Once-guarded login function is used here
 // instead of the per-test save/restore pattern in testutil.LoginWithClient.
+//
+// State assertions go through the SDK directly (testutil.SharedIntegrationClient)
+// rather than via output.CaptureOutput on GetPort/ListPorts. CaptureOutput
+// swaps the global os.Stdout for a tmpfile while it runs; with t.Parallel(),
+// concurrent action goroutines (especially their spinner goroutines, which
+// write asynchronously) end up writing into another test's tmpfile or into a
+// just-closed file descriptor. The result is polluted or empty captures.
+// Side-effecting actions (BuyPort, BuyLAGPort, UpdatePort, DeletePort) still
+// run end-to-end through the CLI code paths; we only skip capture and read
+// the API state directly for verification.
+
+// integrationBuyResponses lets parallel tests retrieve the BuyPortResponse
+// for their port without scraping stdout. The init() hook below wraps
+// buyPortFunc so the SDK response is stored under the request name; tests
+// read the UID back from this map.
+var integrationBuyResponses sync.Map // key: request.Name (string), value: *megaport.BuyPortResponse
+
+func init() {
+	base := buyPortFunc
+	buyPortFunc = func(ctx context.Context, client *megaport.Client, req *megaport.BuyPortRequest) (*megaport.BuyPortResponse, error) {
+		resp, err := base(ctx, client, req)
+		if err == nil && resp != nil && req != nil && req.Name != "" {
+			integrationBuyResponses.Store(req.Name, resp)
+		}
+		return resp, err
+	}
+}
 
 func generateUniqueID(t *testing.T) string {
 	t.Helper()
@@ -37,23 +66,6 @@ func generateUniqueID(t *testing.T) string {
 	_, err := crypto_rand.Read(buf)
 	require.NoError(t, err, "failed to read crypto/rand entropy")
 	return hex.EncodeToString(buf)
-}
-
-// extractCreatedUID parses "<resource> created <uid>" from captured output and
-// returns the UID. PrintResourceCreated writes "<resource> created <uid>" via
-// PrintSuccess; with noColor=true the UID is unstyled, so the next whitespace
-// character terminates it.
-func extractCreatedUID(t *testing.T, captured, resourceLabel string) string {
-	t.Helper()
-	marker := resourceLabel + " created "
-	idx := strings.Index(captured, marker)
-	require.GreaterOrEqualf(t, idx, 0, "expected %q in output, got: %q", marker, captured)
-	rest := captured[idx+len(marker):]
-	end := strings.IndexAny(rest, " \n\r\t")
-	if end < 0 {
-		return strings.TrimSpace(rest)
-	}
-	return strings.TrimSpace(rest[:end])
 }
 
 func newBuyPortCmd() *cobra.Command {
@@ -102,40 +114,12 @@ func newDeletePortCmd() *cobra.Command {
 	return cmd
 }
 
-func newGetPortCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "get"}
-	cmd.Flags().Bool("watch", false, "")
-	cmd.Flags().Bool("export", false, "")
-	return cmd
-}
-
-func newListPortsCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "list"}
-	cmd.Flags().Int("location-id", 0, "")
-	cmd.Flags().Int("port-speed", 0, "")
-	cmd.Flags().String("port-name", "", "")
-	cmd.Flags().Bool("include-inactive", false, "")
-	cmd.Flags().Int("limit", 0, "")
-	cmd.Flags().StringArray("tag", nil, "")
-	return cmd
-}
-
-// captureWithFormat sets the global output format and runs f under
-// output.CaptureOutput. Both happen while CaptureOutput's stdoutMu is held, so
-// parallel tests cannot race on the global format or on stdout swapping.
-func captureWithFormat(format string, f func()) string {
-	return output.CaptureOutput(func() {
-		output.SetOutputFormat(format)
-		f()
-	})
-}
-
-// cleanupStatusTimeout bounds how long registerPortCleanup will poll GetPort
+// cleanupStatusTimeout bounds how long registerPortCleanup will poll the SDK
 // for the port to enter DECOMMISSIONING/DECOMMISSIONED after DeletePort.
 // DeletePort only submits the cancellation request; the API can take a few
 // seconds to reflect the new provisioning_status. Sixty seconds is well
-// above observed transitions on staging without making a stuck cleanup
-// drag the test run out by minutes.
+// above observed transitions on staging without making a stuck cleanup drag
+// the test run out by minutes.
 const (
 	cleanupStatusTimeout  = 60 * time.Second
 	cleanupStatusInterval = 2 * time.Second
@@ -143,8 +127,9 @@ const (
 
 // registerPortCleanup schedules a best-effort delete of the given port. The
 // cleanup runs even when the test fails, ensuring no orphaned resources on
-// staging. After deletion it polls GetPort until the port reports
-// DECOMMISSIONING / DECOMMISSIONED, or until cleanupStatusTimeout elapses.
+// staging. DeletePort writes its progress to the real stdout (interleaved
+// with other parallel tests' cleanups, which is harmless). The post-delete
+// status check polls the SDK directly to avoid CaptureOutput's stdout swap.
 // The package-level login function installed by
 // testutil.RequireSharedIntegrationClient remains active for the cleanup
 // callback (no per-test restore happens).
@@ -155,39 +140,24 @@ func registerPortCleanup(t *testing.T, uid string) {
 		require.NoError(t, delCmd.Flags().Set("now", "true"))
 		require.NoError(t, delCmd.Flags().Set("force", "true"))
 
-		var deleteErr error
-		_ = captureWithFormat("table", func() {
-			deleteErr = DeletePort(delCmd, []string{uid}, true)
-		})
-		if deleteErr != nil {
-			t.Errorf("cleanup: failed to delete port %s: %v", uid, deleteErr)
+		if err := DeletePort(delCmd, []string{uid}, true); err != nil {
+			t.Errorf("cleanup: failed to delete port %s: %v", uid, err)
 			return
 		}
 
+		client := testutil.SharedIntegrationClient(t)
 		deadline := time.Now().Add(cleanupStatusTimeout)
 		var lastStatus string
 		for {
-			getCmd := newGetPortCmd()
-			var getErr error
-			getOut := captureWithFormat("json", func() {
-				getErr = GetPort(getCmd, []string{uid}, true, "json")
-			})
-			if getErr != nil {
-				t.Logf("cleanup: GetPort after delete returned %v (port may already be gone)", getErr)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			port, err := client.PortService.GetPort(ctx, uid)
+			cancel()
+			if err != nil {
+				t.Logf("cleanup: SDK GetPort after delete returned %v (port may already be gone)", err)
 				return
 			}
-			var ports []map[string]any
-			if err := json.Unmarshal([]byte(getOut), &ports); err != nil || len(ports) == 0 {
-				t.Errorf("cleanup: GetPort returned success but body could not be parsed: %v, output: %s", err, getOut)
-				return
-			}
-			status, ok := ports[0]["provisioning_status"].(string)
-			if !ok {
-				t.Errorf("cleanup: provisioning_status missing or not a string in GetPort response: %v", ports[0]["provisioning_status"])
-				return
-			}
-			lastStatus = status
-			if strings.Contains(status, "DECOMMISSIONING") || strings.Contains(status, "DECOMMISSIONED") {
+			lastStatus = port.ProvisioningStatus
+			if strings.Contains(lastStatus, "DECOMMISSIONING") || strings.Contains(lastStatus, "DECOMMISSIONED") {
 				return
 			}
 			if time.Now().After(deadline) {
@@ -199,87 +169,98 @@ func registerPortCleanup(t *testing.T, uid string) {
 	})
 }
 
-// listPortsByName runs ListPorts with --port-name set and returns the parsed
-// records. The port-name filter is applied client-side as a substring match
-// on port names; passing the unique generated name keeps results scoped to
-// the caller's port even when other parallel tests are running.
-func listPortsByName(t *testing.T, name string) []map[string]any {
+// portFromSDK reads the port via the shared SDK client. Used for parallel-safe
+// state assertions instead of scraping GetPort's stdout output.
+func portFromSDK(t *testing.T, uid string) *megaport.Port {
 	t.Helper()
-	cmd := newListPortsCmd()
-	require.NoError(t, cmd.Flags().Set("port-name", name))
-
-	var err error
-	captured := captureWithFormat("json", func() {
-		err = ListPorts(cmd, nil, true, "json")
-	})
-	require.NoErrorf(t, err, "ListPorts failed: %s", captured)
-	var ports []map[string]any
-	require.NoErrorf(t, json.Unmarshal([]byte(captured), &ports), "ListPorts output should be valid JSON: %s", captured)
-	return ports
+	client := testutil.SharedIntegrationClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	port, err := client.PortService.GetPort(ctx, uid)
+	require.NoErrorf(t, err, "SDK GetPort failed for %s", uid)
+	require.NotNilf(t, port, "SDK GetPort returned nil for %s", uid)
+	return port
 }
 
-// portFromGet runs GetPort with JSON output and returns the first port record.
-// Fails the test if the response is empty or malformed.
-func portFromGet(t *testing.T, uid string) map[string]any {
+// portsBySDKNameFilter lists all ports via the shared SDK client and returns
+// those whose name contains the given substring (case-insensitive, matching
+// the ListPorts action's client-side filter). Used for parallel-safe
+// list assertions.
+func portsBySDKNameFilter(t *testing.T, nameSubstring string) []*megaport.Port {
 	t.Helper()
-	cmd := newGetPortCmd()
-	var err error
-	captured := captureWithFormat("json", func() {
-		err = GetPort(cmd, []string{uid}, true, "json")
-	})
-	require.NoError(t, err)
-	var ports []map[string]any
-	require.NoErrorf(t, json.Unmarshal([]byte(captured), &ports), "GetPort output should be valid JSON: %s", captured)
-	require.NotEmptyf(t, ports, "GetPort returned empty array: %s", captured)
-	return ports[0]
+	client := testutil.SharedIntegrationClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	all, err := client.PortService.ListPorts(ctx)
+	require.NoError(t, err, "SDK ListPorts failed")
+	needle := strings.ToLower(nameSubstring)
+	var out []*megaport.Port
+	for _, p := range all {
+		if p == nil {
+			continue
+		}
+		if strings.Contains(strings.ToLower(p.Name), needle) {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
-func runBuyPort(t *testing.T, cmd *cobra.Command, resourceLabel string) string {
+// runBuyPort and runBuyLAGPort intentionally do not wrap BuyPort/BuyLAGPort
+// in output.CaptureOutput. Both actions block until LIVE
+// (WaitForProvision=true), which can take tens of seconds on staging, and
+// CaptureOutput would hold output.stdoutMu for the entire wait — defeating
+// t.Parallel(). Their spinner goroutines also write asynchronously, which
+// races with any concurrent CaptureOutput's stdout swap. The UID is
+// recovered from the response recorded by the init() hook on buyPortFunc
+// instead of scraping stdout.
+//
+// portName is passed explicitly (rather than read from --name) so that JSON
+// buys, which encode the name inside the payload rather than on a cobra
+// flag, work the same way as flag-driven buys. It must match the Name in
+// the final BuyPortRequest the action sends to the SDK.
+func runBuyPort(t *testing.T, cmd *cobra.Command, portName string) string {
 	t.Helper()
-	var err error
-	captured := captureWithFormat("table", func() {
-		err = BuyPort(cmd, nil, true)
-	})
-	require.NoErrorf(t, err, "BuyPort failed: %s", captured)
-	uid := extractCreatedUID(t, captured, resourceLabel)
-	require.NotEmpty(t, uid, "extracted UID is empty")
-	return uid
+	require.NotEmpty(t, portName, "portName must be provided to runBuyPort")
+	require.NoErrorf(t, BuyPort(cmd, nil, true), "BuyPort failed for %q", portName)
+	return uidFromBuyResponse(t, portName)
 }
 
-func runBuyLAGPort(t *testing.T, cmd *cobra.Command) string {
+func runBuyLAGPort(t *testing.T, cmd *cobra.Command, portName string) string {
 	t.Helper()
-	var err error
-	captured := captureWithFormat("table", func() {
-		err = BuyLAGPort(cmd, nil, true)
-	})
-	require.NoErrorf(t, err, "BuyLAGPort failed: %s", captured)
-	uid := extractCreatedUID(t, captured, "LAG Port")
-	require.NotEmpty(t, uid, "extracted LAG UID is empty")
-	return uid
+	require.NotEmpty(t, portName, "portName must be provided to runBuyLAGPort")
+	require.NoErrorf(t, BuyLAGPort(cmd, nil, true), "BuyLAGPort failed for %q", portName)
+	return uidFromBuyResponse(t, portName)
 }
 
+// uidFromBuyResponse returns the first technical service UID recorded for the
+// given port name. Tests rely on init()'s buyPortFunc wrapper to populate
+// integrationBuyResponses with the SDK response.
+func uidFromBuyResponse(t *testing.T, name string) string {
+	t.Helper()
+	v, ok := integrationBuyResponses.Load(name)
+	require.Truef(t, ok, "no buy response recorded for port %q", name)
+	resp, ok := v.(*megaport.BuyPortResponse)
+	require.Truef(t, ok, "buy response for %q has unexpected type %T", name, v)
+	require.NotEmptyf(t, resp.TechnicalServiceUIDs, "buy response for %q has no technical service UIDs", name)
+	return resp.TechnicalServiceUIDs[0]
+}
+
+// runUpdatePortName and runUpdatePortWithFlag also skip CaptureOutput.
+// UpdatePort blocks on WaitForUpdate=true and uses spinners. The test only
+// needs to know the call succeeded; no stdout scraping is required.
 func runUpdatePortName(t *testing.T, uid, newName string) {
 	t.Helper()
 	cmd := newUpdatePortCmd()
 	require.NoError(t, cmd.Flags().Set("name", newName))
-
-	var err error
-	captured := captureWithFormat("table", func() {
-		err = UpdatePort(cmd, []string{uid}, true)
-	})
-	require.NoErrorf(t, err, "UpdatePort failed: %s", captured)
+	require.NoErrorf(t, UpdatePort(cmd, []string{uid}, true), "UpdatePort failed for %s", uid)
 }
 
 func runUpdatePortWithFlag(t *testing.T, uid, flagName, flagValue string) {
 	t.Helper()
 	cmd := newUpdatePortCmd()
 	require.NoError(t, cmd.Flags().Set(flagName, flagValue))
-
-	var err error
-	captured := captureWithFormat("table", func() {
-		err = UpdatePort(cmd, []string{uid}, true)
-	})
-	require.NoErrorf(t, err, "UpdatePort failed: %s", captured)
+	require.NoErrorf(t, UpdatePort(cmd, []string{uid}, true), "UpdatePort failed for %s", uid)
 }
 
 func TestIntegration_PortLifecycle(t *testing.T) {
@@ -296,20 +277,20 @@ func TestIntegration_PortLifecycle(t *testing.T) {
 	require.NoError(t, buyCmd.Flags().Set("marketplace-visibility", "false"))
 	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
 
-	uid := runBuyPort(t, buyCmd, "Port")
+	uid := runBuyPort(t, buyCmd, portName)
 	registerPortCleanup(t, uid)
 	t.Logf("Created port with UID: %s", uid)
 
-	port := portFromGet(t, uid)
-	assert.Equal(t, uid, port["uid"])
-	assert.Equal(t, portName, port["name"])
-	assert.NotEmpty(t, port["provisioning_status"], "provisioning_status should be populated")
+	port := portFromSDK(t, uid)
+	assert.Equal(t, uid, port.UID)
+	assert.Equal(t, portName, port.Name)
+	assert.NotEmpty(t, port.ProvisioningStatus, "provisioning_status should be populated")
 
-	listed := listPortsByName(t, portName)
+	listed := portsBySDKNameFilter(t, portName)
 	require.NotEmpty(t, listed, "newly created port should appear in list filtered by name %q", portName)
 	found := false
 	for _, p := range listed {
-		if p["uid"] == uid {
+		if p.UID == uid {
 			found = true
 			break
 		}
@@ -319,8 +300,8 @@ func TestIntegration_PortLifecycle(t *testing.T) {
 	newName := portName + "-Updated"
 	runUpdatePortName(t, uid, newName)
 
-	updated := portFromGet(t, uid)
-	assert.Equal(t, newName, updated["name"])
+	updated := portFromSDK(t, uid)
+	assert.Equal(t, newName, updated.Name)
 }
 
 func TestIntegration_LAGPortLifecycle(t *testing.T) {
@@ -338,20 +319,20 @@ func TestIntegration_LAGPortLifecycle(t *testing.T) {
 	require.NoError(t, buyCmd.Flags().Set("marketplace-visibility", "false"))
 	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
 
-	uid := runBuyLAGPort(t, buyCmd)
+	uid := runBuyLAGPort(t, buyCmd, portName)
 	registerPortCleanup(t, uid)
 	t.Logf("Created LAG port with UID: %s", uid)
 
-	port := portFromGet(t, uid)
-	assert.Equal(t, uid, port["uid"])
-	assert.Equal(t, portName, port["name"])
-	assert.NotEmpty(t, port["provisioning_status"])
+	port := portFromSDK(t, uid)
+	assert.Equal(t, uid, port.UID)
+	assert.Equal(t, portName, port.Name)
+	assert.NotEmpty(t, port.ProvisioningStatus)
 
 	newName := portName + "-Updated"
 	runUpdatePortName(t, uid, newName)
 
-	updated := portFromGet(t, uid)
-	assert.Equal(t, newName, updated["name"])
+	updated := portFromSDK(t, uid)
+	assert.Equal(t, newName, updated.Name)
 }
 
 func TestIntegration_PortJSONInputLifecycle(t *testing.T) {
@@ -373,14 +354,14 @@ func TestIntegration_PortJSONInputLifecycle(t *testing.T) {
 	buyCmd := newBuyPortCmd()
 	require.NoError(t, buyCmd.Flags().Set("json", string(buyJSON)))
 
-	uid := runBuyPort(t, buyCmd, "Port")
+	uid := runBuyPort(t, buyCmd, portName)
 	registerPortCleanup(t, uid)
 	t.Logf("Created port (JSON input) with UID: %s", uid)
 
-	port := portFromGet(t, uid)
-	assert.Equal(t, uid, port["uid"])
-	assert.Equal(t, portName, port["name"])
-	assert.NotEmpty(t, port["provisioning_status"])
+	port := portFromSDK(t, uid)
+	assert.Equal(t, uid, port.UID)
+	assert.Equal(t, portName, port.Name)
+	assert.NotEmpty(t, port.ProvisioningStatus)
 
 	newName := portName + "-Updated-JSON"
 	updatePayload, err := json.Marshal(map[string]string{"name": newName})
@@ -388,8 +369,8 @@ func TestIntegration_PortJSONInputLifecycle(t *testing.T) {
 
 	runUpdatePortWithFlag(t, uid, "json", string(updatePayload))
 
-	updated := portFromGet(t, uid)
-	assert.Equal(t, newName, updated["name"])
+	updated := portFromSDK(t, uid)
+	assert.Equal(t, newName, updated.Name)
 }
 
 func TestIntegration_PortJSONFileLifecycle(t *testing.T) {
@@ -414,14 +395,14 @@ func TestIntegration_PortJSONFileLifecycle(t *testing.T) {
 	buyCmd := newBuyPortCmd()
 	require.NoError(t, buyCmd.Flags().Set("json-file", buyFile))
 
-	uid := runBuyPort(t, buyCmd, "Port")
+	uid := runBuyPort(t, buyCmd, portName)
 	registerPortCleanup(t, uid)
 	t.Logf("Created port (JSON file) with UID: %s", uid)
 
-	port := portFromGet(t, uid)
-	assert.Equal(t, uid, port["uid"])
-	assert.Equal(t, portName, port["name"])
-	assert.NotEmpty(t, port["provisioning_status"])
+	port := portFromSDK(t, uid)
+	assert.Equal(t, uid, port.UID)
+	assert.Equal(t, portName, port.Name)
+	assert.NotEmpty(t, port.ProvisioningStatus)
 
 	newName := portName + "-Updated-TempJSON"
 	updatePayload, err := json.MarshalIndent(map[string]any{
@@ -435,6 +416,6 @@ func TestIntegration_PortJSONFileLifecycle(t *testing.T) {
 
 	runUpdatePortWithFlag(t, uid, "json-file", updateFile)
 
-	updated := portFromGet(t, uid)
-	assert.Equal(t, newName, updated["name"])
+	updated := portFromSDK(t, uid)
+	assert.Equal(t, newName, updated.Name)
 }

--- a/internal/commands/ports/ports_integration_test.go
+++ b/internal/commands/ports/ports_integration_test.go
@@ -200,9 +200,9 @@ func registerPortCleanup(t *testing.T, uid string) {
 }
 
 // listPortsByName runs ListPorts with --port-name set and returns the parsed
-// records. The port-name filter is a substring match server-side-equivalent on
-// the client; passing the unique generated name keeps results scoped to the
-// caller's port even when other parallel tests are running.
+// records. The port-name filter is applied client-side as a substring match
+// on port names; passing the unique generated name keeps results scoped to
+// the caller's port even when other parallel tests are running.
 func listPortsByName(t *testing.T, name string) []map[string]any {
 	t.Helper()
 	cmd := newListPortsCmd()

--- a/internal/commands/ports/ports_integration_test.go
+++ b/internal/commands/ports/ports_integration_test.go
@@ -3,7 +3,6 @@
 package ports
 
 import (
-	"context"
 	crypto_rand "crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -11,13 +10,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/megaport/megaport-cli/internal/base/output"
-	"github.com/megaport/megaport-cli/internal/commands/config"
-	megaport "github.com/megaport/megaportgo"
+	"github.com/megaport/megaport-cli/internal/testutil"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,52 +27,9 @@ import (
 // exercise.
 const integrationLocationID = 67
 
-// Per-test save/restore of config.LoginFunc is not safe under t.Parallel():
-// concurrent tests can capture each other's installed function as their
-// "original" and leave the global in an unexpected state on cleanup. Instead
-// we install one staging login function for the whole package run via
-// sync.Once. Every test shares the same authorised *megaport.Client, which is
-// fine because they all target the same staging environment.
-var (
-	sharedClient     *megaport.Client
-	sharedClientOnce sync.Once
-	sharedClientErr  error
-)
-
-func requireSharedClient(t *testing.T) {
-	t.Helper()
-	sharedClientOnce.Do(func() {
-		accessKey := os.Getenv("MEGAPORT_ACCESS_KEY")
-		secretKey := os.Getenv("MEGAPORT_SECRET_KEY")
-		if accessKey == "" || secretKey == "" {
-			return
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
-		defer cancel()
-		client, err := megaport.New(nil,
-			megaport.WithCredentials(accessKey, secretKey),
-			megaport.WithEnvironment(megaport.EnvironmentStaging),
-		)
-		if err != nil {
-			sharedClientErr = fmt.Errorf("failed to create megaport client: %w", err)
-			return
-		}
-		if _, err := client.Authorize(ctx); err != nil {
-			sharedClientErr = fmt.Errorf("failed to authorize against staging API: %w", err)
-			return
-		}
-		sharedClient = client
-		config.SetLoginFunc(func(context.Context) (*megaport.Client, error) {
-			return client, nil
-		})
-	})
-	if sharedClientErr != nil {
-		t.Fatalf("integration setup failed: %v", sharedClientErr)
-	}
-	if sharedClient == nil {
-		t.Skip("MEGAPORT_ACCESS_KEY and MEGAPORT_SECRET_KEY required for integration tests")
-	}
-}
+// These tests use t.Parallel(); see testutil.RequireSharedIntegrationClient
+// for why a process-wide sync.Once-guarded login function is used here
+// instead of the per-test save/restore pattern in testutil.LoginWithClient.
 
 func generateUniqueID(t *testing.T) string {
 	t.Helper()
@@ -176,12 +130,24 @@ func captureWithFormat(format string, f func()) string {
 	})
 }
 
+// cleanupStatusTimeout bounds how long registerPortCleanup will poll GetPort
+// for the port to enter DECOMMISSIONING/DECOMMISSIONED after DeletePort.
+// DeletePort only submits the cancellation request; the API can take a few
+// seconds to reflect the new provisioning_status. Sixty seconds is well
+// above observed transitions on staging without making a stuck cleanup
+// drag the test run out by minutes.
+const (
+	cleanupStatusTimeout  = 60 * time.Second
+	cleanupStatusInterval = 2 * time.Second
+)
+
 // registerPortCleanup schedules a best-effort delete of the given port. The
 // cleanup runs even when the test fails, ensuring no orphaned resources on
-// staging. After deletion it asserts the port is reported as
-// DECOMMISSIONING / DECOMMISSIONED. The package-level login function installed
-// by requireSharedClient remains active for the cleanup callback (no
-// per-test restore happens).
+// staging. After deletion it polls GetPort until the port reports
+// DECOMMISSIONING / DECOMMISSIONED, or until cleanupStatusTimeout elapses.
+// The package-level login function installed by
+// testutil.RequireSharedIntegrationClient remains active for the cleanup
+// callback (no per-test restore happens).
 func registerPortCleanup(t *testing.T, uid string) {
 	t.Helper()
 	t.Cleanup(func() {
@@ -198,27 +164,37 @@ func registerPortCleanup(t *testing.T, uid string) {
 			return
 		}
 
-		getCmd := newGetPortCmd()
-		var getErr error
-		getOut := captureWithFormat("json", func() {
-			getErr = GetPort(getCmd, []string{uid}, true, "json")
-		})
-		if getErr != nil {
-			t.Logf("cleanup: GetPort after delete returned %v (port may already be gone)", getErr)
-			return
-		}
-		var ports []map[string]any
-		if err := json.Unmarshal([]byte(getOut), &ports); err != nil || len(ports) == 0 {
-			t.Errorf("cleanup: GetPort returned success but body could not be parsed: %v, output: %s", err, getOut)
-			return
-		}
-		status, ok := ports[0]["provisioning_status"].(string)
-		if !ok {
-			t.Errorf("cleanup: provisioning_status missing or not a string in GetPort response: %v", ports[0]["provisioning_status"])
-			return
-		}
-		if !strings.Contains(status, "DECOMMISSIONING") && !strings.Contains(status, "DECOMMISSIONED") {
-			t.Errorf("expected port %s to be DECOMMISSIONING or DECOMMISSIONED, got %q", uid, status)
+		deadline := time.Now().Add(cleanupStatusTimeout)
+		var lastStatus string
+		for {
+			getCmd := newGetPortCmd()
+			var getErr error
+			getOut := captureWithFormat("json", func() {
+				getErr = GetPort(getCmd, []string{uid}, true, "json")
+			})
+			if getErr != nil {
+				t.Logf("cleanup: GetPort after delete returned %v (port may already be gone)", getErr)
+				return
+			}
+			var ports []map[string]any
+			if err := json.Unmarshal([]byte(getOut), &ports); err != nil || len(ports) == 0 {
+				t.Errorf("cleanup: GetPort returned success but body could not be parsed: %v, output: %s", err, getOut)
+				return
+			}
+			status, ok := ports[0]["provisioning_status"].(string)
+			if !ok {
+				t.Errorf("cleanup: provisioning_status missing or not a string in GetPort response: %v", ports[0]["provisioning_status"])
+				return
+			}
+			lastStatus = status
+			if strings.Contains(status, "DECOMMISSIONING") || strings.Contains(status, "DECOMMISSIONED") {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Errorf("expected port %s to reach DECOMMISSIONING or DECOMMISSIONED within %s, last status %q", uid, cleanupStatusTimeout, lastStatus)
+				return
+			}
+			time.Sleep(cleanupStatusInterval)
 		}
 	})
 }
@@ -308,7 +284,7 @@ func runUpdatePortWithFlag(t *testing.T, uid, flagName, flagValue string) {
 
 func TestIntegration_PortLifecycle(t *testing.T) {
 	t.Parallel()
-	requireSharedClient(t)
+	testutil.RequireSharedIntegrationClient(t)
 
 	portName := fmt.Sprintf("CLI-Test-Port-%s", generateUniqueID(t))
 
@@ -349,7 +325,7 @@ func TestIntegration_PortLifecycle(t *testing.T) {
 
 func TestIntegration_LAGPortLifecycle(t *testing.T) {
 	t.Parallel()
-	requireSharedClient(t)
+	testutil.RequireSharedIntegrationClient(t)
 
 	portName := fmt.Sprintf("CLI-Test-LAG-%s", generateUniqueID(t))
 
@@ -380,7 +356,7 @@ func TestIntegration_LAGPortLifecycle(t *testing.T) {
 
 func TestIntegration_PortJSONInputLifecycle(t *testing.T) {
 	t.Parallel()
-	requireSharedClient(t)
+	testutil.RequireSharedIntegrationClient(t)
 
 	portName := fmt.Sprintf("CLI-Test-Port-JSON-%s", generateUniqueID(t))
 
@@ -418,7 +394,7 @@ func TestIntegration_PortJSONInputLifecycle(t *testing.T) {
 
 func TestIntegration_PortJSONFileLifecycle(t *testing.T) {
 	t.Parallel()
-	requireSharedClient(t)
+	testutil.RequireSharedIntegrationClient(t)
 
 	portName := fmt.Sprintf("CLI-Test-Port-JSONFile-%s", generateUniqueID(t))
 

--- a/internal/commands/ports/ports_integration_test.go
+++ b/internal/commands/ports/ports_integration_test.go
@@ -3,6 +3,7 @@
 package ports
 
 import (
+	"context"
 	crypto_rand "crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -10,10 +11,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/megaport/megaport-cli/internal/base/output"
-	"github.com/megaport/megaport-cli/internal/testutil"
+	"github.com/megaport/megaport-cli/internal/commands/config"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -27,11 +30,58 @@ import (
 // exercise.
 const integrationLocationID = 67
 
-func generateUniqueID() string {
-	buf := make([]byte, 4)
-	if _, err := crypto_rand.Read(buf); err != nil {
-		panic(err)
+// Per-test save/restore of config.LoginFunc is not safe under t.Parallel():
+// concurrent tests can capture each other's installed function as their
+// "original" and leave the global in an unexpected state on cleanup. Instead
+// we install one staging login function for the whole package run via
+// sync.Once. Every test shares the same authorised *megaport.Client, which is
+// fine because they all target the same staging environment.
+var (
+	sharedClient     *megaport.Client
+	sharedClientOnce sync.Once
+	sharedClientErr  error
+)
+
+func requireSharedClient(t *testing.T) {
+	t.Helper()
+	sharedClientOnce.Do(func() {
+		accessKey := os.Getenv("MEGAPORT_ACCESS_KEY")
+		secretKey := os.Getenv("MEGAPORT_SECRET_KEY")
+		if accessKey == "" || secretKey == "" {
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer cancel()
+		client, err := megaport.New(nil,
+			megaport.WithCredentials(accessKey, secretKey),
+			megaport.WithEnvironment(megaport.EnvironmentStaging),
+		)
+		if err != nil {
+			sharedClientErr = fmt.Errorf("failed to create megaport client: %w", err)
+			return
+		}
+		if _, err := client.Authorize(ctx); err != nil {
+			sharedClientErr = fmt.Errorf("failed to authorize against staging API: %w", err)
+			return
+		}
+		sharedClient = client
+		config.SetLoginFunc(func(context.Context) (*megaport.Client, error) {
+			return client, nil
+		})
+	})
+	if sharedClientErr != nil {
+		t.Fatalf("integration setup failed: %v", sharedClientErr)
 	}
+	if sharedClient == nil {
+		t.Skip("MEGAPORT_ACCESS_KEY and MEGAPORT_SECRET_KEY required for integration tests")
+	}
+}
+
+func generateUniqueID(t *testing.T) string {
+	t.Helper()
+	buf := make([]byte, 4)
+	_, err := crypto_rand.Read(buf)
+	require.NoError(t, err, "failed to read crypto/rand entropy")
 	return hex.EncodeToString(buf)
 }
 
@@ -129,20 +179,12 @@ func captureWithFormat(format string, f func()) string {
 // registerPortCleanup schedules a best-effort delete of the given port. The
 // cleanup runs even when the test fails, ensuring no orphaned resources on
 // staging. After deletion it asserts the port is reported as
-// DECOMMISSIONING / DECOMMISSIONED.
-//
-// The cleanup re-installs the staging client into config.LoginFunc for the
-// duration of its run. This is necessary because the outer
-// `defer testutil.LoginWithClient(t, client)()` in the test body runs (and
-// restores the original loginFunc) before any t.Cleanup callback, so cleanup
-// would otherwise hit the real loginFunc — which may resolve to a different
-// environment than staging.
-func registerPortCleanup(t *testing.T, client *megaport.Client, uid string) {
+// DECOMMISSIONING / DECOMMISSIONED. The package-level login function installed
+// by requireSharedClient remains active for the cleanup callback (no
+// per-test restore happens).
+func registerPortCleanup(t *testing.T, uid string) {
 	t.Helper()
 	t.Cleanup(func() {
-		restore := testutil.LoginWithClient(t, client)
-		defer restore()
-
 		delCmd := newDeletePortCmd()
 		require.NoError(t, delCmd.Flags().Set("now", "true"))
 		require.NoError(t, delCmd.Flags().Set("force", "true"))
@@ -266,11 +308,9 @@ func runUpdatePortWithFlag(t *testing.T, uid, flagName, flagValue string) {
 
 func TestIntegration_PortLifecycle(t *testing.T) {
 	t.Parallel()
+	requireSharedClient(t)
 
-	client := testutil.SetupIntegrationClient(t)
-	defer testutil.LoginWithClient(t, client)()
-
-	portName := fmt.Sprintf("CLI-Test-Port-%s", generateUniqueID())
+	portName := fmt.Sprintf("CLI-Test-Port-%s", generateUniqueID(t))
 
 	buyCmd := newBuyPortCmd()
 	require.NoError(t, buyCmd.Flags().Set("name", portName))
@@ -281,7 +321,7 @@ func TestIntegration_PortLifecycle(t *testing.T) {
 	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
 
 	uid := runBuyPort(t, buyCmd, "Port")
-	registerPortCleanup(t, client, uid)
+	registerPortCleanup(t, uid)
 	t.Logf("Created port with UID: %s", uid)
 
 	port := portFromGet(t, uid)
@@ -309,11 +349,9 @@ func TestIntegration_PortLifecycle(t *testing.T) {
 
 func TestIntegration_LAGPortLifecycle(t *testing.T) {
 	t.Parallel()
+	requireSharedClient(t)
 
-	client := testutil.SetupIntegrationClient(t)
-	defer testutil.LoginWithClient(t, client)()
-
-	portName := fmt.Sprintf("CLI-Test-LAG-%s", generateUniqueID())
+	portName := fmt.Sprintf("CLI-Test-LAG-%s", generateUniqueID(t))
 
 	buyCmd := newBuyLAGPortCmd()
 	require.NoError(t, buyCmd.Flags().Set("name", portName))
@@ -325,7 +363,7 @@ func TestIntegration_LAGPortLifecycle(t *testing.T) {
 	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
 
 	uid := runBuyLAGPort(t, buyCmd)
-	registerPortCleanup(t, client, uid)
+	registerPortCleanup(t, uid)
 	t.Logf("Created LAG port with UID: %s", uid)
 
 	port := portFromGet(t, uid)
@@ -342,13 +380,11 @@ func TestIntegration_LAGPortLifecycle(t *testing.T) {
 
 func TestIntegration_PortJSONInputLifecycle(t *testing.T) {
 	t.Parallel()
+	requireSharedClient(t)
 
-	client := testutil.SetupIntegrationClient(t)
-	defer testutil.LoginWithClient(t, client)()
+	portName := fmt.Sprintf("CLI-Test-Port-JSON-%s", generateUniqueID(t))
 
-	portName := fmt.Sprintf("CLI-Test-Port-JSON-%s", generateUniqueID())
-
-	buyPayload := map[string]interface{}{
+	buyPayload := map[string]any{
 		"name":                  portName,
 		"term":                  1,
 		"portSpeed":             1000,
@@ -362,7 +398,7 @@ func TestIntegration_PortJSONInputLifecycle(t *testing.T) {
 	require.NoError(t, buyCmd.Flags().Set("json", string(buyJSON)))
 
 	uid := runBuyPort(t, buyCmd, "Port")
-	registerPortCleanup(t, client, uid)
+	registerPortCleanup(t, uid)
 	t.Logf("Created port (JSON input) with UID: %s", uid)
 
 	port := portFromGet(t, uid)
@@ -382,13 +418,11 @@ func TestIntegration_PortJSONInputLifecycle(t *testing.T) {
 
 func TestIntegration_PortJSONFileLifecycle(t *testing.T) {
 	t.Parallel()
+	requireSharedClient(t)
 
-	client := testutil.SetupIntegrationClient(t)
-	defer testutil.LoginWithClient(t, client)()
+	portName := fmt.Sprintf("CLI-Test-Port-JSONFile-%s", generateUniqueID(t))
 
-	portName := fmt.Sprintf("CLI-Test-Port-JSONFile-%s", generateUniqueID())
-
-	buyPayload := map[string]interface{}{
+	buyPayload := map[string]any{
 		"name":                  portName,
 		"term":                  1,
 		"portSpeed":             1000,
@@ -405,7 +439,7 @@ func TestIntegration_PortJSONFileLifecycle(t *testing.T) {
 	require.NoError(t, buyCmd.Flags().Set("json-file", buyFile))
 
 	uid := runBuyPort(t, buyCmd, "Port")
-	registerPortCleanup(t, client, uid)
+	registerPortCleanup(t, uid)
 	t.Logf("Created port (JSON file) with UID: %s", uid)
 
 	port := portFromGet(t, uid)
@@ -414,7 +448,7 @@ func TestIntegration_PortJSONFileLifecycle(t *testing.T) {
 	assert.NotEmpty(t, port["provisioning_status"])
 
 	newName := portName + "-Updated-TempJSON"
-	updatePayload, err := json.MarshalIndent(map[string]interface{}{
+	updatePayload, err := json.MarshalIndent(map[string]any{
 		"name":                  newName,
 		"marketPlaceVisibility": true,
 	}, "", "  ")

--- a/internal/commands/product/product_mock.go
+++ b/internal/commands/product/product_mock.go
@@ -34,6 +34,12 @@ type MockProductService struct {
 	ListProductResourceTagsResult []megaport.ResourceTag
 
 	UpdateProductResourceTagsErr error
+
+	GetProductPricingErr    error
+	GetProductPricingResult *megaport.PriceBookDTO
+
+	GetProductPricingForCompanyErr    error
+	GetProductPricingForCompanyResult *megaport.PriceBookDTO
 }
 
 func (m *MockProductService) ListProducts(ctx context.Context) ([]megaport.Product, error) {
@@ -74,4 +80,12 @@ func (m *MockProductService) ListProductResourceTags(ctx context.Context, produc
 
 func (m *MockProductService) UpdateProductResourceTags(ctx context.Context, productUID string, tagsReq *megaport.UpdateProductResourceTagsRequest) error {
 	return m.UpdateProductResourceTagsErr
+}
+
+func (m *MockProductService) GetProductPricing(ctx context.Context, req megaport.PriceBookRequest) (*megaport.PriceBookDTO, error) {
+	return m.GetProductPricingResult, m.GetProductPricingErr
+}
+
+func (m *MockProductService) GetProductPricingForCompany(ctx context.Context, req *megaport.GetProductPricingRequest) (*megaport.PriceBookDTO, error) {
+	return m.GetProductPricingForCompanyResult, m.GetProductPricingForCompanyErr
 }

--- a/internal/commands/status/status_mock.go
+++ b/internal/commands/status/status_mock.go
@@ -299,3 +299,7 @@ func (m *MockIXService) UpdateIX(_ context.Context, _ string, _ *megaport.Update
 func (m *MockIXService) DeleteIX(_ context.Context, _ string, _ *megaport.DeleteIXRequest) error {
 	return fmt.Errorf("mock: DeleteIX not configured")
 }
+
+func (m *MockIXService) ListIXPs(_ context.Context, _ *megaport.ListIXPsRequest) ([]*megaport.IXP, error) {
+	return nil, fmt.Errorf("mock: ListIXPs not configured")
+}

--- a/internal/testutil/integration.go
+++ b/internal/testutil/integration.go
@@ -4,7 +4,9 @@ package testutil
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,6 +18,11 @@ import (
 // SetupIntegrationClient reads staging credentials from environment variables,
 // authorises against the staging API, and returns a ready-to-use *megaport.Client.
 // Skips the test if MEGAPORT_ACCESS_KEY or MEGAPORT_SECRET_KEY are not set.
+//
+// Suitable for serial read-only tests. For tests that use t.Parallel(), prefer
+// RequireSharedIntegrationClient which installs the login function exactly
+// once per process via sync.Once and avoids the save/restore race in
+// LoginWithClient.
 func SetupIntegrationClient(t *testing.T) *megaport.Client {
 	t.Helper()
 	accessKey := os.Getenv("MEGAPORT_ACCESS_KEY")
@@ -41,6 +48,10 @@ func SetupIntegrationClient(t *testing.T) *megaport.Client {
 
 // LoginWithClient overrides the login function to return the given client for the
 // duration of the test. Returns a cleanup function that restores the original.
+//
+// Not safe under t.Parallel(): concurrent tests can capture each other's
+// installed function as their "original" and leave the global in an
+// unexpected state on cleanup. Use RequireSharedIntegrationClient instead.
 func LoginWithClient(t *testing.T, client *megaport.Client) func() {
 	t.Helper()
 	original := config.GetLoginFunc()
@@ -48,4 +59,58 @@ func LoginWithClient(t *testing.T, client *megaport.Client) func() {
 		return client, nil
 	})
 	return func() { config.SetLoginFunc(original) }
+}
+
+var (
+	sharedIntegrationClient     *megaport.Client
+	sharedIntegrationClientOnce sync.Once
+	sharedIntegrationClientErr  error
+)
+
+// RequireSharedIntegrationClient installs a process-wide staging client
+// suitable for parallel integration tests. Unlike SetupIntegrationClient +
+// LoginWithClient, it authorises against staging and installs
+// config.SetLoginFunc exactly once via sync.Once and never restores. This
+// avoids a race in which two t.Parallel() tests concurrently capture and
+// restore config.LoginFunc, leaving the global pointing at a stale closure.
+//
+// Sharing one authorised client across parallel tests is safe because they
+// all target the same staging environment. Subsequent callers reuse the
+// cached client. Skips when MEGAPORT_ACCESS_KEY or MEGAPORT_SECRET_KEY are
+// not set.
+func RequireSharedIntegrationClient(t *testing.T) {
+	t.Helper()
+	sharedIntegrationClientOnce.Do(func() {
+		accessKey := os.Getenv("MEGAPORT_ACCESS_KEY")
+		secretKey := os.Getenv("MEGAPORT_SECRET_KEY")
+		if accessKey == "" || secretKey == "" {
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer cancel()
+
+		client, err := megaport.New(nil,
+			megaport.WithCredentials(accessKey, secretKey),
+			megaport.WithEnvironment(megaport.EnvironmentStaging),
+		)
+		if err != nil {
+			sharedIntegrationClientErr = fmt.Errorf("failed to create megaport client: %w", err)
+			return
+		}
+		if _, err := client.Authorize(ctx); err != nil {
+			sharedIntegrationClientErr = fmt.Errorf("failed to authorize against staging API: %w", err)
+			return
+		}
+		sharedIntegrationClient = client
+		config.SetLoginFunc(func(context.Context) (*megaport.Client, error) {
+			return client, nil
+		})
+	})
+	if sharedIntegrationClientErr != nil {
+		t.Fatalf("integration setup failed: %v", sharedIntegrationClientErr)
+	}
+	if sharedIntegrationClient == nil {
+		t.Skip("MEGAPORT_ACCESS_KEY and MEGAPORT_SECRET_KEY required for integration tests")
+	}
 }

--- a/internal/testutil/integration.go
+++ b/internal/testutil/integration.go
@@ -114,3 +114,16 @@ func RequireSharedIntegrationClient(t *testing.T) {
 		t.Skip("MEGAPORT_ACCESS_KEY and MEGAPORT_SECRET_KEY required for integration tests")
 	}
 }
+
+// SharedIntegrationClient returns the process-wide staging client installed by
+// RequireSharedIntegrationClient. Tests use it to read state directly from the
+// SDK in assertions, avoiding output.CaptureOutput on hot paths where parallel
+// goroutines would race on the global os.Stdout swap. Callers must invoke
+// RequireSharedIntegrationClient(t) first; this fails the test if not.
+func SharedIntegrationClient(t *testing.T) *megaport.Client {
+	t.Helper()
+	if sharedIntegrationClient == nil {
+		t.Fatal("SharedIntegrationClient called before RequireSharedIntegrationClient")
+	}
+	return sharedIntegrationClient
+}


### PR DESCRIPTION
Reintroduces a ports integration suite (ESD-1174), replacing the `exec.Command`-based suite under `internal/test/` that #361 removed. The new tests live in their proper place — `internal/commands/ports/ports_integration_test.go`, build tag `integration`, same package — and call the action functions directly (Approach B).

Four lifecycle scenarios, each `t.Parallel()`: single 1G port, 10G LAG, `--json` round-trip, and `--json-file` round-trip (buy → get → list → update → get). Real parallelism brings the wall time to ~139s, down from ~337s on the old serialized baseline.

## Making it parallel-safe

Two pieces of global state made a naive `t.Parallel()` unsafe; both are worth understanding for review:

- **Login.** New `testutil.RequireSharedIntegrationClient` authorizes once per process (`sync.Once`) and installs `config.SetLoginFunc` exactly once. Per-test save/restore pairs would race on the global `config.LoginFunc` and leave it pointing at a stale closure. `LoginWithClient` stays for serial read-only suites (e.g. `locations`).
- **Output capture.** Side-effecting actions (`BuyPort`, `UpdatePort`, …) run without `output.CaptureOutput`, which swaps the process-wide `os.Stdout` under a mutex — under `t.Parallel()` that both serializes every wrapped call and races stdout against other tests' spinner goroutines. The `BuyPort` SDK response is instead recovered via an `init()` hook on `buyPortFunc` into a `sync.Map`. State assertions read through `testutil.SharedIntegrationClient(t)` (direct SDK calls) rather than scraping `GetPort`/`ListPorts` stdout.

## Cleanup

Registered via `t.Cleanup`, so deletion runs even on failure. After `DeletePort` it polls the SDK directly (2s backoff, 60s deadline) until the port reports `DECOMMISSIONING`/`DECOMMISSIONED` — the API takes a few seconds to reflect the transition and exposes no completion signal. This poll loop holds the only `time.Sleep` in the suite; the buy/update paths block on the SDK's `WaitForProvision`/`WaitForUpdate`.

## Notes

- Resource names are prefixed `CLI-Test-` (per `docs/INTEGRATION_TESTING.md`) so cleanup tooling can find leaks; staging location `67` is the canonical ID used across the CLI.
- `docs/INTEGRATION_TESTING.md` gains "Authentication helpers" and "Output capture and parallelism" sections covering the above.
- CI already runs `./internal/commands/ports/...` in `integration-test.yml`; the new file is auto-discovered.

Tests passing against Staging API on 2026/06/03
