### PR TITLE
ESD-1206: support in-place vNIC description updates on MVE

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ megaport-cli mve buy --json '{"name":"My Versa MVE","term":1,"locationId":67,"ve
 
 # Update an existing MVE
 megaport-cli mve update MVE_UID --interactive
-megaport-cli mve update MVE_UID --name "Updated MVE Name" --cost-centre "New Cost Centre" --contract-term 24
+megaport-cli mve update MVE_UID --name "Updated MVE Name" --cost-centre "New Cost Centre" --term 24
 megaport-cli mve update MVE_UID --json '{"name": "New MVE Name", "costCentre": "New Cost Centre", "contractTermMonths": 24}'
 
 # Delete an MVE (immediate)

--- a/docs/megaport-cli_mve_update.md
+++ b/docs/megaport-cli_mve_update.md
@@ -9,9 +9,10 @@ Update an existing Megaport Virtual Edge (MVE).
 This command allows you to update specific properties of an existing MVE without disrupting its service or connectivity. Updates apply immediately but may take a few minutes to fully propagate in the Megaport system.
 
 ### Optional Fields
-  - `contract-term`: The new contract term in months (1, 12, 24, or 36)
   - `cost-centre`: The new cost centre for billing purposes
   - `name`: The new name of the MVE (1-64 characters)
+  - `term`: The new contract term in months (1, 12, 24, or 36)
+  - `vnics`: JSON array of vNIC updates — one entry per existing vNIC, in order. Only `description` is mutable.
 
 ### Important Notes
   - The MVE UID cannot be changed
@@ -19,12 +20,14 @@ This command allows you to update specific properties of an existing MVE without
   - Technical specifications (size, location) cannot be modified
   - Connectivity (VXCs) will not be affected by these changes
   - Changing the contract term may affect billing immediately
+  - vNICs can only have their description updated — the vNIC count and VLAN cannot change after provisioning
 
 ### Example Usage
 
 ```sh
   megaport-cli mve update 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p
-  megaport-cli mve update 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --name "Edge Router West" --cost-centre "IT-Network-2023" --contract-term 24
+  megaport-cli mve update 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --name "Edge Router West" --cost-centre "IT-Network-2023" --term 24
+  megaport-cli mve update 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --vnics '[{"description":"Data Plane"},{"description":"Management"}]'
   megaport-cli mve update 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --json '{"name": "Edge Router West", "costCentre": "IT-Network-2023", "contractTermMonths": 24}'
   megaport-cli mve update 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --json-file ./mve-update.json
 ```
@@ -33,7 +36,11 @@ This command allows you to update specific properties of an existing MVE without
 {
   "name": "Edge Router West",
   "costCentre": "IT-Network-2023",
-  "contractTermMonths": 24
+  "contractTermMonths": 24,
+  "vnics": [
+    {"description": "Data Plane"},
+    {"description": "Management"}
+  ]
 }
 
 ```
@@ -59,6 +66,7 @@ megaport-cli mve update [flags]
 | `--json-file` |  |  | Path to JSON file containing configuration | false |
 | `--name` |  |  | The new name of the MVE (1-64 characters) | false |
 | `--term` |  | `0` | New contract term in months (1, 12, 24, or 36) | false |
+| `--vnics` |  |  | JSON array of vNIC updates — one entry per existing vNIC, in order. Only `description` is mutable, e.g. `[{"description":"Data Plane"}]`. The vNIC count cannot change after provisioning. | false |
 
 ## Subcommands
 * [docs](megaport-cli_mve_update_docs.md)

--- a/internal/base/cmdbuilder/flagsets_test.go
+++ b/internal/base/cmdbuilder/flagsets_test.go
@@ -351,7 +351,7 @@ func TestWithVXCFilterFlags(t *testing.T) {
 func TestWithMVEUpdateFlags(t *testing.T) {
 	cmd := NewCommand("test", "test").WithMVEUpdateFlags().Build()
 
-	expectedFlags := []string{"name", "cost-centre", "term"}
+	expectedFlags := []string{"name", "cost-centre", "term", "vnics"}
 	for _, flag := range expectedFlags {
 		assert.NotNil(t, cmd.Flags().Lookup(flag), "MVE update flag %q should exist", flag)
 	}

--- a/internal/base/cmdbuilder/mve_flagsets.go
+++ b/internal/base/cmdbuilder/mve_flagsets.go
@@ -34,6 +34,7 @@ func (b *CommandBuilder) WithMVEUpdateFlags() *CommandBuilder {
 	b.WithFlag("name", "", "The new name of the MVE (1-64 characters)")
 	b.WithFlag("cost-centre", "", "The new cost centre for billing purposes")
 	b.WithIntFlag("term", 0, fmt.Sprintf("New contract term in months (%s)", validation.FormatIntSlice(validation.ValidContractTerms)))
+	b.WithFlag("vnics", "", "JSON array of vNIC updates — one entry per existing vNIC, in order. Only `description` is mutable, e.g. `[{\"description\":\"Data Plane\"}]`. The vNIC count cannot change after provisioning.")
 	return b
 }
 

--- a/internal/commands/mve/mve.go
+++ b/internal/commands/mve/mve.go
@@ -101,10 +101,10 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithLongDesc("Update an existing Megaport Virtual Edge (MVE).\n\nThis command allows you to update specific properties of an existing MVE without disrupting its service or connectivity. Updates apply immediately but may take a few minutes to fully propagate in the Megaport system.").
 		WithOptionalFlag("name", "The new name of the MVE (1-64 characters)").
 		WithOptionalFlag("cost-centre", "The new cost centre for billing purposes").
-		WithOptionalFlag("contract-term", "The new contract term in months (1, 12, 24, or 36)").
+		WithOptionalFlag("term", "The new contract term in months (1, 12, 24, or 36)").
 		WithOptionalFlag("vnics", "JSON array of vNIC updates — one entry per existing vNIC, in order. Only `description` is mutable.").
 		WithExample("megaport-cli mve update 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p").
-		WithExample("megaport-cli mve update 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --name \"Edge Router West\" --cost-centre \"IT-Network-2023\" --contract-term 24").
+		WithExample("megaport-cli mve update 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --name \"Edge Router West\" --cost-centre \"IT-Network-2023\" --term 24").
 		WithExample("megaport-cli mve update 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --vnics '[{\"description\":\"Data Plane\"},{\"description\":\"Management\"}]'").
 		WithExample("megaport-cli mve update 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --json '{\"name\": \"Edge Router West\", \"costCentre\": \"IT-Network-2023\", \"contractTermMonths\": 24}'").
 		WithExample("megaport-cli mve update 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --json-file ./mve-update.json").

--- a/internal/commands/mve/mve.go
+++ b/internal/commands/mve/mve.go
@@ -102,20 +102,27 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithOptionalFlag("name", "The new name of the MVE (1-64 characters)").
 		WithOptionalFlag("cost-centre", "The new cost centre for billing purposes").
 		WithOptionalFlag("contract-term", "The new contract term in months (1, 12, 24, or 36)").
+		WithOptionalFlag("vnics", "JSON array of vNIC updates — one entry per existing vNIC, in order. Only `description` is mutable.").
 		WithExample("megaport-cli mve update 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p").
 		WithExample("megaport-cli mve update 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --name \"Edge Router West\" --cost-centre \"IT-Network-2023\" --contract-term 24").
+		WithExample("megaport-cli mve update 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --vnics '[{\"description\":\"Data Plane\"},{\"description\":\"Management\"}]'").
 		WithExample("megaport-cli mve update 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --json '{\"name\": \"Edge Router West\", \"costCentre\": \"IT-Network-2023\", \"contractTermMonths\": 24}'").
 		WithExample("megaport-cli mve update 1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p --json-file ./mve-update.json").
 		WithJSONExample(`{
   "name": "Edge Router West",
   "costCentre": "IT-Network-2023",
-  "contractTermMonths": 24
+  "contractTermMonths": 24,
+  "vnics": [
+    {"description": "Data Plane"},
+    {"description": "Management"}
+  ]
 }`).
 		WithImportantNote("The MVE UID cannot be changed").
 		WithImportantNote("Vendor configuration cannot be changed after provisioning").
 		WithImportantNote("Technical specifications (size, location) cannot be modified").
 		WithImportantNote("Connectivity (VXCs) will not be affected by these changes").
 		WithImportantNote("Changing the contract term may affect billing immediately").
+		WithImportantNote("vNICs can only have their description updated — the vNIC count and VLAN cannot change after provisioning").
 		WithRootCmd(rootCmd).
 		Build()
 

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -278,7 +278,7 @@ func UpdateMVE(cmd *cobra.Command, args []string, noColor bool) error {
 
 	flagsProvided := cmd.Flags().Changed("name") ||
 		cmd.Flags().Changed("cost-centre") ||
-		cmd.Flags().Changed("contract-term") ||
+		cmd.Flags().Changed("term") ||
 		cmd.Flags().Changed("vnics")
 
 	var req *megaport.ModifyMVERequest

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -271,6 +271,10 @@ func UpdateMVE(cmd *cobra.Command, args []string, noColor bool) error {
 		output.PrintError("Failed to get original MVE details: %v", noColor, err)
 		return fmt.Errorf("failed to get MVE details: %w", err)
 	}
+	if originalMVE == nil {
+		output.PrintError("MVE %s not found", noColor, mveUID)
+		return fmt.Errorf("MVE %s not found", mveUID)
+	}
 
 	interactive, _ := cmd.Flags().GetBool("interactive")
 	jsonStr, _ := cmd.Flags().GetString("json")

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -307,6 +307,12 @@ func UpdateMVE(cmd *cobra.Command, args []string, noColor bool) error {
 		return fmt.Errorf("no input provided, use --interactive, --json, or flags to specify MVE update details")
 	}
 
+	if len(req.Vnics) > 0 && len(req.Vnics) != len(originalMVE.NetworkInterfaces) {
+		msg := fmt.Sprintf("vnics length (%d) must match the MVE's existing vNIC count (%d) — the vNIC count cannot change after provisioning", len(req.Vnics), len(originalMVE.NetworkInterfaces))
+		output.PrintError("%s", noColor, msg)
+		return fmt.Errorf("%s", msg)
+	}
+
 	req.WaitForUpdate = true
 	req.WaitForTime = utils.DefaultProvisionTimeout
 

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -307,7 +307,7 @@ func UpdateMVE(cmd *cobra.Command, args []string, noColor bool) error {
 		return fmt.Errorf("no input provided, use --interactive, --json, or flags to specify MVE update details")
 	}
 
-	if len(req.Vnics) > 0 && len(req.Vnics) != len(originalMVE.NetworkInterfaces) {
+	if req.Vnics != nil && len(req.Vnics) != len(originalMVE.NetworkInterfaces) {
 		msg := fmt.Sprintf("vnics length (%d) must match the MVE's existing vNIC count (%d) — the vNIC count cannot change after provisioning", len(req.Vnics), len(originalMVE.NetworkInterfaces))
 		output.PrintError("%s", noColor, msg)
 		return fmt.Errorf("%s", msg)

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -278,7 +278,8 @@ func UpdateMVE(cmd *cobra.Command, args []string, noColor bool) error {
 
 	flagsProvided := cmd.Flags().Changed("name") ||
 		cmd.Flags().Changed("cost-centre") ||
-		cmd.Flags().Changed("contract-term")
+		cmd.Flags().Changed("contract-term") ||
+		cmd.Flags().Changed("vnics")
 
 	var req *megaport.ModifyMVERequest
 
@@ -296,7 +297,7 @@ func UpdateMVE(cmd *cobra.Command, args []string, noColor bool) error {
 		}
 	} else if interactive {
 		output.PrintInfo("Starting interactive mode for MVE %s", noColor, formattedUID)
-		req, err = promptForUpdateMVEDetails(mveUID, noColor)
+		req, err = promptForUpdateMVEDetails(mveUID, originalMVE.NetworkInterfaces, noColor)
 		if err != nil {
 			output.PrintError("Failed to get MVE details interactively: %v", noColor, err)
 			return fmt.Errorf("failed to get MVE details interactively: %w", err)

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -422,6 +422,46 @@ func TestUpdateMVE(t *testing.T) {
 			},
 			expectedError: "empty response from API",
 		},
+		{
+			name: "vnic count mismatch",
+			args: []string{"mve-123"},
+			flags: map[string]string{
+				"vnics": `[{"description":"Only One"}]`,
+			},
+			mockSetup: func(m *MockMVEService) {
+				m.GetMVEResult = &megaport.MVE{
+					Name: "Mock MVE",
+					NetworkInterfaces: []*megaport.MVENetworkInterface{
+						{Description: "Data Plane"},
+						{Description: "Management"},
+					},
+				}
+			},
+			expectedError: "vnics length (1) must match the MVE's existing vNIC count (2)",
+		},
+		{
+			name: "vnic count match success",
+			args: []string{"mve-123"},
+			flags: map[string]string{
+				"vnics": `[{"description":"Data Plane Renamed"},{"description":"Mgmt"}]`,
+			},
+			mockSetup: func(m *MockMVEService) {
+				m.ModifyMVEResult = &megaport.ModifyMVEResponse{MVEUpdated: true}
+				m.GetMVEResult = &megaport.MVE{
+					Name: "Mock MVE",
+					NetworkInterfaces: []*megaport.MVENetworkInterface{
+						{Description: "Data Plane"},
+						{Description: "Management"},
+					},
+				}
+			},
+			expectedOutput: "MVE updated mve-123",
+			validateRequest: func(t *testing.T, req *megaport.ModifyMVERequest) {
+				assert.Len(t, req.Vnics, 2)
+				assert.Equal(t, "Data Plane Renamed", req.Vnics[0].Description)
+				assert.Equal(t, "Mgmt", req.Vnics[1].Description)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -448,6 +488,7 @@ func TestUpdateMVE(t *testing.T) {
 			cmd.Flags().String("name", "", "")
 			cmd.Flags().String("cost-centre", "", "")
 			cmd.Flags().Int("term", 0, "")
+			cmd.Flags().String("vnics", "", "")
 
 			testutil.SetFlags(t, cmd, tt.flags)
 

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -465,7 +465,7 @@ func TestUpdateMVE(t *testing.T) {
 					},
 				}
 			},
-			expectedError: "vnics length (0) must match the MVE's existing vNIC count (1)",
+			expectedError: "vnics must contain at least one object",
 		},
 		{
 			name: "vnic count match success",

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -327,9 +327,9 @@ func TestUpdateMVE(t *testing.T) {
 			name: "flag mode success",
 			args: []string{"mve-123"},
 			flags: map[string]string{
-				"name":          "Flag Updated MVE",
-				"cost-centre":   "Flag Cost Centre",
-				"contract-term": "36",
+				"name":        "Flag Updated MVE",
+				"cost-centre": "Flag Cost Centre",
+				"term":        "36",
 			},
 			mockSetup: func(m *MockMVEService) {
 				m.ModifyMVEResult = &megaport.ModifyMVEResponse{
@@ -391,7 +391,7 @@ func TestUpdateMVE(t *testing.T) {
 			name: "invalid contract term",
 			args: []string{"mve-123"},
 			flags: map[string]string{
-				"contract-term": "13",
+				"term": "13",
 			},
 			expectedError: "Invalid contract term: 13 - must be one of: [1 12 24 36]",
 		},
@@ -447,7 +447,7 @@ func TestUpdateMVE(t *testing.T) {
 			cmd.Flags().String("json-file", "", "")
 			cmd.Flags().String("name", "", "")
 			cmd.Flags().String("cost-centre", "", "")
-			cmd.Flags().Int("contract-term", 0, "")
+			cmd.Flags().Int("term", 0, "")
 
 			testutil.SetFlags(t, cmd, tt.flags)
 

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -423,6 +423,17 @@ func TestUpdateMVE(t *testing.T) {
 			expectedError: "empty response from API",
 		},
 		{
+			name: "original MVE not found",
+			args: []string{"mve-123"},
+			flags: map[string]string{
+				"name": "Updated MVE",
+			},
+			mockSetup: func(m *MockMVEService) {
+				m.ForceNilGetMVE = true
+			},
+			expectedError: "MVE mve-123 not found",
+		},
+		{
 			name: "vnic count mismatch",
 			args: []string{"mve-123"},
 			flags: map[string]string{

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -440,6 +440,23 @@ func TestUpdateMVE(t *testing.T) {
 			expectedError: "vnics length (1) must match the MVE's existing vNIC count (2)",
 		},
 		{
+			name: "explicit empty vnics array rejected alongside other updates",
+			args: []string{"mve-123"},
+			flags: map[string]string{
+				"name":  "Renamed",
+				"vnics": `[]`,
+			},
+			mockSetup: func(m *MockMVEService) {
+				m.GetMVEResult = &megaport.MVE{
+					Name: "Mock MVE",
+					NetworkInterfaces: []*megaport.MVENetworkInterface{
+						{Description: "Data Plane"},
+					},
+				}
+			},
+			expectedError: "vnics length (0) must match the MVE's existing vNIC count (1)",
+		},
+		{
 			name: "vnic count match success",
 			args: []string{"mve-123"},
 			flags: map[string]string{

--- a/internal/commands/mve/mve_inputs.go
+++ b/internal/commands/mve/mve_inputs.go
@@ -642,6 +642,14 @@ func processJSONUpdateMVEInput(jsonStr, jsonFilePath, mveUID string) (*megaport.
 		req.ContractTermMonths = &termMonths
 	}
 
+	if vnicsData, ok := jsonData["vnics"].([]interface{}); ok {
+		vnics, err := parseVnicUpdates(vnicsData)
+		if err != nil {
+			return nil, err
+		}
+		req.Vnics = vnics
+	}
+
 	if err := validation.ValidateUpdateMVERequest(req); err != nil {
 		return nil, err
 	}
@@ -653,6 +661,7 @@ func processFlagUpdateMVEInput(cmd *cobra.Command, mveUID string) (*megaport.Mod
 	name, _ := cmd.Flags().GetString("name")
 	costCentre, _ := cmd.Flags().GetString("cost-centre")
 	contractTerm, _ := cmd.Flags().GetInt("contract-term")
+	vnicsStr, _ := cmd.Flags().GetString("vnics")
 
 	req := &megaport.ModifyMVERequest{
 		MVEID: mveUID,
@@ -670,9 +679,40 @@ func processFlagUpdateMVEInput(cmd *cobra.Command, mveUID string) (*megaport.Mod
 		req.ContractTermMonths = &contractTerm
 	}
 
+	if vnicsStr != "" {
+		var vnicsData []interface{}
+		if err := json.Unmarshal([]byte(vnicsStr), &vnicsData); err != nil {
+			return nil, fmt.Errorf("failed to parse vnics JSON string: %w", err)
+		}
+		vnics, err := parseVnicUpdates(vnicsData)
+		if err != nil {
+			return nil, err
+		}
+		req.Vnics = vnics
+	}
+
 	if err := validation.ValidateUpdateMVERequest(req); err != nil {
 		return nil, err
 	}
 
 	return req, nil
+}
+
+// parseVnicUpdates decodes a slice of {description: string} maps into
+// []megaport.MVEVnicUpdate. Order is preserved — the API applies updates
+// positionally to the existing vNICs.
+func parseVnicUpdates(vnicsData []interface{}) ([]megaport.MVEVnicUpdate, error) {
+	vnics := make([]megaport.MVEVnicUpdate, 0, len(vnicsData))
+	for i, vnicData := range vnicsData {
+		vnicMap, ok := vnicData.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("vnics[%d] must be an object with a description field", i)
+		}
+		description, ok := vnicMap["description"].(string)
+		if !ok {
+			return nil, fmt.Errorf("vnics[%d].description is required and must be a string", i)
+		}
+		vnics = append(vnics, megaport.MVEVnicUpdate{Description: description})
+	}
+	return vnics, nil
 }

--- a/internal/commands/mve/mve_inputs.go
+++ b/internal/commands/mve/mve_inputs.go
@@ -683,7 +683,10 @@ func processFlagUpdateMVEInput(cmd *cobra.Command, mveUID string) (*megaport.Mod
 		req.ContractTermMonths = &contractTerm
 	}
 
-	if vnicsStr != "" {
+	if cmd.Flags().Changed("vnics") {
+		if strings.TrimSpace(vnicsStr) == "" {
+			return nil, fmt.Errorf("vnics must be a non-empty JSON array of objects with a description field")
+		}
 		var vnicsData []interface{}
 		if err := json.Unmarshal([]byte(vnicsStr), &vnicsData); err != nil {
 			return nil, fmt.Errorf("failed to parse vnics JSON string: %w", err)

--- a/internal/commands/mve/mve_inputs.go
+++ b/internal/commands/mve/mve_inputs.go
@@ -637,7 +637,7 @@ func processJSONUpdateMVEInput(jsonStr, jsonFilePath, mveUID string) (*megaport.
 		req.CostCentre = costCentre
 	}
 
-	if contractTermMonths, ok := jsonData["contractTermMonths"].(float64); ok && contractTermMonths > 0 {
+	if contractTermMonths, ok := jsonData["contractTermMonths"].(float64); ok {
 		termMonths := int(contractTermMonths)
 		req.ContractTermMonths = &termMonths
 	}
@@ -679,7 +679,7 @@ func processFlagUpdateMVEInput(cmd *cobra.Command, mveUID string) (*megaport.Mod
 		req.CostCentre = costCentre
 	}
 
-	if contractTerm > 0 {
+	if cmd.Flags().Changed("term") {
 		req.ContractTermMonths = &contractTerm
 	}
 
@@ -705,8 +705,13 @@ func processFlagUpdateMVEInput(cmd *cobra.Command, mveUID string) (*megaport.Mod
 // parseVnicUpdates decodes a slice of {description: string} maps into
 // []megaport.MVEVnicUpdate. Order is preserved — the API applies updates
 // positionally to the existing vNICs. Only description can be updated;
-// unknown keys are rejected so callers don't silently lose input.
+// unknown keys are rejected so callers don't silently lose input. An
+// empty array is rejected so callers don't get a misleading
+// "at least one field must be provided" error.
 func parseVnicUpdates(vnicsData []interface{}) ([]megaport.MVEVnicUpdate, error) {
+	if len(vnicsData) == 0 {
+		return nil, fmt.Errorf("vnics must contain at least one object with a description field")
+	}
 	vnics := make([]megaport.MVEVnicUpdate, 0, len(vnicsData))
 	for i, vnicData := range vnicsData {
 		vnicMap, ok := vnicData.(map[string]interface{})

--- a/internal/commands/mve/mve_inputs.go
+++ b/internal/commands/mve/mve_inputs.go
@@ -704,7 +704,8 @@ func processFlagUpdateMVEInput(cmd *cobra.Command, mveUID string) (*megaport.Mod
 
 // parseVnicUpdates decodes a slice of {description: string} maps into
 // []megaport.MVEVnicUpdate. Order is preserved — the API applies updates
-// positionally to the existing vNICs.
+// positionally to the existing vNICs. Only description can be updated;
+// unknown keys are rejected so callers don't silently lose input.
 func parseVnicUpdates(vnicsData []interface{}) ([]megaport.MVEVnicUpdate, error) {
 	vnics := make([]megaport.MVEVnicUpdate, 0, len(vnicsData))
 	for i, vnicData := range vnicsData {
@@ -712,9 +713,18 @@ func parseVnicUpdates(vnicsData []interface{}) ([]megaport.MVEVnicUpdate, error)
 		if !ok {
 			return nil, fmt.Errorf("vnics[%d] must be an object with a description field", i)
 		}
+		for k := range vnicMap {
+			if k != "description" {
+				return nil, fmt.Errorf("vnics[%d].%s is not supported; only description can be updated", i, k)
+			}
+		}
 		description, ok := vnicMap["description"].(string)
 		if !ok {
 			return nil, fmt.Errorf("vnics[%d].description is required and must be a string", i)
+		}
+		description = strings.TrimSpace(description)
+		if description == "" {
+			return nil, fmt.Errorf("vnics[%d].description must not be empty", i)
 		}
 		vnics = append(vnics, megaport.MVEVnicUpdate{Description: description})
 	}

--- a/internal/commands/mve/mve_inputs.go
+++ b/internal/commands/mve/mve_inputs.go
@@ -660,7 +660,7 @@ func processJSONUpdateMVEInput(jsonStr, jsonFilePath, mveUID string) (*megaport.
 func processFlagUpdateMVEInput(cmd *cobra.Command, mveUID string) (*megaport.ModifyMVERequest, error) {
 	name, _ := cmd.Flags().GetString("name")
 	costCentre, _ := cmd.Flags().GetString("cost-centre")
-	contractTerm, _ := cmd.Flags().GetInt("contract-term")
+	contractTerm, _ := cmd.Flags().GetInt("term")
 	vnicsStr, _ := cmd.Flags().GetString("vnics")
 
 	req := &megaport.ModifyMVERequest{

--- a/internal/commands/mve/mve_inputs.go
+++ b/internal/commands/mve/mve_inputs.go
@@ -642,7 +642,11 @@ func processJSONUpdateMVEInput(jsonStr, jsonFilePath, mveUID string) (*megaport.
 		req.ContractTermMonths = &termMonths
 	}
 
-	if vnicsData, ok := jsonData["vnics"].([]interface{}); ok {
+	if rawVnics, exists := jsonData["vnics"]; exists {
+		vnicsData, ok := rawVnics.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("vnics must be an array of objects with a description field")
+		}
 		vnics, err := parseVnicUpdates(vnicsData)
 		if err != nil {
 			return nil, err

--- a/internal/commands/mve/mve_inputs_test.go
+++ b/internal/commands/mve/mve_inputs_test.go
@@ -367,7 +367,7 @@ func TestProcessFlagUpdateMVEInput(t *testing.T) {
 				require.NoError(t, cmd.Flags().Set("cost-centre", tt.costCentre))
 			}
 			if tt.contractTerm > 0 {
-				require.NoError(t, cmd.Flags().Set("contract-term", "24"))
+				require.NoError(t, cmd.Flags().Set("term", "24"))
 			}
 
 			req, err := processFlagUpdateMVEInput(cmd, "mve-123")
@@ -386,7 +386,7 @@ func createTestCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "test"}
 	cmd.Flags().String("name", "", "")
 	cmd.Flags().String("cost-centre", "", "")
-	cmd.Flags().Int("contract-term", 0, "")
+	cmd.Flags().Int("term", 0, "")
 	cmd.Flags().String("vnics", "", "")
 	return cmd
 }

--- a/internal/commands/mve/mve_inputs_test.go
+++ b/internal/commands/mve/mve_inputs_test.go
@@ -401,7 +401,7 @@ func TestProcessJSONUpdateMVEInput_Vnics(t *testing.T) {
 }
 
 func TestProcessJSONUpdateMVEInput_VnicMissingDescription(t *testing.T) {
-	_, err := processJSONUpdateMVEInput(`{"vnics":[{"vlan":100}]}`, "", "mve-123")
+	_, err := processJSONUpdateMVEInput(`{"vnics":[{}]}`, "", "mve-123")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "vnics[0].description")
 }
@@ -454,4 +454,32 @@ func TestProcessJSONUpdateMVEInput_VnicsNotArray(t *testing.T) {
 			assert.Contains(t, err.Error(), "vnics must be an array")
 		})
 	}
+}
+
+func TestProcessJSONUpdateMVEInput_VnicUnsupportedKey(t *testing.T) {
+	_, err := processJSONUpdateMVEInput(`{"vnics":[{"description":"Data Plane","vlan":100}]}`, "", "mve-123")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "vnics[0].vlan is not supported")
+}
+
+func TestProcessJSONUpdateMVEInput_VnicEmptyDescription(t *testing.T) {
+	cases := []string{
+		`{"vnics":[{"description":""}]}`,
+		`{"vnics":[{"description":"   "}]}`,
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			_, err := processJSONUpdateMVEInput(in, "", "mve-123")
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "vnics[0].description must not be empty")
+		})
+	}
+}
+
+func TestProcessJSONUpdateMVEInput_VnicTrimsDescription(t *testing.T) {
+	req, err := processJSONUpdateMVEInput(`{"vnics":[{"description":"  Data Plane  "}]}`, "", "mve-123")
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	require.Len(t, req.Vnics, 1)
+	assert.Equal(t, "Data Plane", req.Vnics[0].Description)
 }

--- a/internal/commands/mve/mve_inputs_test.go
+++ b/internal/commands/mve/mve_inputs_test.go
@@ -387,5 +387,41 @@ func createTestCmd() *cobra.Command {
 	cmd.Flags().String("name", "", "")
 	cmd.Flags().String("cost-centre", "", "")
 	cmd.Flags().Int("contract-term", 0, "")
+	cmd.Flags().String("vnics", "", "")
 	return cmd
+}
+
+func TestProcessJSONUpdateMVEInput_Vnics(t *testing.T) {
+	req, err := processJSONUpdateMVEInput(`{"vnics":[{"description":"Data Plane"},{"description":"Management"}]}`, "", "mve-123")
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	require.Len(t, req.Vnics, 2)
+	assert.Equal(t, "Data Plane", req.Vnics[0].Description)
+	assert.Equal(t, "Management", req.Vnics[1].Description)
+}
+
+func TestProcessJSONUpdateMVEInput_VnicMissingDescription(t *testing.T) {
+	_, err := processJSONUpdateMVEInput(`{"vnics":[{"vlan":100}]}`, "", "mve-123")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "vnics[0].description")
+}
+
+func TestProcessFlagUpdateMVEInput_Vnics(t *testing.T) {
+	cmd := createTestCmd()
+	require.NoError(t, cmd.Flags().Set("vnics", `[{"description":"Data Plane"}]`))
+
+	req, err := processFlagUpdateMVEInput(cmd, "mve-123")
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	require.Len(t, req.Vnics, 1)
+	assert.Equal(t, "Data Plane", req.Vnics[0].Description)
+}
+
+func TestProcessFlagUpdateMVEInput_VnicsInvalidJSON(t *testing.T) {
+	cmd := createTestCmd()
+	require.NoError(t, cmd.Flags().Set("vnics", `[{`))
+
+	_, err := processFlagUpdateMVEInput(cmd, "mve-123")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse vnics JSON")
 }

--- a/internal/commands/mve/mve_inputs_test.go
+++ b/internal/commands/mve/mve_inputs_test.go
@@ -440,3 +440,18 @@ func TestProcessFlagUpdateMVEInput_VnicEntryNotObject(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "vnics[0] must be an object")
 }
+
+func TestProcessJSONUpdateMVEInput_VnicsNotArray(t *testing.T) {
+	cases := []string{
+		`{"vnics":{"description":"Data Plane"}}`,
+		`{"vnics":"Data Plane"}`,
+		`{"vnics":null}`,
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			_, err := processJSONUpdateMVEInput(in, "", "mve-123")
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "vnics must be an array")
+		})
+	}
+}

--- a/internal/commands/mve/mve_inputs_test.go
+++ b/internal/commands/mve/mve_inputs_test.go
@@ -513,3 +513,21 @@ func TestProcessJSONUpdateMVEInput_TermZeroIsValidationError(t *testing.T) {
 	assert.Error(t, err)
 	assert.NotContains(t, err.Error(), "at least one field must be provided")
 }
+
+func TestProcessFlagUpdateMVEInput_VnicsEmptyString(t *testing.T) {
+	cmd := createTestCmd()
+	require.NoError(t, cmd.Flags().Set("vnics", ""))
+
+	_, err := processFlagUpdateMVEInput(cmd, "mve-123")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "vnics must be a non-empty JSON array")
+}
+
+func TestProcessFlagUpdateMVEInput_VnicsWhitespaceString(t *testing.T) {
+	cmd := createTestCmd()
+	require.NoError(t, cmd.Flags().Set("vnics", "   "))
+
+	_, err := processFlagUpdateMVEInput(cmd, "mve-123")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "vnics must be a non-empty JSON array")
+}

--- a/internal/commands/mve/mve_inputs_test.go
+++ b/internal/commands/mve/mve_inputs_test.go
@@ -425,3 +425,18 @@ func TestProcessFlagUpdateMVEInput_VnicsInvalidJSON(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse vnics JSON")
 }
+
+func TestProcessJSONUpdateMVEInput_VnicEntryNotObject(t *testing.T) {
+	_, err := processJSONUpdateMVEInput(`{"vnics":["not-an-object"]}`, "", "mve-123")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "vnics[0] must be an object")
+}
+
+func TestProcessFlagUpdateMVEInput_VnicEntryNotObject(t *testing.T) {
+	cmd := createTestCmd()
+	require.NoError(t, cmd.Flags().Set("vnics", `["not-an-object"]`))
+
+	_, err := processFlagUpdateMVEInput(cmd, "mve-123")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "vnics[0] must be an object")
+}

--- a/internal/commands/mve/mve_inputs_test.go
+++ b/internal/commands/mve/mve_inputs_test.go
@@ -483,3 +483,33 @@ func TestProcessJSONUpdateMVEInput_VnicTrimsDescription(t *testing.T) {
 	require.Len(t, req.Vnics, 1)
 	assert.Equal(t, "Data Plane", req.Vnics[0].Description)
 }
+
+func TestProcessJSONUpdateMVEInput_VnicsEmptyArray(t *testing.T) {
+	_, err := processJSONUpdateMVEInput(`{"vnics":[]}`, "", "mve-123")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "vnics must contain at least one object")
+}
+
+func TestProcessFlagUpdateMVEInput_VnicsEmptyArray(t *testing.T) {
+	cmd := createTestCmd()
+	require.NoError(t, cmd.Flags().Set("vnics", `[]`))
+
+	_, err := processFlagUpdateMVEInput(cmd, "mve-123")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "vnics must contain at least one object")
+}
+
+func TestProcessFlagUpdateMVEInput_TermZeroIsValidationError(t *testing.T) {
+	cmd := createTestCmd()
+	require.NoError(t, cmd.Flags().Set("term", "0"))
+
+	_, err := processFlagUpdateMVEInput(cmd, "mve-123")
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "at least one field must be provided")
+}
+
+func TestProcessJSONUpdateMVEInput_TermZeroIsValidationError(t *testing.T) {
+	_, err := processJSONUpdateMVEInput(`{"contractTermMonths":0}`, "", "mve-123")
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "at least one field must be provided")
+}

--- a/internal/commands/mve/mve_integration_test.go
+++ b/internal/commands/mve/mve_integration_test.go
@@ -3,6 +3,7 @@
 package mve
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -10,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/testutil"
@@ -62,7 +64,8 @@ func integrationMVEUpdateCmd() *cobra.Command {
 	cmd.Flags().Bool("interactive", false, "")
 	cmd.Flags().String("name", "", "")
 	cmd.Flags().String("cost-centre", "", "")
-	cmd.Flags().Int("contract-term", 0, "")
+	cmd.Flags().Int("term", 0, "")
+	cmd.Flags().String("vnics", "", "")
 	cmd.Flags().String("json", "", "")
 	cmd.Flags().String("json-file", "", "")
 	return cmd
@@ -224,6 +227,26 @@ func TestIntegration_MVELifecycle(t *testing.T) {
 	require.NoError(t, updErr, "update MVE output: %s", updOut)
 
 	assert.Equal(t, newName, getMVEJSON(t, mveUID)["name"])
+
+	// Update the vNIC descriptions via --vnics and verify they took effect.
+	// The count and VLANs are immutable, so the update array must have one
+	// entry per existing vNIC, applied in order.
+	vnicUpdate := `[{"description": "MVE VNIC 1 updated"}, {"description": "MVE VNIC 2 updated"}]`
+	vnicCmd := integrationMVEUpdateCmd()
+	require.NoError(t, vnicCmd.Flags().Set("vnics", vnicUpdate))
+	var vnicErr error
+	vnicOut := captureTableOutput(func() { vnicErr = UpdateMVE(vnicCmd, []string{mveUID}, true) })
+	require.NoError(t, vnicErr, "update MVE vNICs output: %s", vnicOut)
+
+	// The CLI's JSON output doesn't expose vNIC descriptions, so read them
+	// back through the SDK client directly.
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	refreshed, err := client.MVEService.GetMVE(ctx, mveUID)
+	require.NoError(t, err, "get MVE via SDK after vNIC update")
+	require.Len(t, refreshed.NetworkInterfaces, 2)
+	assert.Equal(t, "MVE VNIC 1 updated", refreshed.NetworkInterfaces[0].Description)
+	assert.Equal(t, "MVE VNIC 2 updated", refreshed.NetworkInterfaces[1].Description)
 }
 
 func TestIntegration_MVEJSONInputLifecycle(t *testing.T) {

--- a/internal/commands/mve/mve_mock.go
+++ b/internal/commands/mve/mve_mock.go
@@ -184,5 +184,4 @@ func (m *MockMVEService) Reset() {
 	m.CapturedListMVEsRequest = nil
 	m.CapturedDeleteMVERequest = nil
 	m.CapturedUpdateMVEResourceTagsRequest = nil
-	m.ForceNilGetMVE = false
 }

--- a/internal/commands/mve/mve_mock.go
+++ b/internal/commands/mve/mve_mock.go
@@ -184,4 +184,5 @@ func (m *MockMVEService) Reset() {
 	m.CapturedListMVEsRequest = nil
 	m.CapturedDeleteMVERequest = nil
 	m.CapturedUpdateMVEResourceTagsRequest = nil
+	m.ForceNilGetMVE = false
 }

--- a/internal/commands/mve/mve_output.go
+++ b/internal/commands/mve/mve_output.go
@@ -74,5 +74,23 @@ func displayMVEChanges(original, updated *megaport.MVE, noColor bool) {
 		{Label: "Contract Term", OldValue: fmt.Sprintf("%d months", original.ContractTermMonths), NewValue: fmt.Sprintf("%d months", updated.ContractTermMonths)},
 		{Label: "Marketplace Visibility", OldValue: output.FormatBool(original.MarketplaceVisibility), NewValue: output.FormatBool(updated.MarketplaceVisibility)},
 	}
+	limit := len(original.NetworkInterfaces)
+	if len(updated.NetworkInterfaces) < limit {
+		limit = len(updated.NetworkInterfaces)
+	}
+	for i := 0; i < limit; i++ {
+		var oldDesc, newDesc string
+		if original.NetworkInterfaces[i] != nil {
+			oldDesc = original.NetworkInterfaces[i].Description
+		}
+		if updated.NetworkInterfaces[i] != nil {
+			newDesc = updated.NetworkInterfaces[i].Description
+		}
+		changes = append(changes, output.FieldChange{
+			Label:    fmt.Sprintf("vNIC[%d] Description", i),
+			OldValue: oldDesc,
+			NewValue: newDesc,
+		})
+	}
 	output.DisplayChanges(changes, noColor)
 }

--- a/internal/commands/mve/mve_output_test.go
+++ b/internal/commands/mve/mve_output_test.go
@@ -85,6 +85,60 @@ func TestDisplayMVEChanges(t *testing.T) {
 			updated:          &megaport.MVE{Name: "New", ContractTermMonths: 24},
 			expectedContains: []string{"Name", "Contract Term"},
 		},
+		{
+			name: "vnic description changed",
+			original: &megaport.MVE{
+				NetworkInterfaces: []*megaport.MVENetworkInterface{
+					{Description: "Data Plane"},
+					{Description: "Mgmt"},
+				},
+			},
+			updated: &megaport.MVE{
+				NetworkInterfaces: []*megaport.MVENetworkInterface{
+					{Description: "Data Plane Renamed"},
+					{Description: "Mgmt"},
+				},
+			},
+			expectedContains: []string{"vNIC[0] Description", "Data Plane Renamed"},
+		},
+		{
+			name: "vnic count differs uses min length",
+			original: &megaport.MVE{
+				NetworkInterfaces: []*megaport.MVENetworkInterface{{Description: "Only"}},
+			},
+			updated: &megaport.MVE{
+				NetworkInterfaces: []*megaport.MVENetworkInterface{
+					{Description: "Only Renamed"},
+					{Description: "Extra"},
+				},
+			},
+			expectedContains: []string{"vNIC[0] Description", "Only Renamed"},
+		},
+		{
+			name: "nil vnic entry is rendered as empty",
+			original: &megaport.MVE{
+				NetworkInterfaces: []*megaport.MVENetworkInterface{nil},
+			},
+			updated: &megaport.MVE{
+				NetworkInterfaces: []*megaport.MVENetworkInterface{{Description: "Set"}},
+			},
+			expectedContains: []string{"vNIC[0] Description", "Set"},
+		},
+		{
+			name: "updated has fewer vnics than original",
+			original: &megaport.MVE{
+				NetworkInterfaces: []*megaport.MVENetworkInterface{
+					{Description: "Old"},
+					{Description: "Drop"},
+				},
+			},
+			updated: &megaport.MVE{
+				NetworkInterfaces: []*megaport.MVENetworkInterface{
+					{Description: "New"},
+				},
+			},
+			expectedContains: []string{"vNIC[0] Description", "New"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/commands/mve/mve_prompts.go
+++ b/internal/commands/mve/mve_prompts.go
@@ -397,7 +397,7 @@ func promptMVEVnics(noColor bool) ([]megaport.MVENetworkInterface, error) {
 	return vnics, nil
 }
 
-func promptForUpdateMVEDetails(mveUID string, noColor bool) (*megaport.ModifyMVERequest, error) {
+func promptForUpdateMVEDetails(mveUID string, currentVnics []*megaport.MVENetworkInterface, noColor bool) (*megaport.ModifyMVERequest, error) {
 	req := &megaport.ModifyMVERequest{
 		MVEID: mveUID,
 	}
@@ -428,6 +428,31 @@ func promptForUpdateMVEDetails(mveUID string, noColor bool) (*megaport.ModifyMVE
 			return nil, fmt.Errorf("invalid contract term: %w", err)
 		}
 		req.ContractTermMonths = &contractTerm
+	}
+
+	if len(currentVnics) > 0 {
+		updateVnicsStr, err := utils.ResourcePrompt("mve", fmt.Sprintf("Update vNIC descriptions? (y/N, %d vNICs): ", len(currentVnics)), noColor)
+		if err != nil {
+			return nil, err
+		}
+		if answer := strings.ToLower(strings.TrimSpace(updateVnicsStr)); answer == "y" || answer == "yes" {
+			vnics := make([]megaport.MVEVnicUpdate, len(currentVnics))
+			for i, current := range currentVnics {
+				currentDesc := ""
+				if current != nil {
+					currentDesc = current.Description
+				}
+				desc, err := utils.ResourcePrompt("mve", fmt.Sprintf("Description for vNIC[%d] (current: %q, leave empty to keep): ", i, currentDesc), noColor)
+				if err != nil {
+					return nil, err
+				}
+				if strings.TrimSpace(desc) == "" {
+					desc = currentDesc
+				}
+				vnics[i] = megaport.MVEVnicUpdate{Description: desc}
+			}
+			req.Vnics = vnics
+		}
 	}
 
 	if err := validation.ValidateUpdateMVERequest(req); err != nil {

--- a/internal/commands/mve/mve_prompts.go
+++ b/internal/commands/mve/mve_prompts.go
@@ -442,11 +442,21 @@ func promptForUpdateMVEDetails(mveUID string, currentVnics []*megaport.MVENetwor
 				if current != nil {
 					currentDesc = current.Description
 				}
-				desc, err := utils.ResourcePrompt("mve", fmt.Sprintf("Description for vNIC[%d] (current: %q, leave empty to keep): ", i, currentDesc), noColor)
+				var promptMsg string
+				if currentDesc == "" {
+					promptMsg = fmt.Sprintf("Description for vNIC[%d] (no current value, must be non-empty): ", i)
+				} else {
+					promptMsg = fmt.Sprintf("Description for vNIC[%d] (current: %q, leave empty to keep): ", i, currentDesc)
+				}
+				desc, err := utils.ResourcePrompt("mve", promptMsg, noColor)
 				if err != nil {
 					return nil, err
 				}
-				if strings.TrimSpace(desc) == "" {
+				desc = strings.TrimSpace(desc)
+				if desc == "" {
+					if currentDesc == "" {
+						return nil, fmt.Errorf("vnics[%d].description must not be empty", i)
+					}
 					desc = currentDesc
 				}
 				vnics[i] = megaport.MVEVnicUpdate{Description: desc}

--- a/internal/commands/mve/mve_prompts_test.go
+++ b/internal/commands/mve/mve_prompts_test.go
@@ -236,6 +236,23 @@ func TestPromptForUpdateMVEDetails_VnicNilEntryDefaultsToEmpty(t *testing.T) {
 	assert.Equal(t, "New Description", req.Vnics[0].Description)
 }
 
+func TestPromptForUpdateMVEDetails_VnicEmptyCurrentEmptyInputErrors(t *testing.T) {
+	original := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(original) }()
+
+	// name, cost, term, accept vnic update, empty description for vnic with empty current desc
+	utils.SetResourcePrompt(mockPromptSequence([]string{
+		"", "", "",
+		"yes",
+		"",
+	}))
+
+	currentVnics := []*megaport.MVENetworkInterface{{Description: ""}}
+	_, err := promptForUpdateMVEDetails("mve-123", currentVnics, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "vnics[0].description must not be empty")
+}
+
 // promptMVEVnics tests
 
 func TestPromptMVEVnics_NoVnics(t *testing.T) {

--- a/internal/commands/mve/mve_prompts_test.go
+++ b/internal/commands/mve/mve_prompts_test.go
@@ -174,6 +174,68 @@ func TestPromptForUpdateMVEDetails_DeclineVnicUpdate(t *testing.T) {
 	assert.Empty(t, req.Vnics)
 }
 
+func TestPromptForUpdateMVEDetails_VnicYesNoPromptError(t *testing.T) {
+	original := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(original) }()
+
+	// First three prompts (name/cost/term) succeed; fourth (y/N) returns an error.
+	calls := 0
+	utils.SetResourcePrompt(func(_, _ string, _ bool) (string, error) {
+		calls++
+		if calls == 4 {
+			return "", fmt.Errorf("stdin closed")
+		}
+		return "", nil
+	})
+
+	currentVnics := []*megaport.MVENetworkInterface{{Description: "Data Plane"}}
+	_, err := promptForUpdateMVEDetails("mve-123", currentVnics, true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "stdin closed")
+}
+
+func TestPromptForUpdateMVEDetails_VnicDescriptionPromptError(t *testing.T) {
+	original := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(original) }()
+
+	// name/cost/term empty, "y" to update vnics, then error on first description prompt.
+	calls := 0
+	utils.SetResourcePrompt(func(_, _ string, _ bool) (string, error) {
+		calls++
+		switch calls {
+		case 1, 2, 3:
+			return "", nil
+		case 4:
+			return "y", nil
+		default:
+			return "", fmt.Errorf("stdin closed")
+		}
+	})
+
+	currentVnics := []*megaport.MVENetworkInterface{{Description: "Data Plane"}}
+	_, err := promptForUpdateMVEDetails("mve-123", currentVnics, true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "stdin closed")
+}
+
+func TestPromptForUpdateMVEDetails_VnicNilEntryDefaultsToEmpty(t *testing.T) {
+	original := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(original) }()
+
+	// name, cost, term, accept vnic update, description for nil vnic
+	utils.SetResourcePrompt(mockPromptSequence([]string{
+		"", "", "",
+		"yes",
+		"New Description",
+	}))
+
+	currentVnics := []*megaport.MVENetworkInterface{nil}
+	req, err := promptForUpdateMVEDetails("mve-123", currentVnics, true)
+	require.NoError(t, err)
+	require.Len(t, req.Vnics, 1)
+	assert.Equal(t, "New Description", req.Vnics[0].Description)
+}
+
 // promptMVEVnics tests
 
 func TestPromptMVEVnics_NoVnics(t *testing.T) {

--- a/internal/commands/mve/mve_prompts_test.go
+++ b/internal/commands/mve/mve_prompts_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/megaport/megaport-cli/internal/utils"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func mockPromptSequence(responses []string) func(string, string, bool) (string, error) {
@@ -104,7 +105,7 @@ func TestPromptForUpdateMVEDetails_Success(t *testing.T) {
 		"NewName", "", "",
 	}))
 
-	req, err := promptForUpdateMVEDetails("mve-123", true)
+	req, err := promptForUpdateMVEDetails("mve-123", nil, true)
 	assert.NoError(t, err)
 	assert.Equal(t, "mve-123", req.MVEID)
 	assert.Equal(t, "NewName", req.Name)
@@ -118,7 +119,7 @@ func TestPromptForUpdateMVEDetails_NoChanges(t *testing.T) {
 
 	utils.SetResourcePrompt(mockPromptSequence([]string{"", "", ""}))
 
-	_, err := promptForUpdateMVEDetails("mve-123", true)
+	_, err := promptForUpdateMVEDetails("mve-123", nil, true)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "at least one field must be provided for update")
 }
@@ -129,9 +130,48 @@ func TestPromptForUpdateMVEDetails_InvalidContractTerm(t *testing.T) {
 
 	utils.SetResourcePrompt(mockPromptSequence([]string{"", "", "abc"}))
 
-	_, err := promptForUpdateMVEDetails("mve-123", true)
+	_, err := promptForUpdateMVEDetails("mve-123", nil, true)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid contract term")
+}
+
+func TestPromptForUpdateMVEDetails_UpdateVnicDescriptions(t *testing.T) {
+	original := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(original) }()
+
+	// name, costCentre, contractTerm, updateVnics?, vnic[0], vnic[1]
+	utils.SetResourcePrompt(mockPromptSequence([]string{
+		"", "", "",
+		"y",
+		"New Data Plane", "", // second is left empty → keeps "Mgmt"
+	}))
+
+	currentVnics := []*megaport.MVENetworkInterface{
+		{Description: "Data Plane"},
+		{Description: "Mgmt"},
+	}
+	req, err := promptForUpdateMVEDetails("mve-123", currentVnics, true)
+	require.NoError(t, err)
+	require.Len(t, req.Vnics, 2)
+	assert.Equal(t, "New Data Plane", req.Vnics[0].Description)
+	assert.Equal(t, "Mgmt", req.Vnics[1].Description)
+}
+
+func TestPromptForUpdateMVEDetails_DeclineVnicUpdate(t *testing.T) {
+	original := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(original) }()
+
+	// name update, no cost-centre, no term, "n" to vnics
+	utils.SetResourcePrompt(mockPromptSequence([]string{
+		"NewName", "", "",
+		"n",
+	}))
+
+	currentVnics := []*megaport.MVENetworkInterface{{Description: "Data Plane"}}
+	req, err := promptForUpdateMVEDetails("mve-123", currentVnics, true)
+	require.NoError(t, err)
+	assert.Equal(t, "NewName", req.Name)
+	assert.Empty(t, req.Vnics)
 }
 
 // promptMVEVnics tests

--- a/internal/validation/mve.go
+++ b/internal/validation/mve.go
@@ -134,6 +134,12 @@ func ValidateUpdateMVERequest(req *megaport.ModifyMVERequest) error {
 		}
 	}
 
+	for i, v := range req.Vnics {
+		if v.Description == "" {
+			return NewValidationError(fmt.Sprintf("vnics[%d].description", i), v.Description, "must not be empty")
+		}
+	}
+
 	return nil
 }
 

--- a/internal/validation/mve.go
+++ b/internal/validation/mve.go
@@ -121,7 +121,7 @@ func ValidateBuyMVERequest(req *megaport.BuyMVERequest) error {
 //   - nil if all validation checks pass
 func ValidateUpdateMVERequest(req *megaport.ModifyMVERequest) error {
 	// Check if any update fields are provided
-	if req.Name == "" && req.CostCentre == "" && req.ContractTermMonths == nil {
+	if req.Name == "" && req.CostCentre == "" && req.ContractTermMonths == nil && len(req.Vnics) == 0 {
 		return NewValidationError("update request", req, "at least one field must be provided for update")
 	}
 

--- a/internal/validation/mve.go
+++ b/internal/validation/mve.go
@@ -113,7 +113,7 @@ func ValidateBuyMVERequest(req *megaport.BuyMVERequest) error {
 //   - req: The ModifyMVERequest object containing the fields to update
 //
 // Validation checks:
-//   - At least one updateable field must be provided (name, cost center, or contract term)
+//   - At least one updateable field must be provided (name, cost center, contract term, or vNICs)
 //   - If contract term is provided, it must be valid (typically 1, 12, 24, or 36 months)
 //
 // Returns:

--- a/internal/validation/mve_test.go
+++ b/internal/validation/mve_test.go
@@ -424,6 +424,15 @@ func TestValidateUpdateMVERequest(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Empty vnic description rejected",
+			req: &megaport.ModifyMVERequest{
+				MVEID: "mve-uid-123",
+				Vnics: []megaport.MVEVnicUpdate{{Description: "Data Plane"}, {Description: ""}},
+			},
+			wantErr: true,
+			errText: "vnics[1].description",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/validation/mve_test.go
+++ b/internal/validation/mve_test.go
@@ -416,6 +416,14 @@ func TestValidateUpdateMVERequest(t *testing.T) {
 			wantErr: true,
 			errText: fmt.Sprintf("Invalid contract term: 5 - must be one of: %v", ValidContractTerms),
 		},
+		{
+			name: "Valid vnic-only update",
+			req: &megaport.ModifyMVERequest{
+				MVEID: "mve-uid-123",
+				Vnics: []megaport.MVEVnicUpdate{{Description: "Data Plane"}},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Editing a vNIC description on an MVE currently requires deleting and re-creating the MVE. The platform API supports in-place description updates — only the SDK and CLI were missing the wiring.

This PR adds a `--vnics` flag and a `vnics` JSON field to `mve update`. The vNIC count and VLAN remain immutable after provisioning; only descriptions can change.

## Changes
- New `--vnics` flag and `vnics` JSON field accept a positional array of `{description}` objects — one entry per existing vNIC.
- JSON, flag, and interactive prompt paths all build `[]MVEVnicUpdate` and forward through `ModifyMVE`.
- Interactive prompt walks through the MVE's current vNICs and lets the user replace each description (empty keeps current).
- `displayMVEChanges` now surfaces per-vNIC description changes after a successful update.
- `ValidateUpdateMVERequest` now accepts vnic-only updates.

## Depends on
- megaport/megaportgo#156 — adds `ModifyMVERequest.Vnics` and the supporting `MVEVnicUpdate` type. `go.mod` is pinned to the PR head commit; bump to a released version once #156 merges.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run`
- [x] `GOOS=js GOARCH=wasm go build -tags js,wasm ...`
- [ ] Manual: `mve update <UID> --vnics '[{"description":"Data Plane"}]'` against staging
- [ ] Manual: `mve update <UID> --interactive` walkthrough exercises the new prompt