### PR TITLE
ESD-1269: Build-tag glamour out of the WASM build

### DIFF
--- a/internal/base/cmdbuilder/docs_render.go
+++ b/internal/base/cmdbuilder/docs_render.go
@@ -1,4 +1,4 @@
-//go:build !(js && wasm)
+//go:build !js || !wasm
 
 package cmdbuilder
 

--- a/internal/base/cmdbuilder/docs_render.go
+++ b/internal/base/cmdbuilder/docs_render.go
@@ -1,7 +1,8 @@
+//go:build !(js && wasm)
+
 package cmdbuilder
 
 import (
-	"embed"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,14 +14,6 @@ import (
 
 // DocsDirectory is the fallback location for markdown documentation files
 var DocsDirectory = "./docs"
-
-// embeddedDocsFS holds the embedded documentation files
-var embeddedDocsFS embed.FS
-
-// RegisterEmbeddedDocs registers the embedded documentation filesystem
-func RegisterEmbeddedDocs(docs embed.FS) {
-	embeddedDocsFS = docs
-}
 
 // FindDocFile locates the markdown file for a specific command
 func FindDocFile(cmd *cobra.Command) (string, error) {
@@ -102,22 +95,4 @@ func ShowDocumentation(cmd *cobra.Command) error {
 	// Print the rendered documentation
 	fmt.Println(rendered)
 	return nil
-}
-
-// getCommandPath returns the file path-style name for a command (e.g., "megaport-cli_mcr_buy")
-func getCommandPath(cmd *cobra.Command) string {
-	if cmd.Parent() == nil {
-		return "megaport-cli"
-	}
-
-	// Build the full path
-	path := cmd.Name()
-	parent := cmd.Parent()
-
-	for parent != nil && parent.Name() != "" && parent.Name() != "megaport-cli" {
-		path = parent.Name() + "_" + path
-		parent = parent.Parent()
-	}
-
-	return "megaport-cli_" + path
 }

--- a/internal/base/cmdbuilder/docs_render_common.go
+++ b/internal/base/cmdbuilder/docs_render_common.go
@@ -1,0 +1,33 @@
+package cmdbuilder
+
+import (
+	"embed"
+
+	"github.com/spf13/cobra"
+)
+
+// embeddedDocsFS holds the embedded documentation files
+var embeddedDocsFS embed.FS
+
+// RegisterEmbeddedDocs registers the embedded documentation filesystem
+func RegisterEmbeddedDocs(docs embed.FS) {
+	embeddedDocsFS = docs
+}
+
+// getCommandPath returns the file path-style name for a command (e.g., "megaport-cli_mcr_buy")
+func getCommandPath(cmd *cobra.Command) string {
+	if cmd.Parent() == nil {
+		return "megaport-cli"
+	}
+
+	// Build the full path
+	path := cmd.Name()
+	parent := cmd.Parent()
+
+	for parent != nil && parent.Name() != "" && parent.Name() != "megaport-cli" {
+		path = parent.Name() + "_" + path
+		parent = parent.Parent()
+	}
+
+	return "megaport-cli_" + path
+}

--- a/internal/base/cmdbuilder/docs_render_common_test.go
+++ b/internal/base/cmdbuilder/docs_render_common_test.go
@@ -1,0 +1,46 @@
+package cmdbuilder
+
+import (
+	"embed"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+//go:embed testdata/sample.md
+var testDocsFS embed.FS
+
+func TestGetCommandPath(t *testing.T) {
+	root := &cobra.Command{Use: "megaport-cli"}
+	mcr := &cobra.Command{Use: "mcr"}
+	buy := &cobra.Command{Use: "buy"}
+	root.AddCommand(mcr)
+	mcr.AddCommand(buy)
+
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+		want string
+	}{
+		{"root has no parent", root, "megaport-cli"},
+		{"one level deep", mcr, "megaport-cli_mcr"},
+		{"two levels deep", buy, "megaport-cli_mcr_buy"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, getCommandPath(tt.cmd))
+		})
+	}
+}
+
+func TestRegisterEmbeddedDocs(t *testing.T) {
+	orig := embeddedDocsFS
+	t.Cleanup(func() { embeddedDocsFS = orig })
+
+	RegisterEmbeddedDocs(testDocsFS)
+
+	content, err := embeddedDocsFS.ReadFile("testdata/sample.md")
+	assert.NoError(t, err)
+	assert.Contains(t, string(content), "Sample")
+}

--- a/internal/base/cmdbuilder/docs_render_wasm.go
+++ b/internal/base/cmdbuilder/docs_render_wasm.go
@@ -20,6 +20,8 @@ func ShowDocumentation(cmd *cobra.Command) error {
 		return fmt.Errorf("documentation file not found for %s: %w", cmdPath, err)
 	}
 
-	fmt.Println(string(content))
+	// Write to the Cobra writer (WasmOutputBuffer in the browser), not os.Stdout
+	// via fmt.Println — the latter goes to the dev console, not the terminal UI.
+	fmt.Fprintln(cmd.OutOrStdout(), string(content))
 	return nil
 }

--- a/internal/base/cmdbuilder/docs_render_wasm.go
+++ b/internal/base/cmdbuilder/docs_render_wasm.go
@@ -1,0 +1,25 @@
+//go:build js && wasm
+
+package cmdbuilder
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+// ShowDocumentation prints the embedded markdown for a command. The browser
+// terminal styles it, so glamour (and its goldmark/chroma deps) is left out of
+// the WASM build.
+func ShowDocumentation(cmd *cobra.Command) error {
+	cmdPath := getCommandPath(cmd)
+
+	content, err := embeddedDocsFS.ReadFile(filepath.Join("docs", cmdPath+".md"))
+	if err != nil {
+		return fmt.Errorf("documentation file not found for %s: %w", cmdPath, err)
+	}
+
+	fmt.Println(string(content))
+	return nil
+}

--- a/internal/base/cmdbuilder/testdata/sample.md
+++ b/internal/base/cmdbuilder/testdata/sample.md
@@ -1,0 +1,3 @@
+# Sample
+
+Sample documentation used by docs_render tests.


### PR DESCRIPTION
The glamour terminal markdown renderer (which pulls in goldmark + chroma) was being compiled into the WASM build, even though the browser renders output via xterm rather than the in-binary ANSI renderer. This build-tags it out of WASM and drops in a lightweight stub that emits the embedded markdown raw for the browser to style.

- `docs_render.go` now carries `//go:build !(js && wasm)` — native still renders via glamour, unchanged.
- New `docs_render_wasm.go` stub provides `ShowDocumentation` that prints raw embedded markdown (no glamour).
- Shared `RegisterEmbeddedDocs` + `getCommandPath` moved to an untagged `docs_render_common.go` so both render paths stay thin and the path-naming logic can't drift.

glamour / goldmark / chroma are no longer in the WASM dependency graph (`GOOS=js GOARCH=wasm go list -deps -tags js,wasm .` reports 0).

### WASM size (before → after)

|            | before    | after     | saved  |
|------------|-----------|-----------|--------|
| raw        | 32.82 MiB | 18.50 MiB | −43.6% |
| brotli q11 | 4.75 MiB  | 2.89 MiB  | −39.2% |

### Works in tandem with #370

Paired with #370 (ESD-1268), which pre-compresses the WASM for CDN serving. This PR shrinks the raw binary; #370 emits the brotli/gzip objects the CDN actually serves. Together the browser fetches a brotli object of ~2.89 MiB — down from the ~4.75 MiB it would be today. No file overlap, so they land in any order.
