### PR TITLE
ESD-1309: Migrate MCR and MVE integration tests to direct action function calls

### DIFF
--- a/internal/commands/mcr/mcr_integration_test.go
+++ b/internal/commands/mcr/mcr_integration_test.go
@@ -157,9 +157,12 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 	require.NoError(t, buyErr, "buy MCR output: %s", buyOut)
 
 	mcrUID := parseCreatedUID(buyOut, "MCR")
-	require.NotEmpty(t, mcrUID, "could not parse MCR UID from: %s", buyOut)
-
+	// Register cleanup before asserting on mcrUID, so any created MCR is
+	// deleted even if the UID parse fails.
 	t.Cleanup(func() {
+		if mcrUID == "" {
+			return
+		}
 		delCmd := integrationMCRDeleteCmd()
 		_ = delCmd.Flags().Set("force", "true")
 		var delErr error
@@ -170,6 +173,7 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 		}
 		t.Logf("cleanup: delete MCR %s: %s", mcrUID, out)
 	})
+	require.NotEmpty(t, mcrUID, "could not parse MCR UID from: %s", buyOut)
 
 	// Get and verify the core fields are present.
 	mcr := getMCRJSON(t, mcrUID)
@@ -301,9 +305,12 @@ func TestIntegration_MCRJSONInputLifecycle(t *testing.T) {
 	require.NoError(t, buyErr, "buy MCR (JSON) output: %s", buyOut)
 
 	mcrUID := parseCreatedUID(buyOut, "MCR")
-	require.NotEmpty(t, mcrUID, "could not parse MCR UID from: %s", buyOut)
-
+	// Register cleanup before asserting on mcrUID, so any created MCR is
+	// deleted even if the UID parse fails.
 	t.Cleanup(func() {
+		if mcrUID == "" {
+			return
+		}
 		delCmd := integrationMCRDeleteCmd()
 		_ = delCmd.Flags().Set("force", "true")
 		var delErr error
@@ -314,6 +321,7 @@ func TestIntegration_MCRJSONInputLifecycle(t *testing.T) {
 		}
 		t.Logf("cleanup: delete MCR %s: %s", mcrUID, out)
 	})
+	require.NotEmpty(t, mcrUID, "could not parse MCR UID from: %s", buyOut)
 
 	mcr := getMCRJSON(t, mcrUID)
 	assert.Equal(t, mcrUID, mcr["uid"])

--- a/internal/commands/mcr/mcr_integration_test.go
+++ b/internal/commands/mcr/mcr_integration_test.go
@@ -259,7 +259,7 @@ func TestIntegration_MCRJSONInputLifecycle(t *testing.T) {
 		"term": 1,
 		"portSpeed": 1000,
 		"locationId": %d,
-		"marketPlaceVisibility": false
+		"marketplaceVisibility": false
 	}`, name, stagingMCRLocationID)
 
 	buyCmd := integrationMCRBuyCmd()

--- a/internal/commands/mcr/mcr_integration_test.go
+++ b/internal/commands/mcr/mcr_integration_test.go
@@ -124,6 +124,11 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 	client := testutil.SetupIntegrationClient(t)
 	defer testutil.LoginWithClient(t, client)()
 
+	// Action functions mutate the process-wide output format; restore it so
+	// test order can't leak state between tests in this package.
+	origFmt := output.GetOutputFormat()
+	t.Cleanup(func() { output.SetOutputFormat(origFmt) })
+
 	name := fmt.Sprintf("CLI-Test-MCR-%s", generateUniqueID())
 
 	// Buy a new MCR using flags. BuyMCR waits for provisioning (no --no-wait),
@@ -251,6 +256,11 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 func TestIntegration_MCRJSONInputLifecycle(t *testing.T) {
 	client := testutil.SetupIntegrationClient(t)
 	defer testutil.LoginWithClient(t, client)()
+
+	// Action functions mutate the process-wide output format; restore it so
+	// test order can't leak state between tests in this package.
+	origFmt := output.GetOutputFormat()
+	t.Cleanup(func() { output.SetOutputFormat(origFmt) })
 
 	name := fmt.Sprintf("CLI-JSON-MCR-%s", generateUniqueID())
 

--- a/internal/commands/mcr/mcr_integration_test.go
+++ b/internal/commands/mcr/mcr_integration_test.go
@@ -155,7 +155,12 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 	t.Cleanup(func() {
 		delCmd := integrationMCRDeleteCmd()
 		_ = delCmd.Flags().Set("force", "true")
-		out := output.CaptureOutput(func() { _ = DeleteMCR(delCmd, []string{mcrUID}, true) })
+		var delErr error
+		out := output.CaptureOutput(func() { delErr = DeleteMCR(delCmd, []string{mcrUID}, true) })
+		if delErr != nil {
+			t.Logf("cleanup: delete MCR %s failed: %v; output: %s", mcrUID, delErr, out)
+			return
+		}
 		t.Logf("cleanup: delete MCR %s: %s", mcrUID, out)
 	})
 
@@ -201,9 +206,14 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 	// Best-effort cleanup. Registered after the MCR cleanup so it runs first
 	// (cleanups run LIFO) — the list must be gone before the MCR is deleted.
 	t.Cleanup(func() {
+		var delErr error
 		out := output.CaptureOutput(func() {
-			_ = DeleteMCRPrefixFilterList(&cobra.Command{Use: "delete"}, []string{mcrUID, pflID}, true)
+			delErr = DeleteMCRPrefixFilterList(&cobra.Command{Use: "delete"}, []string{mcrUID, pflID}, true)
 		})
+		if delErr != nil {
+			t.Logf("cleanup: delete prefix filter list %s failed: %v; output: %s", pflID, delErr, out)
+			return
+		}
 		t.Logf("cleanup: delete prefix filter list %s: %s", pflID, out)
 	})
 
@@ -292,7 +302,12 @@ func TestIntegration_MCRJSONInputLifecycle(t *testing.T) {
 	t.Cleanup(func() {
 		delCmd := integrationMCRDeleteCmd()
 		_ = delCmd.Flags().Set("force", "true")
-		out := output.CaptureOutput(func() { _ = DeleteMCR(delCmd, []string{mcrUID}, true) })
+		var delErr error
+		out := output.CaptureOutput(func() { delErr = DeleteMCR(delCmd, []string{mcrUID}, true) })
+		if delErr != nil {
+			t.Logf("cleanup: delete MCR %s failed: %v; output: %s", mcrUID, delErr, out)
+			return
+		}
 		t.Logf("cleanup: delete MCR %s: %s", mcrUID, out)
 	})
 

--- a/internal/commands/mcr/mcr_integration_test.go
+++ b/internal/commands/mcr/mcr_integration_test.go
@@ -122,7 +122,10 @@ func getMCRJSON(t *testing.T, uid string) map[string]interface{} {
 
 func TestIntegration_MCRLifecycle(t *testing.T) {
 	client := testutil.SetupIntegrationClient(t)
-	defer testutil.LoginWithClient(t, client)()
+	// Restore login via t.Cleanup, not defer: defers run before t.Cleanup, so a
+	// deferred restore would swap back the default login (wrong environment)
+	// before the resource-deletion cleanups below get to run.
+	t.Cleanup(testutil.LoginWithClient(t, client))
 
 	// Action functions mutate the process-wide output format; restore it so
 	// test order can't leak state between tests in this package.
@@ -255,7 +258,10 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 
 func TestIntegration_MCRJSONInputLifecycle(t *testing.T) {
 	client := testutil.SetupIntegrationClient(t)
-	defer testutil.LoginWithClient(t, client)()
+	// Restore login via t.Cleanup, not defer: defers run before t.Cleanup, so a
+	// deferred restore would swap back the default login (wrong environment)
+	// before the resource-deletion cleanups below get to run.
+	t.Cleanup(testutil.LoginWithClient(t, client))
 
 	// Action functions mutate the process-wide output format; restore it so
 	// test order can't leak state between tests in this package.

--- a/internal/commands/mcr/mcr_integration_test.go
+++ b/internal/commands/mcr/mcr_integration_test.go
@@ -30,6 +30,14 @@ func generateUniqueID() string {
 	return hex.EncodeToString(buf)
 }
 
+// captureTableOutput captures stdout with the output format forced to "table",
+// since JSON mode routes success/info messages to stderr where CaptureOutput
+// can't see them.
+func captureTableOutput(f func()) string {
+	output.SetOutputFormat("table")
+	return output.CaptureOutput(f)
+}
+
 func integrationMCRBuyCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "buy"}
 	cmd.Flags().Bool("interactive", false, "")
@@ -144,9 +152,8 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 	require.NoError(t, buyCmd.Flags().Set("marketplace-visibility", "false"))
 	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
 
-	output.SetOutputFormat("table") // route the success message to stdout
 	var buyErr error
-	buyOut := output.CaptureOutput(func() { buyErr = BuyMCR(buyCmd, nil, true) })
+	buyOut := captureTableOutput(func() { buyErr = BuyMCR(buyCmd, nil, true) })
 	require.NoError(t, buyErr, "buy MCR output: %s", buyOut)
 
 	mcrUID := parseCreatedUID(buyOut, "MCR")
@@ -156,7 +163,7 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 		delCmd := integrationMCRDeleteCmd()
 		_ = delCmd.Flags().Set("force", "true")
 		var delErr error
-		out := output.CaptureOutput(func() { delErr = DeleteMCR(delCmd, []string{mcrUID}, true) })
+		out := captureTableOutput(func() { delErr = DeleteMCR(delCmd, []string{mcrUID}, true) })
 		if delErr != nil {
 			t.Logf("cleanup: delete MCR %s failed: %v; output: %s", mcrUID, delErr, out)
 			return
@@ -176,7 +183,7 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 	updCmd := integrationMCRUpdateCmd()
 	require.NoError(t, updCmd.Flags().Set("name", newName))
 	var updErr error
-	updOut := output.CaptureOutput(func() { updErr = UpdateMCR(updCmd, []string{mcrUID}, true) })
+	updOut := captureTableOutput(func() { updErr = UpdateMCR(updCmd, []string{mcrUID}, true) })
 	require.NoError(t, updErr, "update MCR output: %s", updOut)
 
 	assert.Equal(t, newName, getMCRJSON(t, mcrUID)["name"])
@@ -193,9 +200,8 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 
 	createCmd := integrationMCRPrefixFilterCmd()
 	require.NoError(t, createCmd.Flags().Set("json", createPFLJSON))
-	output.SetOutputFormat("table") // route the success message to stdout
 	var createErr error
-	createOut := output.CaptureOutput(func() {
+	createOut := captureTableOutput(func() {
 		createErr = CreateMCRPrefixFilterList(createCmd, []string{mcrUID}, true)
 	})
 	require.NoError(t, createErr, "create prefix filter list output: %s", createOut)
@@ -207,7 +213,7 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 	// (cleanups run LIFO) — the list must be gone before the MCR is deleted.
 	t.Cleanup(func() {
 		var delErr error
-		out := output.CaptureOutput(func() {
+		out := captureTableOutput(func() {
 			delErr = DeleteMCRPrefixFilterList(&cobra.Command{Use: "delete"}, []string{mcrUID, pflID}, true)
 		})
 		if delErr != nil {
@@ -240,7 +246,7 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 	updatePFLCmd := integrationMCRPrefixFilterCmd()
 	require.NoError(t, updatePFLCmd.Flags().Set("json", updatePFLJSON))
 	var updatePFLErr error
-	updatePFLOut := output.CaptureOutput(func() {
+	updatePFLOut := captureTableOutput(func() {
 		updatePFLErr = UpdateMCRPrefixFilterList(updatePFLCmd, []string{mcrUID, pflID}, true)
 	})
 	require.NoError(t, updatePFLErr, "update prefix filter list output: %s", updatePFLOut)
@@ -255,9 +261,8 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 	assert.Contains(t, verifyPFLOut, "192.168.0.0/16")
 
 	// Delete the prefix filter list and assert it is gone.
-	output.SetOutputFormat("table")
 	var deletePFLErr error
-	deletePFLOut := output.CaptureOutput(func() {
+	deletePFLOut := captureTableOutput(func() {
 		deletePFLErr = DeleteMCRPrefixFilterList(&cobra.Command{Use: "delete"}, []string{mcrUID, pflID}, true)
 	})
 	require.NoError(t, deletePFLErr, "delete prefix filter list output: %s", deletePFLOut)
@@ -291,9 +296,8 @@ func TestIntegration_MCRJSONInputLifecycle(t *testing.T) {
 	buyCmd := integrationMCRBuyCmd()
 	require.NoError(t, buyCmd.Flags().Set("json", buyJSON))
 
-	output.SetOutputFormat("table")
 	var buyErr error
-	buyOut := output.CaptureOutput(func() { buyErr = BuyMCR(buyCmd, nil, true) })
+	buyOut := captureTableOutput(func() { buyErr = BuyMCR(buyCmd, nil, true) })
 	require.NoError(t, buyErr, "buy MCR (JSON) output: %s", buyOut)
 
 	mcrUID := parseCreatedUID(buyOut, "MCR")
@@ -303,7 +307,7 @@ func TestIntegration_MCRJSONInputLifecycle(t *testing.T) {
 		delCmd := integrationMCRDeleteCmd()
 		_ = delCmd.Flags().Set("force", "true")
 		var delErr error
-		out := output.CaptureOutput(func() { delErr = DeleteMCR(delCmd, []string{mcrUID}, true) })
+		out := captureTableOutput(func() { delErr = DeleteMCR(delCmd, []string{mcrUID}, true) })
 		if delErr != nil {
 			t.Logf("cleanup: delete MCR %s failed: %v; output: %s", mcrUID, delErr, out)
 			return
@@ -319,7 +323,7 @@ func TestIntegration_MCRJSONInputLifecycle(t *testing.T) {
 	updCmd := integrationMCRUpdateCmd()
 	require.NoError(t, updCmd.Flags().Set("name", newName))
 	var updErr error
-	updOut := output.CaptureOutput(func() { updErr = UpdateMCR(updCmd, []string{mcrUID}, true) })
+	updOut := captureTableOutput(func() { updErr = UpdateMCR(updCmd, []string{mcrUID}, true) })
 	require.NoError(t, updErr, "update MCR output: %s", updOut)
 
 	assert.Equal(t, newName, getMCRJSON(t, mcrUID)["name"])

--- a/internal/commands/mcr/mcr_integration_test.go
+++ b/internal/commands/mcr/mcr_integration_test.go
@@ -65,7 +65,6 @@ func integrationMCRDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "delete"}
 	cmd.Flags().BoolP("force", "f", false, "")
 	cmd.Flags().Bool("safe-delete", false, "")
-	cmd.Flags().Bool("now", false, "")
 	return cmd
 }
 
@@ -148,7 +147,6 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 	t.Cleanup(func() {
 		delCmd := integrationMCRDeleteCmd()
 		_ = delCmd.Flags().Set("force", "true")
-		_ = delCmd.Flags().Set("now", "true")
 		out := output.CaptureOutput(func() { _ = DeleteMCR(delCmd, []string{mcrUID}, true) })
 		t.Logf("cleanup: delete MCR %s: %s", mcrUID, out)
 	})
@@ -278,7 +276,6 @@ func TestIntegration_MCRJSONInputLifecycle(t *testing.T) {
 	t.Cleanup(func() {
 		delCmd := integrationMCRDeleteCmd()
 		_ = delCmd.Flags().Set("force", "true")
-		_ = delCmd.Flags().Set("now", "true")
 		out := output.CaptureOutput(func() { _ = DeleteMCR(delCmd, []string{mcrUID}, true) })
 		t.Logf("cleanup: delete MCR %s: %s", mcrUID, out)
 	})

--- a/internal/commands/mcr/mcr_integration_test.go
+++ b/internal/commands/mcr/mcr_integration_test.go
@@ -1,0 +1,298 @@
+//go:build integration
+
+package mcr
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/testutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stagingMCRLocationID is a known MCR-capable staging location. Discovering one
+// via ListLocations would be overengineering for this lifecycle test.
+const stagingMCRLocationID = 67
+
+func generateUniqueID() string {
+	buf := make([]byte, 4)
+	if _, err := rand.Read(buf); err != nil {
+		panic(fmt.Sprintf("failed to generate random bytes: %v", err))
+	}
+	return hex.EncodeToString(buf)
+}
+
+func integrationMCRBuyCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "buy"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().Bool("yes", false, "")
+	cmd.Flags().Bool("no-wait", false, "")
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().Int("term", 0, "")
+	cmd.Flags().Int("port-speed", 0, "")
+	cmd.Flags().Int("location-id", 0, "")
+	cmd.Flags().Int("mcr-asn", 0, "")
+	cmd.Flags().String("diversity-zone", "", "")
+	cmd.Flags().String("cost-centre", "", "")
+	cmd.Flags().String("promo-code", "", "")
+	cmd.Flags().Bool("marketplace-visibility", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	return cmd
+}
+
+func integrationMCRUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("cost-centre", "", "")
+	cmd.Flags().Bool("marketplace-visibility", false, "")
+	cmd.Flags().Int("term", 0, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	return cmd
+}
+
+func integrationMCRDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "delete"}
+	cmd.Flags().BoolP("force", "f", false, "")
+	cmd.Flags().Bool("safe-delete", false, "")
+	cmd.Flags().Bool("now", false, "")
+	return cmd
+}
+
+func integrationMCRPrefixFilterCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "prefix-filter-list"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("description", "", "")
+	cmd.Flags().String("address-family", "", "")
+	cmd.Flags().String("entries", "", "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	return cmd
+}
+
+// parseCreatedUID pulls the resource UID out of a "<resource> created <uid>"
+// success message.
+func parseCreatedUID(out, resource string) string {
+	marker := resource + " created "
+	for _, line := range strings.Split(out, "\n") {
+		if i := strings.Index(line, marker); i >= 0 {
+			return strings.TrimSpace(line[i+len(marker):])
+		}
+	}
+	return ""
+}
+
+// parsePrefixFilterListID pulls the numeric ID out of the
+// "Prefix filter list created successfully - ID: <n>" success message.
+func parsePrefixFilterListID(out string) string {
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.Contains(line, "created successfully") {
+			continue
+		}
+		if i := strings.Index(line, "ID:"); i >= 0 {
+			return strings.TrimSpace(line[i+len("ID:"):])
+		}
+	}
+	return ""
+}
+
+// getMCRJSON retrieves an MCR as JSON and returns the decoded object.
+func getMCRJSON(t *testing.T, uid string) map[string]interface{} {
+	t.Helper()
+	var err error
+	out := output.CaptureOutput(func() {
+		err = GetMCR(&cobra.Command{Use: "get"}, []string{uid}, true, "json")
+	})
+	require.NoError(t, err, "get MCR output: %s", out)
+
+	var mcrs []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(out), &mcrs), "MCR output should be valid JSON: %s", out)
+	require.Len(t, mcrs, 1, "expected exactly one MCR")
+	return mcrs[0]
+}
+
+func TestIntegration_MCRLifecycle(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	name := fmt.Sprintf("CLI-Test-MCR-%s", generateUniqueID())
+
+	// Buy a new MCR using flags. BuyMCR waits for provisioning (no --no-wait),
+	// so the MCR is ready for prefix-filter-list operations once it returns.
+	buyCmd := integrationMCRBuyCmd()
+	require.NoError(t, buyCmd.Flags().Set("name", name))
+	require.NoError(t, buyCmd.Flags().Set("term", "1"))
+	require.NoError(t, buyCmd.Flags().Set("port-speed", "1000"))
+	require.NoError(t, buyCmd.Flags().Set("location-id", strconv.Itoa(stagingMCRLocationID)))
+	require.NoError(t, buyCmd.Flags().Set("marketplace-visibility", "false"))
+	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
+
+	output.SetOutputFormat("table") // route the success message to stdout
+	var buyErr error
+	buyOut := output.CaptureOutput(func() { buyErr = BuyMCR(buyCmd, nil, true) })
+	require.NoError(t, buyErr, "buy MCR output: %s", buyOut)
+
+	mcrUID := parseCreatedUID(buyOut, "MCR")
+	require.NotEmpty(t, mcrUID, "could not parse MCR UID from: %s", buyOut)
+
+	t.Cleanup(func() {
+		delCmd := integrationMCRDeleteCmd()
+		_ = delCmd.Flags().Set("force", "true")
+		_ = delCmd.Flags().Set("now", "true")
+		out := output.CaptureOutput(func() { _ = DeleteMCR(delCmd, []string{mcrUID}, true) })
+		t.Logf("cleanup: delete MCR %s: %s", mcrUID, out)
+	})
+
+	// Get and verify the core fields are present.
+	mcr := getMCRJSON(t, mcrUID)
+	assert.Equal(t, mcrUID, mcr["uid"])
+	assert.Equal(t, name, mcr["name"])
+	assert.Contains(t, mcr, "provisioning_status")
+	assert.NotEmpty(t, mcr["provisioning_status"])
+
+	// Update the name and verify it took effect.
+	newName := name + "-updated"
+	updCmd := integrationMCRUpdateCmd()
+	require.NoError(t, updCmd.Flags().Set("name", newName))
+	var updErr error
+	updOut := output.CaptureOutput(func() { updErr = UpdateMCR(updCmd, []string{mcrUID}, true) })
+	require.NoError(t, updErr, "update MCR output: %s", updOut)
+
+	assert.Equal(t, newName, getMCRJSON(t, mcrUID)["name"])
+
+	// Prefix filter list lifecycle (create -> get -> update -> delete).
+	createPFLJSON := `{
+		"description": "Test Prefix Filter List",
+		"addressFamily": "IPv4",
+		"entries": [
+			{"action": "permit", "prefix": "10.0.1.0/24", "ge": 25, "le": 32},
+			{"action": "deny", "prefix": "10.0.2.0/24", "ge": 0, "le": 25}
+		]
+	}`
+
+	createCmd := integrationMCRPrefixFilterCmd()
+	require.NoError(t, createCmd.Flags().Set("json", createPFLJSON))
+	output.SetOutputFormat("table") // route the success message to stdout
+	var createErr error
+	createOut := output.CaptureOutput(func() {
+		createErr = CreateMCRPrefixFilterList(createCmd, []string{mcrUID}, true)
+	})
+	require.NoError(t, createErr, "create prefix filter list output: %s", createOut)
+
+	pflID := parsePrefixFilterListID(createOut)
+	require.NotEmpty(t, pflID, "could not parse prefix filter list ID from: %s", createOut)
+
+	// Best-effort cleanup. Registered after the MCR cleanup so it runs first
+	// (cleanups run LIFO) — the list must be gone before the MCR is deleted.
+	t.Cleanup(func() {
+		out := output.CaptureOutput(func() {
+			_ = DeleteMCRPrefixFilterList(&cobra.Command{Use: "delete"}, []string{mcrUID, pflID}, true)
+		})
+		t.Logf("cleanup: delete prefix filter list %s: %s", pflID, out)
+	})
+
+	// Get the prefix filter list and assert it exists with the expected content.
+	var getPFLErr error
+	getPFLOut := output.CaptureOutput(func() {
+		getPFLErr = GetMCRPrefixFilterList(&cobra.Command{Use: "get"}, []string{mcrUID, pflID}, true, "json")
+	})
+	require.NoError(t, getPFLErr, "get prefix filter list output: %s", getPFLOut)
+	assert.Contains(t, getPFLOut, "Test Prefix Filter List")
+	assert.Contains(t, getPFLOut, "10.0.1.0/24")
+	assert.Contains(t, getPFLOut, "10.0.2.0/24")
+
+	// Update the prefix filter list, adding a new entry.
+	updatePFLJSON := `{
+		"description": "Test Prefix Filter List Updated",
+		"addressFamily": "IPv4",
+		"entries": [
+			{"action": "permit", "prefix": "10.0.1.0/24", "ge": 25, "le": 32},
+			{"action": "deny", "prefix": "10.0.2.0/24", "ge": 0, "le": 25},
+			{"action": "permit", "prefix": "192.168.0.0/16", "ge": 24, "le": 32}
+		]
+	}`
+	updatePFLCmd := integrationMCRPrefixFilterCmd()
+	require.NoError(t, updatePFLCmd.Flags().Set("json", updatePFLJSON))
+	var updatePFLErr error
+	updatePFLOut := output.CaptureOutput(func() {
+		updatePFLErr = UpdateMCRPrefixFilterList(updatePFLCmd, []string{mcrUID, pflID}, true)
+	})
+	require.NoError(t, updatePFLErr, "update prefix filter list output: %s", updatePFLOut)
+
+	// Verify the update landed.
+	var verifyPFLErr error
+	verifyPFLOut := output.CaptureOutput(func() {
+		verifyPFLErr = GetMCRPrefixFilterList(&cobra.Command{Use: "get"}, []string{mcrUID, pflID}, true, "json")
+	})
+	require.NoError(t, verifyPFLErr, "verify prefix filter list output: %s", verifyPFLOut)
+	assert.Contains(t, verifyPFLOut, "Test Prefix Filter List Updated")
+	assert.Contains(t, verifyPFLOut, "192.168.0.0/16")
+
+	// Delete the prefix filter list and assert it is gone.
+	output.SetOutputFormat("table")
+	var deletePFLErr error
+	deletePFLOut := output.CaptureOutput(func() {
+		deletePFLErr = DeleteMCRPrefixFilterList(&cobra.Command{Use: "delete"}, []string{mcrUID, pflID}, true)
+	})
+	require.NoError(t, deletePFLErr, "delete prefix filter list output: %s", deletePFLOut)
+
+	goneErr := GetMCRPrefixFilterList(&cobra.Command{Use: "get"}, []string{mcrUID, pflID}, true, "json")
+	assert.Error(t, goneErr, "prefix filter list should no longer exist")
+}
+
+func TestIntegration_MCRJSONInputLifecycle(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	name := fmt.Sprintf("CLI-JSON-MCR-%s", generateUniqueID())
+
+	buyJSON := fmt.Sprintf(`{
+		"name": "%s",
+		"term": 1,
+		"portSpeed": 1000,
+		"locationId": %d,
+		"marketPlaceVisibility": false
+	}`, name, stagingMCRLocationID)
+
+	buyCmd := integrationMCRBuyCmd()
+	require.NoError(t, buyCmd.Flags().Set("json", buyJSON))
+
+	output.SetOutputFormat("table")
+	var buyErr error
+	buyOut := output.CaptureOutput(func() { buyErr = BuyMCR(buyCmd, nil, true) })
+	require.NoError(t, buyErr, "buy MCR (JSON) output: %s", buyOut)
+
+	mcrUID := parseCreatedUID(buyOut, "MCR")
+	require.NotEmpty(t, mcrUID, "could not parse MCR UID from: %s", buyOut)
+
+	t.Cleanup(func() {
+		delCmd := integrationMCRDeleteCmd()
+		_ = delCmd.Flags().Set("force", "true")
+		_ = delCmd.Flags().Set("now", "true")
+		out := output.CaptureOutput(func() { _ = DeleteMCR(delCmd, []string{mcrUID}, true) })
+		t.Logf("cleanup: delete MCR %s: %s", mcrUID, out)
+	})
+
+	mcr := getMCRJSON(t, mcrUID)
+	assert.Equal(t, mcrUID, mcr["uid"])
+	assert.Equal(t, name, mcr["name"])
+
+	newName := name + "-updated"
+	updCmd := integrationMCRUpdateCmd()
+	require.NoError(t, updCmd.Flags().Set("name", newName))
+	var updErr error
+	updOut := output.CaptureOutput(func() { updErr = UpdateMCR(updCmd, []string{mcrUID}, true) })
+	require.NoError(t, updErr, "update MCR output: %s", updOut)
+
+	assert.Equal(t, newName, getMCRJSON(t, mcrUID)["name"])
+}

--- a/internal/commands/mve/mve_inputs.go
+++ b/internal/commands/mve/mve_inputs.go
@@ -195,7 +195,7 @@ func parseSixwindConfig(config map[string]interface{}) (*megaport.SixwindVSRConf
 	if !ok {
 		return nil, fmt.Errorf("productSize is required for 6WIND configuration")
 	}
-	productSize = strings.ToUpper(productSize)
+	productSize = validation.NormalizeMVEProductSize(strings.ToUpper(productSize))
 
 	mveLabel, _ := getStringFromMap(config, "mveLabel")
 
@@ -223,7 +223,7 @@ func parseArubaConfig(config map[string]interface{}) (*megaport.ArubaConfig, err
 	if !ok {
 		return nil, fmt.Errorf("productSize is required for Aruba configuration")
 	}
-	productSize = strings.ToUpper(productSize)
+	productSize = validation.NormalizeMVEProductSize(strings.ToUpper(productSize))
 
 	mveLabel, _ := getStringFromMap(config, "mveLabel")
 
@@ -260,7 +260,7 @@ func parseAviatrixConfig(config map[string]interface{}) (*megaport.AviatrixConfi
 	if !ok {
 		return nil, fmt.Errorf("productSize is required for Aviatrix configuration")
 	}
-	productSize = strings.ToUpper(productSize)
+	productSize = validation.NormalizeMVEProductSize(strings.ToUpper(productSize))
 
 	mveLabel, _ := getStringFromMap(config, "mveLabel")
 
@@ -288,7 +288,7 @@ func parseCiscoConfig(config map[string]interface{}) (*megaport.CiscoConfig, err
 	if !ok {
 		return nil, fmt.Errorf("productSize is required for Cisco configuration")
 	}
-	productSize = strings.ToUpper(productSize)
+	productSize = validation.NormalizeMVEProductSize(strings.ToUpper(productSize))
 
 	mveLabel, ok := getStringFromMap(config, "mveLabel")
 	if !ok {
@@ -358,7 +358,7 @@ func parseFortinetConfig(config map[string]interface{}) (*megaport.FortinetConfi
 	if !ok {
 		return nil, fmt.Errorf("productSize is required for Fortinet configuration")
 	}
-	productSize = strings.ToUpper(productSize)
+	productSize = validation.NormalizeMVEProductSize(strings.ToUpper(productSize))
 
 	mveLabel, _ := getStringFromMap(config, "mveLabel")
 
@@ -398,7 +398,7 @@ func parsePaloAltoConfig(config map[string]interface{}) (*megaport.PaloAltoConfi
 	if !ok {
 		return nil, fmt.Errorf("productSize is required for PaloAlto configuration")
 	}
-	productSize = strings.ToUpper(productSize)
+	productSize = validation.NormalizeMVEProductSize(strings.ToUpper(productSize))
 
 	mveLabel, _ := getStringFromMap(config, "mveLabel")
 
@@ -437,7 +437,7 @@ func parsePrismaConfig(config map[string]interface{}) (*megaport.PrismaConfig, e
 	if !ok {
 		return nil, fmt.Errorf("productSize is required for Prisma configuration")
 	}
-	productSize = strings.ToUpper(productSize)
+	productSize = validation.NormalizeMVEProductSize(strings.ToUpper(productSize))
 
 	mveLabel, _ := getStringFromMap(config, "mveLabel")
 
@@ -471,7 +471,7 @@ func parseVersaConfig(config map[string]interface{}) (*megaport.VersaConfig, err
 	if !ok {
 		return nil, fmt.Errorf("productSize is required for Versa configuration")
 	}
-	productSize = strings.ToUpper(productSize)
+	productSize = validation.NormalizeMVEProductSize(strings.ToUpper(productSize))
 
 	mveLabel, _ := getStringFromMap(config, "mveLabel")
 
@@ -523,7 +523,7 @@ func parseVmwareConfig(config map[string]interface{}) (*megaport.VmwareConfig, e
 	if !ok {
 		return nil, fmt.Errorf("productSize is required for VMware configuration")
 	}
-	productSize = strings.ToUpper(productSize)
+	productSize = validation.NormalizeMVEProductSize(strings.ToUpper(productSize))
 
 	mveLabel, _ := getStringFromMap(config, "mveLabel")
 
@@ -570,7 +570,7 @@ func parseMerakiConfig(config map[string]interface{}) (*megaport.MerakiConfig, e
 		return nil, fmt.Errorf("productSize is required for Meraki configuration")
 	}
 
-	productSize = strings.ToUpper(productSize)
+	productSize = validation.NormalizeMVEProductSize(strings.ToUpper(productSize))
 
 	mveLabel, _ := getStringFromMap(config, "mveLabel")
 

--- a/internal/commands/mve/mve_integration_test.go
+++ b/internal/commands/mve/mve_integration_test.go
@@ -63,7 +63,6 @@ func integrationMVEDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "delete"}
 	cmd.Flags().BoolP("force", "f", false, "")
 	cmd.Flags().Bool("safe-delete", false, "")
-	cmd.Flags().Bool("now", false, "")
 	return cmd
 }
 
@@ -176,7 +175,6 @@ func TestIntegration_MVELifecycle(t *testing.T) {
 	t.Cleanup(func() {
 		delCmd := integrationMVEDeleteCmd()
 		_ = delCmd.Flags().Set("force", "true")
-		_ = delCmd.Flags().Set("now", "true")
 		out := output.CaptureOutput(func() { _ = DeleteMVE(delCmd, []string{mveUID}, true) })
 		t.Logf("cleanup: delete MVE %s: %s", mveUID, out)
 	})
@@ -236,7 +234,6 @@ func TestIntegration_MVEJSONInputLifecycle(t *testing.T) {
 	t.Cleanup(func() {
 		delCmd := integrationMVEDeleteCmd()
 		_ = delCmd.Flags().Set("force", "true")
-		_ = delCmd.Flags().Set("now", "true")
 		out := output.CaptureOutput(func() { _ = DeleteMVE(delCmd, []string{mveUID}, true) })
 		t.Logf("cleanup: delete MVE %s: %s", mveUID, out)
 	})

--- a/internal/commands/mve/mve_integration_test.go
+++ b/internal/commands/mve/mve_integration_test.go
@@ -139,7 +139,10 @@ func getMVEJSON(t *testing.T, uid string) map[string]interface{} {
 
 func TestIntegration_MVELifecycle(t *testing.T) {
 	client := testutil.SetupIntegrationClient(t)
-	defer testutil.LoginWithClient(t, client)()
+	// Restore login via t.Cleanup, not defer: defers run before t.Cleanup, so a
+	// deferred restore would swap back the default login (wrong environment)
+	// before the resource-deletion cleanups below get to run.
+	t.Cleanup(testutil.LoginWithClient(t, client))
 
 	// Action functions mutate the process-wide output format; restore it so
 	// test order can't leak state between tests in this package.
@@ -205,7 +208,10 @@ func TestIntegration_MVELifecycle(t *testing.T) {
 
 func TestIntegration_MVEJSONInputLifecycle(t *testing.T) {
 	client := testutil.SetupIntegrationClient(t)
-	defer testutil.LoginWithClient(t, client)()
+	// Restore login via t.Cleanup, not defer: defers run before t.Cleanup, so a
+	// deferred restore would swap back the default login (wrong environment)
+	// before the resource-deletion cleanups below get to run.
+	t.Cleanup(testutil.LoginWithClient(t, client))
 
 	// Action functions mutate the process-wide output format; restore it so
 	// test order can't leak state between tests in this package.

--- a/internal/commands/mve/mve_integration_test.go
+++ b/internal/commands/mve/mve_integration_test.go
@@ -141,6 +141,11 @@ func TestIntegration_MVELifecycle(t *testing.T) {
 	client := testutil.SetupIntegrationClient(t)
 	defer testutil.LoginWithClient(t, client)()
 
+	// Action functions mutate the process-wide output format; restore it so
+	// test order can't leak state between tests in this package.
+	origFmt := output.GetOutputFormat()
+	t.Cleanup(func() { output.SetOutputFormat(origFmt) })
+
 	img := discoverArubaImage(t)
 	name := fmt.Sprintf("CLI-Test-MVE-%s", generateUniqueID())
 
@@ -201,6 +206,11 @@ func TestIntegration_MVELifecycle(t *testing.T) {
 func TestIntegration_MVEJSONInputLifecycle(t *testing.T) {
 	client := testutil.SetupIntegrationClient(t)
 	defer testutil.LoginWithClient(t, client)()
+
+	// Action functions mutate the process-wide output format; restore it so
+	// test order can't leak state between tests in this package.
+	origFmt := output.GetOutputFormat()
+	t.Cleanup(func() { output.SetOutputFormat(origFmt) })
 
 	img := discoverArubaImage(t)
 	name := fmt.Sprintf("CLI-JSON-MVE-%s", generateUniqueID())

--- a/internal/commands/mve/mve_integration_test.go
+++ b/internal/commands/mve/mve_integration_test.go
@@ -30,6 +30,14 @@ func generateUniqueID() string {
 	return hex.EncodeToString(buf)
 }
 
+// captureTableOutput captures stdout with the output format forced to "table",
+// since JSON mode routes success/info messages to stderr where CaptureOutput
+// can't see them.
+func captureTableOutput(f func()) string {
+	output.SetOutputFormat("table")
+	return output.CaptureOutput(f)
+}
+
 func integrationMVEBuyCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "buy"}
 	cmd.Flags().Bool("interactive", false, "")
@@ -172,9 +180,8 @@ func TestIntegration_MVELifecycle(t *testing.T) {
 	require.NoError(t, buyCmd.Flags().Set("vnics", vnics))
 	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
 
-	output.SetOutputFormat("table") // route the success message to stdout
 	var buyErr error
-	buyOut := output.CaptureOutput(func() { buyErr = BuyMVE(buyCmd, nil, true) })
+	buyOut := captureTableOutput(func() { buyErr = BuyMVE(buyCmd, nil, true) })
 	require.NoError(t, buyErr, "buy MVE output: %s", buyOut)
 
 	mveUID := parseCreatedUID(buyOut, "MVE")
@@ -184,7 +191,7 @@ func TestIntegration_MVELifecycle(t *testing.T) {
 		delCmd := integrationMVEDeleteCmd()
 		_ = delCmd.Flags().Set("force", "true")
 		var delErr error
-		out := output.CaptureOutput(func() { delErr = DeleteMVE(delCmd, []string{mveUID}, true) })
+		out := captureTableOutput(func() { delErr = DeleteMVE(delCmd, []string{mveUID}, true) })
 		if delErr != nil {
 			t.Logf("cleanup: delete MVE %s failed: %v; output: %s", mveUID, delErr, out)
 			return
@@ -205,7 +212,7 @@ func TestIntegration_MVELifecycle(t *testing.T) {
 	updCmd := integrationMVEUpdateCmd()
 	require.NoError(t, updCmd.Flags().Set("name", newName))
 	var updErr error
-	updOut := output.CaptureOutput(func() { updErr = UpdateMVE(updCmd, []string{mveUID}, true) })
+	updOut := captureTableOutput(func() { updErr = UpdateMVE(updCmd, []string{mveUID}, true) })
 	require.NoError(t, updErr, "update MVE output: %s", updOut)
 
 	assert.Equal(t, newName, getMVEJSON(t, mveUID)["name"])
@@ -244,9 +251,8 @@ func TestIntegration_MVEJSONInputLifecycle(t *testing.T) {
 	buyCmd := integrationMVEBuyCmd()
 	require.NoError(t, buyCmd.Flags().Set("json", buyJSON))
 
-	output.SetOutputFormat("table")
 	var buyErr error
-	buyOut := output.CaptureOutput(func() { buyErr = BuyMVE(buyCmd, nil, true) })
+	buyOut := captureTableOutput(func() { buyErr = BuyMVE(buyCmd, nil, true) })
 	require.NoError(t, buyErr, "buy MVE (JSON) output: %s", buyOut)
 
 	mveUID := parseCreatedUID(buyOut, "MVE")
@@ -256,7 +262,7 @@ func TestIntegration_MVEJSONInputLifecycle(t *testing.T) {
 		delCmd := integrationMVEDeleteCmd()
 		_ = delCmd.Flags().Set("force", "true")
 		var delErr error
-		out := output.CaptureOutput(func() { delErr = DeleteMVE(delCmd, []string{mveUID}, true) })
+		out := captureTableOutput(func() { delErr = DeleteMVE(delCmd, []string{mveUID}, true) })
 		if delErr != nil {
 			t.Logf("cleanup: delete MVE %s failed: %v; output: %s", mveUID, delErr, out)
 			return
@@ -274,7 +280,7 @@ func TestIntegration_MVEJSONInputLifecycle(t *testing.T) {
 	updCmd := integrationMVEUpdateCmd()
 	require.NoError(t, updCmd.Flags().Set("name", newName))
 	var updErr error
-	updOut := output.CaptureOutput(func() { updErr = UpdateMVE(updCmd, []string{mveUID}, true) })
+	updOut := captureTableOutput(func() { updErr = UpdateMVE(updCmd, []string{mveUID}, true) })
 	require.NoError(t, updErr, "update MVE output: %s", updOut)
 
 	assert.Equal(t, newName, getMVEJSON(t, mveUID)["name"])

--- a/internal/commands/mve/mve_integration_test.go
+++ b/internal/commands/mve/mve_integration_test.go
@@ -1,0 +1,258 @@
+//go:build integration
+
+package mve
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/testutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stagingMVELocationID is a known MVE-capable staging location. Discovering one
+// via ListLocations would be overengineering for this lifecycle test.
+const stagingMVELocationID = 65
+
+func generateUniqueID() string {
+	buf := make([]byte, 4)
+	if _, err := rand.Read(buf); err != nil {
+		panic(fmt.Sprintf("failed to generate random bytes: %v", err))
+	}
+	return hex.EncodeToString(buf)
+}
+
+func integrationMVEBuyCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "buy"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().Bool("yes", false, "")
+	cmd.Flags().Bool("no-wait", false, "")
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().Int("term", 0, "")
+	cmd.Flags().Int("location-id", 0, "")
+	cmd.Flags().String("diversity-zone", "", "")
+	cmd.Flags().String("promo-code", "", "")
+	cmd.Flags().String("cost-centre", "", "")
+	cmd.Flags().String("vendor-config", "", "")
+	cmd.Flags().String("vnics", "", "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	return cmd
+}
+
+func integrationMVEUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("cost-centre", "", "")
+	cmd.Flags().Int("contract-term", 0, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	return cmd
+}
+
+func integrationMVEDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "delete"}
+	cmd.Flags().BoolP("force", "f", false, "")
+	cmd.Flags().Bool("safe-delete", false, "")
+	cmd.Flags().Bool("now", false, "")
+	return cmd
+}
+
+// parseCreatedUID pulls the resource UID out of a "<resource> created <uid>"
+// success message.
+func parseCreatedUID(out, resource string) string {
+	marker := resource + " created "
+	for _, line := range strings.Split(out, "\n") {
+		if i := strings.Index(line, marker); i >= 0 {
+			return strings.TrimSpace(line[i+len(marker):])
+		}
+	}
+	return ""
+}
+
+type discoveredImage struct {
+	ID             int      `json:"id"`
+	Vendor         string   `json:"vendor"`
+	ProductCode    string   `json:"productCode"`
+	AvailableSizes []string `json:"availableSizes"`
+}
+
+// discoverArubaImage lists staging MVE images and returns the first Aruba image,
+// skipping the test if none are available. The vendor is fixed (Aruba's vendor
+// config is simple to construct); only the image ID is discovered dynamically,
+// since image IDs change on staging.
+func discoverArubaImage(t *testing.T) discoveredImage {
+	t.Helper()
+	var err error
+	out := output.CaptureOutput(func() {
+		err = ListMVEImages(&cobra.Command{Use: "list-images"}, nil, true, "json")
+	})
+	require.NoError(t, err, "list MVE images output: %s", out)
+
+	var images []discoveredImage
+	require.NoError(t, json.Unmarshal([]byte(out), &images), "images output should be valid JSON: %s", out)
+
+	for _, img := range images {
+		if strings.EqualFold(img.Vendor, "aruba") && img.ID > 0 {
+			return img
+		}
+	}
+	t.Skip("no Aruba MVE image available on staging")
+	return discoveredImage{}
+}
+
+// productSize picks a size the image supports, preferring MEDIUM.
+func (d discoveredImage) productSize() string {
+	for _, s := range d.AvailableSizes {
+		if strings.EqualFold(s, "MEDIUM") {
+			return "MEDIUM"
+		}
+	}
+	if len(d.AvailableSizes) > 0 {
+		return d.AvailableSizes[0]
+	}
+	return "MEDIUM"
+}
+
+// getMVEJSON retrieves an MVE as JSON and returns the decoded object.
+func getMVEJSON(t *testing.T, uid string) map[string]interface{} {
+	t.Helper()
+	var err error
+	out := output.CaptureOutput(func() {
+		err = GetMVE(&cobra.Command{Use: "get"}, []string{uid}, true, "json")
+	})
+	require.NoError(t, err, "get MVE output: %s", out)
+
+	var mves []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(out), &mves), "MVE output should be valid JSON: %s", out)
+	require.Len(t, mves, 1, "expected exactly one MVE")
+	return mves[0]
+}
+
+func TestIntegration_MVELifecycle(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	img := discoverArubaImage(t)
+	name := fmt.Sprintf("CLI-Test-MVE-%s", generateUniqueID())
+
+	vendorConfig := fmt.Sprintf(`{
+		"vendor": "aruba",
+		"productSize": "%s",
+		"imageId": %d,
+		"accountName": "test",
+		"accountKey": "test",
+		"systemTag": "test"
+	}`, img.productSize(), img.ID)
+	vnics := `[{"description": "MVE VNIC 1", "vlan": 55}]`
+
+	// BuyMVE waits for provisioning (no --no-wait), so the MVE is ready once it
+	// returns.
+	buyCmd := integrationMVEBuyCmd()
+	require.NoError(t, buyCmd.Flags().Set("name", name))
+	require.NoError(t, buyCmd.Flags().Set("term", "1"))
+	require.NoError(t, buyCmd.Flags().Set("location-id", strconv.Itoa(stagingMVELocationID)))
+	require.NoError(t, buyCmd.Flags().Set("vendor-config", vendorConfig))
+	require.NoError(t, buyCmd.Flags().Set("vnics", vnics))
+	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
+
+	output.SetOutputFormat("table") // route the success message to stdout
+	var buyErr error
+	buyOut := output.CaptureOutput(func() { buyErr = BuyMVE(buyCmd, nil, true) })
+	require.NoError(t, buyErr, "buy MVE output: %s", buyOut)
+
+	mveUID := parseCreatedUID(buyOut, "MVE")
+	require.NotEmpty(t, mveUID, "could not parse MVE UID from: %s", buyOut)
+
+	t.Cleanup(func() {
+		delCmd := integrationMVEDeleteCmd()
+		_ = delCmd.Flags().Set("force", "true")
+		_ = delCmd.Flags().Set("now", "true")
+		out := output.CaptureOutput(func() { _ = DeleteMVE(delCmd, []string{mveUID}, true) })
+		t.Logf("cleanup: delete MVE %s: %s", mveUID, out)
+	})
+
+	// Get and verify the core fields.
+	mve := getMVEJSON(t, mveUID)
+	assert.Equal(t, mveUID, mve["uid"])
+	assert.Equal(t, name, mve["name"])
+	assert.Contains(t, mve, "status")
+	assert.NotEmpty(t, mve["status"])
+	assert.Equal(t, "aruba", strings.ToLower(fmt.Sprintf("%v", mve["vendor"])))
+
+	// Update the name and verify it took effect.
+	newName := name + "-updated"
+	updCmd := integrationMVEUpdateCmd()
+	require.NoError(t, updCmd.Flags().Set("name", newName))
+	var updErr error
+	updOut := output.CaptureOutput(func() { updErr = UpdateMVE(updCmd, []string{mveUID}, true) })
+	require.NoError(t, updErr, "update MVE output: %s", updOut)
+
+	assert.Equal(t, newName, getMVEJSON(t, mveUID)["name"])
+}
+
+func TestIntegration_MVEJSONInputLifecycle(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	img := discoverArubaImage(t)
+	name := fmt.Sprintf("CLI-JSON-MVE-%s", generateUniqueID())
+
+	buyJSON := fmt.Sprintf(`{
+		"name": "%s",
+		"term": 1,
+		"locationId": %d,
+		"vendorConfig": {
+			"vendor": "aruba",
+			"productSize": "%s",
+			"imageId": %d,
+			"accountName": "test",
+			"accountKey": "test",
+			"systemTag": "test"
+		},
+		"vnics": [{"description": "MVE VNIC 1", "vlan": 55}]
+	}`, name, stagingMVELocationID, img.productSize(), img.ID)
+
+	buyCmd := integrationMVEBuyCmd()
+	require.NoError(t, buyCmd.Flags().Set("json", buyJSON))
+
+	output.SetOutputFormat("table")
+	var buyErr error
+	buyOut := output.CaptureOutput(func() { buyErr = BuyMVE(buyCmd, nil, true) })
+	require.NoError(t, buyErr, "buy MVE (JSON) output: %s", buyOut)
+
+	mveUID := parseCreatedUID(buyOut, "MVE")
+	require.NotEmpty(t, mveUID, "could not parse MVE UID from: %s", buyOut)
+
+	t.Cleanup(func() {
+		delCmd := integrationMVEDeleteCmd()
+		_ = delCmd.Flags().Set("force", "true")
+		_ = delCmd.Flags().Set("now", "true")
+		out := output.CaptureOutput(func() { _ = DeleteMVE(delCmd, []string{mveUID}, true) })
+		t.Logf("cleanup: delete MVE %s: %s", mveUID, out)
+	})
+
+	mve := getMVEJSON(t, mveUID)
+	assert.Equal(t, mveUID, mve["uid"])
+	assert.Equal(t, name, mve["name"])
+	assert.Contains(t, mve, "status")
+	assert.Equal(t, "aruba", strings.ToLower(fmt.Sprintf("%v", mve["vendor"])))
+
+	newName := name + "-updated"
+	updCmd := integrationMVEUpdateCmd()
+	require.NoError(t, updCmd.Flags().Set("name", newName))
+	var updErr error
+	updOut := output.CaptureOutput(func() { updErr = UpdateMVE(updCmd, []string{mveUID}, true) })
+	require.NoError(t, updErr, "update MVE output: %s", updOut)
+
+	assert.Equal(t, newName, getMVEJSON(t, mveUID)["name"])
+}

--- a/internal/commands/mve/mve_integration_test.go
+++ b/internal/commands/mve/mve_integration_test.go
@@ -183,7 +183,12 @@ func TestIntegration_MVELifecycle(t *testing.T) {
 	t.Cleanup(func() {
 		delCmd := integrationMVEDeleteCmd()
 		_ = delCmd.Flags().Set("force", "true")
-		out := output.CaptureOutput(func() { _ = DeleteMVE(delCmd, []string{mveUID}, true) })
+		var delErr error
+		out := output.CaptureOutput(func() { delErr = DeleteMVE(delCmd, []string{mveUID}, true) })
+		if delErr != nil {
+			t.Logf("cleanup: delete MVE %s failed: %v; output: %s", mveUID, delErr, out)
+			return
+		}
 		t.Logf("cleanup: delete MVE %s: %s", mveUID, out)
 	})
 
@@ -250,7 +255,12 @@ func TestIntegration_MVEJSONInputLifecycle(t *testing.T) {
 	t.Cleanup(func() {
 		delCmd := integrationMVEDeleteCmd()
 		_ = delCmd.Flags().Set("force", "true")
-		out := output.CaptureOutput(func() { _ = DeleteMVE(delCmd, []string{mveUID}, true) })
+		var delErr error
+		out := output.CaptureOutput(func() { delErr = DeleteMVE(delCmd, []string{mveUID}, true) })
+		if delErr != nil {
+			t.Logf("cleanup: delete MVE %s failed: %v; output: %s", mveUID, delErr, out)
+			return
+		}
 		t.Logf("cleanup: delete MVE %s: %s", mveUID, out)
 	})
 

--- a/internal/commands/mve/mve_integration_test.go
+++ b/internal/commands/mve/mve_integration_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/testutil"
+	"github.com/megaport/megaport-cli/internal/validation"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -118,14 +119,17 @@ func discoverArubaImage(t *testing.T) discoveredImage {
 }
 
 // productSize picks a size the image supports, preferring MEDIUM.
+// It normalizes label-format strings (e.g. "MVE 4/16") to their programmatic
+// equivalents (e.g. "MEDIUM") so the value is valid for the buy command.
 func (d discoveredImage) productSize() string {
 	for _, s := range d.AvailableSizes {
-		if strings.EqualFold(s, "MEDIUM") {
+		normalized := validation.NormalizeMVEProductSize(strings.ToUpper(s))
+		if normalized == "MEDIUM" {
 			return "MEDIUM"
 		}
 	}
 	if len(d.AvailableSizes) > 0 {
-		return d.AvailableSizes[0]
+		return validation.NormalizeMVEProductSize(strings.ToUpper(d.AvailableSizes[0]))
 	}
 	return "MEDIUM"
 }

--- a/internal/commands/mve/mve_integration_test.go
+++ b/internal/commands/mve/mve_integration_test.go
@@ -172,7 +172,7 @@ func TestIntegration_MVELifecycle(t *testing.T) {
 		"accountKey": "test",
 		"systemTag": "test"
 	}`, img.productSize(), img.ID)
-	vnics := `[{"description": "MVE VNIC 1", "vlan": 55}]`
+	vnics := `[{"description": "MVE VNIC 1", "vlan": 55}, {"description": "MVE VNIC 2", "vlan": 56}]`
 
 	// BuyMVE waits for provisioning (no --no-wait), so the MVE is ready once it
 	// returns.
@@ -249,7 +249,7 @@ func TestIntegration_MVEJSONInputLifecycle(t *testing.T) {
 			"accountKey": "test",
 			"systemTag": "test"
 		},
-		"vnics": [{"description": "MVE VNIC 1", "vlan": 55}]
+		"vnics": [{"description": "MVE VNIC 1", "vlan": 55}, {"description": "MVE VNIC 2", "vlan": 56}]
 	}`, name, stagingMVELocationID, img.productSize(), img.ID)
 
 	buyCmd := integrationMVEBuyCmd()

--- a/internal/commands/mve/mve_integration_test.go
+++ b/internal/commands/mve/mve_integration_test.go
@@ -189,9 +189,12 @@ func TestIntegration_MVELifecycle(t *testing.T) {
 	require.NoError(t, buyErr, "buy MVE output: %s", buyOut)
 
 	mveUID := parseCreatedUID(buyOut, "MVE")
-	require.NotEmpty(t, mveUID, "could not parse MVE UID from: %s", buyOut)
-
+	// Register cleanup before asserting on mveUID, so any created MVE is
+	// cleaned up even if the UID assertion below fails.
 	t.Cleanup(func() {
+		if mveUID == "" {
+			return
+		}
 		delCmd := integrationMVEDeleteCmd()
 		_ = delCmd.Flags().Set("force", "true")
 		var delErr error
@@ -202,6 +205,7 @@ func TestIntegration_MVELifecycle(t *testing.T) {
 		}
 		t.Logf("cleanup: delete MVE %s: %s", mveUID, out)
 	})
+	require.NotEmpty(t, mveUID, "could not parse MVE UID from: %s", buyOut)
 
 	// Get and verify the core fields.
 	mve := getMVEJSON(t, mveUID)
@@ -260,9 +264,12 @@ func TestIntegration_MVEJSONInputLifecycle(t *testing.T) {
 	require.NoError(t, buyErr, "buy MVE (JSON) output: %s", buyOut)
 
 	mveUID := parseCreatedUID(buyOut, "MVE")
-	require.NotEmpty(t, mveUID, "could not parse MVE UID from: %s", buyOut)
-
+	// Register cleanup before asserting on mveUID, so any created MVE is
+	// cleaned up even if the UID assertion below fails.
 	t.Cleanup(func() {
+		if mveUID == "" {
+			return
+		}
 		delCmd := integrationMVEDeleteCmd()
 		_ = delCmd.Flags().Set("force", "true")
 		var delErr error
@@ -273,6 +280,7 @@ func TestIntegration_MVEJSONInputLifecycle(t *testing.T) {
 		}
 		t.Logf("cleanup: delete MVE %s: %s", mveUID, out)
 	})
+	require.NotEmpty(t, mveUID, "could not parse MVE UID from: %s", buyOut)
 
 	mve := getMVEJSON(t, mveUID)
 	assert.Equal(t, mveUID, mve["uid"])

--- a/internal/commands/topology/topology_mock.go
+++ b/internal/commands/topology/topology_mock.go
@@ -112,9 +112,6 @@ func (m *MockMCRService) UpdateMCRWithAddOn(ctx context.Context, mcrID string, r
 func (m *MockMCRService) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, addOnUID string, tunnelCount int) error {
 	return fmt.Errorf("mock: UpdateMCRIPsecAddOn not configured")
 }
-func (m *MockMCRService) GetMCRIPsec(ctx context.Context, mcrID string) (*megaport.MCRIPsecConfiguration, error) {
-	return nil, fmt.Errorf("mock: GetMCRIPsec not configured")
-}
 func (m *MockMCRService) WaitForMCRReady(ctx context.Context, mcrID string, timeout time.Duration) error {
 	return fmt.Errorf("mock: WaitForMCRReady not configured")
 }

--- a/internal/commands/topology/topology_mock.go
+++ b/internal/commands/topology/topology_mock.go
@@ -112,6 +112,9 @@ func (m *MockMCRService) UpdateMCRWithAddOn(ctx context.Context, mcrID string, r
 func (m *MockMCRService) UpdateMCRIPsecAddOn(ctx context.Context, mcrID string, addOnUID string, tunnelCount int) error {
 	return fmt.Errorf("mock: UpdateMCRIPsecAddOn not configured")
 }
+func (m *MockMCRService) GetMCRIPsec(ctx context.Context, mcrID string) (*megaport.MCRIPsecConfiguration, error) {
+	return nil, fmt.Errorf("mock: GetMCRIPsec not configured")
+}
 func (m *MockMCRService) WaitForMCRReady(ctx context.Context, mcrID string, timeout time.Duration) error {
 	return fmt.Errorf("mock: WaitForMCRReady not configured")
 }

--- a/internal/validation/mve.go
+++ b/internal/validation/mve.go
@@ -22,6 +22,25 @@ var (
 	}
 )
 
+// MVELabelToProductSize maps human-readable MVE size labels (as returned by the
+// images API in the availableSizes field) to their canonical programmatic names.
+var MVELabelToProductSize = map[string]string{
+	"MVE 2/8":   "SMALL",
+	"MVE 4/16":  "MEDIUM",
+	"MVE 8/32":  "LARGE",
+	"MVE 12/48": "X_LARGE_12",
+}
+
+// NormalizeMVEProductSize converts an MVE product size to its canonical form.
+// It accepts both programmatic names ("SMALL") and human-readable labels
+// ("MVE 2/8") as returned by the list-images API.
+func NormalizeMVEProductSize(size string) string {
+	if canonical, ok := MVELabelToProductSize[size]; ok {
+		return canonical
+	}
+	return size
+}
+
 // ValidateMVEProductSize validates the product size for an MVE (Megaport Virtual Edge) instance.
 // This function ensures the specified size is among the allowed values for MVE deployments.
 //


### PR DESCRIPTION
Migrates the MCR and MVE integration tests from Approach A (driving the compiled binary via `exec.Command`) to Approach B: tests live in each resource package, gated behind `//go:build integration`, and call the action functions directly with a mock-injected staging client.

- Add `internal/commands/mcr/mcr_integration_test.go` — full MCR lifecycle (flag-based and JSON input), plus the prefix filter list create/get/update/delete lifecycle, with cleanup ordered so the filter list is removed before the MCR.
- Add `internal/commands/mve/mve_integration_test.go` — full MVE lifecycle (flag-based and JSON input). Image IDs are discovered dynamically via `ListMVEImages` since they change on staging; no hardcoded image IDs.
- Both files use `testutil.SetupIntegrationClient` + `testutil.LoginWithClient`, lean on the SDK's wait-for-provision so there are no `time.Sleep` calls, and generate unique resource names per run.

Also fixes MVE validation and integration test logic for MVE Size. 

This is a follow up to https://github.com/megaport/megaport-cli/pull/344 allowing for Integration Tests to operate across a CI pipeline. 

MCR and MVE integration tests passing against staging 2026/06/03