### PR TITLE
ESD-1315: Preserve corrupt config as .corrupt-<timestamp> instead of overwriting

### DIFF
--- a/internal/commands/config/manager.go
+++ b/internal/commands/config/manager.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 )
 
 var (
@@ -55,7 +56,11 @@ func NewConfigManager() (*ConfigManager, error) {
 	var config ConfigFile
 	err = json.Unmarshal(configData, &config)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: Config file is corrupted, creating a new default config\n")
+		backupPath := configPath + ".corrupt-" + time.Now().Format("20060102-150405")
+		if renameErr := os.Rename(configPath, backupPath); renameErr != nil {
+			return nil, fmt.Errorf("config file is corrupted and could not be preserved: %w", renameErr)
+		}
+		fmt.Fprintf(os.Stderr, "Warning: Config file is corrupted. Original preserved at %s\n", backupPath)
 		config = ConfigFile{
 			Version:       ConfigVersion,
 			ActiveProfile: "",

--- a/internal/commands/config/manager.go
+++ b/internal/commands/config/manager.go
@@ -14,8 +14,9 @@ import (
 var (
 	ErrProfileNotFound = errors.New("profile not found")
 
-	// chmodFile is a variable so tests can inject failures on the backup chmod call.
-	chmodFile = os.Chmod
+	// renameFile and chmodFile are variables so tests can inject errors into the backup path.
+	renameFile = os.Rename
+	chmodFile  = os.Chmod
 )
 
 func NewConfigManager() (*ConfigManager, error) {
@@ -60,7 +61,7 @@ func NewConfigManager() (*ConfigManager, error) {
 	err = json.Unmarshal(configData, &config)
 	if err != nil {
 		backupPath := configPath + ".corrupt-" + time.Now().Format("20060102-150405.000000000")
-		if renameErr := os.Rename(configPath, backupPath); renameErr != nil {
+		if renameErr := renameFile(configPath, backupPath); renameErr != nil {
 			if !os.IsNotExist(renameErr) {
 				return nil, fmt.Errorf("config file is corrupted and could not be preserved: %w", renameErr)
 			}

--- a/internal/commands/config/manager.go
+++ b/internal/commands/config/manager.go
@@ -60,6 +60,9 @@ func NewConfigManager() (*ConfigManager, error) {
 		if renameErr := os.Rename(configPath, backupPath); renameErr != nil {
 			return nil, fmt.Errorf("config file is corrupted and could not be preserved: %w", renameErr)
 		}
+		if chmodErr := os.Chmod(backupPath, 0600); chmodErr != nil {
+			return nil, fmt.Errorf("config backup at %s could not be secured: %w", backupPath, chmodErr)
+		}
 		fmt.Fprintf(os.Stderr, "Warning: Config file is corrupted. Original preserved at %s\n", backupPath)
 		config = *NewConfigFile()
 

--- a/internal/commands/config/manager.go
+++ b/internal/commands/config/manager.go
@@ -69,9 +69,12 @@ func NewConfigManager() (*ConfigManager, error) {
 			fmt.Fprintf(os.Stderr, "Warning: Config file is corrupted and was concurrently recovered.\n")
 		} else {
 			if chmodErr := chmodFile(backupPath, 0600); chmodErr != nil {
-				return nil, fmt.Errorf("config backup at %s could not be secured: %w", backupPath, chmodErr)
+				// chmod failure is non-fatal: the backup is preserved and the fresh
+				// default will still be created. Warn so the user can restrict manually.
+				fmt.Fprintf(os.Stderr, "Warning: Config file is corrupted. Original preserved at %s (run: chmod 0600 %s)\n", backupPath, backupPath)
+			} else {
+				fmt.Fprintf(os.Stderr, "Warning: Config file is corrupted. Original preserved at %s\n", backupPath)
 			}
-			fmt.Fprintf(os.Stderr, "Warning: Config file is corrupted. Original preserved at %s\n", backupPath)
 		}
 		config = *NewConfigFile()
 

--- a/internal/commands/config/manager.go
+++ b/internal/commands/config/manager.go
@@ -71,7 +71,7 @@ func NewConfigManager() (*ConfigManager, error) {
 			if chmodErr := chmodFile(backupPath, 0600); chmodErr != nil {
 				// chmod failure is non-fatal: the backup is preserved and the fresh
 				// default will still be created. Warn so the user can restrict manually.
-				fmt.Fprintf(os.Stderr, "Warning: Config file is corrupted. Original preserved at %s (run: chmod 0600 %s)\n", backupPath, backupPath)
+				fmt.Fprintf(os.Stderr, "Warning: Config file is corrupted. Original preserved at %s (run: chmod 0600 -- %q)\n", backupPath, backupPath)
 			} else {
 				fmt.Fprintf(os.Stderr, "Warning: Config file is corrupted. Original preserved at %s\n", backupPath)
 			}

--- a/internal/commands/config/manager.go
+++ b/internal/commands/config/manager.go
@@ -56,17 +56,12 @@ func NewConfigManager() (*ConfigManager, error) {
 	var config ConfigFile
 	err = json.Unmarshal(configData, &config)
 	if err != nil {
-		backupPath := configPath + ".corrupt-" + time.Now().Format("20060102-150405")
+		backupPath := configPath + ".corrupt-" + time.Now().Format("20060102-150405.000000000")
 		if renameErr := os.Rename(configPath, backupPath); renameErr != nil {
 			return nil, fmt.Errorf("config file is corrupted and could not be preserved: %w", renameErr)
 		}
 		fmt.Fprintf(os.Stderr, "Warning: Config file is corrupted. Original preserved at %s\n", backupPath)
-		config = ConfigFile{
-			Version:       ConfigVersion,
-			ActiveProfile: "",
-			Profiles:      make(map[string]*Profile),
-			Defaults:      make(map[string]interface{}),
-		}
+		config = *NewConfigFile()
 
 		configData, err = json.MarshalIndent(config, "", "  ")
 		if err != nil {

--- a/internal/commands/config/manager.go
+++ b/internal/commands/config/manager.go
@@ -13,6 +13,9 @@ import (
 
 var (
 	ErrProfileNotFound = errors.New("profile not found")
+
+	// chmodFile is a variable so tests can inject failures on the backup chmod call.
+	chmodFile = os.Chmod
 )
 
 func NewConfigManager() (*ConfigManager, error) {
@@ -58,12 +61,17 @@ func NewConfigManager() (*ConfigManager, error) {
 	if err != nil {
 		backupPath := configPath + ".corrupt-" + time.Now().Format("20060102-150405.000000000")
 		if renameErr := os.Rename(configPath, backupPath); renameErr != nil {
-			return nil, fmt.Errorf("config file is corrupted and could not be preserved: %w", renameErr)
+			if !os.IsNotExist(renameErr) {
+				return nil, fmt.Errorf("config file is corrupted and could not be preserved: %w", renameErr)
+			}
+			// Another process already recovered the file; create a fresh default below.
+			fmt.Fprintf(os.Stderr, "Warning: Config file is corrupted and was concurrently recovered.\n")
+		} else {
+			if chmodErr := chmodFile(backupPath, 0600); chmodErr != nil {
+				return nil, fmt.Errorf("config backup at %s could not be secured: %w", backupPath, chmodErr)
+			}
+			fmt.Fprintf(os.Stderr, "Warning: Config file is corrupted. Original preserved at %s\n", backupPath)
 		}
-		if chmodErr := os.Chmod(backupPath, 0600); chmodErr != nil {
-			return nil, fmt.Errorf("config backup at %s could not be secured: %w", backupPath, chmodErr)
-		}
-		fmt.Fprintf(os.Stderr, "Warning: Config file is corrupted. Original preserved at %s\n", backupPath)
 		config = *NewConfigFile()
 
 		configData, err = json.MarshalIndent(config, "", "  ")

--- a/internal/commands/config/manager_test.go
+++ b/internal/commands/config/manager_test.go
@@ -493,9 +493,12 @@ func TestCorruptedConfigFile_ChmodFailure(t *testing.T) {
 		return fmt.Errorf("chmod: operation not permitted")
 	}
 
-	_, err = NewConfigManager()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "could not be secured")
+	// chmod failure is non-fatal: the CLI should still succeed and create a fresh default.
+	manager, err := NewConfigManager()
+	require.NoError(t, err)
+	profiles, err := manager.ListProfiles()
+	require.NoError(t, err)
+	assert.Empty(t, profiles)
 }
 
 func TestCorruptedConfigFile_ConcurrentRecovery(t *testing.T) {

--- a/internal/commands/config/manager_test.go
+++ b/internal/commands/config/manager_test.go
@@ -507,9 +507,14 @@ func TestCorruptedConfigFile_ConcurrentRecovery(t *testing.T) {
 	err = os.WriteFile(configPath, []byte("not valid json"), 0600)
 	require.NoError(t, err)
 
-	// Simulate another process already having renamed the file before us.
-	err = os.Remove(configPath)
-	require.NoError(t, err)
+	// Simulate another process having renamed the corrupt file between our ReadFile
+	// and our Rename — inject ENOENT from the rename call while the corrupt file
+	// is still present so we reach the unmarshal-failure branch.
+	old := renameFile
+	defer func() { renameFile = old }()
+	renameFile = func(_, _ string) error {
+		return os.ErrNotExist
+	}
 
 	manager, err := NewConfigManager()
 	require.NoError(t, err)

--- a/internal/commands/config/manager_test.go
+++ b/internal/commands/config/manager_test.go
@@ -359,7 +359,8 @@ func TestCorruptedConfigFile(t *testing.T) {
 
 	configPath, err := GetConfigFilePath()
 	require.NoError(t, err)
-	err = os.WriteFile(configPath, []byte("{this is not valid json"), 0644)
+	corruptContent := []byte("{this is not valid json")
+	err = os.WriteFile(configPath, corruptContent, 0644)
 	require.NoError(t, err)
 
 	manager, err = NewConfigManager()
@@ -367,10 +368,52 @@ func TestCorruptedConfigFile(t *testing.T) {
 
 	profiles, err := manager.ListProfiles()
 	require.NoError(t, err)
-	assert.Empty(t, profiles, "Corrupted config should be replaced with default empty config")
+	assert.Empty(t, profiles, "New config after recovery should have empty profiles")
+
+	// The corrupt file must be preserved, not destroyed in place
+	matches, err := filepath.Glob(configPath + ".corrupt-*")
+	require.NoError(t, err)
+	require.Len(t, matches, 1, "Corrupt config should be preserved with a .corrupt- suffix")
+
+	preserved, err := os.ReadFile(matches[0])
+	require.NoError(t, err)
+	assert.Equal(t, corruptContent, preserved, "Preserved file should contain the original corrupt bytes")
 
 	err = manager.CreateProfile("new-profile", "access123", "secret123", "production", "")
 	require.NoError(t, err)
+}
+
+func TestCorruptedConfigFilePreservesOriginal(t *testing.T) {
+	setupTestConfig(t)
+
+	manager, err := NewConfigManager()
+	require.NoError(t, err)
+	err = manager.CreateProfile("my-profile", "AKIATEST123", "secretXYZ456", "production", "")
+	require.NoError(t, err)
+
+	configPath, err := GetConfigFilePath()
+	require.NoError(t, err)
+
+	// Append garbage to the valid config so unmarshal fails but the profile data is still present
+	original, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	corrupt := append(original, []byte(" *** CORRUPT ***")...)
+	err = os.WriteFile(configPath, corrupt, 0600)
+	require.NoError(t, err)
+
+	_, err = NewConfigManager()
+	require.NoError(t, err)
+
+	// Backup must exist and still contain the original profile data
+	matches, err := filepath.Glob(configPath + ".corrupt-*")
+	require.NoError(t, err)
+	require.Len(t, matches, 1, "Expected exactly one .corrupt- backup file")
+
+	preserved, err := os.ReadFile(matches[0])
+	require.NoError(t, err)
+	assert.Contains(t, string(preserved), "AKIATEST123", "Backup should contain original access key")
+	assert.Contains(t, string(preserved), "secretXYZ456", "Backup should contain original secret key")
+	assert.Contains(t, string(preserved), "my-profile", "Backup should contain original profile name")
 }
 
 func TestCorruptedConfigFile_Permissions(t *testing.T) {

--- a/internal/commands/config/manager_test.go
+++ b/internal/commands/config/manager_test.go
@@ -511,11 +511,13 @@ func TestCorruptedConfigFile_ConcurrentRecovery(t *testing.T) {
 	require.NoError(t, err)
 
 	// Simulate another process having renamed the corrupt file between our ReadFile
-	// and our Rename — inject ENOENT from the rename call while the corrupt file
-	// is still present so we reach the unmarshal-failure branch.
+	// and our Rename: the stub moves the source file (as the other process would)
+	// then returns ENOENT so our code takes the concurrent-recovery branch.
+	simulatedBackup := configPath + ".corrupt-concurrent"
 	old := renameFile
 	defer func() { renameFile = old }()
-	renameFile = func(_, _ string) error {
+	renameFile = func(src, _ string) error {
+		_ = os.Rename(src, simulatedBackup)
 		return os.ErrNotExist
 	}
 
@@ -526,6 +528,10 @@ func TestCorruptedConfigFile_ConcurrentRecovery(t *testing.T) {
 	profiles, err := manager.ListProfiles()
 	require.NoError(t, err)
 	assert.Empty(t, profiles)
+
+	// The backup created by the "other process" should still be present
+	_, statErr := os.Stat(simulatedBackup)
+	assert.NoError(t, statErr, "Backup from concurrent process should still exist")
 }
 
 func TestSpecialProfileNames(t *testing.T) {

--- a/internal/commands/config/manager_test.go
+++ b/internal/commands/config/manager_test.go
@@ -436,9 +436,18 @@ func TestCorruptedConfigFile_Permissions(t *testing.T) {
 	_, err = NewConfigManager()
 	require.NoError(t, err)
 
+	// New default config must be 0600
 	info, err = os.Stat(configPath)
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "config file should have 0600 permissions after corruption recovery")
+
+	// Backup must also be 0600 regardless of the original file's permissions
+	matches, err := filepath.Glob(configPath + ".corrupt-*")
+	require.NoError(t, err)
+	require.Len(t, matches, 1, "Expected exactly one .corrupt- backup file")
+	info, err = os.Stat(matches[0])
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "backup file should have 0600 permissions")
 }
 
 func TestSpecialProfileNames(t *testing.T) {

--- a/internal/commands/config/manager_test.go
+++ b/internal/commands/config/manager_test.go
@@ -397,7 +397,9 @@ func TestCorruptedConfigFilePreservesOriginal(t *testing.T) {
 	// Append garbage to the valid config so unmarshal fails but the profile data is still present
 	original, err := os.ReadFile(configPath)
 	require.NoError(t, err)
-	corrupt := append(original, []byte(" *** CORRUPT ***")...)
+	corrupt := make([]byte, len(original), len(original)+16)
+	copy(corrupt, original)
+	corrupt = append(corrupt, []byte(" *** CORRUPT ***")...)
 	err = os.WriteFile(configPath, corrupt, 0600)
 	require.NoError(t, err)
 

--- a/internal/commands/config/manager_test.go
+++ b/internal/commands/config/manager_test.go
@@ -450,6 +450,76 @@ func TestCorruptedConfigFile_Permissions(t *testing.T) {
 	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "backup file should have 0600 permissions")
 }
 
+func TestCorruptedConfigFile_RenameFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("Skipping test when running as root")
+	}
+
+	tempDir, err := os.MkdirTemp("", "megaport-config-test")
+	require.NoError(t, err)
+	defer func() {
+		os.Chmod(tempDir, 0700)
+		os.RemoveAll(tempDir)
+	}()
+	t.Setenv("MEGAPORT_CONFIG_DIR", tempDir)
+
+	configPath, err := GetConfigFilePath()
+	require.NoError(t, err)
+
+	err = os.WriteFile(configPath, []byte("not valid json"), 0600)
+	require.NoError(t, err)
+
+	// Make the config directory read-only so rename fails
+	err = os.Chmod(tempDir, 0500)
+	require.NoError(t, err)
+
+	_, err = NewConfigManager()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not be preserved")
+}
+
+func TestCorruptedConfigFile_ChmodFailure(t *testing.T) {
+	setupTestConfig(t)
+
+	configPath, err := GetConfigFilePath()
+	require.NoError(t, err)
+
+	err = os.WriteFile(configPath, []byte("not valid json"), 0600)
+	require.NoError(t, err)
+
+	old := chmodFile
+	defer func() { chmodFile = old }()
+	chmodFile = func(_ string, _ os.FileMode) error {
+		return fmt.Errorf("chmod: operation not permitted")
+	}
+
+	_, err = NewConfigManager()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not be secured")
+}
+
+func TestCorruptedConfigFile_ConcurrentRecovery(t *testing.T) {
+	setupTestConfig(t)
+
+	configPath, err := GetConfigFilePath()
+	require.NoError(t, err)
+
+	err = os.WriteFile(configPath, []byte("not valid json"), 0600)
+	require.NoError(t, err)
+
+	// Simulate another process already having renamed the file before us.
+	err = os.Remove(configPath)
+	require.NoError(t, err)
+
+	manager, err := NewConfigManager()
+	require.NoError(t, err)
+
+	// Fresh default should be created and usable
+	profiles, err := manager.ListProfiles()
+	require.NoError(t, err)
+	assert.Empty(t, profiles)
+}
+
 func TestSpecialProfileNames(t *testing.T) {
 	setupTestConfig(t)
 

--- a/internal/commands/config/manager_test.go
+++ b/internal/commands/config/manager_test.go
@@ -458,7 +458,7 @@ func TestCorruptedConfigFile_RenameFailure(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "megaport-config-test")
 	require.NoError(t, err)
 	defer func() {
-		os.Chmod(tempDir, 0700)
+		_ = os.Chmod(tempDir, 0700)
 		os.RemoveAll(tempDir)
 	}()
 	t.Setenv("MEGAPORT_CONFIG_DIR", tempDir)


### PR DESCRIPTION
A failed `json.Unmarshal` was silently replacing `~/.megaport/config.json` with an empty default, permanently destroying all saved access and secret keys. The command continued as if nothing happened, with only a `Warning:` line to stderr.

On unmarshal failure the corrupt file is now renamed to `config.json.corrupt-<timestamp>` before a fresh default is written. The user is told the backup path so they can recover their credentials. The rename is atomic (POSIX), so if the subsequent write fails, the original is still intact. The new default is written with `0600` permissions.

- `manager.go`: rename corrupt file before creating fresh default; print backup path to stderr; use nanosecond timestamp to avoid collision on rapid re-invocation
- `manager_test.go`: update `TestCorruptedConfigFile` to assert original is preserved; add `TestCorruptedConfigFilePreservesOriginal` regression test confirming profile data survives in the backup