### PR TITLE
ESD-1322: Add integration tests for partners, servicekeys, users, managed_account

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -46,6 +46,7 @@ jobs:
             ./internal/commands/vxc/... \
             ./internal/commands/mcr/... \
             ./internal/commands/mve/... \
+            ./internal/commands/ix/... \
             ./internal/commands/servicekeys/... \
             ./internal/commands/users/... 2>&1); then
             echo "::error::go test -list failed — see build/compile errors below."
@@ -61,7 +62,7 @@ jobs:
           echo "Discovered tests:"
           echo "$discovered"
       - name: Run provisioning integration tests
-        run: go test -tags 'integration provisioning' -run '^TestIntegration_' -v -timeout 30m ./internal/commands/ports/... ./internal/commands/vxc/... ./internal/commands/mcr/... ./internal/commands/mve/... ./internal/commands/servicekeys/... ./internal/commands/users/...
+        run: go test -tags 'integration provisioning' -run '^TestIntegration_' -v -timeout 30m ./internal/commands/ports/... ./internal/commands/vxc/... ./internal/commands/mcr/... ./internal/commands/mve/... ./internal/commands/ix/... ./internal/commands/servicekeys/... ./internal/commands/users/...
         env:
           MEGAPORT_ACCESS_KEY: ${{ secrets.MEGAPORT_ACCESS_KEY }}
           MEGAPORT_SECRET_KEY: ${{ secrets.MEGAPORT_SECRET_KEY }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Run read-only integration tests
-        run: go test -tags integration -run '^TestIntegration_' -v -timeout 5m ./internal/commands/locations/...
+        run: go test -tags integration -run '^TestIntegration_' -v -timeout 5m ./internal/commands/locations/... ./internal/commands/partners/... ./internal/commands/servicekeys/... ./internal/commands/users/... ./internal/commands/managed_account/...
         env:
           MEGAPORT_ACCESS_KEY: ${{ secrets.MEGAPORT_ACCESS_KEY }}
           MEGAPORT_SECRET_KEY: ${{ secrets.MEGAPORT_SECRET_KEY }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -41,11 +41,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if ! list_output=$(go test -tags integration -list '^TestIntegration_' \
+          if ! list_output=$(go test -tags 'integration provisioning' -list '^TestIntegration_' \
             ./internal/commands/ports/... \
             ./internal/commands/vxc/... \
             ./internal/commands/mcr/... \
-            ./internal/commands/mve/... 2>&1); then
+            ./internal/commands/mve/... \
+            ./internal/commands/servicekeys/... \
+            ./internal/commands/users/... 2>&1); then
             echo "::error::go test -list failed — see build/compile errors below."
             echo "$list_output"
             exit 1
@@ -59,7 +61,7 @@ jobs:
           echo "Discovered tests:"
           echo "$discovered"
       - name: Run provisioning integration tests
-        run: go test -tags integration -run '^TestIntegration_' -v -timeout 30m ./internal/commands/ports/... ./internal/commands/vxc/... ./internal/commands/mcr/... ./internal/commands/mve/...
+        run: go test -tags 'integration provisioning' -run '^TestIntegration_' -v -timeout 30m ./internal/commands/ports/... ./internal/commands/vxc/... ./internal/commands/mcr/... ./internal/commands/mve/... ./internal/commands/servicekeys/... ./internal/commands/users/...
         env:
           MEGAPORT_ACCESS_KEY: ${{ secrets.MEGAPORT_ACCESS_KEY }}
           MEGAPORT_SECRET_KEY: ${{ secrets.MEGAPORT_SECRET_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,10 @@ test-cover:
 	@rm -f coverage.out
 
 # Run integration tests against staging API (requires credentials — see docs/INTEGRATION_TESTING.md)
+# The `provisioning` tag also pulls in lifecycle tests that create and tear down
+# real staging resources (e.g. the service key test provisions a port).
 test-integration:
-	go test -tags integration -run '^TestIntegration_' -v -timeout 30m ./internal/commands/...
+	go test -tags 'integration provisioning' -run '^TestIntegration_' -v -timeout 30m ./internal/commands/...
 
 # Run only read-only integration tests — fast, no resources provisioned
 test-integration-readonly:

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,10 @@ test-cover:
 test-integration:
 	go test -tags 'integration provisioning' -run '^TestIntegration_' -v -timeout 30m ./internal/commands/...
 
-# Run only read-only integration tests — fast, no resources provisioned
+# Run only read-only integration tests — fast, no resources provisioned.
+# Package list mirrors the integration-readonly CI job.
 test-integration-readonly:
-	go test -tags integration -run '^TestIntegration_' -v -timeout 5m ./internal/commands/locations/...
+	go test -tags integration -run '^TestIntegration_' -v -timeout 5m ./internal/commands/locations/... ./internal/commands/partners/... ./internal/commands/servicekeys/... ./internal/commands/users/... ./internal/commands/managed_account/...
 
 # Run linter
 lint:

--- a/docs/INTEGRATION_TESTING.md
+++ b/docs/INTEGRATION_TESTING.md
@@ -65,7 +65,7 @@ This keeps them out of the nightly read-only job (which builds only `-tags integ
 Integration tests run in CI via `.github/workflows/integration-test.yml`:
 
 - **Read-only job**: runs nightly on `main` and on manual trigger, tests `locations`, `partners`, `servicekeys`, `users`, and `managed_account` (read-only `list`/`get` only). Fast, no resource cost.
-- **Provisioning job**: manual trigger only (`workflow_dispatch`), built with `-tags 'integration provisioning'`. Runs lifecycle tests for ports, VXC, MCR, MVE, plus the service key and user create/update/delete lifecycles.
+- **Provisioning job**: manual trigger only (`workflow_dispatch`), built with `-tags 'integration provisioning'`. Runs lifecycle tests for ports, VXC, MCR, MVE, IX, plus the service key and user lifecycles.
 
 ## Adding a new integration test
 

--- a/docs/INTEGRATION_TESTING.md
+++ b/docs/INTEGRATION_TESTING.md
@@ -62,7 +62,7 @@ This keeps them out of the nightly read-only job (which builds only `-tags integ
 Integration tests run in CI via `.github/workflows/integration-test.yml`:
 
 - **Read-only job**: runs nightly on `main` and on manual trigger, tests `locations`, `partners`, `servicekeys`, `users`, and `managed_account` (read-only `list`/`get` only). Fast, no resource cost.
-- **Provisioning job**: manual trigger only (`workflow_dispatch`), built with `-tags 'integration provisioning'`. Runs lifecycle tests for ports, VXC, MCR, MVE, IX, plus the service key and user lifecycles.
+- **Provisioning job**: manual trigger only (`workflow_dispatch`), built with `-tags 'integration provisioning'`. Runs lifecycle tests for ports, MCR, MVE, IX, plus the service key and user lifecycles. The `vxc` package is in the job's package list but has no lifecycle test yet, so nothing runs for it.
 
 ## Adding a new integration test
 

--- a/docs/INTEGRATION_TESTING.md
+++ b/docs/INTEGRATION_TESTING.md
@@ -47,7 +47,7 @@ Running `go test ./...` (without `-tags integration`) excludes these files entir
 
 ### The `provisioning` sub-tag
 
-Lifecycle tests that create and tear down real staging resources carry an extra `provisioning` tag alongside `integration`:
+A lifecycle test that lives in a package the nightly read-only job also runs carries an extra `provisioning` tag alongside `integration`:
 
 ```go
 //go:build integration && provisioning
@@ -55,7 +55,7 @@ Lifecycle tests that create and tear down real staging resources carry an extra 
 package servicekeys
 ```
 
-This keeps them out of the nightly read-only job (which builds only `-tags integration`) even when they live in a package the read-only job otherwise covers. For example, `servicekeys` and `users` run read-only `list`/`get` tests nightly, but their lifecycle tests provision resources (the service key test buys a port to use as its product) and only build under `-tags 'integration provisioning'` in the manual provisioning job.
+The nightly read-only job builds only `-tags integration`, so this tag keeps the mutating test out of it. It is needed only for packages that the read-only job runs — currently `servicekeys` and `users`, which have read-only `list`/`get` tests nightly but whose lifecycle tests provision resources (the service key test buys a port to use as its product). Lifecycle tests in packages the read-only job does not run (ports, VXC, MCR, MVE, IX) are excluded from nightly by package selection alone, so they stay `//go:build integration` only.
 
 ## CI
 
@@ -71,7 +71,7 @@ Integration tests run in CI via `.github/workflows/integration-test.yml`:
 3. Authenticate using one of the helpers below (see "Authentication helpers")
 4. Call action functions directly. For parallel tests, read state via `testutil.SharedIntegrationClient(t)` rather than `output.CaptureOutput` (see "Output capture and parallelism")
 5. Use `t.Cleanup()` for resource deletion (e.g. deleting staging ports/VXCs) so cleanup runs even on test failure; `defer` is fine for non-resource cleanup like restoring login state
-6. If the test creates or mutates real resources, add `&& provisioning` to the build tag and put it in its own file so the nightly read-only job skips it
+6. If the test mutates real resources *and* lives in a package the nightly read-only job runs (e.g. `servicekeys`, `users`), add `&& provisioning` to the build tag and put it in its own file so the read-only job skips it. A mutating test in a package the read-only job does not run needs only `//go:build integration` — package selection keeps it out of nightly
 7. Add the package to the provisioning job in `.github/workflows/integration-test.yml`
 
 See `internal/commands/locations/locations_integration_test.go` for a serial read-only example and `internal/commands/ports/ports_integration_test.go` for a parallel provisioning-lifecycle example.

--- a/docs/INTEGRATION_TESTING.md
+++ b/docs/INTEGRATION_TESTING.md
@@ -20,8 +20,7 @@ Staging credentials can be obtained from the Megaport staging portal. The stagin
 # Read-only tests only — fast (< 5 min), no resources provisioned
 make test-integration-readonly
 
-# Full suite including any provisioning lifecycle tests (~20–30 min)
-# Currently only read-only tests exist; provisioning tests will be added incrementally.
+# Full suite including provisioning lifecycle tests (~15 min against staging)
 make test-integration
 
 # A single package
@@ -30,11 +29,9 @@ go test -tags integration -run '^TestIntegration_' -v -timeout 30m ./internal/co
 
 ## What gets created on staging
 
-Once provisioning lifecycle tests are written (ports, VXC, MCR, MVE, IX, NAT Gateway), they will create real resources on the staging account. All test resources will be named with the prefix `CLI-Test-` for easy identification.
+The provisioning lifecycle tests create real resources on the staging account: ports, MCR, MVE, IX, a service key (against a port the test buys), and a pending-invite user. Most test resources are named with the prefix `CLI-Test-` for easy identification. VXC and NAT Gateway lifecycle tests do not exist yet.
 
-Resources will be cleaned up automatically via `t.Cleanup()` at the end of each test, even when the test fails. However, if a test run is interrupted (e.g. `Ctrl+C`), cleanup may not run. In that case, log in to the staging portal and delete any resources prefixed with `CLI-Test-`.
-
-Currently, only read-only integration tests exist (`locations`). No resources are provisioned.
+Resources are cleaned up automatically via `t.Cleanup()` at the end of each test, even when the test fails. However, if a test run is interrupted (e.g. `Ctrl+C`), cleanup may not run. In that case, log in to the staging portal and delete any leftover resources prefixed with `CLI-Test-`.
 
 ## Build tag
 
@@ -58,7 +55,7 @@ Lifecycle tests that create and tear down real staging resources carry an extra 
 package servicekeys
 ```
 
-This keeps them out of the nightly read-only job (which builds only `-tags integration`) even when they live in a package the read-only job otherwise covers. For example, `servicekeys` and `users` run read-only `list`/`get` tests nightly, but their create/update/delete lifecycle tests provision resources (the service key test buys a port to use as its product) and only build under `-tags 'integration provisioning'` in the manual provisioning job.
+This keeps them out of the nightly read-only job (which builds only `-tags integration`) even when they live in a package the read-only job otherwise covers. For example, `servicekeys` and `users` run read-only `list`/`get` tests nightly, but their lifecycle tests provision resources (the service key test buys a port to use as its product) and only build under `-tags 'integration provisioning'` in the manual provisioning job.
 
 ## CI
 

--- a/docs/INTEGRATION_TESTING.md
+++ b/docs/INTEGRATION_TESTING.md
@@ -48,12 +48,24 @@ package ports
 
 Running `go test ./...` (without `-tags integration`) excludes these files entirely. They only compile and run when `-tags integration` is passed explicitly.
 
+### The `provisioning` sub-tag
+
+Lifecycle tests that create and tear down real staging resources carry an extra `provisioning` tag alongside `integration`:
+
+```go
+//go:build integration && provisioning
+
+package servicekeys
+```
+
+This keeps them out of the nightly read-only job (which builds only `-tags integration`) even when they live in a package the read-only job otherwise covers. For example, `servicekeys` and `users` run read-only `list`/`get` tests nightly, but their create/update/delete lifecycle tests provision resources (the service key test buys a port to use as its product) and only build under `-tags 'integration provisioning'` in the manual provisioning job.
+
 ## CI
 
 Integration tests run in CI via `.github/workflows/integration-test.yml`:
 
-- **Read-only job**: runs nightly on `main` and on manual trigger, tests `locations` (and additional packages as read-only integration tests are written). Fast, no resource cost.
-- **Provisioning job**: manual trigger only (`workflow_dispatch`). Runs lifecycle tests for ports, VXC, MCR, MVE, and additional resources as they are added.
+- **Read-only job**: runs nightly on `main` and on manual trigger, tests `locations`, `partners`, `servicekeys`, `users`, and `managed_account` (read-only `list`/`get` only). Fast, no resource cost.
+- **Provisioning job**: manual trigger only (`workflow_dispatch`), built with `-tags 'integration provisioning'`. Runs lifecycle tests for ports, VXC, MCR, MVE, plus the service key and user create/update/delete lifecycles.
 
 ## Adding a new integration test
 
@@ -62,7 +74,8 @@ Integration tests run in CI via `.github/workflows/integration-test.yml`:
 3. Authenticate using one of the helpers below (see "Authentication helpers")
 4. Call action functions directly. For parallel tests, read state via `testutil.SharedIntegrationClient(t)` rather than `output.CaptureOutput` (see "Output capture and parallelism")
 5. Use `t.Cleanup()` for resource deletion (e.g. deleting staging ports/VXCs) so cleanup runs even on test failure; `defer` is fine for non-resource cleanup like restoring login state
-6. Add the package to the provisioning job in `.github/workflows/integration-test.yml`
+6. If the test creates or mutates real resources, add `&& provisioning` to the build tag and put it in its own file so the nightly read-only job skips it
+7. Add the package to the provisioning job in `.github/workflows/integration-test.yml`
 
 See `internal/commands/locations/locations_integration_test.go` for a serial read-only example and `internal/commands/ports/ports_integration_test.go` for a parallel provisioning-lifecycle example.
 

--- a/internal/commands/managed_account/managed_account_integration_test.go
+++ b/internal/commands/managed_account/managed_account_integration_test.go
@@ -4,6 +4,7 @@ package managed_account
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/megaport/megaport-cli/internal/base/output"
@@ -32,7 +33,13 @@ func TestIntegration_ListManagedAccounts(t *testing.T) {
 		err = ListManagedAccounts(cmd, nil, true, "json")
 	})
 
-	require.NoError(t, err)
+	if err != nil {
+		if strings.Contains(err.Error(), "not configured to create managed companies") ||
+			strings.Contains(err.Error(), "403") {
+			t.Skip("staging account not configured for managed companies — skipping")
+		}
+		require.NoError(t, err)
+	}
 
 	// An empty result with json format produces no output — that's acceptable for
 	// staging accounts that have no managed accounts configured.
@@ -59,7 +66,13 @@ func TestIntegration_GetManagedAccount(t *testing.T) {
 	listOut := output.CaptureOutput(func() {
 		listErr = ListManagedAccounts(listCmd, nil, true, "json")
 	})
-	require.NoError(t, listErr)
+	if listErr != nil {
+		if strings.Contains(listErr.Error(), "not configured to create managed companies") ||
+			strings.Contains(listErr.Error(), "403") {
+			t.Skip("staging account not configured for managed companies — skipping")
+		}
+		require.NoError(t, listErr)
+	}
 
 	if listOut == "" {
 		t.Skip("no managed accounts on staging to test GetManagedAccount")

--- a/internal/commands/managed_account/managed_account_integration_test.go
+++ b/internal/commands/managed_account/managed_account_integration_test.go
@@ -1,0 +1,91 @@
+//go:build integration
+
+package managed_account
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/testutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func integrationListManagedAccountsCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "list"}
+	cmd.Flags().String("account-name", "", "")
+	cmd.Flags().String("account-ref", "", "")
+	cmd.Flags().Int("limit", 0, "")
+	return cmd
+}
+
+func TestIntegration_ListManagedAccounts(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	cmd := integrationListManagedAccountsCmd()
+
+	var err error
+	captured := output.CaptureOutput(func() {
+		err = ListManagedAccounts(cmd, nil, true, "json")
+	})
+
+	require.NoError(t, err)
+
+	// An empty result with json format produces no output — that's acceptable for
+	// staging accounts that have no managed accounts configured.
+	if captured == "" {
+		t.Skip("no managed accounts on staging — acceptable")
+	}
+
+	var accounts []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(captured), &accounts), "output should be valid JSON")
+
+	for _, a := range accounts {
+		assert.Contains(t, a, "account_name")
+		assert.Contains(t, a, "company_uid")
+	}
+}
+
+func TestIntegration_GetManagedAccount(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	listCmd := integrationListManagedAccountsCmd()
+
+	var listErr error
+	listOut := output.CaptureOutput(func() {
+		listErr = ListManagedAccounts(listCmd, nil, true, "json")
+	})
+	require.NoError(t, listErr)
+
+	if listOut == "" {
+		t.Skip("no managed accounts on staging to test GetManagedAccount")
+	}
+
+	var accounts []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(listOut), &accounts))
+	require.NotEmpty(t, accounts, "expected non-empty accounts after non-empty JSON output")
+
+	companyUID, ok := accounts[0]["company_uid"].(string)
+	require.True(t, ok, "company_uid should be a string")
+	accountName, ok := accounts[0]["account_name"].(string)
+	require.True(t, ok, "account_name should be a string")
+
+	getCmd := &cobra.Command{Use: "get"}
+
+	var getErr error
+	getOut := output.CaptureOutput(func() {
+		getErr = GetManagedAccount(getCmd, []string{companyUID, accountName}, true, "json")
+	})
+
+	require.NoError(t, getErr)
+
+	var got []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(getOut), &got), "get output should be valid JSON")
+	require.NotEmpty(t, got)
+	assert.Equal(t, companyUID, got[0]["company_uid"])
+	assert.Equal(t, accountName, got[0]["account_name"])
+}

--- a/internal/commands/partners/partners_integration_test.go
+++ b/internal/commands/partners/partners_integration_test.go
@@ -1,0 +1,78 @@
+//go:build integration
+
+package partners
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/testutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func integrationListPartnersCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "list"}
+	cmd.Flags().String("product-name", "", "")
+	cmd.Flags().String("connect-type", "", "")
+	cmd.Flags().String("company-name", "", "")
+	cmd.Flags().Int("location-id", 0, "")
+	cmd.Flags().String("diversity-zone", "", "")
+	cmd.Flags().Int("limit", 0, "")
+	return cmd
+}
+
+func TestIntegration_ListPartners(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	cmd := integrationListPartnersCmd()
+
+	var err error
+	captured := output.CaptureOutput(func() {
+		err = ListPartners(cmd, nil, true, "json")
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, captured, "expected JSON output; ListPartners prints nothing for an empty result set in json mode")
+
+	var partners []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(captured), &partners), "output should be valid JSON")
+	assert.NotEmpty(t, partners, "staging should return at least one partner port")
+
+	for _, p := range partners {
+		assert.Contains(t, p, "product_name")
+		assert.Contains(t, p, "uid")
+		assert.Contains(t, p, "connect_type")
+		assert.Contains(t, p, "company_name")
+	}
+}
+
+func TestIntegration_ListPartners_FilterByConnectType(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	cmd := integrationListPartnersCmd()
+	require.NoError(t, cmd.Flags().Set("connect-type", "AWS"))
+
+	var err error
+	captured := output.CaptureOutput(func() {
+		err = ListPartners(cmd, nil, true, "json")
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, captured, "expected JSON output; ListPartners prints nothing for an empty result set in json mode")
+
+	var partners []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(captured), &partners))
+	assert.NotEmpty(t, partners, "AWS partner ports should exist on staging")
+
+	for _, p := range partners {
+		ct, ok := p["connect_type"].(string)
+		assert.True(t, ok, "connect_type should be a string in result %v", p)
+		assert.True(t, strings.EqualFold("AWS", ct), "filtered results should all have connect_type AWS (case-insensitive), got %q", ct)
+	}
+}

--- a/internal/commands/partners/partners_integration_test.go
+++ b/internal/commands/partners/partners_integration_test.go
@@ -72,7 +72,7 @@ func TestIntegration_ListPartners_FilterByConnectType(t *testing.T) {
 
 	for _, p := range partners {
 		ct, ok := p["connect_type"].(string)
-		assert.True(t, ok, "connect_type should be a string in result %v", p)
-		assert.True(t, strings.EqualFold("AWS", ct), "filtered results should all have connect_type AWS (case-insensitive), got %q", ct)
+		assert.Truef(t, ok, "connect_type should be a string in result %v", p)
+		assert.Truef(t, strings.EqualFold("AWS", ct), "filtered results should all have connect_type AWS (case-insensitive), got %q", ct)
 	}
 }

--- a/internal/commands/servicekeys/servicekeys_integration_test.go
+++ b/internal/commands/servicekeys/servicekeys_integration_test.go
@@ -1,0 +1,94 @@
+//go:build integration
+
+package servicekeys
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/testutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func integrationListServiceKeysCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "list"}
+	cmd.Flags().String("product-uid", "", "")
+	cmd.Flags().Int("limit", 0, "")
+	return cmd
+}
+
+func TestIntegration_ListServiceKeys(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	listCmd := integrationListServiceKeysCmd()
+
+	var listErr error
+	listOut := output.CaptureOutput(func() {
+		listErr = ListServiceKeys(listCmd, nil, true, "json")
+	})
+
+	require.NoError(t, listErr)
+
+	if listOut == "" {
+		t.Skip("no service keys on staging")
+	}
+
+	var keys []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(listOut), &keys), "list output should be valid JSON")
+
+	if len(keys) == 0 {
+		t.Skip("no service keys on staging")
+	}
+
+	for _, k := range keys {
+		assert.Contains(t, k, "key_uid")
+		assert.Contains(t, k, "product_uid")
+		assert.Contains(t, k, "description")
+	}
+}
+
+func TestIntegration_GetServiceKey(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	listCmd := integrationListServiceKeysCmd()
+
+	var listErr error
+	listOut := output.CaptureOutput(func() {
+		listErr = ListServiceKeys(listCmd, nil, true, "json")
+	})
+	require.NoError(t, listErr)
+
+	if listOut == "" {
+		t.Skip("no service keys on staging to test GetServiceKey")
+	}
+
+	var keys []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(listOut), &keys), "list output should be valid JSON")
+	require.NotEmpty(t, keys, "need at least one service key to test GetServiceKey")
+
+	keyUID, ok := keys[0]["key_uid"].(string)
+	require.True(t, ok, "key_uid should be a string")
+	require.NotEmpty(t, keyUID)
+
+	getCmd := &cobra.Command{Use: "get"}
+
+	var getErr error
+	getOut := output.CaptureOutput(func() {
+		getErr = GetServiceKey(getCmd, []string{keyUID}, true, "json")
+	})
+
+	require.NoError(t, getErr)
+
+	var got []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(getOut), &got), "get output should be valid JSON")
+	require.NotEmpty(t, got)
+	assert.Equal(t, keyUID, got[0]["key_uid"])
+	assert.Contains(t, got[0], "product_uid")
+}
+
+// TODO: lifecycle test requires a live port as product-uid — skipping until one can be provisioned cheaply in CI.

--- a/internal/commands/servicekeys/servicekeys_integration_test.go
+++ b/internal/commands/servicekeys/servicekeys_integration_test.go
@@ -90,5 +90,3 @@ func TestIntegration_GetServiceKey(t *testing.T) {
 	assert.Equal(t, keyUID, got[0]["key_uid"])
 	assert.Contains(t, got[0], "product_uid")
 }
-
-// TODO: lifecycle test requires a live port as product-uid — skipping until one can be provisioned cheaply in CI.

--- a/internal/commands/servicekeys/servicekeys_lifecycle_integration_test.go
+++ b/internal/commands/servicekeys/servicekeys_lifecycle_integration_test.go
@@ -1,0 +1,169 @@
+//go:build integration && provisioning
+
+package servicekeys
+
+import (
+	"context"
+	crypto_rand "crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/testutil"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// integrationLocationID is the staging data center used to provision the
+// throwaway port a service key needs as its product. ID 67 is the canonical
+// staging example location reused across the CLI's other integration tests.
+const integrationLocationID = 67
+
+func uniqueSuffix(t *testing.T) string {
+	t.Helper()
+	buf := make([]byte, 4)
+	_, err := crypto_rand.Read(buf)
+	require.NoError(t, err, "failed to read crypto/rand entropy")
+	return hex.EncodeToString(buf)
+}
+
+// provisionPortForServiceKey buys a 1G port on staging via the SDK and registers
+// its teardown. A service key must reference an existing product (port), so the
+// lifecycle test provisions a real one and deletes it in t.Cleanup even on failure.
+func provisionPortForServiceKey(t *testing.T, client *megaport.Client) string {
+	t.Helper()
+	portName := fmt.Sprintf("CLI-Test-SvcKey-Port-%s", uniqueSuffix(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
+	defer cancel()
+
+	resp, err := client.PortService.BuyPort(ctx, &megaport.BuyPortRequest{
+		Name:                  portName,
+		Term:                  1,
+		PortSpeed:             1000,
+		LocationId:            integrationLocationID,
+		MarketPlaceVisibility: false,
+		WaitForProvision:      true,
+		WaitForTime:           10 * time.Minute,
+	})
+	require.NoError(t, err, "failed to provision port for service key test")
+	require.NotEmpty(t, resp.TechnicalServiceUIDs, "buy port returned no technical service UIDs")
+	portUID := resp.TechnicalServiceUIDs[0]
+
+	t.Cleanup(func() {
+		delCtx, delCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer delCancel()
+		if _, err := client.PortService.DeletePort(delCtx, &megaport.DeletePortRequest{
+			PortID:    portUID,
+			DeleteNow: true,
+		}); err != nil {
+			t.Errorf("cleanup: failed to delete port %s: %v", portUID, err)
+		}
+	})
+
+	return portUID
+}
+
+// serviceKeyUIDForProduct finds the key just created against productUID by its
+// unique description. CreateServiceKey prints the UID but does not return it, so
+// the test recovers it from the SDK list filtered by product.
+func serviceKeyUIDForProduct(t *testing.T, client *megaport.Client, productUID, description string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	resp, err := client.ServiceKeyService.ListServiceKeys(ctx, &megaport.ListServiceKeysRequest{ProductUID: &productUID})
+	require.NoError(t, err, "SDK ListServiceKeys failed")
+	require.NotNil(t, resp)
+	for _, k := range resp.ServiceKeys {
+		if k != nil && k.Description == description {
+			require.NotEmpty(t, k.Key, "service key UID should not be empty")
+			return k.Key
+		}
+	}
+	t.Fatalf("created service key with description %q not found for product %s", description, productUID)
+	return ""
+}
+
+func serviceKeyFromSDK(t *testing.T, client *megaport.Client, keyUID string) *megaport.ServiceKey {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	sk, err := client.ServiceKeyService.GetServiceKey(ctx, keyUID)
+	require.NoErrorf(t, err, "SDK GetServiceKey failed for %s", keyUID)
+	require.NotNil(t, sk)
+	return sk
+}
+
+func newCreateServiceKeyCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "create"}
+	cmd.Flags().String("product-uid", "", "")
+	cmd.Flags().Int("product-id", 0, "")
+	cmd.Flags().Bool("single-use", false, "")
+	cmd.Flags().String("description", "", "")
+	cmd.Flags().String("start-date", "", "")
+	cmd.Flags().String("end-date", "", "")
+	cmd.Flags().Int("max-speed", 0, "")
+	cmd.Flags().Bool("active", false, "")
+	cmd.Flags().Bool("pre-approved", false, "")
+	cmd.Flags().Int("vlan", 0, "")
+	return cmd
+}
+
+func newUpdateServiceKeyCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().String("product-uid", "", "")
+	cmd.Flags().Int("product-id", 0, "")
+	cmd.Flags().Bool("single-use", false, "")
+	cmd.Flags().String("description", "", "")
+	cmd.Flags().Bool("active", false, "")
+	return cmd
+}
+
+// TestIntegration_ServiceKeyLifecycle provisions a port, then exercises the full
+// create/get/update path of the service key CLI actions against it. The port and
+// any created resources are torn down in t.Cleanup. This test carries the extra
+// `provisioning` build tag so the nightly read-only job (which builds only
+// `-tags integration`) never runs it; it runs in the manual provisioning job.
+func TestIntegration_ServiceKeyLifecycle(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	portUID := provisionPortForServiceKey(t, client)
+	t.Logf("provisioned port %s for service key lifecycle", portUID)
+
+	description := fmt.Sprintf("CLI-Test-Key-%s", uniqueSuffix(t))
+
+	createCmd := newCreateServiceKeyCmd()
+	require.NoError(t, createCmd.Flags().Set("product-uid", portUID))
+	require.NoError(t, createCmd.Flags().Set("description", description))
+	require.NoError(t, createCmd.Flags().Set("max-speed", "1000"))
+
+	require.NoError(t, CreateServiceKey(createCmd, nil, true), "CreateServiceKey failed")
+
+	keyUID := serviceKeyUIDForProduct(t, client, portUID, description)
+	t.Logf("created service key %s", keyUID)
+
+	getCmd := &cobra.Command{Use: "get"}
+	getOut := output.CaptureOutput(func() {
+		require.NoError(t, GetServiceKey(getCmd, []string{keyUID}, true, "json"))
+	})
+
+	var got []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(getOut), &got), "get output should be valid JSON")
+	require.NotEmpty(t, got)
+	assert.Equal(t, keyUID, got[0]["key_uid"])
+	assert.Equal(t, portUID, got[0]["product_uid"])
+	assert.Equal(t, description, got[0]["description"])
+
+	updateCmd := newUpdateServiceKeyCmd()
+	require.NoError(t, updateCmd.Flags().Set("active", "true"))
+	require.NoError(t, UpdateServiceKey(updateCmd, []string{keyUID}, true), "UpdateServiceKey failed")
+
+	updated := serviceKeyFromSDK(t, client, keyUID)
+	assert.True(t, updated.Active, "service key should be active after update")
+}

--- a/internal/commands/servicekeys/servicekeys_lifecycle_integration_test.go
+++ b/internal/commands/servicekeys/servicekeys_lifecycle_integration_test.go
@@ -32,12 +32,56 @@ func uniqueSuffix(t *testing.T) string {
 	return hex.EncodeToString(buf)
 }
 
+// findPortUIDByName looks up the port with the given name and returns its UID,
+// with ok=false if no live (non-decommissioned) port matches. It returns the
+// list error rather than aborting, so it is safe to call from a t.Cleanup
+// callback, where a FailNow would mask the original failure.
+func findPortUIDByName(client *megaport.Client, name string) (uid string, ok bool, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	ports, err := client.PortService.ListPorts(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	for _, p := range ports {
+		if p == nil || p.Name != name || p.ProvisioningStatus == "DECOMMISSIONED" || p.ProvisioningStatus == "CANCELLED" {
+			continue
+		}
+		return p.UID, true, nil
+	}
+	return "", false, nil
+}
+
 // provisionPortForServiceKey buys a 1G port on staging via the SDK and registers
 // its teardown. A service key must reference an existing product (port), so the
 // lifecycle test provisions a real one and deletes it in t.Cleanup even on failure.
 func provisionPortForServiceKey(t *testing.T, client *megaport.Client) string {
 	t.Helper()
 	portName := fmt.Sprintf("CLI-Test-SvcKey-Port-%s", uniqueSuffix(t))
+
+	// Safety net registered before BuyPort: if the buy partially succeeds (e.g.
+	// the port is created but provisioning times out and BuyPort returns an
+	// error), this still removes the port. It resolves the UID by the unique
+	// name at cleanup time and is best-effort, so it is harmless when the port
+	// was never created or is already gone.
+	t.Cleanup(func() {
+		uid, ok, err := findPortUIDByName(client, portName)
+		if err != nil {
+			t.Logf("cleanup: could not list ports to find %s: %v", portName, err)
+			return
+		}
+		if !ok {
+			return
+		}
+		delCtx, delCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer delCancel()
+		if _, err := client.PortService.DeletePort(delCtx, &megaport.DeletePortRequest{
+			PortID:    uid,
+			DeleteNow: true,
+		}); err != nil {
+			t.Errorf("cleanup: failed to delete port %s (%s): %v", uid, portName, err)
+		}
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
 	defer cancel()
@@ -54,17 +98,6 @@ func provisionPortForServiceKey(t *testing.T, client *megaport.Client) string {
 	require.NoError(t, err, "failed to provision port for service key test")
 	require.NotEmpty(t, resp.TechnicalServiceUIDs, "buy port returned no technical service UIDs")
 	portUID := resp.TechnicalServiceUIDs[0]
-
-	t.Cleanup(func() {
-		delCtx, delCancel := context.WithTimeout(context.Background(), 60*time.Second)
-		defer delCancel()
-		if _, err := client.PortService.DeletePort(delCtx, &megaport.DeletePortRequest{
-			PortID:    portUID,
-			DeleteNow: true,
-		}); err != nil {
-			t.Errorf("cleanup: failed to delete port %s: %v", portUID, err)
-		}
-	})
 
 	return portUID
 }

--- a/internal/commands/servicekeys/servicekeys_lifecycle_integration_test.go
+++ b/internal/commands/servicekeys/servicekeys_lifecycle_integration_test.go
@@ -125,10 +125,11 @@ func newUpdateServiceKeyCmd() *cobra.Command {
 }
 
 // TestIntegration_ServiceKeyLifecycle provisions a port, then exercises the full
-// create/get/update path of the service key CLI actions against it. The port and
-// any created resources are torn down in t.Cleanup. This test carries the extra
-// `provisioning` build tag so the nightly read-only job (which builds only
-// `-tags integration`) never runs it; it runs in the manual provisioning job.
+// create/get/update path of the service key CLI actions against it. Only the port
+// is torn down in t.Cleanup; service keys have no delete API and are left attached
+// to the (deleted) port. This test carries the extra `provisioning` build tag so
+// the nightly read-only job (which builds only `-tags integration`) never runs it;
+// it runs in the manual provisioning job.
 func TestIntegration_ServiceKeyLifecycle(t *testing.T) {
 	client := testutil.SetupIntegrationClient(t)
 	defer testutil.LoginWithClient(t, client)()

--- a/internal/commands/users/users_integration_test.go
+++ b/internal/commands/users/users_integration_test.go
@@ -1,0 +1,86 @@
+//go:build integration
+
+package users
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/testutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func integrationListUsersCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "list"}
+	cmd.Flags().String("position", "", "")
+	cmd.Flags().Bool("active-only", false, "")
+	cmd.Flags().Bool("inactive-only", false, "")
+	return cmd
+}
+
+func TestIntegration_ListUsers(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	cmd := integrationListUsersCmd()
+
+	var err error
+	captured := output.CaptureOutput(func() {
+		err = ListUsers(cmd, nil, true, "json")
+	})
+
+	require.NoError(t, err)
+
+	var users []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(captured), &users), "output should be valid JSON")
+	assert.NotEmpty(t, users, "the authenticated account should have at least one user")
+
+	for _, u := range users {
+		assert.Contains(t, u, "employee_id")
+		assert.Contains(t, u, "first_name")
+		assert.Contains(t, u, "last_name")
+		assert.Contains(t, u, "email")
+	}
+}
+
+func TestIntegration_GetUser(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	listCmd := integrationListUsersCmd()
+
+	var listErr error
+	listOut := output.CaptureOutput(func() {
+		listErr = ListUsers(listCmd, nil, true, "json")
+	})
+	require.NoError(t, listErr)
+
+	var users []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(listOut), &users))
+	require.NotEmpty(t, users, "need at least one user to test GetUser")
+
+	empIDFloat, ok := users[0]["employee_id"].(float64)
+	require.True(t, ok, "employee_id should be a number")
+	employeeID := strconv.Itoa(int(empIDFloat))
+
+	getCmd := &cobra.Command{Use: "get"}
+
+	var getErr error
+	getOut := output.CaptureOutput(func() {
+		getErr = GetUser(getCmd, []string{employeeID}, true, "json")
+	})
+
+	require.NoError(t, getErr)
+
+	var got []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(getOut), &got), "get output should be valid JSON")
+	require.NotEmpty(t, got)
+	gotIDFloat, ok := got[0]["employee_id"].(float64)
+	require.True(t, ok, "employee_id should be a number in response")
+	assert.Equal(t, employeeID, strconv.Itoa(int(gotIDFloat)))
+	assert.Contains(t, got[0], "email")
+}

--- a/internal/commands/users/users_lifecycle_integration_test.go
+++ b/internal/commands/users/users_lifecycle_integration_test.go
@@ -47,26 +47,41 @@ func newDeleteUserCmd() *cobra.Command {
 	return cmd
 }
 
-// employeeIDByEmail polls the company user list for the user with the given
-// email and returns its employee ID (PartyId, falling back to PersonId — the
-// same derivation the get/list output uses). It retries briefly because a
-// freshly created user can take a moment to appear in the list.
+// findUserIDByEmail looks up the user with the given email and returns its
+// employee ID (PartyId, falling back to PersonId — the same derivation the
+// get/list output uses), with ok=false if no such user is present. It returns
+// the list error rather than aborting, so it is safe to call from a t.Cleanup
+// callback, where a FailNow would mask the original failure.
+func findUserIDByEmail(client *megaport.Client, email string) (id int, ok bool, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	users, err := client.UserManagementService.ListCompanyUsers(ctx)
+	if err != nil {
+		return 0, false, err
+	}
+	for _, u := range users {
+		if u == nil || u.Email != email {
+			continue
+		}
+		id := u.PartyId
+		if id == 0 {
+			id = u.PersonId
+		}
+		return id, true, nil
+	}
+	return 0, false, nil
+}
+
+// employeeIDByEmail polls until the user appears in the company user list and
+// returns its employee ID. It retries briefly because a freshly created user
+// can take a moment to appear.
 func employeeIDByEmail(t *testing.T, client *megaport.Client, email string) int {
 	t.Helper()
 	deadline := time.Now().Add(30 * time.Second)
 	for {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		users, err := client.UserManagementService.ListCompanyUsers(ctx)
-		cancel()
+		id, ok, err := findUserIDByEmail(client, email)
 		require.NoError(t, err, "SDK ListCompanyUsers failed")
-		for _, u := range users {
-			if u == nil || u.Email != email {
-				continue
-			}
-			id := u.PartyId
-			if id == 0 {
-				id = u.PersonId
-			}
+		if ok {
 			require.NotZerof(t, id, "user %s has no usable employee ID", email)
 			return id
 		}
@@ -75,24 +90,6 @@ func employeeIDByEmail(t *testing.T, client *megaport.Client, email string) int 
 		}
 		time.Sleep(2 * time.Second)
 	}
-}
-
-// userExistsByEmail reports whether a user with the given email is present. It
-// returns the list error rather than aborting so it is safe to call from a
-// t.Cleanup callback, where a FailNow would mask the original failure.
-func userExistsByEmail(client *megaport.Client, email string) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	users, err := client.UserManagementService.ListCompanyUsers(ctx)
-	if err != nil {
-		return false, err
-	}
-	for _, u := range users {
-		if u != nil && u.Email == email {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 // TestIntegration_UserLifecycle exercises the create/get/delete path of the user
@@ -122,25 +119,28 @@ func TestIntegration_UserLifecycle(t *testing.T) {
 
 	require.NoError(t, CreateUser(createCmd, nil, true), "CreateUser failed")
 
-	employeeID := employeeIDByEmail(t, client, email)
-	t.Logf("created user %s with employee ID %d", email, employeeID)
-
-	// Safety net: remove the user even if a later step fails. Best-effort —
-	// the happy path deletes the user itself, so this may find it already gone.
-	// On a list error we attempt the delete anyway rather than risk a leak.
+	// Safety net registered before the ID lookup below can fail: if CreateUser
+	// succeeded but employeeIDByEmail times out, this still removes the user.
+	// It resolves the ID by email at cleanup time and is best-effort — the happy
+	// path deletes the user itself, so this often finds it already gone.
 	t.Cleanup(func() {
-		exists, err := userExistsByEmail(client, email)
+		id, ok, err := findUserIDByEmail(client, email)
 		if err != nil {
-			t.Logf("cleanup: could not list users to check %s: %v; attempting delete anyway", email, err)
-		} else if !exists {
+			t.Logf("cleanup: could not list users to find %s: %v", email, err)
+			return
+		}
+		if !ok {
 			return
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		if err := client.UserManagementService.DeleteUser(ctx, employeeID); err != nil {
-			t.Logf("cleanup: failed to delete user %d (%s): %v", employeeID, email, err)
+		if err := client.UserManagementService.DeleteUser(ctx, id); err != nil {
+			t.Logf("cleanup: failed to delete user %d (%s): %v", id, email, err)
 		}
 	})
+
+	employeeID := employeeIDByEmail(t, client, email)
+	t.Logf("created user %s with employee ID %d", email, employeeID)
 
 	idArg := strconv.Itoa(employeeID)
 
@@ -159,7 +159,7 @@ func TestIntegration_UserLifecycle(t *testing.T) {
 	require.NoError(t, deleteCmd.Flags().Set("force", "true"))
 	require.NoError(t, DeleteUser(deleteCmd, []string{idArg}, true), "DeleteUser failed")
 
-	stillExists, err := userExistsByEmail(client, email)
+	_, stillExists, err := findUserIDByEmail(client, email)
 	require.NoError(t, err, "SDK ListCompanyUsers failed")
 	assert.False(t, stillExists, "user should be gone after delete")
 }

--- a/internal/commands/users/users_lifecycle_integration_test.go
+++ b/internal/commands/users/users_lifecycle_integration_test.go
@@ -77,18 +77,22 @@ func employeeIDByEmail(t *testing.T, client *megaport.Client, email string) int 
 	}
 }
 
-func userExistsByEmail(t *testing.T, client *megaport.Client, email string) bool {
-	t.Helper()
+// userExistsByEmail reports whether a user with the given email is present. It
+// returns the list error rather than aborting so it is safe to call from a
+// t.Cleanup callback, where a FailNow would mask the original failure.
+func userExistsByEmail(client *megaport.Client, email string) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	users, err := client.UserManagementService.ListCompanyUsers(ctx)
-	require.NoError(t, err, "SDK ListCompanyUsers failed")
+	if err != nil {
+		return false, err
+	}
 	for _, u := range users {
 		if u != nil && u.Email == email {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // TestIntegration_UserLifecycle exercises the create/get/delete path of the user
@@ -123,8 +127,12 @@ func TestIntegration_UserLifecycle(t *testing.T) {
 
 	// Safety net: remove the user even if a later step fails. Best-effort —
 	// the happy path deletes the user itself, so this may find it already gone.
+	// On a list error we attempt the delete anyway rather than risk a leak.
 	t.Cleanup(func() {
-		if !userExistsByEmail(t, client, email) {
+		exists, err := userExistsByEmail(client, email)
+		if err != nil {
+			t.Logf("cleanup: could not list users to check %s: %v; attempting delete anyway", email, err)
+		} else if !exists {
 			return
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -151,5 +159,7 @@ func TestIntegration_UserLifecycle(t *testing.T) {
 	require.NoError(t, deleteCmd.Flags().Set("force", "true"))
 	require.NoError(t, DeleteUser(deleteCmd, []string{idArg}, true), "DeleteUser failed")
 
-	assert.False(t, userExistsByEmail(t, client, email), "user should be gone after delete")
+	stillExists, err := userExistsByEmail(client, email)
+	require.NoError(t, err, "SDK ListCompanyUsers failed")
+	assert.False(t, stillExists, "user should be gone after delete")
 }

--- a/internal/commands/users/users_lifecycle_integration_test.go
+++ b/internal/commands/users/users_lifecycle_integration_test.go
@@ -1,0 +1,179 @@
+//go:build integration && provisioning
+
+package users
+
+import (
+	"context"
+	crypto_rand "crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/testutil"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func uniqueSuffix(t *testing.T) string {
+	t.Helper()
+	buf := make([]byte, 4)
+	_, err := crypto_rand.Read(buf)
+	require.NoError(t, err, "failed to read crypto/rand entropy")
+	return hex.EncodeToString(buf)
+}
+
+func newCreateUserCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "create"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().String("first-name", "", "")
+	cmd.Flags().String("last-name", "", "")
+	cmd.Flags().String("email", "", "")
+	cmd.Flags().String("position", "", "")
+	cmd.Flags().String("phone", "", "")
+	return cmd
+}
+
+func newUpdateUserCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().String("first-name", "", "")
+	cmd.Flags().String("last-name", "", "")
+	cmd.Flags().String("email", "", "")
+	cmd.Flags().String("position", "", "")
+	cmd.Flags().String("phone", "", "")
+	cmd.Flags().Bool("active", false, "")
+	cmd.Flags().Bool("notification-enabled", false, "")
+	return cmd
+}
+
+func newDeleteUserCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "delete"}
+	cmd.Flags().Bool("force", false, "")
+	return cmd
+}
+
+// employeeIDByEmail polls the company user list for the user with the given
+// email and returns its employee ID (PartyId, falling back to PersonId — the
+// same derivation the get/list output uses). It retries briefly because a
+// freshly created user can take a moment to appear in the list.
+func employeeIDByEmail(t *testing.T, client *megaport.Client, email string) int {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		users, err := client.UserManagementService.ListCompanyUsers(ctx)
+		cancel()
+		require.NoError(t, err, "SDK ListCompanyUsers failed")
+		for _, u := range users {
+			if u == nil || u.Email != email {
+				continue
+			}
+			id := u.PartyId
+			if id == 0 {
+				id = u.PersonId
+			}
+			require.NotZerof(t, id, "user %s has no usable employee ID", email)
+			return id
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("created user %s did not appear in company user list within timeout", email)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+func userExistsByEmail(t *testing.T, client *megaport.Client, email string) bool {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	users, err := client.UserManagementService.ListCompanyUsers(ctx)
+	require.NoError(t, err, "SDK ListCompanyUsers failed")
+	for _, u := range users {
+		if u != nil && u.Email == email {
+			return true
+		}
+	}
+	return false
+}
+
+// TestIntegration_UserLifecycle exercises the full create/get/update/delete path
+// of the user CLI actions against staging. The invited user is created with an
+// @example.com address (a reserved domain that never delivers mail) and is in a
+// pending-invitation state, which is the only state in which a user can be
+// deleted. A t.Cleanup safety net removes the user if the test fails before its
+// own delete step. This test carries the extra `provisioning` build tag so the
+// nightly read-only job never runs it; it runs in the manual provisioning job.
+func TestIntegration_UserLifecycle(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	suffix := uniqueSuffix(t)
+	email := fmt.Sprintf("cli-test-%s@example.com", suffix)
+	firstName := "CLITest"
+	lastName := "User-" + suffix
+
+	createCmd := newCreateUserCmd()
+	require.NoError(t, createCmd.Flags().Set("first-name", firstName))
+	require.NoError(t, createCmd.Flags().Set("last-name", lastName))
+	require.NoError(t, createCmd.Flags().Set("email", email))
+	require.NoError(t, createCmd.Flags().Set("position", "Read Only"))
+
+	require.NoError(t, CreateUser(createCmd, nil, true), "CreateUser failed")
+
+	employeeID := employeeIDByEmail(t, client, email)
+	t.Logf("created user %s with employee ID %d", email, employeeID)
+
+	// Safety net: remove the user even if a later step fails. Best-effort —
+	// the happy path deletes the user itself, so this may find it already gone.
+	t.Cleanup(func() {
+		if !userExistsByEmail(t, client, email) {
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := client.UserManagementService.DeleteUser(ctx, employeeID); err != nil {
+			t.Logf("cleanup: failed to delete user %d (%s): %v", employeeID, email, err)
+		}
+	})
+
+	idArg := strconv.Itoa(employeeID)
+
+	getCmd := &cobra.Command{Use: "get"}
+	getOut := output.CaptureOutput(func() {
+		require.NoError(t, GetUser(getCmd, []string{idArg}, true, "json"))
+	})
+
+	var got []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(getOut), &got), "get output should be valid JSON")
+	require.NotEmpty(t, got)
+	assert.Equal(t, email, got[0]["email"])
+	assert.Equal(t, firstName, got[0]["first_name"])
+
+	newFirstName := "CLIUpdated"
+	updateCmd := newUpdateUserCmd()
+	require.NoError(t, updateCmd.Flags().Set("first-name", newFirstName))
+	require.NoError(t, UpdateUser(updateCmd, []string{idArg}, true), "UpdateUser failed")
+
+	updatedCtx, updatedCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	updated, err := client.UserManagementService.GetUser(updatedCtx, employeeID)
+	updatedCancel()
+	require.NoError(t, err, "SDK GetUser failed after update")
+	require.NotNil(t, updated)
+	assert.Equal(t, newFirstName, updated.FirstName, "first name should be updated")
+
+	deleteCmd := newDeleteUserCmd()
+	require.NoError(t, deleteCmd.Flags().Set("force", "true"))
+	require.NoError(t, DeleteUser(deleteCmd, []string{idArg}, true), "DeleteUser failed")
+
+	assert.False(t, userExistsByEmail(t, client, email), "user should be gone after delete")
+}

--- a/internal/commands/users/users_lifecycle_integration_test.go
+++ b/internal/commands/users/users_lifecycle_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -60,7 +61,9 @@ func findUserIDByEmail(client *megaport.Client, email string) (id int, ok bool, 
 		return 0, false, err
 	}
 	for _, u := range users {
-		if u == nil || u.Email != email {
+		// Email match is case-insensitive: the API may normalize the
+		// local-part casing of the address we sent.
+		if u == nil || !strings.EqualFold(u.Email, email) {
 			continue
 		}
 		id := u.PartyId
@@ -107,7 +110,9 @@ func TestIntegration_UserLifecycle(t *testing.T) {
 	defer testutil.LoginWithClient(t, client)()
 
 	suffix := uniqueSuffix(t)
-	email := fmt.Sprintf("cli-test-%s@sink.megaport.com", suffix)
+	// CLI-Test- prefix matches the convention other provisioning tests use so
+	// leftover staging artifacts are easy to find.
+	email := fmt.Sprintf("CLI-Test-%s@sink.megaport.com", suffix)
 	firstName := "CLITest"
 	lastName := "User-" + suffix
 
@@ -152,7 +157,8 @@ func TestIntegration_UserLifecycle(t *testing.T) {
 	var got []map[string]interface{}
 	require.NoError(t, json.Unmarshal([]byte(getOut), &got), "get output should be valid JSON")
 	require.NotEmpty(t, got)
-	assert.Equal(t, email, got[0]["email"])
+	gotEmail, _ := got[0]["email"].(string)
+	assert.Truef(t, strings.EqualFold(email, gotEmail), "email mismatch: want %q got %q", email, gotEmail)
 	assert.Equal(t, firstName, got[0]["first_name"])
 
 	deleteCmd := newDeleteUserCmd()

--- a/internal/commands/users/users_lifecycle_integration_test.go
+++ b/internal/commands/users/users_lifecycle_integration_test.go
@@ -41,21 +41,6 @@ func newCreateUserCmd() *cobra.Command {
 	return cmd
 }
 
-func newUpdateUserCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "update"}
-	cmd.Flags().Bool("interactive", false, "")
-	cmd.Flags().String("json", "", "")
-	cmd.Flags().String("json-file", "", "")
-	cmd.Flags().String("first-name", "", "")
-	cmd.Flags().String("last-name", "", "")
-	cmd.Flags().String("email", "", "")
-	cmd.Flags().String("position", "", "")
-	cmd.Flags().String("phone", "", "")
-	cmd.Flags().Bool("active", false, "")
-	cmd.Flags().Bool("notification-enabled", false, "")
-	return cmd
-}
-
 func newDeleteUserCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "delete"}
 	cmd.Flags().Bool("force", false, "")
@@ -106,19 +91,22 @@ func userExistsByEmail(t *testing.T, client *megaport.Client, email string) bool
 	return false
 }
 
-// TestIntegration_UserLifecycle exercises the full create/get/update/delete path
-// of the user CLI actions against staging. The invited user is created with an
-// @example.com address (a reserved domain that never delivers mail) and is in a
-// pending-invitation state, which is the only state in which a user can be
-// deleted. A t.Cleanup safety net removes the user if the test fails before its
-// own delete step. This test carries the extra `provisioning` build tag so the
-// nightly read-only job never runs it; it runs in the manual provisioning job.
+// TestIntegration_UserLifecycle exercises the create/get/delete path of the user
+// CLI actions against staging. The invited user is created with an
+// @sink.megaport.com address (the sink domain the staging account requires; mail
+// to it is never delivered) and stays in a pending-invitation state. Update is
+// deliberately not exercised: staging rejects updates to a pending user, and a
+// test can't accept an emailed invitation. Delete, by contrast, is only allowed
+// while the invitation is pending. A t.Cleanup safety net removes the user if the
+// test fails before its own delete step. This test carries the extra
+// `provisioning` build tag so the nightly read-only job never runs it; it runs in
+// the manual provisioning job.
 func TestIntegration_UserLifecycle(t *testing.T) {
 	client := testutil.SetupIntegrationClient(t)
 	defer testutil.LoginWithClient(t, client)()
 
 	suffix := uniqueSuffix(t)
-	email := fmt.Sprintf("cli-test-%s@example.com", suffix)
+	email := fmt.Sprintf("cli-test-%s@sink.megaport.com", suffix)
 	firstName := "CLITest"
 	lastName := "User-" + suffix
 
@@ -158,18 +146,6 @@ func TestIntegration_UserLifecycle(t *testing.T) {
 	require.NotEmpty(t, got)
 	assert.Equal(t, email, got[0]["email"])
 	assert.Equal(t, firstName, got[0]["first_name"])
-
-	newFirstName := "CLIUpdated"
-	updateCmd := newUpdateUserCmd()
-	require.NoError(t, updateCmd.Flags().Set("first-name", newFirstName))
-	require.NoError(t, UpdateUser(updateCmd, []string{idArg}, true), "UpdateUser failed")
-
-	updatedCtx, updatedCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	updated, err := client.UserManagementService.GetUser(updatedCtx, employeeID)
-	updatedCancel()
-	require.NoError(t, err, "SDK GetUser failed after update")
-	require.NotNil(t, updated)
-	assert.Equal(t, newFirstName, updated.FirstName, "first name should be updated")
 
 	deleteCmd := newDeleteUserCmd()
 	require.NoError(t, deleteCmd.Flags().Set("force", "true"))


### PR DESCRIPTION
Adds `//go:build integration` tests for four account-scoped packages, fixes the CI gap where `partners` was listed in the workflow but had no real integration test, and adds full CRUD lifecycle tests for service keys and users.

Read-only tests (nightly read-only job) follow the canonical pattern from `locations_integration_test.go`: `SetupIntegrationClient` + `LoginWithClient`, JSON output capture, and field-presence assertions.

- `partners`: `ListPartners` with and without a connect-type filter
- `servicekeys`: `ListServiceKeys` and `GetServiceKey` (skips if no keys on staging)
- `users`: `ListUsers` and `GetUser`
- `managed_account`: `ListManagedAccounts` and `GetManagedAccount`, skips on a 403 or no managed accounts

Lifecycle tests mutate staging, so they carry an extra `provisioning` build tag and run only in the manual provisioning job, never nightly:

- `servicekeys`: provisions a port via the SDK, then create -> get -> update a key against it; the port is torn down in `t.Cleanup`
- `users`: creates a pending-invite user (`@sink.megaport.com`, the sink domain staging requires), then get -> delete, with a `t.Cleanup` safety net for early failures. Update is skipped because staging rejects updates to a pending user and a test can't accept the emailed invite

The `integration-readonly` job runs the five read-only packages nightly. The `integration-provisioning` job (manual, built with `-tags 'integration provisioning'`) now also covers the service key and user lifecycles, and wires in the `ix` lifecycle test (added on main but previously listed in no job, so it ran nowhere). The new sub-tag is documented in `docs/INTEGRATION_TESTING.md`. Managed-account lifecycle is still out of scope.

Verified by running the full provisioning suite against staging end-to-end (~13 min): all lifecycle tests pass.

