### PR TITLE
ESD-1318: Guard nil API responses and wrap provisioning errors

### DIFF
--- a/internal/commands/apply/apply_actions.go
+++ b/internal/commands/apply/apply_actions.go
@@ -150,6 +150,14 @@ func ApplyConfig(cmd *cobra.Command, _ []string, noColor bool, outputFormat stri
 		})
 		if err != nil {
 			createSpinner.Stop()
+			err = utils.WrapAPIError(err, "Port", p.Name)
+			results = append(results, ApplyResult{Type: "Port", Name: p.Name, Status: statusError + ": " + err.Error()})
+			return handleFailure(ctx, client, created, results, outputFormat, noColor, rollback,
+				fmt.Errorf("failed to provision port %q: %w", p.Name, err))
+		}
+		if resp == nil {
+			createSpinner.Stop()
+			err := fmt.Errorf("empty response from API")
 			results = append(results, ApplyResult{Type: "Port", Name: p.Name, Status: statusError + ": " + err.Error()})
 			return handleFailure(ctx, client, created, results, outputFormat, noColor, rollback,
 				fmt.Errorf("failed to provision port %q: %w", p.Name, err))
@@ -220,6 +228,14 @@ func ApplyConfig(cmd *cobra.Command, _ []string, noColor bool, outputFormat stri
 		})
 		if err != nil {
 			createSpinner.Stop()
+			err = utils.WrapAPIError(err, "MCR", m.Name)
+			results = append(results, ApplyResult{Type: "MCR", Name: m.Name, Status: statusError + ": " + err.Error()})
+			return handleFailure(ctx, client, created, results, outputFormat, noColor, rollback,
+				fmt.Errorf("failed to provision MCR %q: %w", m.Name, err))
+		}
+		if resp == nil {
+			createSpinner.Stop()
+			err := fmt.Errorf("empty response from API")
 			results = append(results, ApplyResult{Type: "MCR", Name: m.Name, Status: statusError + ": " + err.Error()})
 			return handleFailure(ctx, client, created, results, outputFormat, noColor, rollback,
 				fmt.Errorf("failed to provision MCR %q: %w", m.Name, err))
@@ -298,6 +314,14 @@ func ApplyConfig(cmd *cobra.Command, _ []string, noColor bool, outputFormat stri
 		})
 		if err != nil {
 			createSpinner.Stop()
+			err = utils.WrapAPIError(err, "MVE", mv.Name)
+			results = append(results, ApplyResult{Type: "MVE", Name: mv.Name, Status: statusError + ": " + err.Error()})
+			return handleFailure(ctx, client, created, results, outputFormat, noColor, rollback,
+				fmt.Errorf("failed to provision MVE %q: %w", mv.Name, err))
+		}
+		if resp == nil {
+			createSpinner.Stop()
+			err := fmt.Errorf("empty response from API")
 			results = append(results, ApplyResult{Type: "MVE", Name: mv.Name, Status: statusError + ": " + err.Error()})
 			return handleFailure(ctx, client, created, results, outputFormat, noColor, rollback,
 				fmt.Errorf("failed to provision MVE %q: %w", mv.Name, err))
@@ -383,6 +407,14 @@ func ApplyConfig(cmd *cobra.Command, _ []string, noColor bool, outputFormat stri
 		})
 		if err != nil {
 			createSpinner.Stop()
+			err = utils.WrapAPIError(err, "VXC", v.Name)
+			results = append(results, ApplyResult{Type: "VXC", Name: v.Name, Status: statusError + ": " + err.Error()})
+			return handleFailure(ctx, client, created, results, outputFormat, noColor, rollback,
+				fmt.Errorf("failed to provision VXC %q: %w", v.Name, err))
+		}
+		if resp == nil {
+			createSpinner.Stop()
+			err := fmt.Errorf("empty response from API")
 			results = append(results, ApplyResult{Type: "VXC", Name: v.Name, Status: statusError + ": " + err.Error()})
 			return handleFailure(ctx, client, created, results, outputFormat, noColor, rollback,
 				fmt.Errorf("failed to provision VXC %q: %w", v.Name, err))

--- a/internal/commands/apply/apply_mock.go
+++ b/internal/commands/apply/apply_mock.go
@@ -12,6 +12,7 @@ import (
 type MockPortService struct {
 	BuyPortResult        *megaport.BuyPortResponse
 	BuyPortErr           error
+	BuyPortNilResp       bool
 	ValidatePortOrderErr error
 	CapturedPortRequest  *megaport.BuyPortRequest
 	DeletePortErr        error
@@ -22,6 +23,9 @@ type MockPortService struct {
 
 func (m *MockPortService) BuyPort(ctx context.Context, req *megaport.BuyPortRequest) (*megaport.BuyPortResponse, error) {
 	m.CapturedPortRequest = req
+	if m.BuyPortNilResp {
+		return nil, nil
+	}
 	if m.BuyPortErr != nil {
 		return nil, m.BuyPortErr
 	}
@@ -81,6 +85,7 @@ func (m *MockPortService) UpdatePortResourceTags(ctx context.Context, portID str
 type MockMCRService struct {
 	BuyMCRResult         *megaport.BuyMCRResponse
 	BuyMCRErr            error
+	BuyMCRNilResp        bool
 	ValidateMCROrderErr  error
 	CapturedMCRRequest   *megaport.BuyMCRRequest
 	WaitForMCRReadyDelay time.Duration
@@ -93,6 +98,9 @@ type MockMCRService struct {
 
 func (m *MockMCRService) BuyMCR(ctx context.Context, req *megaport.BuyMCRRequest) (*megaport.BuyMCRResponse, error) {
 	m.CapturedMCRRequest = req
+	if m.BuyMCRNilResp {
+		return nil, nil
+	}
 	if m.BuyMCRErr != nil {
 		return nil, m.BuyMCRErr
 	}
@@ -179,6 +187,7 @@ func (m *MockMCRService) WaitForMCRReady(ctx context.Context, mcrID string, time
 type MockMVEService struct {
 	BuyMVEResult        *megaport.BuyMVEResponse
 	BuyMVEErr           error
+	BuyMVENilResp       bool
 	ValidateMVEOrderErr error
 	DeleteMVEErr        error
 	DeleteMVECalledWith []string
@@ -187,6 +196,9 @@ type MockMVEService struct {
 }
 
 func (m *MockMVEService) BuyMVE(ctx context.Context, req *megaport.BuyMVERequest) (*megaport.BuyMVEResponse, error) {
+	if m.BuyMVENilResp {
+		return nil, nil
+	}
 	if m.BuyMVEErr != nil {
 		return nil, m.BuyMVEErr
 	}
@@ -242,6 +254,7 @@ type MockVXCService struct {
 	BuyVXCErr           error
 	BuyVXCErrOnCall     int // if > 0, return BuyVXCErr only on this call number (1-based)
 	buyVXCCallCount     int
+	BuyVXCNilResp       bool
 	ValidateVXCOrderErr error
 	CapturedVXCRequest  *megaport.BuyVXCRequest
 	DeleteVXCErr        error
@@ -252,6 +265,9 @@ type MockVXCService struct {
 
 func (m *MockVXCService) BuyVXC(ctx context.Context, req *megaport.BuyVXCRequest) (*megaport.BuyVXCResponse, error) {
 	m.CapturedVXCRequest = req
+	if m.BuyVXCNilResp {
+		return nil, nil
+	}
 	m.buyVXCCallCount++
 	if m.BuyVXCErr != nil && (m.BuyVXCErrOnCall == 0 || m.buyVXCCallCount == m.BuyVXCErrOnCall) {
 		return nil, m.BuyVXCErr

--- a/internal/commands/apply/apply_test.go
+++ b/internal/commands/apply/apply_test.go
@@ -943,6 +943,122 @@ func TestApplyModule_RegistersRollbackFlag(t *testing.T) {
 	assert.NotNil(t, applyC.Flag("rollback-on-failure"))
 }
 
+// --- nil API response tests ---
+
+func TestApplyConfig_PortNilResponse(t *testing.T) {
+	mockPort := &MockPortService{BuyPortNilResp: true}
+	defer setupMockClient(mockPort, &MockMCRService{}, &MockMVEService{}, &MockVXCService{})()
+
+	yaml := `
+ports:
+  - name: Nil-Port
+    location_id: 1
+    speed: 1000
+    term: 12
+    marketplace_visibility: false
+`
+	f := writeTempFile(t, "config.yaml", yaml)
+	cmd := applyCmd(f, false, true)
+
+	var err error
+	require.NotPanics(t, func() {
+		output.CaptureOutput(func() {
+			err = ApplyConfig(cmd, nil, true, "table")
+		})
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response")
+}
+
+func TestApplyConfig_MCRNilResponse(t *testing.T) {
+	mockMCR := &MockMCRService{BuyMCRNilResp: true}
+	defer setupMockClient(&MockPortService{}, mockMCR, &MockMVEService{}, &MockVXCService{})()
+
+	yaml := `
+mcrs:
+  - name: Nil-MCR
+    location_id: 1
+    speed: 1000
+    term: 12
+`
+	f := writeTempFile(t, "config.yaml", yaml)
+	cmd := applyCmd(f, false, true)
+
+	var err error
+	require.NotPanics(t, func() {
+		output.CaptureOutput(func() {
+			err = ApplyConfig(cmd, nil, true, "table")
+		})
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response")
+}
+
+func TestApplyConfig_MVENilResponse(t *testing.T) {
+	mockMVE := &MockMVEService{BuyMVENilResp: true}
+	defer setupMockClient(&MockPortService{}, &MockMCRService{}, mockMVE, &MockVXCService{})()
+
+	yaml := `
+mves:
+  - name: Nil-MVE
+    location_id: 1
+    term: 1
+    vendor_config:
+      vendor: 6wind
+      imageId: 42
+      productSize: SMALL
+      sshPublicKey: "ssh-rsa AAAA"
+`
+	f := writeTempFile(t, "config.yaml", yaml)
+	cmd := applyCmd(f, false, true)
+
+	var err error
+	require.NotPanics(t, func() {
+		output.CaptureOutput(func() {
+			err = ApplyConfig(cmd, nil, true, "table")
+		})
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response")
+}
+
+func TestApplyConfig_VXCNilResponse(t *testing.T) {
+	mockPort := &MockPortService{
+		BuyPortResult: &megaport.BuyPortResponse{TechnicalServiceUIDs: []string{"port-uid-abc"}},
+	}
+	mockVXC := &MockVXCService{BuyVXCNilResp: true}
+	defer setupMockClient(mockPort, &MockMCRService{}, &MockMVEService{}, mockVXC)()
+
+	yaml := `
+ports:
+  - name: Test-Port
+    location_id: 1
+    speed: 1000
+    term: 12
+    marketplace_visibility: false
+
+vxcs:
+  - name: Nil-VXC
+    rate_limit: 100
+    term: 12
+    a_end:
+      product_uid: "{{.port.Test-Port}}"
+    b_end:
+      product_uid: some-uid
+`
+	f := writeTempFile(t, "config.yaml", yaml)
+	cmd := applyCmd(f, false, true)
+
+	var err error
+	require.NotPanics(t, func() {
+		output.CaptureOutput(func() {
+			err = ApplyConfig(cmd, nil, true, "table")
+		})
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response")
+}
+
 // --- helpers (also used by other test functions) ---
 
 func TestResolveTemplates_NoTemplate(t *testing.T) {

--- a/internal/commands/apply/apply_test.go
+++ b/internal/commands/apply/apply_test.go
@@ -3,6 +3,7 @@ package apply
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -375,7 +376,15 @@ vxcs:
 }
 
 func TestApplyConfig_MVEAPIError(t *testing.T) {
-	mockMVE := &MockMVEService{BuyMVEErr: fmt.Errorf("MVE unavailable")}
+	apiErr := &megaport.ErrorResponse{
+		Response: &http.Response{
+			StatusCode: 401,
+			Header:     http.Header{},
+			Request:    &http.Request{},
+		},
+		Message: "unauthorized",
+	}
+	mockMVE := &MockMVEService{BuyMVEErr: apiErr}
 	defer setupMockClient(&MockPortService{}, &MockMCRService{}, mockMVE, &MockVXCService{})()
 
 	yaml := `
@@ -397,7 +406,7 @@ mves:
 		err = ApplyConfig(cmd, nil, true, "table")
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "MVE unavailable")
+	assert.Contains(t, err.Error(), "authentication failed")
 }
 
 func TestApplyConfig_MCRAPIError(t *testing.T) {

--- a/internal/commands/apply/apply_test.go
+++ b/internal/commands/apply/apply_test.go
@@ -374,6 +374,32 @@ vxcs:
 	assert.Contains(t, captured, "Undeclared")
 }
 
+func TestApplyConfig_MVEAPIError(t *testing.T) {
+	mockMVE := &MockMVEService{BuyMVEErr: fmt.Errorf("MVE unavailable")}
+	defer setupMockClient(&MockPortService{}, &MockMCRService{}, mockMVE, &MockVXCService{})()
+
+	yaml := `
+mves:
+  - name: Bad-MVE
+    location_id: 1
+    term: 1
+    vendor_config:
+      vendor: 6wind
+      imageId: 42
+      productSize: SMALL
+      sshPublicKey: "ssh-rsa AAAA"
+`
+	f := writeTempFile(t, "config.yaml", yaml)
+	cmd := applyCmd(f, false, true)
+
+	var err error
+	output.CaptureOutput(func() {
+		err = ApplyConfig(cmd, nil, true, "table")
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MVE unavailable")
+}
+
 func TestApplyConfig_MCRAPIError(t *testing.T) {
 	mockMCR := &MockMCRService{BuyMCRErr: fmt.Errorf("MCR unavailable")}
 	defer setupMockClient(&MockPortService{}, mockMCR, &MockMVEService{}, &MockVXCService{})()

--- a/internal/commands/apply/apply_test.go
+++ b/internal/commands/apply/apply_test.go
@@ -172,7 +172,15 @@ vxcs:
 }
 
 func TestApplyConfig_PortAPIError(t *testing.T) {
-	mockPort := &MockPortService{BuyPortErr: fmt.Errorf("API unavailable")}
+	apiErr := &megaport.ErrorResponse{
+		Response: &http.Response{
+			StatusCode: 403,
+			Header:     http.Header{},
+			Request:    &http.Request{},
+		},
+		Message: "forbidden",
+	}
+	mockPort := &MockPortService{BuyPortErr: apiErr}
 	defer setupMockClient(mockPort, &MockMCRService{}, &MockMVEService{}, &MockVXCService{})()
 
 	yaml := `
@@ -192,7 +200,7 @@ ports:
 	})
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "API unavailable")
+	assert.Contains(t, err.Error(), "permission denied")
 }
 
 func TestApplyConfig_UnresolvedTemplate(t *testing.T) {
@@ -410,7 +418,15 @@ mves:
 }
 
 func TestApplyConfig_MCRAPIError(t *testing.T) {
-	mockMCR := &MockMCRService{BuyMCRErr: fmt.Errorf("MCR unavailable")}
+	apiErr := &megaport.ErrorResponse{
+		Response: &http.Response{
+			StatusCode: 429,
+			Header:     http.Header{},
+			Request:    &http.Request{},
+		},
+		Message: "rate limited",
+	}
+	mockMCR := &MockMCRService{BuyMCRErr: apiErr}
 	defer setupMockClient(&MockPortService{}, mockMCR, &MockMVEService{}, &MockVXCService{})()
 
 	yaml := `
@@ -428,14 +444,22 @@ mcrs:
 		err = ApplyConfig(cmd, nil, true, "table")
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "MCR unavailable")
+	assert.Contains(t, err.Error(), "rate limit exceeded")
 }
 
 func TestApplyConfig_VXCAPIError(t *testing.T) {
 	mockPort := &MockPortService{
 		BuyPortResult: &megaport.BuyPortResponse{TechnicalServiceUIDs: []string{"port-uid-abc"}},
 	}
-	mockVXC := &MockVXCService{BuyVXCErr: fmt.Errorf("VXC service down")}
+	vxcAPIErr := &megaport.ErrorResponse{
+		Response: &http.Response{
+			StatusCode: 401,
+			Header:     http.Header{},
+			Request:    &http.Request{},
+		},
+		Message: "unauthorized",
+	}
+	mockVXC := &MockVXCService{BuyVXCErr: vxcAPIErr}
 	defer setupMockClient(mockPort, &MockMCRService{}, &MockMVEService{}, mockVXC)()
 
 	yaml := `
@@ -463,7 +487,7 @@ vxcs:
 		err = ApplyConfig(cmd, nil, true, "table")
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "VXC service down")
+	assert.Contains(t, err.Error(), "authentication failed")
 }
 
 func TestApplyConfig_NoFileFlag(t *testing.T) {

--- a/internal/commands/mcr/mcr_actions.go
+++ b/internal/commands/mcr/mcr_actions.go
@@ -140,6 +140,11 @@ func BuyMCR(cmd *cobra.Command, args []string, noColor bool) error {
 		return err
 	}
 
+	if resp == nil {
+		output.PrintError("MCR created but no response returned", noColor)
+		return fmt.Errorf("MCR created but no response returned")
+	}
+
 	output.PrintResourceCreated("MCR", resp.TechnicalServiceUID, noColor)
 	return nil
 }

--- a/internal/commands/mcr/mcr_actions.go
+++ b/internal/commands/mcr/mcr_actions.go
@@ -141,8 +141,8 @@ func BuyMCR(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	if resp == nil {
-		output.PrintError("MCR created but no response returned", noColor)
-		return fmt.Errorf("MCR created but no response returned")
+		output.PrintError("MCR buy returned an empty API response", noColor)
+		return fmt.Errorf("empty response from API")
 	}
 
 	output.PrintResourceCreated("MCR", resp.TechnicalServiceUID, noColor)

--- a/internal/commands/mcr/mcr_actions.go
+++ b/internal/commands/mcr/mcr_actions.go
@@ -245,6 +245,11 @@ func UpdateMCR(cmd *cobra.Command, args []string, noColor bool) error {
 		return err
 	}
 
+	if resp == nil {
+		output.PrintError("MCR update returned an empty API response", noColor)
+		return fmt.Errorf("empty response from API")
+	}
+
 	if !resp.IsUpdated {
 		output.PrintError("MCR update request was not successful", noColor)
 		return fmt.Errorf("MCR update request was not successful")

--- a/internal/commands/mcr/mcr_actions_test.go
+++ b/internal/commands/mcr/mcr_actions_test.go
@@ -870,6 +870,20 @@ func TestBuyMCRCmd_WithMockClient(t *testing.T) {
 			expectedError: "API error: service unavailable",
 		},
 		{
+			name: "nil response from API",
+			flags: map[string]string{
+				"name":        "Test MCR",
+				"term":        "12",
+				"port-speed":  "10000",
+				"location-id": "123",
+				"mcr-asn":     "65000",
+			},
+			setupMock: func(m *MockMCRService) {
+				// BuyMCRResult left nil → mock returns (nil, nil)
+			},
+			expectedError: "empty response from API",
+		},
+		{
 			name:          "no input provided",
 			expectedError: "no input provided",
 		},

--- a/internal/commands/mcr/mcr_actions_test.go
+++ b/internal/commands/mcr/mcr_actions_test.go
@@ -1990,6 +1990,35 @@ func TestUpdateMCR(t *testing.T) {
 			},
 			expectedError: "API error: service unavailable",
 		},
+		{
+			name: "nil response from API",
+			args: []string{"mcr-nil"},
+			flags: map[string]string{
+				"name": "Updated MCR",
+			},
+			setupLogin: func() {
+				config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+					client := &megaport.Client{}
+					client.MCRService = &MockMCRService{}
+					return client, nil
+				})
+			},
+			setupGetMCR: func() {
+				getMCRFunc = func(ctx context.Context, client *megaport.Client, mcrUID string) (*megaport.MCR, error) {
+					return &megaport.MCR{
+						UID:                mcrUID,
+						Name:               "Original MCR",
+						ProvisioningStatus: "LIVE",
+					}, nil
+				}
+			},
+			setupUpdateMCR: func() {
+				updateMCRFunc = func(ctx context.Context, client *megaport.Client, req *megaport.ModifyMCRRequest) (*megaport.ModifyMCRResponse, error) {
+					return nil, nil
+				}
+			},
+			expectedError: "empty response from API",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -326,8 +326,8 @@ func UpdateMVE(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	if resp == nil {
-		output.PrintError("MVE update returned no response", noColor)
-		return fmt.Errorf("MVE update returned no response")
+		output.PrintError("MVE update returned an empty API response", noColor)
+		return fmt.Errorf("empty response from API")
 	}
 
 	if !resp.MVEUpdated {

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -208,8 +208,8 @@ func BuyMVE(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	if resp == nil {
-		output.PrintError("MVE created but no response returned", noColor)
-		return fmt.Errorf("MVE created but no response returned")
+		output.PrintError("MVE buy returned an empty API response", noColor)
+		return fmt.Errorf("empty response from API")
 	}
 
 	output.PrintResourceCreated("MVE", resp.TechnicalServiceUID, noColor)

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -549,6 +549,11 @@ func DeleteMVE(cmd *cobra.Command, args []string, noColor bool) error {
 		return fmt.Errorf("failed to delete MVE: %w", err)
 	}
 
+	if resp == nil {
+		output.PrintError("MVE delete returned an empty API response", noColor)
+		return fmt.Errorf("empty response from API")
+	}
+
 	// MVEs always delete immediately (SDK hardcodes DeleteNow: true).
 	if resp.IsDeleted {
 		output.PrintResourceDeleted("MVE", mveUID, true, noColor)

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -207,6 +207,11 @@ func BuyMVE(cmd *cobra.Command, args []string, noColor bool) error {
 		return err
 	}
 
+	if resp == nil {
+		output.PrintError("MVE created but no response returned", noColor)
+		return fmt.Errorf("MVE created but no response returned")
+	}
+
 	output.PrintResourceCreated("MVE", resp.TechnicalServiceUID, noColor)
 	return nil
 }
@@ -318,6 +323,11 @@ func UpdateMVE(cmd *cobra.Command, args []string, noColor bool) error {
 	if err != nil {
 		output.PrintError("Failed to update MVE: %v", noColor, err)
 		return err
+	}
+
+	if resp == nil {
+		output.PrintError("MVE update returned no response", noColor)
+		return fmt.Errorf("MVE update returned no response")
 	}
 
 	if !resp.MVEUpdated {

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -792,6 +792,20 @@ func TestBuyMVE(t *testing.T) {
 			expectedError: "purchase failed",
 		},
 		{
+			name: "nil response from API",
+			flags: map[string]string{
+				"name":          "Nil-MVE",
+				"term":          "12",
+				"location-id":   "1",
+				"vendor-config": `{"vendor":"cisco","imageId":1,"productSize":"LARGE","mveLabel":"label-1","manageLocally":true,"adminSshPublicKey":"admin-ssh","sshPublicKey":"ssh-key","cloudInit":"cloud-init","fmcIpAddress":"fmc-ip","fmcRegistrationKey":"fmc-key","fmcNatId":"fmc-nat"}`,
+				"vnics":         `[{"description":"VNIC 1","vlan":100}]`,
+			},
+			mockSetup: func(m *MockMVEService) {
+				m.BuyMVENilResp = true
+			},
+			expectedError: "empty response from API",
+		},
+		{
 			name: "invalid JSON returns error",
 			flags: map[string]string{
 				"json": `{bad json}`,

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -520,6 +520,14 @@ func TestDeleteMVE(t *testing.T) {
 			forceFlag:      true,
 			expectedOutput: "MVE deleted mve-uid",
 		},
+		{
+			name: "nil response from API",
+			mockSetup: func(m *MockMVEService) {
+				m.DeleteMVENilResp = true
+			},
+			forceFlag:     true,
+			expectedError: "empty response from API",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -411,6 +411,17 @@ func TestUpdateMVE(t *testing.T) {
 			},
 			expectedError: "MVE update request was not successful",
 		},
+		{
+			name: "nil response from API",
+			args: []string{"mve-123"},
+			flags: map[string]string{
+				"name": "Updated MVE",
+			},
+			mockSetup: func(m *MockMVEService) {
+				m.ModifyMVENilResp = true
+			},
+			expectedError: "empty response from API",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/commands/mve/mve_mock.go
+++ b/internal/commands/mve/mve_mock.go
@@ -15,6 +15,7 @@ type MockMVEService struct {
 	BuyMVENilResp                        bool
 	BuyMVEResult                         *megaport.BuyMVEResponse
 	DeleteMVEErr                         error
+	DeleteMVENilResp                     bool
 	DeleteMVEResult                      *megaport.DeleteMVEResponse
 	CapturedDeleteMVERequest             *megaport.DeleteMVERequest
 	ModifyMVEErr                         error
@@ -86,6 +87,9 @@ func (m *MockMVEService) ValidateMVEOrder(ctx context.Context, req *megaport.Buy
 
 func (m *MockMVEService) DeleteMVE(ctx context.Context, req *megaport.DeleteMVERequest) (*megaport.DeleteMVEResponse, error) {
 	m.CapturedDeleteMVERequest = req
+	if m.DeleteMVENilResp {
+		return nil, nil
+	}
 	if m.DeleteMVEErr != nil {
 		return nil, m.DeleteMVEErr
 	}
@@ -153,6 +157,7 @@ func (m *MockMVEService) Reset() {
 	m.ListMVEsErr = nil
 	m.BuyMVEErr = nil
 	m.BuyMVENilResp = false
+	m.DeleteMVENilResp = false
 	m.DeleteMVEErr = nil
 	m.ModifyMVEErr = nil
 	m.ValidateMVEOrderErr = nil

--- a/internal/commands/mve/mve_mock.go
+++ b/internal/commands/mve/mve_mock.go
@@ -158,20 +158,30 @@ func (m *MockMVEService) ListAvailableMVESizes(ctx context.Context) ([]*megaport
 
 func (m *MockMVEService) Reset() {
 	m.GetMVEErr = nil
+	m.GetMVEResult = nil
 	m.ListMVEsErr = nil
+	m.ListMVEsResult = nil
 	m.BuyMVEErr = nil
 	m.BuyMVENilResp = false
-	m.DeleteMVENilResp = false
+	m.BuyMVEResult = nil
 	m.DeleteMVEErr = nil
-	m.ModifyMVENilResp = false
+	m.DeleteMVENilResp = false
+	m.DeleteMVEResult = nil
 	m.ModifyMVEErr = nil
+	m.ModifyMVENilResp = false
+	m.ModifyMVEResult = nil
 	m.ValidateMVEOrderErr = nil
 	m.ListMVEResourceTagsErr = nil
+	m.ListMVEResourceTagsResult = nil
 	m.UpdateMVEResourceTagsErr = nil
 	m.ListMVEImagesErr = nil
+	m.ListMVEImagesResult = nil
 	m.ListAvailableMVESizesErr = nil
+	m.ListAvailableMVESizesResult = nil
+	m.ForceNilGetMVE = false
 	m.CapturedBuyMVERequest = nil
 	m.CapturedModifyMVERequest = nil
 	m.CapturedListMVEsRequest = nil
+	m.CapturedDeleteMVERequest = nil
 	m.CapturedUpdateMVEResourceTagsRequest = nil
 }

--- a/internal/commands/mve/mve_mock.go
+++ b/internal/commands/mve/mve_mock.go
@@ -12,6 +12,7 @@ type MockMVEService struct {
 	ListMVEsErr                          error
 	ListMVEsResult                       []*megaport.MVE
 	BuyMVEErr                            error
+	BuyMVENilResp                        bool
 	BuyMVEResult                         *megaport.BuyMVEResponse
 	DeleteMVEErr                         error
 	DeleteMVEResult                      *megaport.DeleteMVEResponse
@@ -65,6 +66,9 @@ func (m *MockMVEService) ListMVEs(ctx context.Context, req *megaport.ListMVEsReq
 
 func (m *MockMVEService) BuyMVE(ctx context.Context, req *megaport.BuyMVERequest) (*megaport.BuyMVEResponse, error) {
 	m.CapturedBuyMVERequest = req
+	if m.BuyMVENilResp {
+		return nil, nil
+	}
 	if m.BuyMVEErr != nil {
 		return nil, m.BuyMVEErr
 	}
@@ -148,6 +152,7 @@ func (m *MockMVEService) Reset() {
 	m.GetMVEErr = nil
 	m.ListMVEsErr = nil
 	m.BuyMVEErr = nil
+	m.BuyMVENilResp = false
 	m.DeleteMVEErr = nil
 	m.ModifyMVEErr = nil
 	m.ValidateMVEOrderErr = nil

--- a/internal/commands/mve/mve_mock.go
+++ b/internal/commands/mve/mve_mock.go
@@ -19,6 +19,7 @@ type MockMVEService struct {
 	DeleteMVEResult                      *megaport.DeleteMVEResponse
 	CapturedDeleteMVERequest             *megaport.DeleteMVERequest
 	ModifyMVEErr                         error
+	ModifyMVENilResp                     bool
 	ModifyMVEResult                      *megaport.ModifyMVEResponse
 	ValidateMVEOrderErr                  error
 	ListMVEResourceTagsErr               error
@@ -103,6 +104,9 @@ func (m *MockMVEService) DeleteMVE(ctx context.Context, req *megaport.DeleteMVER
 
 func (m *MockMVEService) ModifyMVE(ctx context.Context, req *megaport.ModifyMVERequest) (*megaport.ModifyMVEResponse, error) {
 	m.CapturedModifyMVERequest = req
+	if m.ModifyMVENilResp {
+		return nil, nil
+	}
 	if m.ModifyMVEErr != nil {
 		return nil, m.ModifyMVEErr
 	}
@@ -159,6 +163,7 @@ func (m *MockMVEService) Reset() {
 	m.BuyMVENilResp = false
 	m.DeleteMVENilResp = false
 	m.DeleteMVEErr = nil
+	m.ModifyMVENilResp = false
 	m.ModifyMVEErr = nil
 	m.ValidateMVEOrderErr = nil
 	m.ListMVEResourceTagsErr = nil

--- a/internal/commands/ports/ports_actions.go
+++ b/internal/commands/ports/ports_actions.go
@@ -132,6 +132,11 @@ func BuyPort(cmd *cobra.Command, args []string, noColor bool) error {
 		return err
 	}
 
+	if resp == nil {
+		output.PrintError("Port created but no response returned", noColor)
+		return fmt.Errorf("port created but no response returned")
+	}
+
 	if len(resp.TechnicalServiceUIDs) == 0 {
 		output.PrintError("Port created but no UID returned", noColor)
 		return fmt.Errorf("port created but no UID returned")
@@ -258,6 +263,11 @@ func BuyLAGPort(cmd *cobra.Command, args []string, noColor bool) error {
 	if err != nil {
 		output.PrintError("Failed to buy LAG port: %v", noColor, err)
 		return err
+	}
+
+	if resp == nil {
+		output.PrintError("LAG port created but no response returned", noColor)
+		return fmt.Errorf("LAG port created but no response returned")
 	}
 
 	if len(resp.TechnicalServiceUIDs) == 0 {

--- a/internal/commands/ports/ports_actions.go
+++ b/internal/commands/ports/ports_actions.go
@@ -133,8 +133,8 @@ func BuyPort(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	if resp == nil {
-		output.PrintError("Port created but no response returned", noColor)
-		return fmt.Errorf("port created but no response returned")
+		output.PrintError("Port buy returned an empty API response", noColor)
+		return fmt.Errorf("empty response from API")
 	}
 
 	if len(resp.TechnicalServiceUIDs) == 0 {
@@ -266,8 +266,8 @@ func BuyLAGPort(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	if resp == nil {
-		output.PrintError("LAG port created but no response returned", noColor)
-		return fmt.Errorf("LAG port created but no response returned")
+		output.PrintError("LAG port buy returned an empty API response", noColor)
+		return fmt.Errorf("empty response from API")
 	}
 
 	if len(resp.TechnicalServiceUIDs) == 0 {

--- a/internal/commands/ports/ports_actions_test.go
+++ b/internal/commands/ports/ports_actions_test.go
@@ -331,6 +331,55 @@ func TestBuyLAGPort_EmptyUIDs(t *testing.T) {
 	assert.Contains(t, err.Error(), "no UID returned")
 }
 
+func TestBuyLAGPort_NilResponse(t *testing.T) {
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
+	defer cleanup()
+	originalBuyPortFunc := buyPortFunc
+	defer func() {
+		buyPortFunc = originalBuyPortFunc
+	}()
+	originalBuyConfirmPrompt := utils.GetBuyConfirmPrompt()
+	defer func() { utils.SetBuyConfirmPrompt(originalBuyConfirmPrompt) }()
+	utils.SetBuyConfirmPrompt(func(_ string, _ []utils.BuyConfirmDetail, _ bool) bool { return true })
+
+	mockService := &MockPortService{}
+	config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+		client := &megaport.Client{}
+		client.PortService = mockService
+		return client, nil
+	})
+	buyPortFunc = func(ctx context.Context, client *megaport.Client, req *megaport.BuyPortRequest) (*megaport.BuyPortResponse, error) {
+		return nil, nil
+	}
+
+	cmd := &cobra.Command{Use: "buy-lag"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().String("name", "test-lag", "")
+	cmd.Flags().Int("term", 12, "")
+	cmd.Flags().Int("port-speed", 10000, "")
+	cmd.Flags().Int("location-id", 1, "")
+	cmd.Flags().Int("lag-count", 2, "")
+	cmd.Flags().Bool("marketplace-visibility", false, "")
+	cmd.Flags().String("diversity-zone", "", "")
+	cmd.Flags().Bool("cost-confirm", true, "")
+	require.NoError(t, cmd.Flags().Set("name", "test-lag"))
+	require.NoError(t, cmd.Flags().Set("term", "12"))
+	require.NoError(t, cmd.Flags().Set("port-speed", "10000"))
+	require.NoError(t, cmd.Flags().Set("location-id", "1"))
+	require.NoError(t, cmd.Flags().Set("lag-count", "2"))
+	require.NoError(t, cmd.Flags().Set("marketplace-visibility", "true"))
+
+	var err error
+	output.CaptureOutput(func() {
+		err = BuyLAGPort(cmd, nil, true)
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response from API")
+}
+
 func TestDeletePort_SafeDeleteFlag(t *testing.T) {
 	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
 	defer cleanup()
@@ -829,6 +878,21 @@ func TestBuyPort(t *testing.T) {
 				return nil, fmt.Errorf("buy port failed")
 			},
 			expectedError: "buy port failed",
+		},
+		{
+			name: "nil response from buyPortFunc",
+			flags: map[string]string{
+				"name":                   "test-port",
+				"term":                   "12",
+				"port-speed":             "1000",
+				"location-id":            "1",
+				"marketplace-visibility": "true",
+			},
+			setupMock: func(m *MockPortService) {},
+			buyPortOverride: func(ctx context.Context, client *megaport.Client, req *megaport.BuyPortRequest) (*megaport.BuyPortResponse, error) {
+				return nil, nil
+			},
+			expectedError: "empty response from API",
 		},
 		{
 			name: "validation error",


### PR DESCRIPTION
## Contributions

Please read the (Contribution Guidelines)[https://github.com/megaport/megaportgo/wiki/Contributing.md]
prior to lodging Pull Requests (PR).

## Description

This PR hardens provisioning and lifecycle command paths against unexpected `(nil, nil)` SDK responses and improves actionable API error handling in `apply`.

Changes included:

- Route `apply` buy-call API errors through `utils.WrapAPIError` for Port/MCR/MVE/VXC provisioning so 401/403/429 responses include actionable guidance.
- Add `resp == nil` guards before post-`WithRetry` dereferences in:
  - `internal/commands/apply/apply_actions.go` (Port, MCR, MVE, VXC buy paths)
  - `internal/commands/ports/ports_actions.go` (`BuyPort`, `BuyLAGPort`)
  - `internal/commands/mve/mve_actions.go` (`BuyMVE`, `UpdateMVE`, `DeleteMVE`)
  - `internal/commands/mcr/mcr_actions.go` (`BuyMCR`, `UpdateMCR`)
- Normalize all nil-response error messages to `"empty response from API"` so that no guard site incorrectly asserts a successful operation and error handling is consistent across all command paths.
- Extend `MockMVEService.Reset()` to clear all result fields (`GetMVEResult`, `BuyMVEResult`, `DeleteMVEResult`, `ModifyMVEResult`, all list results), `ForceNilGetMVE`, and all captured request pointers, preventing test order-dependency in table-driven tests.
- Extend tests to cover nil-response behavior in apply and standalone command paths (including `TestUpdateMCR`, `TestDeleteMVE`, and `TestUpdateMVE`) to verify clean errors and no panic behavior.
- Expand `apply` error-wrapping coverage to use `*megaport.ErrorResponse` assertions across all provisioning paths:
  - Port: 403 → permission guidance
  - MCR: 429 → rate-limit guidance
  - VXC: 401 → authentication guidance
  - MVE: 401 → authentication guidance
- Guard the standalone `vxc buy` path against a nil API response (the one remaining unguarded deref) and drop em-dashes from the WrapAPIError user-facing messages.

No new dependencies were added.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Contributor Agreement

Lodging this Pull Request (PR) indicates agreement with the project's 
(Contributor License Agreement)[https://github.com/megaport/megaportgo/wiki/Megaport_Contributor_Licence_Agreement.md].

Please read the Contributor Licence Agreement (CLA) and affirm your acceptance here:

[I have read and accept the CLA]

**NOTE** If multiple authors have commited to this PR, each one will need to comment on this PR and 
agree to the CLA before this PR can be accepted.
