### PR TITLE
ESD-1317: Prompt securely for credentials in config profile commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The Megaport CLI uses a profile-based configuration system that securely stores 
 ### Basic Usage
 
 ```bash
-# Create a profile (omit --access-key / --secret-key to be prompted securely)
+# Create a profile (omit --access-key / --secret-key to be prompted; masked on TTY)
 megaport-cli config create-profile myprofile --environment production
 
 # Switch active profile

--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ The Megaport CLI uses a profile-based configuration system that securely stores 
 ### Basic Usage
 
 ```bash
-# Create a profile
-megaport-cli config create-profile myprofile --access-key xxx --secret-key xxx
+# Create a profile (omit --access-key / --secret-key to be prompted securely)
+megaport-cli config create-profile myprofile --environment production
 
 # Switch active profile
 megaport-cli config use-profile myprofile

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Megaport CLI Documentation
 
-> Generated on April 13, 2026 for version v0.7.1
+> Generated on June 3, 2026 for version v0.10.0
 
 ## Available Commands
 
@@ -113,6 +113,16 @@
 | [megaport-cli mcr list-tags docs](megaport-cli_mcr_list-tags_docs.md) | Show documentation for this command |
 | [megaport-cli mcr lock](megaport-cli_mcr_lock.md) | Lock an MCR |
 | [megaport-cli mcr lock docs](megaport-cli_mcr_lock_docs.md) | Show documentation for this command |
+| [megaport-cli mcr looking-glass](megaport-cli_mcr_looking-glass.md) | MCR Looking Glass diagnostic commands |
+| [megaport-cli mcr looking-glass bgp-neighbor-routes](megaport-cli_mcr_looking-glass_bgp-neighbor-routes.md) | List routes advertised to or received from a BGP neighbor |
+| [megaport-cli mcr looking-glass bgp-neighbor-routes docs](megaport-cli_mcr_looking-glass_bgp-neighbor-routes_docs.md) | Show documentation for this command |
+| [megaport-cli mcr looking-glass bgp-routes](megaport-cli_mcr_looking-glass_bgp-routes.md) | List BGP routes with full BGP attributes |
+| [megaport-cli mcr looking-glass bgp-routes docs](megaport-cli_mcr_looking-glass_bgp-routes_docs.md) | Show documentation for this command |
+| [megaport-cli mcr looking-glass bgp-sessions](megaport-cli_mcr_looking-glass_bgp-sessions.md) | List BGP sessions configured on the MCR |
+| [megaport-cli mcr looking-glass bgp-sessions docs](megaport-cli_mcr_looking-glass_bgp-sessions_docs.md) | Show documentation for this command |
+| [megaport-cli mcr looking-glass docs](megaport-cli_mcr_looking-glass_docs.md) | Show documentation for this command |
+| [megaport-cli mcr looking-glass ip-routes](megaport-cli_mcr_looking-glass_ip-routes.md) | List IP routes from the MCR routing table |
+| [megaport-cli mcr looking-glass ip-routes docs](megaport-cli_mcr_looking-glass_ip-routes_docs.md) | Show documentation for this command |
 | [megaport-cli mcr restore](megaport-cli_mcr_restore.md) | Restore a deleted MCR |
 | [megaport-cli mcr restore docs](megaport-cli_mcr_restore_docs.md) | Show documentation for this command |
 | [megaport-cli mcr status](megaport-cli_mcr_status.md) | Check the provisioning status of an MCR |
@@ -159,6 +169,26 @@
 | [megaport-cli mve update-tags docs](megaport-cli_mve_update-tags_docs.md) | Show documentation for this command |
 | [megaport-cli mve validate](megaport-cli_mve_validate.md) | Validate an MVE order without purchasing |
 | [megaport-cli mve validate docs](megaport-cli_mve_validate_docs.md) | Show documentation for this command |
+| [megaport-cli nat-gateway](megaport-cli_nat-gateway.md) | Manage NAT Gateways in the Megaport API |
+| [megaport-cli nat-gateway buy](megaport-cli_nat-gateway_buy.md) | Purchase a NAT Gateway design to begin provisioning |
+| [megaport-cli nat-gateway buy docs](megaport-cli_nat-gateway_buy_docs.md) | Show documentation for this command |
+| [megaport-cli nat-gateway create](megaport-cli_nat-gateway_create.md) | Create a new NAT Gateway |
+| [megaport-cli nat-gateway create docs](megaport-cli_nat-gateway_create_docs.md) | Show documentation for this command |
+| [megaport-cli nat-gateway delete](megaport-cli_nat-gateway_delete.md) | Delete a NAT Gateway |
+| [megaport-cli nat-gateway delete docs](megaport-cli_nat-gateway_delete_docs.md) | Show documentation for this command |
+| [megaport-cli nat-gateway docs](megaport-cli_nat-gateway_docs.md) | Show documentation for this command |
+| [megaport-cli nat-gateway get](megaport-cli_nat-gateway_get.md) | Get details for a single NAT Gateway |
+| [megaport-cli nat-gateway get docs](megaport-cli_nat-gateway_get_docs.md) | Show documentation for this command |
+| [megaport-cli nat-gateway list](megaport-cli_nat-gateway_list.md) | List all NAT Gateways |
+| [megaport-cli nat-gateway list docs](megaport-cli_nat-gateway_list_docs.md) | Show documentation for this command |
+| [megaport-cli nat-gateway list-sessions](megaport-cli_nat-gateway_list-sessions.md) | List available NAT Gateway speed/session-count combinations |
+| [megaport-cli nat-gateway list-sessions docs](megaport-cli_nat-gateway_list-sessions_docs.md) | Show documentation for this command |
+| [megaport-cli nat-gateway telemetry](megaport-cli_nat-gateway_telemetry.md) | Get telemetry data for a NAT Gateway |
+| [megaport-cli nat-gateway telemetry docs](megaport-cli_nat-gateway_telemetry_docs.md) | Show documentation for this command |
+| [megaport-cli nat-gateway update](megaport-cli_nat-gateway_update.md) | Update an existing NAT Gateway |
+| [megaport-cli nat-gateway update docs](megaport-cli_nat-gateway_update_docs.md) | Show documentation for this command |
+| [megaport-cli nat-gateway validate](megaport-cli_nat-gateway_validate.md) | Validate a NAT Gateway design without purchasing |
+| [megaport-cli nat-gateway validate docs](megaport-cli_nat-gateway_validate_docs.md) | Show documentation for this command |
 | [megaport-cli partners](megaport-cli_partners.md) | Manage partner ports in the Megaport API |
 | [megaport-cli partners docs](megaport-cli_partners_docs.md) | Show documentation for this command |
 | [megaport-cli partners find](megaport-cli_partners_find.md) | Find partner ports interactively |

--- a/docs/megaport-cli.md
+++ b/docs/megaport-cli.md
@@ -13,9 +13,12 @@ The CLI allows you to manage Megaport resources such as ports, VXCs, MCRs, MVEs,
   - `--help`: Show help for any command
   - `--max-retries`: Maximum number of retries for transient API failures (default 3)
   - `--no-color`: Disable colored output
+  - `--no-header`: Suppress table and CSV column headers (useful for scripting)
+  - `--no-pager`: Disable pager for long table output
   - `--no-retry`: Disable automatic retry on transient API failures
-  - `--output`: Output format (json, yaml, table, csv, xml)
+  - `--output`: Output format (table, json, csv, xml, go-template)
   - `--quiet`: Suppress informational output, only show errors and data
+  - `--template`: Go template string for --output go-template
   - `--verbose`: Show additional debug information
 
 ### Important Notes
@@ -49,11 +52,14 @@ megaport-cli [flags]
 | `--log-http` |  | `false` | Log raw HTTP requests/responses to stderr for debugging (may include sensitive data such as auth tokens) | false |
 | `--max-retries` |  | `3` | Maximum number of retries for transient API failures | false |
 | `--no-color` |  | `false` | Disable colorful output | false |
+| `--no-header` |  | `false` | Suppress table and CSV column headers (useful for scripting) | false |
+| `--no-pager` |  | `false` | Disable pager for long table output | false |
 | `--no-retry` |  | `false` | Disable automatic retry on transient API failures | false |
-| `--output` | `-o` | `table` | Output format (table, json, csv, xml) | false |
+| `--output` | `-o` | `table` | Output format (table, json, csv, xml, go-template; requires --template when using go-template) | false |
 | `--profile` |  |  | Use a specific config profile for this command | false |
 | `--query` |  |  | JMESPath query to filter JSON output (requires --output json) | false |
 | `--quiet` | `-q` | `false` | Suppress informational output, only show errors and data | false |
+| `--template` |  |  | Go template string for --output go-template (e.g. '{{range .}}{{.Name}}{{"\n"}}{{end}}') | false |
 | `--timeout` |  | `0s` | Request timeout duration (e.g., 30s, 2m, 5m); 0 uses the internal default of 90s | false |
 | `--verbose` | `-v` | `false` | Show additional debug information | false |
 
@@ -69,6 +75,7 @@ megaport-cli [flags]
 * [managed-account](megaport-cli_managed-account.md)
 * [mcr](megaport-cli_mcr.md)
 * [mve](megaport-cli_mve.md)
+* [nat-gateway](megaport-cli_nat-gateway.md)
 * [partners](megaport-cli_partners.md)
 * [ports](megaport-cli_ports.md)
 * [product](megaport-cli_product.md)

--- a/docs/megaport-cli_config.md
+++ b/docs/megaport-cli_config.md
@@ -23,7 +23,7 @@ Configuration Precedence:
 ### Example Usage
 
 ```sh
-  megaport-cli config create-profile production --access-key xxx --secret-key xxx --environment production
+  megaport-cli config create-profile production --environment production
   megaport-cli config use-profile production
 ```
 

--- a/docs/megaport-cli_config_create-profile.md
+++ b/docs/megaport-cli_config_create-profile.md
@@ -10,18 +10,17 @@ Profiles store your Megaport API access and secret keys along with environment s
 
 Credentials are stored in ~/.megaport/config.json with secure file permissions.
 
-### Required Fields
-  - `access-key`: Megaport API access key from the Megaport Portal
-  - `secret-key`: Megaport API secret key from the Megaport Portal
+If --access-key or --secret-key are not provided, you will be prompted. On an interactive terminal input is masked; on piped/non-TTY stdin it is read without masking.
 
 ### Important Notes
   - API credentials are stored with 0600 permissions (readable only by the current user)
+  - Passing --access-key or --secret-key on the command line exposes credentials in shell history and process listings. Omit them to be prompted securely, or use env vars MEGAPORT_ACCESS_KEY / MEGAPORT_SECRET_KEY instead. Note: the secure prompt masks input only on an interactive terminal; piped input is read without masking.
 
 ### Example Usage
 
 ```sh
-  megaport-cli config create-profile production --access-key xxx --secret-key xxx --environment production --description "Production credentials"
-  megaport-cli config create-profile staging --access-key yyy --secret-key yyy --environment staging
+  megaport-cli config create-profile production --environment production
+  megaport-cli config create-profile staging --environment staging --description "Staging credentials"
 ```
 
 ## Usage
@@ -38,10 +37,10 @@ megaport-cli config create-profile [flags]
 
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
-| `--access-key` |  |  | Megaport API access key from the Megaport Portal | true |
+| `--access-key` |  |  | Megaport API access key (omit to be prompted; masked on TTY only) | false |
 | `--description` |  |  | Optional description for this profile | false |
 | `--environment` |  | `production` | Target API environment: 'production', 'staging', or 'development' | false |
-| `--secret-key` |  |  | Megaport API secret key from the Megaport Portal | true |
+| `--secret-key` |  |  | Megaport API secret key (omit to be prompted; masked on TTY only) | false |
 
 ## Subcommands
 * [docs](megaport-cli_config_create-profile_docs.md)

--- a/docs/megaport-cli_config_update-profile.md
+++ b/docs/megaport-cli_config_update-profile.md
@@ -10,7 +10,7 @@ To avoid recording the secret value in shell history, pass an empty string (e.g.
 
 ### Important Notes
   - Keep your Megaport API credentials secure; they provide full account access
-  - Passing --access-key or --secret-key on the command line exposes credentials in shell history and process listings. Pass an empty value to be prompted instead (masked on a TTY; echoed on piped/non-TTY stdin).
+  - Passing --access-key or --secret-key on the command line exposes credentials in shell history and process listings. Pass an empty value to be prompted instead (masked on a TTY; read without masking on piped/non-TTY stdin).
 
 ### Example Usage
 

--- a/docs/megaport-cli_config_update-profile.md
+++ b/docs/megaport-cli_config_update-profile.md
@@ -6,14 +6,17 @@ Update an existing profile
 
 Update an existing profile with new credentials or settings.
 
+To avoid recording the secret value in shell history, pass an empty string (e.g. --secret-key "") and you will be prompted instead of providing the value on the command line. On an interactive terminal input is masked; on piped/non-TTY stdin it is read without masking. Alternatively, use env vars MEGAPORT_ACCESS_KEY / MEGAPORT_SECRET_KEY which always take precedence over stored profiles.
+
 ### Important Notes
   - Keep your Megaport API credentials secure; they provide full account access
+  - Passing --access-key or --secret-key on the command line exposes credentials in shell history and process listings. Pass an empty value to be prompted instead (masked on a TTY; echoed on piped/non-TTY stdin).
 
 ### Example Usage
 
 ```sh
-  megaport-cli config update-profile myprofile --access-key xxx --secret-key xxx
   megaport-cli config update-profile myprofile --environment staging
+  megaport-cli config update-profile myprofile --secret-key ""
 ```
 
 ## Usage
@@ -30,10 +33,10 @@ megaport-cli config update-profile [flags]
 
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
-| `--access-key` |  |  | Megaport API access key | false |
+| `--access-key` |  |  | New Megaport API access key (pass empty string to be prompted; masked on TTY only) | false |
 | `--description` |  |  | Profile description (use empty string to clear) | false |
 | `--environment` |  |  | Target API environment: 'production', 'staging', or 'development' | false |
-| `--secret-key` |  |  | Megaport API secret key | false |
+| `--secret-key` |  |  | New Megaport API secret key (pass empty string to be prompted; masked on TTY only) | false |
 
 ## Subcommands
 * [docs](megaport-cli_config_update-profile_docs.md)

--- a/docs/megaport-cli_ix_buy.md
+++ b/docs/megaport-cli_ix_buy.md
@@ -64,6 +64,7 @@ megaport-cli ix buy [flags]
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
 | `--asn` |  | `0` | ASN (Autonomous System Number) for BGP peering | true |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_ix_update.md
+++ b/docs/megaport-cli_ix_update.md
@@ -63,6 +63,7 @@ megaport-cli ix update [flags]
 | `--a-end-product-uid` |  |  | Move the IX by changing the A-End of the IX | false |
 | `--asn` |  | `0` | ASN (Autonomous System Number) for BGP peering | false |
 | `--cost-centre` |  |  | Cost centre for invoicing purposes | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_managed-account_create.md
+++ b/docs/megaport-cli_managed-account_create.md
@@ -48,6 +48,7 @@ megaport-cli managed-account create [flags]
 |------|-----------|---------|-------------|----------|
 | `--account-name` |  |  | The name of the managed account | true |
 | `--account-ref` |  |  | The reference ID for the managed account | true |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_managed-account_update.md
+++ b/docs/megaport-cli_managed-account_update.md
@@ -49,6 +49,7 @@ megaport-cli managed-account update [flags]
 |------|-----------|---------|-------------|----------|
 | `--account-name` |  |  | The new name of the managed account | false |
 | `--account-ref` |  |  | The new reference ID for the managed account | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_mcr.md
+++ b/docs/megaport-cli_mcr.md
@@ -49,6 +49,7 @@ megaport-cli mcr [flags]
 * [list-prefix-filter-lists](megaport-cli_mcr_list-prefix-filter-lists.md)
 * [list-tags](megaport-cli_mcr_list-tags.md)
 * [lock](megaport-cli_mcr_lock.md)
+* [looking-glass](megaport-cli_mcr_looking-glass.md)
 * [restore](megaport-cli_mcr_restore.md)
 * [status](megaport-cli_mcr_status.md)
 * [unlock](megaport-cli_mcr_unlock.md)

--- a/docs/megaport-cli_mcr_add-ipsec-addon.md
+++ b/docs/megaport-cli_mcr_add-ipsec-addon.md
@@ -45,6 +45,7 @@ megaport-cli mcr add-ipsec-addon [flags]
 
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_mcr_buy.md
+++ b/docs/megaport-cli_mcr_buy.md
@@ -80,6 +80,7 @@ megaport-cli mcr buy [flags]
 |------|-----------|---------|-------------|----------|
 | `--cost-centre` |  |  | The cost centre for billing purposes | false |
 | `--diversity-zone` |  |  | The diversity zone for the MCR | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--ipsec-tunnel-count` |  | `0` | IPSec tunnel count for an add-on (10, 20, or 30) | false |
 | `--json` |  |  | JSON string containing configuration | false |

--- a/docs/megaport-cli_mcr_create-prefix-filter-list.md
+++ b/docs/megaport-cli_mcr_create-prefix-filter-list.md
@@ -60,6 +60,7 @@ megaport-cli mcr create-prefix-filter-list [flags]
 | `--address-family` |  |  | Address family (IPv4 or IPv6) | false |
 | `--description` |  |  | Description of the prefix filter list | false |
 | `--entries` |  |  | JSON array of prefix filter entries | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_mcr_list.md
+++ b/docs/megaport-cli_mcr_list.md
@@ -6,13 +6,14 @@ List all MCRs with optional filters
 
 List all MCRs available in the Megaport API.
 
-This command fetches and displays a list of MCRs with details such as MCR ID, name, location, speed, and status. By default, only active MCRs are shown.
+This command fetches and displays a list of MCRs with details such as MCR ID, name, location, speed, and status. By default, only active MCRs are shown. You can also filter by resource tags.
 
 ### Optional Fields
   - `include-inactive`: Include MCRs in CANCELLED, DECOMMISSIONED, or DECOMMISSIONING states
   - `location-id`: Filter MCRs by location ID
   - `name`: Filter MCRs by name
   - `port-speed`: Filter MCRs by port speed
+  - `tag`: Filter by resource tag (format: key=value or key; repeatable, AND logic)
 
 ### Example Usage
 
@@ -23,6 +24,8 @@ This command fetches and displays a list of MCRs with details such as MCR ID, na
   megaport-cli mcr list --name "My MCR"
   megaport-cli mcr list --include-inactive
   megaport-cli mcr list --location-id 1 --port-speed 10000 --name "My MCR"
+  megaport-cli mcr list --tag env=prod
+  megaport-cli mcr list --tag env=prod --tag team=network
 ```
 
 ## Usage
@@ -48,6 +51,7 @@ megaport-cli mcr list [flags]
 | `--location-id` |  | `0` | Filter MCRs by location ID | false |
 | `--name` |  |  | Filter MCRs by name | false |
 | `--port-speed` |  | `0` | Filter MCRs by port speed | false |
+| `--tag` |  | `[]` | Filter by resource tag (format: key=value or key; repeatable, AND logic) | false |
 
 ## Subcommands
 * [docs](megaport-cli_mcr_list_docs.md)

--- a/docs/megaport-cli_mcr_looking-glass.md
+++ b/docs/megaport-cli_mcr_looking-glass.md
@@ -1,0 +1,44 @@
+# looking-glass
+
+MCR Looking Glass diagnostic commands
+
+## Description
+
+MCR Looking Glass diagnostic commands.
+
+The Looking Glass provides visibility into traffic routing on your MCR, helping you troubleshoot connections by showing the status of protocols and routing tables.
+
+### Important Notes
+  - Looking Glass commands are read-only diagnostic tools
+  - Use --ip flag to filter routes by IP address or prefix
+
+### Example Usage
+
+```sh
+  megaport-cli mcr looking-glass ip-routes [mcrUID]
+  megaport-cli mcr looking-glass bgp-routes [mcrUID]
+  megaport-cli mcr looking-glass bgp-sessions [mcrUID]
+```
+
+## Usage
+
+```sh
+megaport-cli mcr looking-glass [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli mcr](megaport-cli_mcr.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+
+## Subcommands
+* [bgp-neighbor-routes](megaport-cli_mcr_looking-glass_bgp-neighbor-routes.md)
+* [bgp-routes](megaport-cli_mcr_looking-glass_bgp-routes.md)
+* [bgp-sessions](megaport-cli_mcr_looking-glass_bgp-sessions.md)
+* [docs](megaport-cli_mcr_looking-glass_docs.md)
+* [ip-routes](megaport-cli_mcr_looking-glass_ip-routes.md)
+

--- a/docs/megaport-cli_mcr_looking-glass_bgp-neighbor-routes.md
+++ b/docs/megaport-cli_mcr_looking-glass_bgp-neighbor-routes.md
@@ -1,0 +1,41 @@
+# bgp-neighbor-routes
+
+List routes advertised to or received from a BGP neighbor
+
+## Description
+
+List routes advertised to or received from a specific BGP neighbor.
+
+This command shows routes that are either being advertised to a neighbor or received from a neighbor. Use the session ID from 'bgp-sessions' command.
+
+### Important Notes
+  - Direction must be 'advertised' or 'received'
+  - Get session ID from 'mcr looking-glass bgp-sessions' command
+
+### Example Usage
+
+```sh
+  megaport-cli mcr looking-glass bgp-neighbor-routes [mcrUID] [sessionID] advertised
+  megaport-cli mcr looking-glass bgp-neighbor-routes [mcrUID] [sessionID] received
+  megaport-cli mcr looking-glass bgp-neighbor-routes [mcrUID] [sessionID] received --ip 10.0.0.0/8
+```
+
+## Usage
+
+```sh
+megaport-cli mcr looking-glass bgp-neighbor-routes [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli mcr looking-glass](megaport-cli_mcr_looking-glass.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+| `--ip` |  |  | Filter by IP address or prefix (e.g., 10.0.0.0/8 or 192.168.1.1) | false |
+
+## Subcommands
+* [docs](megaport-cli_mcr_looking-glass_bgp-neighbor-routes_docs.md)
+

--- a/docs/megaport-cli_mcr_looking-glass_bgp-neighbor-routes_docs.md
+++ b/docs/megaport-cli_mcr_looking-glass_bgp-neighbor-routes_docs.md
@@ -1,0 +1,23 @@
+# docs
+
+Show documentation for this command
+
+## Description
+
+Display formatted documentation for this command from markdown files
+
+## Usage
+
+```sh
+megaport-cli mcr looking-glass bgp-neighbor-routes docs [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli mcr looking-glass bgp-neighbor-routes](megaport-cli_mcr_looking-glass_bgp-neighbor-routes.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+

--- a/docs/megaport-cli_mcr_looking-glass_bgp-routes.md
+++ b/docs/megaport-cli_mcr_looking-glass_bgp-routes.md
@@ -1,0 +1,39 @@
+# bgp-routes
+
+List BGP routes with full BGP attributes
+
+## Description
+
+List BGP routes from the MCR Looking Glass.
+
+This command retrieves routes learned via BGP with full BGP attributes including AS path, local preference, MED, communities, and origin.
+
+### Important Notes
+  - Shows BGP-specific attributes like AS path, local preference, MED, and communities
+
+### Example Usage
+
+```sh
+  megaport-cli mcr looking-glass bgp-routes [mcrUID]
+  megaport-cli mcr looking-glass bgp-routes [mcrUID] --ip 10.0.0.0/8
+```
+
+## Usage
+
+```sh
+megaport-cli mcr looking-glass bgp-routes [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli mcr looking-glass](megaport-cli_mcr_looking-glass.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+| `--ip` |  |  | Filter by IP address or prefix (e.g., 10.0.0.0/8 or 192.168.1.1) | false |
+
+## Subcommands
+* [docs](megaport-cli_mcr_looking-glass_bgp-routes_docs.md)
+

--- a/docs/megaport-cli_mcr_looking-glass_bgp-routes_docs.md
+++ b/docs/megaport-cli_mcr_looking-glass_bgp-routes_docs.md
@@ -1,0 +1,23 @@
+# docs
+
+Show documentation for this command
+
+## Description
+
+Display formatted documentation for this command from markdown files
+
+## Usage
+
+```sh
+megaport-cli mcr looking-glass bgp-routes docs [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli mcr looking-glass bgp-routes](megaport-cli_mcr_looking-glass_bgp-routes.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+

--- a/docs/megaport-cli_mcr_looking-glass_bgp-sessions.md
+++ b/docs/megaport-cli_mcr_looking-glass_bgp-sessions.md
@@ -1,0 +1,38 @@
+# bgp-sessions
+
+List BGP sessions configured on the MCR
+
+## Description
+
+List all BGP sessions configured on the MCR.
+
+This command shows the status of all BGP peering sessions including neighbor address, ASN, session status, uptime, and prefix counts.
+
+### Important Notes
+  - Session status can be UP, DOWN, or UNKNOWN
+  - Use the session ID from this output with bgp-neighbor-routes command
+
+### Example Usage
+
+```sh
+  megaport-cli mcr looking-glass bgp-sessions [mcrUID]
+```
+
+## Usage
+
+```sh
+megaport-cli mcr looking-glass bgp-sessions [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli mcr looking-glass](megaport-cli_mcr_looking-glass.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+
+## Subcommands
+* [docs](megaport-cli_mcr_looking-glass_bgp-sessions_docs.md)
+

--- a/docs/megaport-cli_mcr_looking-glass_bgp-sessions_docs.md
+++ b/docs/megaport-cli_mcr_looking-glass_bgp-sessions_docs.md
@@ -1,0 +1,23 @@
+# docs
+
+Show documentation for this command
+
+## Description
+
+Display formatted documentation for this command from markdown files
+
+## Usage
+
+```sh
+megaport-cli mcr looking-glass bgp-sessions docs [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli mcr looking-glass bgp-sessions](megaport-cli_mcr_looking-glass_bgp-sessions.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+

--- a/docs/megaport-cli_mcr_looking-glass_docs.md
+++ b/docs/megaport-cli_mcr_looking-glass_docs.md
@@ -1,0 +1,23 @@
+# docs
+
+Show documentation for this command
+
+## Description
+
+Display formatted documentation for this command from markdown files
+
+## Usage
+
+```sh
+megaport-cli mcr looking-glass docs [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli mcr looking-glass](megaport-cli_mcr_looking-glass.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+

--- a/docs/megaport-cli_mcr_looking-glass_ip-routes.md
+++ b/docs/megaport-cli_mcr_looking-glass_ip-routes.md
@@ -1,0 +1,42 @@
+# ip-routes
+
+List IP routes from the MCR routing table
+
+## Description
+
+List IP routes from the MCR Looking Glass.
+
+This command retrieves all routes (BGP, static, connected, local) from the MCR's routing table. You can filter by protocol or IP address/prefix.
+
+### Important Notes
+  - Protocol values: BGP, STATIC, CONNECTED, LOCAL
+
+### Example Usage
+
+```sh
+  megaport-cli mcr looking-glass ip-routes [mcrUID]
+  megaport-cli mcr looking-glass ip-routes [mcrUID] --protocol BGP
+  megaport-cli mcr looking-glass ip-routes [mcrUID] --ip 10.0.0.0/8
+  megaport-cli mcr looking-glass ip-routes [mcrUID] --protocol STATIC --ip 192.168.0.0/16
+```
+
+## Usage
+
+```sh
+megaport-cli mcr looking-glass ip-routes [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli mcr looking-glass](megaport-cli_mcr_looking-glass.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+| `--ip` |  |  | Filter by IP address or prefix (e.g., 10.0.0.0/8 or 192.168.1.1) | false |
+| `--protocol` |  |  | Filter by protocol (BGP, STATIC, CONNECTED, LOCAL) | false |
+
+## Subcommands
+* [docs](megaport-cli_mcr_looking-glass_ip-routes_docs.md)
+

--- a/docs/megaport-cli_mcr_looking-glass_ip-routes_docs.md
+++ b/docs/megaport-cli_mcr_looking-glass_ip-routes_docs.md
@@ -1,0 +1,23 @@
+# docs
+
+Show documentation for this command
+
+## Description
+
+Display formatted documentation for this command from markdown files
+
+## Usage
+
+```sh
+megaport-cli mcr looking-glass ip-routes docs [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli mcr looking-glass ip-routes](megaport-cli_mcr_looking-glass_ip-routes.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+

--- a/docs/megaport-cli_mcr_update-ipsec-addon.md
+++ b/docs/megaport-cli_mcr_update-ipsec-addon.md
@@ -45,6 +45,7 @@ megaport-cli mcr update-ipsec-addon [flags]
 
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_mcr_update-prefix-filter-list.md
+++ b/docs/megaport-cli_mcr_update-prefix-filter-list.md
@@ -54,6 +54,7 @@ megaport-cli mcr update-prefix-filter-list [flags]
 | `--address-family` |  |  | Address family (IPv4 or IPv6) | false |
 | `--description` |  |  | Description of the prefix filter list | false |
 | `--entries` |  |  | JSON array of prefix filter entries | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_mcr_update-tags.md
+++ b/docs/megaport-cli_mcr_update-tags.md
@@ -20,6 +20,8 @@ megaport-cli mcr update-tags [flags]
 
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
+| `--force` |  | `false` | Skip the confirmation prompt | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_mcr_update.md
+++ b/docs/megaport-cli_mcr_update.md
@@ -12,6 +12,7 @@ This command allows you to update the details of an existing MCR.
   - `cost-centre`: The new cost centre for the MCR
   - `marketplace-visibility`: Whether the MCR is visible in the marketplace (true/false)
   - `name`: The new name of the MCR (1-64 characters)
+  - `term`: The new contract term for the MCR (1, 12, 24, or 36 months)
 
 ### Important Notes
   - The MCR UID cannot be changed
@@ -23,6 +24,7 @@ This command allows you to update the details of an existing MCR.
 ```sh
   megaport-cli mcr update [mcrUID] --interactive
   megaport-cli mcr update [mcrUID] --name "Updated MCR" --marketplace-visibility true --cost-centre "Finance"
+  megaport-cli mcr update [mcrUID] --term 24
   megaport-cli mcr update [mcrUID] --json '{"name":"Updated MCR","marketplaceVisibility":true,"costCentre":"Finance"}'
   megaport-cli mcr update [mcrUID] --json-file ./update-mcr-config.json
 ```
@@ -52,11 +54,13 @@ megaport-cli mcr update [flags]
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
 | `--cost-centre` |  |  | The new cost centre for the MCR | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |
 | `--marketplace-visibility` |  | `false` | Whether the MCR is visible in the marketplace (true/false) | false |
 | `--name` |  |  | The new name of the MCR (1-64 characters) | false |
+| `--term` |  | `0` | The new contract term for the MCR (1, 12, 24, or 36 months) | false |
 
 ## Subcommands
 * [docs](megaport-cli_mcr_update_docs.md)

--- a/docs/megaport-cli_mve_buy.md
+++ b/docs/megaport-cli_mve_buy.md
@@ -54,6 +54,7 @@ This command allows you to purchase an MVE by providing the necessary details.
     "manageLocally": true,
     "adminSshPublicKey": "ssh-rsa AAAA...",
     "sshPublicKey": "ssh-rsa AAAA...",
+    "adminPassword": "S3cretP@ss",
     "cloudInit": "#cloud-config\npackages:\n - nginx\n"
   },
   "vnics": [
@@ -85,6 +86,7 @@ megaport-cli mve buy [flags]
 |------|-----------|---------|-------------|----------|
 | `--cost-centre` |  |  | Cost centre for billing | false |
 | `--diversity-zone` |  |  | The diversity zone for the MVE | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_mve_list.md
+++ b/docs/megaport-cli_mve_list.md
@@ -6,7 +6,10 @@ List all MVEs with optional filters
 
 List all MVEs available in the Megaport API.
 
-This command fetches and displays a list of MVEs with details such as MVE ID, name, location, vendor, and status. By default, only active MVEs are shown.
+This command fetches and displays a list of MVEs with details such as MVE ID, name, location, vendor, and status. By default, only active MVEs are shown. You can also filter by resource tags.
+
+### Optional Fields
+  - `tag`: Filter by resource tag (format: key=value or key; repeatable, AND logic)
 
 ### Example Usage
 
@@ -17,6 +20,8 @@ This command fetches and displays a list of MVEs with details such as MVE ID, na
   megaport-cli mve list --name "Edge Router"
   megaport-cli mve list --include-inactive
   megaport-cli mve list --location-id 123 --vendor "Cisco" --name "Edge"
+  megaport-cli mve list --tag env=prod
+  megaport-cli mve list --tag env=prod --tag team=network
 ```
 
 ## Usage
@@ -41,6 +46,7 @@ megaport-cli mve list [flags]
 | `--limit` |  | `0` | Maximum number of results to display (0 = unlimited) | false |
 | `--location-id` |  | `0` | Filter MVEs by location ID | false |
 | `--name` |  |  | Filter MVEs by name | false |
+| `--tag` |  | `[]` | Filter by resource tag (format: key=value or key; repeatable, AND logic) | false |
 | `--vendor` |  |  | Filter MVEs by vendor | false |
 
 ## Subcommands

--- a/docs/megaport-cli_mve_update-tags.md
+++ b/docs/megaport-cli_mve_update-tags.md
@@ -20,6 +20,8 @@ megaport-cli mve update-tags [flags]
 
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
+| `--force` |  | `false` | Skip the confirmation prompt | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_mve_update.md
+++ b/docs/megaport-cli_mve_update.md
@@ -53,6 +53,7 @@ megaport-cli mve update [flags]
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
 | `--cost-centre` |  |  | The new cost centre for billing purposes | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_nat-gateway.md
+++ b/docs/megaport-cli_nat-gateway.md
@@ -1,0 +1,48 @@
+# nat-gateway
+
+Manage NAT Gateways in the Megaport API
+
+## Description
+
+Manage NAT Gateways in the Megaport API.
+
+This command groups all operations related to Megaport NAT Gateways. NAT Gateways provide network address translation services within the Megaport fabric.
+
+### Example Usage
+
+```sh
+  megaport-cli nat-gateway get [uid]
+  megaport-cli nat-gateway list
+  megaport-cli nat-gateway create
+  megaport-cli nat-gateway update [uid]
+  megaport-cli nat-gateway delete [uid]
+  megaport-cli nat-gateway validate [uid]
+  megaport-cli nat-gateway buy [uid]
+  megaport-cli nat-gateway list-sessions
+  megaport-cli nat-gateway telemetry [uid] --types BITS --days 7
+```
+
+## Usage
+
+```sh
+megaport-cli nat-gateway [flags]
+```
+
+
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+
+## Subcommands
+* [buy](megaport-cli_nat-gateway_buy.md)
+* [create](megaport-cli_nat-gateway_create.md)
+* [delete](megaport-cli_nat-gateway_delete.md)
+* [docs](megaport-cli_nat-gateway_docs.md)
+* [get](megaport-cli_nat-gateway_get.md)
+* [list](megaport-cli_nat-gateway_list.md)
+* [list-sessions](megaport-cli_nat-gateway_list-sessions.md)
+* [telemetry](megaport-cli_nat-gateway_telemetry.md)
+* [update](megaport-cli_nat-gateway_update.md)
+* [validate](megaport-cli_nat-gateway_validate.md)
+

--- a/docs/megaport-cli_nat-gateway_buy.md
+++ b/docs/megaport-cli_nat-gateway_buy.md
@@ -1,0 +1,39 @@
+# buy
+
+Purchase a NAT Gateway design to begin provisioning
+
+## Description
+
+Purchase a NAT Gateway design via /v3/networkdesign/buy.
+
+Run this after 'nat-gateway validate' to kick off provisioning of a NAT Gateway that currently exists in DESIGN state. Billing begins once the order is accepted.
+
+### Important Notes
+  - This action begins billing for the NAT Gateway and cannot be undone without deleting the resource.
+
+### Example Usage
+
+```sh
+  megaport-cli nat-gateway buy a1b2c3d4-e5f6-7890-1234-567890abcdef
+  megaport-cli nat-gateway buy a1b2c3d4-e5f6-7890-1234-567890abcdef --yes
+```
+
+## Usage
+
+```sh
+megaport-cli nat-gateway buy [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway](megaport-cli_nat-gateway.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+| `--yes` |  | `false` | Skip the confirmation prompt | false |
+
+## Subcommands
+* [docs](megaport-cli_nat-gateway_buy_docs.md)
+

--- a/docs/megaport-cli_nat-gateway_buy_docs.md
+++ b/docs/megaport-cli_nat-gateway_buy_docs.md
@@ -1,0 +1,23 @@
+# docs
+
+Show documentation for this command
+
+## Description
+
+Display formatted documentation for this command from markdown files
+
+## Usage
+
+```sh
+megaport-cli nat-gateway buy docs [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway buy](megaport-cli_nat-gateway_buy.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+

--- a/docs/megaport-cli_nat-gateway_create.md
+++ b/docs/megaport-cli_nat-gateway_create.md
@@ -1,0 +1,89 @@
+# create
+
+Create a new NAT Gateway
+
+## Description
+
+Create a new NAT Gateway through the Megaport API.
+
+This command creates a NAT Gateway by providing the necessary details.
+
+### Required Fields
+  - `location-id`: The ID of the location where the NAT Gateway will be provisioned
+  - `name`: The name of the NAT Gateway
+  - `speed`: The speed of the NAT Gateway in Mbps
+  - `term`: The contract term in months (1, 12, 24, or 36)
+
+### Optional Fields
+  - `auto-renew`: Whether to automatically renew the contract term
+  - `diversity-zone`: The diversity zone for the NAT Gateway
+  - `promo-code`: A promotional code for discounts
+  - `resource-tags`: Resource tags as a JSON string (e.g. {"key1":"value1","key2":"value2"})
+  - `resource-tags-file`: Path to JSON file containing resource tags
+  - `service-level-reference`: A service level reference for the NAT Gateway
+  - `session-count`: The number of NAT sessions
+
+### Important Notes
+  - Required flags can be skipped when using --interactive, --json, or --json-file
+
+### Example Usage
+
+```sh
+  megaport-cli nat-gateway create --interactive
+  megaport-cli nat-gateway create --name "My NAT GW" --term 12 --speed 1000 --location-id 123
+  megaport-cli nat-gateway create --json '{"name":"My NAT GW","term":12,"speed":1000,"locationId":123}'
+  megaport-cli nat-gateway create --json-file ./nat-gw-config.json
+```
+### JSON Format Example
+```json
+{
+  "name": "My NAT Gateway",
+  "term": 12,
+  "speed": 1000,
+  "locationId": 123,
+  "sessionCount": 100,
+  "diversityZone": "blue",
+  "autoRenewTerm": false,
+  "promoCode": "",
+  "resourceTags": {
+    "environment": "production",
+    "team": "network"
+  }
+}
+
+```
+
+## Usage
+
+```sh
+megaport-cli nat-gateway create [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway](megaport-cli_nat-gateway.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+| `--auto-renew` |  | `false` | Whether to automatically renew the contract term | false |
+| `--diversity-zone` |  |  | The diversity zone for the NAT Gateway (optional) | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
+| `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
+| `--json` |  |  | JSON string containing configuration | false |
+| `--json-file` |  |  | Path to JSON file containing configuration | false |
+| `--location-id` |  | `0` | The ID of the location where the NAT Gateway will be provisioned | true |
+| `--name` |  |  | The name of the NAT Gateway | true |
+| `--promo-code` |  |  | A promotional code for discounts (optional) | false |
+| `--resource-tags` |  |  | Resource tags as a JSON string (e.g. {"key1":"value1","key2":"value2"}) | false |
+| `--resource-tags-file` |  |  | Path to JSON file containing resource tags | false |
+| `--service-level-reference` |  |  | A service level reference for the NAT Gateway (optional) | false |
+| `--session-count` |  | `0` | The number of NAT sessions (optional) | false |
+| `--speed` |  | `0` | The speed of the NAT Gateway in Mbps | true |
+| `--term` |  | `0` | The contract term in months (1, 12, 24, or 36) | true |
+| `--yes` | `-y` | `false` | Skip confirmation prompt for purchase | false |
+
+## Subcommands
+* [docs](megaport-cli_nat-gateway_create_docs.md)
+

--- a/docs/megaport-cli_nat-gateway_create_docs.md
+++ b/docs/megaport-cli_nat-gateway_create_docs.md
@@ -1,0 +1,23 @@
+# docs
+
+Show documentation for this command
+
+## Description
+
+Display formatted documentation for this command from markdown files
+
+## Usage
+
+```sh
+megaport-cli nat-gateway create docs [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway create](megaport-cli_nat-gateway_create.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+

--- a/docs/megaport-cli_nat-gateway_delete.md
+++ b/docs/megaport-cli_nat-gateway_delete.md
@@ -1,0 +1,44 @@
+# delete
+
+Delete a NAT Gateway
+
+## Description
+
+Delete a NAT Gateway.
+
+This command deletes an existing NAT Gateway by its product UID.
+
+### Important Notes
+  - This action is irreversible. The NAT Gateway will be deleted immediately.
+
+### Example Usage
+
+```sh
+  megaport-cli nat-gateway delete a1b2c3d4-e5f6-7890-1234-567890abcdef
+  megaport-cli nat-gateway delete a1b2c3d4-e5f6-7890-1234-567890abcdef --force
+```
+
+## Usage
+
+```sh
+megaport-cli nat-gateway delete [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway](megaport-cli_nat-gateway.md)
+
+## Aliases
+
+* rm
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+| `--force` |  | `false` | Skip the confirmation prompt | false |
+| `--yes` |  | `false` | Skip the confirmation prompt (alias of --force) | false |
+
+## Subcommands
+* [docs](megaport-cli_nat-gateway_delete_docs.md)
+

--- a/docs/megaport-cli_nat-gateway_delete_docs.md
+++ b/docs/megaport-cli_nat-gateway_delete_docs.md
@@ -1,0 +1,23 @@
+# docs
+
+Show documentation for this command
+
+## Description
+
+Display formatted documentation for this command from markdown files
+
+## Usage
+
+```sh
+megaport-cli nat-gateway delete docs [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway delete](megaport-cli_nat-gateway_delete.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+

--- a/docs/megaport-cli_nat-gateway_docs.md
+++ b/docs/megaport-cli_nat-gateway_docs.md
@@ -1,0 +1,23 @@
+# docs
+
+Show documentation for this command
+
+## Description
+
+Display formatted documentation for this command from markdown files
+
+## Usage
+
+```sh
+megaport-cli nat-gateway docs [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway](megaport-cli_nat-gateway.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+

--- a/docs/megaport-cli_nat-gateway_get.md
+++ b/docs/megaport-cli_nat-gateway_get.md
@@ -1,0 +1,43 @@
+# get
+
+Get details for a single NAT Gateway
+
+## Description
+
+Get details for a single NAT Gateway.
+
+Retrieves and displays detailed information for a single NAT Gateway by its product UID.
+
+### Example Usage
+
+```sh
+  megaport-cli nat-gateway get a1b2c3d4-e5f6-7890-1234-567890abcdef
+  megaport-cli nat-gateway get a1b2c3d4-e5f6-7890-1234-567890abcdef --export
+  megaport-cli nat-gateway get a1b2c3d4-e5f6-7890-1234-567890abcdef --watch
+```
+
+## Usage
+
+```sh
+megaport-cli nat-gateway get [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway](megaport-cli_nat-gateway.md)
+
+## Aliases
+
+* show
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+| `--export` |  | `false` | Output recreatable JSON config for use with create --json-file | false |
+| `--interval` |  | `5s` | Polling interval for --watch mode (e.g. 5s, 1m) | false |
+| `--watch` | `-w` | `false` | Continuously poll and display resource status (Ctrl+C to stop) | false |
+
+## Subcommands
+* [docs](megaport-cli_nat-gateway_get_docs.md)
+

--- a/docs/megaport-cli_nat-gateway_get_docs.md
+++ b/docs/megaport-cli_nat-gateway_get_docs.md
@@ -1,0 +1,23 @@
+# docs
+
+Show documentation for this command
+
+## Description
+
+Display formatted documentation for this command from markdown files
+
+## Usage
+
+```sh
+megaport-cli nat-gateway get docs [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway get](megaport-cli_nat-gateway_get.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+

--- a/docs/megaport-cli_nat-gateway_list-sessions.md
+++ b/docs/megaport-cli_nat-gateway_list-sessions.md
@@ -1,0 +1,35 @@
+# list-sessions
+
+List available NAT Gateway speed/session-count combinations
+
+## Description
+
+List the available speed and session-count combinations for NAT Gateways.
+
+Use this command to discover valid speed/session-count pairs before creating a NAT Gateway.
+
+### Example Usage
+
+```sh
+  megaport-cli nat-gateway list-sessions
+  megaport-cli nat-gateway list-sessions --output json
+```
+
+## Usage
+
+```sh
+megaport-cli nat-gateway list-sessions [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway](megaport-cli_nat-gateway.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+
+## Subcommands
+* [docs](megaport-cli_nat-gateway_list-sessions_docs.md)
+

--- a/docs/megaport-cli_nat-gateway_list-sessions_docs.md
+++ b/docs/megaport-cli_nat-gateway_list-sessions_docs.md
@@ -1,0 +1,23 @@
+# docs
+
+Show documentation for this command
+
+## Description
+
+Display formatted documentation for this command from markdown files
+
+## Usage
+
+```sh
+megaport-cli nat-gateway list-sessions docs [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway list-sessions](megaport-cli_nat-gateway_list-sessions.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+

--- a/docs/megaport-cli_nat-gateway_list.md
+++ b/docs/megaport-cli_nat-gateway_list.md
@@ -1,0 +1,51 @@
+# list
+
+List all NAT Gateways
+
+## Description
+
+List all NAT Gateways for your account.
+
+This command retrieves and displays all NAT Gateways, with optional filtering.
+
+### Optional Fields
+  - `include-inactive`: Include inactive NAT Gateways in the results
+  - `limit`: Limit the number of results returned
+  - `location-id`: Filter NAT Gateways by location ID
+  - `name`: Filter NAT Gateways by name (substring match)
+
+### Example Usage
+
+```sh
+  megaport-cli nat-gateway list
+  megaport-cli nat-gateway list --location-id 67
+  megaport-cli nat-gateway list --name "my-gw"
+  megaport-cli nat-gateway list --include-inactive
+```
+
+## Usage
+
+```sh
+megaport-cli nat-gateway list [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway](megaport-cli_nat-gateway.md)
+
+## Aliases
+
+* ls
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+| `--include-inactive` |  | `false` | Include inactive NAT Gateways in the list | false |
+| `--limit` |  | `0` | Limit the number of results returned | false |
+| `--location-id` |  | `0` | Filter NAT Gateways by location ID | false |
+| `--name` |  |  | Filter NAT Gateways by name (substring match) | false |
+
+## Subcommands
+* [docs](megaport-cli_nat-gateway_list_docs.md)
+

--- a/docs/megaport-cli_nat-gateway_list_docs.md
+++ b/docs/megaport-cli_nat-gateway_list_docs.md
@@ -1,0 +1,23 @@
+# docs
+
+Show documentation for this command
+
+## Description
+
+Display formatted documentation for this command from markdown files
+
+## Usage
+
+```sh
+megaport-cli nat-gateway list docs [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway list](megaport-cli_nat-gateway_list.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+

--- a/docs/megaport-cli_nat-gateway_telemetry.md
+++ b/docs/megaport-cli_nat-gateway_telemetry.md
@@ -1,0 +1,51 @@
+# telemetry
+
+Get telemetry data for a NAT Gateway
+
+## Description
+
+Get telemetry data for a NAT Gateway.
+
+Retrieves metric samples (bits, packets, speed, etc.) for a NAT Gateway over a specified time window.
+
+### Required Fields
+  - `types`: Comma-separated telemetry types (e.g. BITS,PACKETS,SPEED)
+
+### Optional Fields
+  - `days`: Number of days of telemetry to retrieve (1-180)
+  - `from`: Start time for telemetry (RFC3339); requires --to
+  - `to`: End time for telemetry (RFC3339); requires --from
+
+### Important Notes
+  - Use --days for a rolling window, or --from/--to for an absolute range (they are mutually exclusive)
+
+### Example Usage
+
+```sh
+  megaport-cli nat-gateway telemetry [uid] --types BITS --days 7
+  megaport-cli nat-gateway telemetry [uid] --types BITS,PACKETS --from 2024-01-01T00:00:00Z --to 2024-01-07T00:00:00Z
+  megaport-cli nat-gateway telemetry [uid] --types SPEED --days 30 --output json
+```
+
+## Usage
+
+```sh
+megaport-cli nat-gateway telemetry [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway](megaport-cli_nat-gateway.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+| `--days` |  | `0` | Number of days of telemetry to retrieve (1-180); mutually exclusive with --from/--to | false |
+| `--from` |  |  | Start time for telemetry in RFC3339 format (e.g. 2024-01-01T00:00:00Z); use with --to | false |
+| `--to` |  |  | End time for telemetry in RFC3339 format; use with --from | false |
+| `--types` |  |  | Comma-separated telemetry types (e.g. BITS,PACKETS,SPEED) | true |
+
+## Subcommands
+* [docs](megaport-cli_nat-gateway_telemetry_docs.md)
+

--- a/docs/megaport-cli_nat-gateway_telemetry_docs.md
+++ b/docs/megaport-cli_nat-gateway_telemetry_docs.md
@@ -1,0 +1,23 @@
+# docs
+
+Show documentation for this command
+
+## Description
+
+Display formatted documentation for this command from markdown files
+
+## Usage
+
+```sh
+megaport-cli nat-gateway telemetry docs [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway telemetry](megaport-cli_nat-gateway_telemetry.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+

--- a/docs/megaport-cli_nat-gateway_update.md
+++ b/docs/megaport-cli_nat-gateway_update.md
@@ -1,0 +1,76 @@
+# update
+
+Update an existing NAT Gateway
+
+## Description
+
+Update an existing NAT Gateway.
+
+This command allows you to update the details of an existing NAT Gateway.
+
+### Optional Fields
+  - `auto-renew`: Whether to automatically renew the contract term
+  - `diversity-zone`: The new diversity zone
+  - `location-id`: The new location ID
+  - `name`: The new name of the NAT Gateway
+  - `promo-code`: A promotional code
+  - `resource-tags`: Resource tags as a JSON string (e.g. {"key1":"value1","key2":"value2"})
+  - `resource-tags-file`: Path to JSON file containing resource tags
+  - `service-level-reference`: A service level reference
+  - `session-count`: The new session count
+  - `speed`: The new speed of the NAT Gateway in Mbps
+  - `term`: The new contract term in months
+
+### Example Usage
+
+```sh
+  megaport-cli nat-gateway update [uid] --interactive
+  megaport-cli nat-gateway update [uid] --name "Updated GW" --speed 2000
+  megaport-cli nat-gateway update [uid] --json '{"name":"Updated GW","speed":2000,"locationId":123,"term":12}'
+  megaport-cli nat-gateway update [uid] --json-file ./update-config.json
+```
+### JSON Format Example
+```json
+{
+  "name": "Updated NAT Gateway",
+  "term": 12,
+  "speed": 2000,
+  "locationId": 123,
+  "sessionCount": 200
+}
+
+```
+
+## Usage
+
+```sh
+megaport-cli nat-gateway update [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway](megaport-cli_nat-gateway.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+| `--auto-renew` |  | `false` | Whether to automatically renew the contract term | false |
+| `--diversity-zone` |  |  | The new diversity zone | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
+| `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
+| `--json` |  |  | JSON string containing configuration | false |
+| `--json-file` |  |  | Path to JSON file containing configuration | false |
+| `--location-id` |  | `0` | The new location ID | false |
+| `--name` |  |  | The new name of the NAT Gateway | false |
+| `--promo-code` |  |  | A promotional code | false |
+| `--resource-tags` |  |  | Resource tags as a JSON string (e.g. {"key1":"value1","key2":"value2"}) | false |
+| `--resource-tags-file` |  |  | Path to JSON file containing resource tags | false |
+| `--service-level-reference` |  |  | A service level reference | false |
+| `--session-count` |  | `0` | The new session count | false |
+| `--speed` |  | `0` | The new speed of the NAT Gateway in Mbps | false |
+| `--term` |  | `0` | The new contract term in months (1, 12, 24, or 36) | false |
+
+## Subcommands
+* [docs](megaport-cli_nat-gateway_update_docs.md)
+

--- a/docs/megaport-cli_nat-gateway_update_docs.md
+++ b/docs/megaport-cli_nat-gateway_update_docs.md
@@ -1,0 +1,23 @@
+# docs
+
+Show documentation for this command
+
+## Description
+
+Display formatted documentation for this command from markdown files
+
+## Usage
+
+```sh
+megaport-cli nat-gateway update docs [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway update](megaport-cli_nat-gateway_update.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+

--- a/docs/megaport-cli_nat-gateway_validate.md
+++ b/docs/megaport-cli_nat-gateway_validate.md
@@ -1,0 +1,38 @@
+# validate
+
+Validate a NAT Gateway design without purchasing
+
+## Description
+
+Validate a NAT Gateway design via /v3/networkdesign/validate.
+
+Use this after 'nat-gateway create' to preview pricing and confirm the design is valid before calling 'nat-gateway buy'. No resources are provisioned and no charges are incurred.
+
+### Important Notes
+  - The NAT Gateway must already exist in DESIGN state (create it first with 'nat-gateway create').
+
+### Example Usage
+
+```sh
+  megaport-cli nat-gateway validate a1b2c3d4-e5f6-7890-1234-567890abcdef
+  megaport-cli nat-gateway validate a1b2c3d4-e5f6-7890-1234-567890abcdef --output json
+```
+
+## Usage
+
+```sh
+megaport-cli nat-gateway validate [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway](megaport-cli_nat-gateway.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+
+## Subcommands
+* [docs](megaport-cli_nat-gateway_validate_docs.md)
+

--- a/docs/megaport-cli_nat-gateway_validate_docs.md
+++ b/docs/megaport-cli_nat-gateway_validate_docs.md
@@ -1,0 +1,23 @@
+# docs
+
+Show documentation for this command
+
+## Description
+
+Display formatted documentation for this command from markdown files
+
+## Usage
+
+```sh
+megaport-cli nat-gateway validate docs [flags]
+```
+
+
+## Parent Command
+
+* [megaport-cli nat-gateway validate](megaport-cli_nat-gateway_validate.md)
+## Flags
+
+| Name | Shorthand | Default | Description | Required |
+|------|-----------|---------|-------------|----------|
+

--- a/docs/megaport-cli_ports_buy-lag.md
+++ b/docs/megaport-cli_ports_buy-lag.md
@@ -71,6 +71,7 @@ megaport-cli ports buy-lag [flags]
 |------|-----------|---------|-------------|----------|
 | `--cost-centre` |  |  | Cost centre for billing | false |
 | `--diversity-zone` |  |  | Diversity zone for the port | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_ports_buy.md
+++ b/docs/megaport-cli_ports_buy.md
@@ -71,6 +71,7 @@ megaport-cli ports buy [flags]
 |------|-----------|---------|-------------|----------|
 | `--cost-centre` |  |  | Cost centre for billing | false |
 | `--diversity-zone` |  |  | Diversity zone for the port | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_ports_check-vlan.md
+++ b/docs/megaport-cli_ports_check-vlan.md
@@ -8,7 +8,7 @@ Check if a VLAN is available on a port in the Megaport API.
 
 This command verifies whether a specific VLAN ID is available for use on a port. This is useful when planning new VXCs to ensure the VLAN ID you want to use is not already in use by another connection.
 
-VLAN ID must be between 2 and 4094 (inclusive).
+VLAN ID must be between 2 and 4093 (inclusive).
 
 ### Example Usage
 

--- a/docs/megaport-cli_ports_list.md
+++ b/docs/megaport-cli_ports_list.md
@@ -6,13 +6,14 @@ List all ports with optional filters
 
 List all ports available in the Megaport API.
 
-This command fetches and displays a list of ports with details such as port ID, name, location, speed, and status. By default, only active ports are shown.
+This command fetches and displays a list of ports with details such as port ID, name, location, speed, and status. By default, only active ports are shown. You can also filter by resource tags.
 
 ### Optional Fields
   - `include-inactive`: Include ports in CANCELLED, DECOMMISSIONED, or DECOMMISSIONING states
   - `location-id`: Filter ports by location ID
   - `port-name`: Filter ports by port name
   - `port-speed`: Filter ports by port speed
+  - `tag`: Filter by resource tag (format: key=value or key; repeatable, AND logic)
 
 ### Example Usage
 
@@ -23,6 +24,8 @@ This command fetches and displays a list of ports with details such as port ID, 
   megaport-cli ports list --port-name "Data Center Primary"
   megaport-cli ports list --include-inactive
   megaport-cli ports list --location-id 1 --port-speed 10000 --port-name "Data Center Primary"
+  megaport-cli ports list --tag env=prod
+  megaport-cli ports list --tag env=prod --tag team=network
 ```
 
 ## Usage
@@ -48,6 +51,7 @@ megaport-cli ports list [flags]
 | `--location-id` |  | `0` | Filter ports by location ID | false |
 | `--port-name` |  |  | Filter ports by port name | false |
 | `--port-speed` |  | `0` | Filter ports by port speed | false |
+| `--tag` |  | `[]` | Filter by resource tag (format: key=value or key; repeatable, AND logic) | false |
 
 ## Subcommands
 * [docs](megaport-cli_ports_list_docs.md)

--- a/docs/megaport-cli_ports_update-tags.md
+++ b/docs/megaport-cli_ports_update-tags.md
@@ -20,6 +20,7 @@ megaport-cli ports update-tags [flags]
 
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
+| `--force` |  | `false` | Skip the confirmation prompt | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_ports_update.md
+++ b/docs/megaport-cli_ports_update.md
@@ -22,8 +22,18 @@ This command allows you to update the details of an existing port by providing t
 ```sh
   megaport-cli ports update port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --interactive
   megaport-cli ports update port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --name "Updated Port" --marketplace-visibility true --cost-centre "Finance"
-  megaport-cli ports update port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --json '{"name":"Updated Port","marketplaceVisibility":true,"costCentre":"Finance"}'
+  megaport-cli ports update port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --json '{"name":"Updated Port","marketPlaceVisibility":true,"costCentre":"Finance"}'
   megaport-cli ports update port-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --json-file ./update-port-config.json
+```
+### JSON Format Example
+```json
+{
+  "name": "Updated Port",
+  "marketPlaceVisibility": true,
+  "costCentre": "IT-2024",
+  "contractTermMonths": 24
+}
+
 ```
 
 ## Usage
@@ -41,6 +51,7 @@ megaport-cli ports update [flags]
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
 | `--cost-centre` |  |  | Cost centre for billing | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_users_create.md
+++ b/docs/megaport-cli_users_create.md
@@ -56,6 +56,7 @@ megaport-cli users create [flags]
 |------|-----------|---------|-------------|----------|
 | `--email` |  |  | Email address of the user | true |
 | `--first-name` |  |  | First name of the user | true |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_users_update.md
+++ b/docs/megaport-cli_users_update.md
@@ -27,6 +27,21 @@ This command allows you to update specific properties of an existing user. Only 
   megaport-cli users update 12345 --first-name "Jane" --last-name "Smith"
   megaport-cli users update 12345 --json '{"firstName":"Jane"}'
 ```
+### JSON Format Example
+```json
+{
+  "firstName": "Jane",
+  "lastName": "Smith",
+  "email": "jane.smith@example.com",
+  "phone": "+61400000000",
+  "position": "Network Engineer",
+  "active": true,
+  "notificationEnabled": true,
+  "newsletter": false,
+  "promotions": false
+}
+
+```
 
 ## Usage
 
@@ -45,6 +60,7 @@ megaport-cli users update [flags]
 | `--active` |  | `false` | Set user active status | false |
 | `--email` |  |  | New email address | false |
 | `--first-name` |  |  | New first name | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_vxc_buy.md
+++ b/docs/megaport-cli_vxc_buy.md
@@ -10,9 +10,9 @@ This command allows you to create a VXC by providing the necessary details.
 
 ### Required Fields
   - `a-end-uid`: UID of the A-End product
-  - `a-end-vlan`: VLAN for A-End (0-4093, except 1)
+  - `a-end-vlan`: VLAN for A-End (0=auto-assign, -1=untagged, 2-4094 for specific VLAN (1 is reserved))
   - `b-end-uid`: UID of the B-End product (if not using partner configuration)
-  - `b-end-vlan`: VLAN for B-End (0-4093, except 1)
+  - `b-end-vlan`: VLAN for B-End (0=auto-assign, -1=untagged, 2-4094 for specific VLAN (1 is reserved))
   - `name`: Name of the VXC
   - `rate-limit`: Bandwidth in Mbps
   - `term`: Contract term in months (1, 12, 24, or 36)
@@ -68,17 +68,18 @@ megaport-cli vxc buy [flags]
 
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
-| `--a-end-inner-vlan` |  | `0` | Inner VLAN for A-End (-1 or higher) | false |
+| `--a-end-inner-vlan` |  | `0` | Inner VLAN for A-End (0=none, -1=untagged, 2-4094 for specific VLAN (1 is reserved)) | false |
 | `--a-end-partner-config` |  |  | JSON string with A-End partner configuration | false |
 | `--a-end-uid` |  |  | UID of the A-End product | true |
-| `--a-end-vlan` |  | `0` | VLAN for A-End (0-4093, except 1) | true |
+| `--a-end-vlan` |  | `0` | VLAN for A-End (0=auto-assign, -1=untagged, 2-4094 for specific VLAN (1 is reserved)) | true |
 | `--a-end-vnic-index` |  | `0` | vNIC index for A-End MVE | false |
-| `--b-end-inner-vlan` |  | `0` | Inner VLAN for B-End (-1 or higher) | false |
+| `--b-end-inner-vlan` |  | `0` | Inner VLAN for B-End (0=none, -1=untagged, 2-4094 for specific VLAN (1 is reserved)) | false |
 | `--b-end-partner-config` |  |  | JSON string with B-End partner configuration | false |
 | `--b-end-uid` |  |  | UID of the B-End product (if not using partner configuration) | true |
-| `--b-end-vlan` |  | `0` | VLAN for B-End (0-4093, except 1) | true |
+| `--b-end-vlan` |  | `0` | VLAN for B-End (0=auto-assign, -1=untagged, 2-4094 for specific VLAN (1 is reserved)) | true |
 | `--b-end-vnic-index` |  | `0` | vNIC index for B-End MVE | false |
 | `--cost-centre` |  |  | Cost centre for billing | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_vxc_list.md
+++ b/docs/megaport-cli_vxc_list.md
@@ -6,16 +6,17 @@ List all VXCs with optional filters
 
 List all VXCs available in the Megaport API.
 
-This command retrieves all Virtual Cross Connects (VXCs) associated with your account. You can filter results by name, rate limit, A-End UID, B-End UID, or status.
+This command retrieves all Virtual Cross Connects (VXCs) associated with your account. You can filter results by name, rate limit, A-End UID, B-End UID, status, or resource tags.
 
 ### Optional Fields
   - `a-end-uid`: Filter VXCs by A-End product UID
   - `b-end-uid`: Filter VXCs by B-End product UID
   - `include-inactive`: Include inactive VXCs in the list
-  - `name`: Filter VXCs by name (partial match)
-  - `name-contains`: Filter VXCs by partial name match (server-side)
+  - `name`: Filter VXCs by name (case-sensitive partial match)
+  - `name-contains`: Filter VXCs by name (case-sensitive partial match; takes precedence over --name)
   - `rate-limit`: Filter VXCs by rate limit in Mbps
   - `status`: Filter VXCs by status (comma-separated, e.g. LIVE,CONFIGURED)
+  - `tag`: Filter by resource tag (format: key=value or key; repeatable, AND logic)
 
 ### Example Usage
 
@@ -25,6 +26,8 @@ This command retrieves all Virtual Cross Connects (VXCs) associated with your ac
   megaport-cli vxc list --a-end-uid port-abc123
   megaport-cli vxc list --status LIVE,CONFIGURED
   megaport-cli vxc list --include-inactive
+  megaport-cli vxc list --tag env=prod
+  megaport-cli vxc list --tag env=prod --tag team=network
 ```
 
 ## Usage
@@ -49,10 +52,11 @@ megaport-cli vxc list [flags]
 | `--b-end-uid` |  |  | Filter VXCs by B-End product UID | false |
 | `--include-inactive` |  | `false` | Include inactive VXCs in the list | false |
 | `--limit` |  | `0` | Maximum number of results to display (0 = unlimited) | false |
-| `--name` |  |  | Filter VXCs by name (partial match) | false |
-| `--name-contains` |  |  | Filter VXCs by partial name match (server-side) | false |
+| `--name` |  |  | Filter VXCs by name (case-sensitive partial match) | false |
+| `--name-contains` |  |  | Filter VXCs by name (case-sensitive partial match; takes precedence over --name) | false |
 | `--rate-limit` |  | `0` | Filter VXCs by rate limit in Mbps | false |
 | `--status` |  |  | Filter VXCs by status (comma-separated, e.g. LIVE,CONFIGURED) | false |
+| `--tag` |  | `[]` | Filter by resource tag (format: key=value or key; repeatable, AND logic) | false |
 
 ## Subcommands
 * [docs](megaport-cli_vxc_list_docs.md)

--- a/docs/megaport-cli_vxc_update-tags.md
+++ b/docs/megaport-cli_vxc_update-tags.md
@@ -20,6 +20,8 @@ megaport-cli vxc update-tags [flags]
 
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
+| `--force` |  | `false` | Skip the confirmation prompt | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |

--- a/docs/megaport-cli_vxc_update.md
+++ b/docs/megaport-cli_vxc_update.md
@@ -9,14 +9,14 @@ Update an existing Virtual Cross Connect (VXC) through the Megaport API.
 This command allows you to update an existing VXC by providing the necessary details.
 
 ### Optional Fields
-  - `a-end-inner-vlan`: New inner VLAN for A-End (-1 or higher, only for QinQ)
+  - `a-end-inner-vlan`: New inner VLAN for A-End (0=none, -1=untagged, 2-4094 for specific VLAN (1 is reserved), only for QinQ)
   - `a-end-partner-config`: JSON string with A-End VRouter partner configuration
   - `a-end-uid`: New A-End product UID
-  - `a-end-vlan`: New VLAN for A-End (2-4093, except 4090)
-  - `b-end-inner-vlan`: New inner VLAN for B-End (-1 or higher, only for QinQ)
+  - `a-end-vlan`: New VLAN for A-End (0=auto-assign, -1=untagged, 2-4094 for specific VLAN (1 is reserved))
+  - `b-end-inner-vlan`: New inner VLAN for B-End (0=none, -1=untagged, 2-4094 for specific VLAN (1 is reserved), only for QinQ)
   - `b-end-partner-config`: JSON string with B-End VRouter partner configuration
   - `b-end-uid`: New B-End product UID
-  - `b-end-vlan`: New VLAN for B-End (2-4093, except 4090)
+  - `b-end-vlan`: New VLAN for B-End (0=auto-assign, -1=untagged, 2-4094 for specific VLAN (1 is reserved))
   - `cost-centre`: New cost centre for billing
   - `name`: New name for the VXC (1-64 characters)
   - `rate-limit`: New bandwidth in Mbps (50 - 10000)
@@ -66,17 +66,18 @@ megaport-cli vxc update [flags]
 
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
-| `--a-end-inner-vlan` |  | `0` | Inner VLAN for A-End (-1 or higher) | false |
+| `--a-end-inner-vlan` |  | `0` | Inner VLAN for A-End (0=none, -1=untagged, 2-4094 for specific VLAN (1 is reserved)) | false |
 | `--a-end-partner-config` |  |  | JSON string with A-End partner configuration | false |
 | `--a-end-uid` |  |  | UID of the A-End product | false |
-| `--a-end-vlan` |  | `0` | VLAN for A-End (0-4093, except 1) | false |
+| `--a-end-vlan` |  | `0` | VLAN for A-End (0=auto-assign, -1=untagged, 2-4094 for specific VLAN (1 is reserved)) | false |
 | `--a-vnic-index` |  | `-1` | New A-End vNIC index when moving a VXC on an MVE | false |
-| `--b-end-inner-vlan` |  | `0` | Inner VLAN for B-End (-1 or higher) | false |
+| `--b-end-inner-vlan` |  | `0` | Inner VLAN for B-End (0=none, -1=untagged, 2-4094 for specific VLAN (1 is reserved)) | false |
 | `--b-end-partner-config` |  |  | JSON string with B-End partner configuration | false |
 | `--b-end-uid` |  |  | UID of the B-End product | false |
-| `--b-end-vlan` |  | `0` | VLAN for B-End (0-4093, except 1) | false |
+| `--b-end-vlan` |  | `0` | VLAN for B-End (0=auto-assign, -1=untagged, 2-4094 for specific VLAN (1 is reserved)) | false |
 | `--b-vnic-index` |  | `-1` | New B-End vNIC index when moving a VXC on an MVE | false |
 | `--cost-centre` |  |  | Cost centre for billing | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
 | `--interactive` |  | `false` | Use interactive mode | false |
 | `--is-approved` |  | `false` | Approve or reject a VXC via the Megaport Marketplace | false |
 | `--json` |  |  | JSON string containing configuration | false |

--- a/docs/megaport-cli_vxc_validate.md
+++ b/docs/megaport-cli_vxc_validate.md
@@ -42,15 +42,15 @@ megaport-cli vxc validate [flags]
 
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
-| `--a-end-inner-vlan` |  | `0` | Inner VLAN for A-End (-1 or higher) | false |
+| `--a-end-inner-vlan` |  | `0` | Inner VLAN for A-End (0=none, -1=untagged, 2-4094 for specific VLAN (1 is reserved)) | false |
 | `--a-end-partner-config` |  |  | JSON string with A-End partner configuration | false |
 | `--a-end-uid` |  |  | UID of the A-End product | true |
-| `--a-end-vlan` |  | `0` | VLAN for A-End (0-4093, except 1) | false |
+| `--a-end-vlan` |  | `0` | VLAN for A-End (0=auto-assign, -1=untagged, 2-4094 for specific VLAN (1 is reserved)) | false |
 | `--a-end-vnic-index` |  | `0` | vNIC index for A-End MVE | false |
-| `--b-end-inner-vlan` |  | `0` | Inner VLAN for B-End (-1 or higher) | false |
+| `--b-end-inner-vlan` |  | `0` | Inner VLAN for B-End (0=none, -1=untagged, 2-4094 for specific VLAN (1 is reserved)) | false |
 | `--b-end-partner-config` |  |  | JSON string with B-End partner configuration | false |
 | `--b-end-uid` |  |  | UID of the B-End product | false |
-| `--b-end-vlan` |  | `0` | VLAN for B-End (0-4093, except 1) | false |
+| `--b-end-vlan` |  | `0` | VLAN for B-End (0=auto-assign, -1=untagged, 2-4094 for specific VLAN (1 is reserved)) | false |
 | `--b-end-vnic-index` |  | `0` | vNIC index for B-End MVE | false |
 | `--cost-centre` |  |  | Cost centre for billing | false |
 | `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |

--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -20,7 +20,7 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 			"2. Environment variables (MEGAPORT_ACCESS_KEY, MEGAPORT_SECRET_KEY, etc.)\n" +
 			"3. Active profile in config file\n" +
 			"4. Default settings in config file (lowest precedence)").
-		WithExample("megaport-cli config create-profile production --access-key xxx --secret-key xxx --environment production").
+		WithExample("megaport-cli config create-profile production --environment production").
 		WithExample("megaport-cli config use-profile production").
 		WithImportantNote("Configuration contains sensitive credentials - ensure ~/.megaport directory has appropriate permissions").
 		WithImportantNote("Environment variables (MEGAPORT_ACCESS_KEY, MEGAPORT_SECRET_KEY) take precedence over stored profiles").
@@ -33,30 +33,34 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithLongDesc("Create a new profile with Megaport API credentials and environment settings.\n\n"+
 			"Profiles store your Megaport API access and secret keys along with environment settings for secure reuse. "+
 			"The profile name is case-sensitive and must be unique.\n\n"+
-			"Credentials are stored in ~/.megaport/config.json with secure file permissions.").
-		WithFlag("access-key", "", "Megaport API access key from the Megaport Portal").
-		WithRequiredFlag("access-key", "Megaport API access key from the Megaport Portal").
-		WithFlag("secret-key", "", "Megaport API secret key from the Megaport Portal").
-		WithRequiredFlag("secret-key", "Megaport API secret key from the Megaport Portal").
+			"Credentials are stored in ~/.megaport/config.json with secure file permissions.\n\n"+
+			"If --access-key or --secret-key are not provided, you will be prompted securely (input is not echoed).").
+		WithFlag("access-key", "", "Megaport API access key (omit to be prompted securely)").
+		WithFlag("secret-key", "", "Megaport API secret key (omit to be prompted securely)").
 		WithFlag("environment", "production", "Target API environment: 'production', 'staging', or 'development'").
 		WithFlag("description", "", "Optional description for this profile").
-		WithExample("megaport-cli config create-profile production --access-key xxx --secret-key xxx --environment production --description \"Production credentials\"").
-		WithExample("megaport-cli config create-profile staging --access-key yyy --secret-key yyy --environment staging").
+		WithExample("megaport-cli config create-profile production --environment production").
+		WithExample("megaport-cli config create-profile staging --environment staging --description \"Staging credentials\"").
 		WithImportantNote("API credentials are stored with 0600 permissions (readable only by the current user)").
+		WithImportantNote("Passing --access-key or --secret-key on the command line exposes credentials in shell history and process listings. Omit them to be prompted securely, or use env vars MEGAPORT_ACCESS_KEY / MEGAPORT_SECRET_KEY instead.").
 		WithRootCmd(rootCmd).
 		Build()
 
 	updateProfileCmd := cmdbuilder.NewCommand("update-profile", "Update an existing profile").
 		WithArgs(cobra.ExactArgs(1)).
 		WithColorAwareRunFunc(UpdateProfile).
-		WithLongDesc("Update an existing profile with new credentials or settings.").
-		WithFlag("access-key", "", "Megaport API access key").
-		WithFlag("secret-key", "", "Megaport API secret key").
+		WithLongDesc("Update an existing profile with new credentials or settings.\n\n"+
+			"To update credentials without exposing them in shell history, pass an empty value "+
+			"(e.g. --secret-key \"\") and you will be prompted securely. "+
+			"Alternatively, use env vars MEGAPORT_ACCESS_KEY / MEGAPORT_SECRET_KEY which always take precedence over stored profiles.").
+		WithFlag("access-key", "", "New Megaport API access key (pass empty string to be prompted securely)").
+		WithFlag("secret-key", "", "New Megaport API secret key (pass empty string to be prompted securely)").
 		WithFlag("environment", "", "Target API environment: 'production', 'staging', or 'development'").
 		WithFlag("description", "", "Profile description (use empty string to clear)").
-		WithExample("megaport-cli config update-profile myprofile --access-key xxx --secret-key xxx").
 		WithExample("megaport-cli config update-profile myprofile --environment staging").
+		WithExample("megaport-cli config update-profile myprofile --secret-key \"\"").
 		WithImportantNote("Keep your Megaport API credentials secure; they provide full account access").
+		WithImportantNote("Passing --access-key or --secret-key on the command line exposes credentials in shell history and process listings. Pass an empty value to be prompted securely instead.").
 		WithRootCmd(rootCmd).
 		Build()
 

--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -42,7 +42,7 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithExample("megaport-cli config create-profile production --environment production").
 		WithExample("megaport-cli config create-profile staging --environment staging --description \"Staging credentials\"").
 		WithImportantNote("API credentials are stored with 0600 permissions (readable only by the current user)").
-		WithImportantNote("Passing --access-key or --secret-key on the command line exposes credentials in shell history and process listings. Omit them to be prompted securely, or use env vars MEGAPORT_ACCESS_KEY / MEGAPORT_SECRET_KEY instead.").
+		WithImportantNote("Passing --access-key or --secret-key on the command line exposes credentials in shell history and process listings. Omit them to be prompted securely, or use env vars MEGAPORT_ACCESS_KEY / MEGAPORT_SECRET_KEY instead. Note: the secure prompt masks input only on an interactive terminal; piped input is read without masking.").
 		WithRootCmd(rootCmd).
 		Build()
 
@@ -50,8 +50,8 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithArgs(cobra.ExactArgs(1)).
 		WithColorAwareRunFunc(UpdateProfile).
 		WithLongDesc("Update an existing profile with new credentials or settings.\n\n"+
-			"To update credentials without exposing them in shell history, pass an empty value "+
-			"(e.g. --secret-key \"\") and you will be prompted securely. "+
+			"To avoid recording the secret value in shell history, pass an empty string "+
+			"(e.g. --secret-key \"\") and you will be prompted securely instead of providing the value on the command line. "+
 			"Alternatively, use env vars MEGAPORT_ACCESS_KEY / MEGAPORT_SECRET_KEY which always take precedence over stored profiles.").
 		WithFlag("access-key", "", "New Megaport API access key (pass empty string to be prompted securely)").
 		WithFlag("secret-key", "", "New Megaport API secret key (pass empty string to be prompted securely)").

--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -62,7 +62,7 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithExample("megaport-cli config update-profile myprofile --environment staging").
 		WithExample("megaport-cli config update-profile myprofile --secret-key \"\"").
 		WithImportantNote("Keep your Megaport API credentials secure; they provide full account access").
-		WithImportantNote("Passing --access-key or --secret-key on the command line exposes credentials in shell history and process listings. Pass an empty value to be prompted instead (masked on a TTY; echoed on piped/non-TTY stdin).").
+		WithImportantNote("Passing --access-key or --secret-key on the command line exposes credentials in shell history and process listings. Pass an empty value to be prompted instead (masked on a TTY; read without masking on piped/non-TTY stdin).").
 		WithRootCmd(rootCmd).
 		Build()
 

--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -36,8 +36,8 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 			"Credentials are stored in ~/.megaport/config.json with secure file permissions.\n\n"+
 			"If --access-key or --secret-key are not provided, you will be prompted. "+
 			"On an interactive terminal input is masked; on piped/non-TTY stdin it is read without masking.").
-		WithFlag("access-key", "", "Megaport API access key (omit to be prompted securely)").
-		WithFlag("secret-key", "", "Megaport API secret key (omit to be prompted securely)").
+		WithFlag("access-key", "", "Megaport API access key (omit to be prompted; masked on TTY only)").
+		WithFlag("secret-key", "", "Megaport API secret key (omit to be prompted; masked on TTY only)").
 		WithFlag("environment", "production", "Target API environment: 'production', 'staging', or 'development'").
 		WithFlag("description", "", "Optional description for this profile").
 		WithExample("megaport-cli config create-profile production --environment production").
@@ -55,8 +55,8 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 			"(e.g. --secret-key \"\") and you will be prompted instead of providing the value on the command line. "+
 			"On an interactive terminal input is masked; on piped/non-TTY stdin it is read without masking. "+
 			"Alternatively, use env vars MEGAPORT_ACCESS_KEY / MEGAPORT_SECRET_KEY which always take precedence over stored profiles.").
-		WithFlag("access-key", "", "New Megaport API access key (pass empty string to be prompted securely)").
-		WithFlag("secret-key", "", "New Megaport API secret key (pass empty string to be prompted securely)").
+		WithFlag("access-key", "", "New Megaport API access key (pass empty string to be prompted; masked on TTY only)").
+		WithFlag("secret-key", "", "New Megaport API secret key (pass empty string to be prompted; masked on TTY only)").
 		WithFlag("environment", "", "Target API environment: 'production', 'staging', or 'development'").
 		WithFlag("description", "", "Profile description (use empty string to clear)").
 		WithExample("megaport-cli config update-profile myprofile --environment staging").

--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -51,7 +51,8 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithColorAwareRunFunc(UpdateProfile).
 		WithLongDesc("Update an existing profile with new credentials or settings.\n\n"+
 			"To avoid recording the secret value in shell history, pass an empty string "+
-			"(e.g. --secret-key \"\") and you will be prompted securely instead of providing the value on the command line. "+
+			"(e.g. --secret-key \"\") and you will be prompted instead of providing the value on the command line. "+
+			"On an interactive terminal input is masked; on piped/non-TTY stdin it is read without masking. "+
 			"Alternatively, use env vars MEGAPORT_ACCESS_KEY / MEGAPORT_SECRET_KEY which always take precedence over stored profiles.").
 		WithFlag("access-key", "", "New Megaport API access key (pass empty string to be prompted securely)").
 		WithFlag("secret-key", "", "New Megaport API secret key (pass empty string to be prompted securely)").
@@ -60,7 +61,7 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithExample("megaport-cli config update-profile myprofile --environment staging").
 		WithExample("megaport-cli config update-profile myprofile --secret-key \"\"").
 		WithImportantNote("Keep your Megaport API credentials secure; they provide full account access").
-		WithImportantNote("Passing --access-key or --secret-key on the command line exposes credentials in shell history and process listings. Pass an empty value to be prompted securely instead.").
+		WithImportantNote("Passing --access-key or --secret-key on the command line exposes credentials in shell history and process listings. Pass an empty value to be prompted instead (masked on a TTY; echoed on piped/non-TTY stdin).").
 		WithRootCmd(rootCmd).
 		Build()
 

--- a/internal/commands/config/config.go
+++ b/internal/commands/config/config.go
@@ -34,7 +34,8 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 			"Profiles store your Megaport API access and secret keys along with environment settings for secure reuse. "+
 			"The profile name is case-sensitive and must be unique.\n\n"+
 			"Credentials are stored in ~/.megaport/config.json with secure file permissions.\n\n"+
-			"If --access-key or --secret-key are not provided, you will be prompted securely (input is not echoed).").
+			"If --access-key or --secret-key are not provided, you will be prompted. "+
+			"On an interactive terminal input is masked; on piped/non-TTY stdin it is read without masking.").
 		WithFlag("access-key", "", "Megaport API access key (omit to be prompted securely)").
 		WithFlag("secret-key", "", "Megaport API secret key (omit to be prompted securely)").
 		WithFlag("environment", "production", "Target API environment: 'production', 'staging', or 'development'").

--- a/internal/commands/config/config.md
+++ b/internal/commands/config/config.md
@@ -66,8 +66,10 @@ Settings are applied in the following order (highest to lowest precedence):
 Profiles store API credentials and environment settings for convenient reuse. Create them with:
 
 ```
-megaport-cli config create-profile myprofile --access-key xxx --secret-key xxx --environment production
+megaport-cli config create-profile myprofile --environment production
 ```
+
+Omit `--access-key` and `--secret-key` to be prompted instead of passing secrets on the command line (input is masked on an interactive terminal).
 
 ### Switching Profiles
 
@@ -82,8 +84,11 @@ megaport-cli config use-profile myprofile
 Update an existing profile with:
 
 ```
-megaport-cli config update-profile myprofile --access-key xxx --environment staging
+megaport-cli config update-profile myprofile --environment staging
+megaport-cli config update-profile myprofile --secret-key ""
 ```
+
+Pass an empty string for a key flag (e.g. `--secret-key ""`) to be prompted instead of providing the value on the command line.
 
 Only specified fields will be updated, others remain unchanged.
 

--- a/internal/commands/config/config.md
+++ b/internal/commands/config/config.md
@@ -69,7 +69,7 @@ Profiles store API credentials and environment settings for convenient reuse. Cr
 megaport-cli config create-profile myprofile --environment production
 ```
 
-Omit `--access-key` and `--secret-key` to be prompted instead of passing secrets on the command line (input is masked on an interactive terminal).
+Omit `--access-key` and `--secret-key` to be prompted instead of passing secrets on the command line. Input is masked on an interactive terminal; on piped/non-TTY stdin it is read without masking.
 
 ### Switching Profiles
 
@@ -88,7 +88,7 @@ megaport-cli config update-profile myprofile --environment staging
 megaport-cli config update-profile myprofile --secret-key ""
 ```
 
-Pass an empty string for a key flag (e.g. `--secret-key ""`) to be prompted instead of providing the value on the command line.
+Pass an empty string for a key flag (e.g. `--secret-key ""`) to be prompted instead of providing the value on the command line. Input is masked on an interactive terminal; on piped/non-TTY stdin it is read without masking.
 
 Only specified fields will be updated, others remain unchanged.
 

--- a/internal/commands/config/config_actions.go
+++ b/internal/commands/config/config_actions.go
@@ -90,10 +90,9 @@ func UpdateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 	if accessKeyChanged {
 		accessKey, _ = cmd.Flags().GetString("access-key")
 		if accessKey == "" {
-			var promptErr error
-			accessKey, promptErr = utils.SecretResourcePrompt("config", "Enter new Megaport API access key: ", noColor)
-			if promptErr != nil {
-				return promptErr
+			accessKey, err = utils.SecretResourcePrompt("config", "Enter new Megaport API access key: ", noColor)
+			if err != nil {
+				return err
 			}
 			if accessKey == "" {
 				return fmt.Errorf("access key cannot be empty")
@@ -105,10 +104,9 @@ func UpdateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 	if secretKeyChanged {
 		secretKey, _ = cmd.Flags().GetString("secret-key")
 		if secretKey == "" {
-			var promptErr error
-			secretKey, promptErr = utils.SecretResourcePrompt("config", "Enter new Megaport API secret key: ", noColor)
-			if promptErr != nil {
-				return promptErr
+			secretKey, err = utils.SecretResourcePrompt("config", "Enter new Megaport API secret key: ", noColor)
+			if err != nil {
+				return err
 			}
 			if secretKey == "" {
 				return fmt.Errorf("secret key cannot be empty")

--- a/internal/commands/config/config_actions.go
+++ b/internal/commands/config/config_actions.go
@@ -35,6 +35,27 @@ func CreateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 	environment, _ := cmd.Flags().GetString("environment")
 	description, _ := cmd.Flags().GetString("description")
 
+	var err error
+	if accessKey == "" {
+		accessKey, err = utils.SecretResourcePrompt("config", "Enter Megaport API access key: ", noColor)
+		if err != nil {
+			return err
+		}
+	}
+	if secretKey == "" {
+		secretKey, err = utils.SecretResourcePrompt("config", "Enter Megaport API secret key: ", noColor)
+		if err != nil {
+			return err
+		}
+	}
+
+	if accessKey == "" {
+		return fmt.Errorf("access key is required")
+	}
+	if secretKey == "" {
+		return fmt.Errorf("secret key is required")
+	}
+
 	if environment != "production" && environment != "staging" && environment != "development" {
 		return fmt.Errorf("environment must be 'production', 'staging', or 'development'")
 	}
@@ -68,11 +89,31 @@ func UpdateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 	accessKey := ""
 	if accessKeyChanged {
 		accessKey, _ = cmd.Flags().GetString("access-key")
+		if accessKey == "" {
+			var promptErr error
+			accessKey, promptErr = utils.SecretResourcePrompt("config", "Enter new Megaport API access key: ", noColor)
+			if promptErr != nil {
+				return promptErr
+			}
+			if accessKey == "" {
+				return fmt.Errorf("access key cannot be empty")
+			}
+		}
 	}
 
 	secretKey := ""
 	if secretKeyChanged {
 		secretKey, _ = cmd.Flags().GetString("secret-key")
+		if secretKey == "" {
+			var promptErr error
+			secretKey, promptErr = utils.SecretResourcePrompt("config", "Enter new Megaport API secret key: ", noColor)
+			if promptErr != nil {
+				return promptErr
+			}
+			if secretKey == "" {
+				return fmt.Errorf("secret key cannot be empty")
+			}
+		}
 	}
 
 	environment := ""

--- a/internal/commands/config/config_actions.go
+++ b/internal/commands/config/config_actions.go
@@ -56,23 +56,27 @@ func CreateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 		return fmt.Errorf("profile '%s' already exists", profileName)
 	}
 
+	accessKey = strings.TrimSpace(accessKey)
 	if accessKey == "" {
 		accessKey, err = utils.SecretResourcePrompt("config", "Enter Megaport API access key: ", noColor)
 		if err != nil {
 			return fmt.Errorf("failed to read access key: %w", err)
 		}
-		if accessKey == "" {
+		if strings.TrimSpace(accessKey) == "" {
 			return fmt.Errorf("access key is required")
 		}
+		accessKey = strings.TrimSpace(accessKey)
 	}
+	secretKey = strings.TrimSpace(secretKey)
 	if secretKey == "" {
 		secretKey, err = utils.SecretResourcePrompt("config", "Enter Megaport API secret key: ", noColor)
 		if err != nil {
 			return fmt.Errorf("failed to read secret key: %w", err)
 		}
-		if secretKey == "" {
+		if strings.TrimSpace(secretKey) == "" {
 			return fmt.Errorf("secret key is required")
 		}
+		secretKey = strings.TrimSpace(secretKey)
 	}
 
 	if err := manager.CreateProfile(profileName, accessKey, secretKey, environment, description); err != nil {
@@ -107,28 +111,32 @@ func UpdateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 	accessKey := ""
 	if accessKeyChanged {
 		accessKey, _ = cmd.Flags().GetString("access-key")
+		accessKey = strings.TrimSpace(accessKey)
 		if accessKey == "" {
 			accessKey, err = utils.SecretResourcePrompt("config", "Enter new Megaport API access key: ", noColor)
 			if err != nil {
 				return fmt.Errorf("failed to read access key: %w", err)
 			}
-			if accessKey == "" {
+			if strings.TrimSpace(accessKey) == "" {
 				return fmt.Errorf("access key cannot be empty")
 			}
+			accessKey = strings.TrimSpace(accessKey)
 		}
 	}
 
 	secretKey := ""
 	if secretKeyChanged {
 		secretKey, _ = cmd.Flags().GetString("secret-key")
+		secretKey = strings.TrimSpace(secretKey)
 		if secretKey == "" {
 			secretKey, err = utils.SecretResourcePrompt("config", "Enter new Megaport API secret key: ", noColor)
 			if err != nil {
 				return fmt.Errorf("failed to read secret key: %w", err)
 			}
-			if secretKey == "" {
+			if strings.TrimSpace(secretKey) == "" {
 				return fmt.Errorf("secret key cannot be empty")
 			}
+			secretKey = strings.TrimSpace(secretKey)
 		}
 	}
 

--- a/internal/commands/config/config_actions.go
+++ b/internal/commands/config/config_actions.go
@@ -35,6 +35,10 @@ func CreateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 	environment, _ := cmd.Flags().GetString("environment")
 	description, _ := cmd.Flags().GetString("description")
 
+	if environment != "production" && environment != "staging" && environment != "development" {
+		return fmt.Errorf("environment must be 'production', 'staging', or 'development'")
+	}
+
 	var err error
 	if accessKey == "" {
 		accessKey, err = utils.SecretResourcePrompt("config", "Enter Megaport API access key: ", noColor)
@@ -53,10 +57,6 @@ func CreateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 		if secretKey == "" {
 			return fmt.Errorf("secret key is required")
 		}
-	}
-
-	if environment != "production" && environment != "staging" && environment != "development" {
-		return fmt.Errorf("environment must be 'production', 'staging', or 'development'")
 	}
 
 	manager, err := NewConfigManager()
@@ -78,6 +78,14 @@ func UpdateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 	manager, err := NewConfigManager()
 	if err != nil {
 		return err
+	}
+
+	profiles, err := manager.ListProfiles()
+	if err != nil {
+		return err
+	}
+	if _, exists := profiles[profileName]; !exists {
+		return fmt.Errorf("profile '%s' not found", profileName)
 	}
 
 	accessKeyChanged := cmd.Flags().Changed("access-key")

--- a/internal/commands/config/config_actions.go
+++ b/internal/commands/config/config_actions.go
@@ -39,13 +39,13 @@ func CreateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 	if accessKey == "" {
 		accessKey, err = utils.SecretResourcePrompt("config", "Enter Megaport API access key: ", noColor)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to read access key: %w", err)
 		}
 	}
 	if secretKey == "" {
 		secretKey, err = utils.SecretResourcePrompt("config", "Enter Megaport API secret key: ", noColor)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to read secret key: %w", err)
 		}
 	}
 
@@ -92,7 +92,7 @@ func UpdateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 		if accessKey == "" {
 			accessKey, err = utils.SecretResourcePrompt("config", "Enter new Megaport API access key: ", noColor)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to read access key: %w", err)
 			}
 			if accessKey == "" {
 				return fmt.Errorf("access key cannot be empty")
@@ -106,7 +106,7 @@ func UpdateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 		if secretKey == "" {
 			secretKey, err = utils.SecretResourcePrompt("config", "Enter new Megaport API secret key: ", noColor)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to read secret key: %w", err)
 			}
 			if secretKey == "" {
 				return fmt.Errorf("secret key cannot be empty")

--- a/internal/commands/config/config_actions.go
+++ b/internal/commands/config/config_actions.go
@@ -35,6 +35,10 @@ func CreateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 	environment, _ := cmd.Flags().GetString("environment")
 	description, _ := cmd.Flags().GetString("description")
 
+	if strings.TrimSpace(profileName) == "" {
+		return fmt.Errorf("profile name cannot be empty or whitespace")
+	}
+
 	if environment != "production" && environment != "staging" && environment != "development" {
 		return fmt.Errorf("environment must be 'production', 'staging', or 'development'")
 	}

--- a/internal/commands/config/config_actions.go
+++ b/internal/commands/config/config_actions.go
@@ -39,7 +39,19 @@ func CreateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 		return fmt.Errorf("environment must be 'production', 'staging', or 'development'")
 	}
 
-	var err error
+	manager, err := NewConfigManager()
+	if err != nil {
+		return err
+	}
+
+	existingProfiles, err := manager.ListProfiles()
+	if err != nil {
+		return err
+	}
+	if _, exists := existingProfiles[profileName]; exists {
+		return fmt.Errorf("profile '%s' already exists", profileName)
+	}
+
 	if accessKey == "" {
 		accessKey, err = utils.SecretResourcePrompt("config", "Enter Megaport API access key: ", noColor)
 		if err != nil {
@@ -57,11 +69,6 @@ func CreateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 		if secretKey == "" {
 			return fmt.Errorf("secret key is required")
 		}
-	}
-
-	manager, err := NewConfigManager()
-	if err != nil {
-		return err
 	}
 
 	if err := manager.CreateProfile(profileName, accessKey, secretKey, environment, description); err != nil {

--- a/internal/commands/config/config_actions.go
+++ b/internal/commands/config/config_actions.go
@@ -41,19 +41,18 @@ func CreateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 		if err != nil {
 			return fmt.Errorf("failed to read access key: %w", err)
 		}
+		if accessKey == "" {
+			return fmt.Errorf("access key is required")
+		}
 	}
 	if secretKey == "" {
 		secretKey, err = utils.SecretResourcePrompt("config", "Enter Megaport API secret key: ", noColor)
 		if err != nil {
 			return fmt.Errorf("failed to read secret key: %w", err)
 		}
-	}
-
-	if accessKey == "" {
-		return fmt.Errorf("access key is required")
-	}
-	if secretKey == "" {
-		return fmt.Errorf("secret key is required")
+		if secretKey == "" {
+			return fmt.Errorf("secret key is required")
+		}
 	}
 
 	if environment != "production" && environment != "staging" && environment != "development" {

--- a/internal/commands/config/config_actions_test.go
+++ b/internal/commands/config/config_actions_test.go
@@ -935,7 +935,7 @@ func TestCreateProfile_FlagValueSkipsPrompt(t *testing.T) {
 	assert.Equal(t, "flag-secret", profiles["flag-profile"].SecretKey)
 }
 
-func TestCreateProfile_EmptyPromptReturnsError(t *testing.T) {
+func TestCreateProfile_EmptyAccessKeyPromptReturnsError(t *testing.T) {
 	setupTestConfigEnv(t)
 
 	orig := utils.GetSecretResourcePrompt()
@@ -955,6 +955,33 @@ func TestCreateProfile_EmptyPromptReturnsError(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "access key is required")
+}
+
+func TestCreateProfile_EmptySecretKeyPromptReturnsError(t *testing.T) {
+	setupTestConfigEnv(t)
+
+	orig := utils.GetSecretResourcePrompt()
+	defer utils.SetSecretResourcePrompt(orig)
+
+	calls := []string{"some-access-key", ""}
+	i := 0
+	utils.SetSecretResourcePrompt(func(_, _ string, _ bool) (string, error) {
+		v := calls[i]
+		i++
+		return v, nil
+	})
+
+	cmd, _ := setupTestCmd()
+	cmd.Flags().String("access-key", "", "")
+	cmd.Flags().String("secret-key", "", "")
+	cmd.Flags().String("environment", "production", "")
+	cmd.Flags().String("description", "", "")
+
+	_, err := captureOutputFromAction(func() error {
+		return CreateProfile(cmd, []string{"empty-secret-profile"}, false)
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret key is required")
 }
 
 func TestUpdateProfile_EmptyFlagTriggersPrompt(t *testing.T) {

--- a/internal/commands/config/config_actions_test.go
+++ b/internal/commands/config/config_actions_test.go
@@ -879,6 +879,9 @@ func TestCreateProfile_InteractivePrompt(t *testing.T) {
 	calls := []string{"prompted-access-key", "prompted-secret-key"}
 	i := 0
 	utils.SetSecretResourcePrompt(func(_, _ string, _ bool) (string, error) {
+		if i >= len(calls) {
+			t.Fatalf("unexpected extra prompt call %d (expected at most %d)", i+1, len(calls))
+		}
 		v := calls[i]
 		i++
 		return v, nil
@@ -966,6 +969,9 @@ func TestCreateProfile_EmptySecretKeyPromptReturnsError(t *testing.T) {
 	calls := []string{"some-access-key", ""}
 	i := 0
 	utils.SetSecretResourcePrompt(func(_, _ string, _ bool) (string, error) {
+		if i >= len(calls) {
+			t.Fatalf("unexpected extra prompt call %d (expected at most %d)", i+1, len(calls))
+		}
 		v := calls[i]
 		i++
 		return v, nil

--- a/internal/commands/config/config_actions_test.go
+++ b/internal/commands/config/config_actions_test.go
@@ -869,3 +869,125 @@ func TestImportConfig_Cancelled(t *testing.T) {
 	assert.Contains(t, err.Error(), "cancelled by user")
 	assert.Contains(t, outputText, "Import cancelled")
 }
+
+func TestCreateProfile_InteractivePrompt(t *testing.T) {
+	setupTestConfigEnv(t)
+
+	orig := utils.GetSecretResourcePrompt()
+	defer utils.SetSecretResourcePrompt(orig)
+
+	calls := []string{"prompted-access-key", "prompted-secret-key"}
+	i := 0
+	utils.SetSecretResourcePrompt(func(_, _ string, _ bool) (string, error) {
+		v := calls[i]
+		i++
+		return v, nil
+	})
+
+	cmd, _ := setupTestCmd()
+	cmd.Flags().String("access-key", "", "")
+	cmd.Flags().String("secret-key", "", "")
+	cmd.Flags().String("environment", "production", "")
+	cmd.Flags().String("description", "", "")
+
+	outputText, err := captureOutputFromAction(func() error {
+		return CreateProfile(cmd, []string{"prompted-profile"}, false)
+	})
+	require.NoError(t, err)
+	assert.Contains(t, outputText, "Profile 'prompted-profile' created successfully")
+
+	manager, err := NewConfigManager()
+	require.NoError(t, err)
+	profiles, err := manager.ListProfiles()
+	require.NoError(t, err)
+	assert.Equal(t, "prompted-access-key", profiles["prompted-profile"].AccessKey)
+	assert.Equal(t, "prompted-secret-key", profiles["prompted-profile"].SecretKey)
+}
+
+func TestCreateProfile_FlagValueSkipsPrompt(t *testing.T) {
+	setupTestConfigEnv(t)
+
+	orig := utils.GetSecretResourcePrompt()
+	defer utils.SetSecretResourcePrompt(orig)
+	utils.SetSecretResourcePrompt(func(_, _ string, _ bool) (string, error) {
+		t.Fatal("prompt should not be called when flags are provided")
+		return "", nil
+	})
+
+	cmd, _ := setupTestCmd()
+	cmd.Flags().String("access-key", "", "")
+	cmd.Flags().String("secret-key", "", "")
+	cmd.Flags().String("environment", "production", "")
+	cmd.Flags().String("description", "", "")
+	require.NoError(t, cmd.ParseFlags([]string{"--access-key=flag-access", "--secret-key=flag-secret"}))
+
+	outputText, err := captureOutputFromAction(func() error {
+		return CreateProfile(cmd, []string{"flag-profile"}, false)
+	})
+	require.NoError(t, err)
+	assert.Contains(t, outputText, "Profile 'flag-profile' created successfully")
+
+	manager, err := NewConfigManager()
+	require.NoError(t, err)
+	profiles, err := manager.ListProfiles()
+	require.NoError(t, err)
+	assert.Equal(t, "flag-access", profiles["flag-profile"].AccessKey)
+	assert.Equal(t, "flag-secret", profiles["flag-profile"].SecretKey)
+}
+
+func TestCreateProfile_EmptyPromptReturnsError(t *testing.T) {
+	setupTestConfigEnv(t)
+
+	orig := utils.GetSecretResourcePrompt()
+	defer utils.SetSecretResourcePrompt(orig)
+	utils.SetSecretResourcePrompt(func(_, _ string, _ bool) (string, error) {
+		return "", nil // simulate user pressing enter with nothing
+	})
+
+	cmd, _ := setupTestCmd()
+	cmd.Flags().String("access-key", "", "")
+	cmd.Flags().String("secret-key", "", "")
+	cmd.Flags().String("environment", "production", "")
+	cmd.Flags().String("description", "", "")
+
+	_, err := captureOutputFromAction(func() error {
+		return CreateProfile(cmd, []string{"empty-profile"}, false)
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "access key is required")
+}
+
+func TestUpdateProfile_EmptyFlagTriggersPrompt(t *testing.T) {
+	setupTestConfigEnv(t)
+
+	manager, err := NewConfigManager()
+	require.NoError(t, err)
+	require.NoError(t, manager.CreateProfile("update-test", "old-access", "old-secret", "production", ""))
+
+	orig := utils.GetSecretResourcePrompt()
+	defer utils.SetSecretResourcePrompt(orig)
+	utils.SetSecretResourcePrompt(func(_, _ string, _ bool) (string, error) {
+		return "new-secret-from-prompt", nil
+	})
+
+	cmd, _ := setupTestCmd()
+	cmd.Flags().String("access-key", "", "")
+	cmd.Flags().String("secret-key", "", "")
+	cmd.Flags().String("environment", "", "")
+	cmd.Flags().String("description", "", "")
+	// Pass --secret-key="" to trigger the prompt path
+	require.NoError(t, cmd.ParseFlags([]string{"--secret-key="}))
+
+	outputText, err := captureOutputFromAction(func() error {
+		return UpdateProfile(cmd, []string{"update-test"}, false)
+	})
+	require.NoError(t, err)
+	assert.Contains(t, outputText, "Profile 'update-test' updated successfully")
+
+	manager, err = NewConfigManager()
+	require.NoError(t, err)
+	profiles, err := manager.ListProfiles()
+	require.NoError(t, err)
+	assert.Equal(t, "new-secret-from-prompt", profiles["update-test"].SecretKey)
+	assert.Equal(t, "old-access", profiles["update-test"].AccessKey)
+}

--- a/internal/commands/config/config_actions_test.go
+++ b/internal/commands/config/config_actions_test.go
@@ -1020,7 +1020,7 @@ func TestUpdateProfile_EmptyFlagTriggersPrompt(t *testing.T) {
 }
 
 func TestUpdateProfile_EmptyAccessKeyFlagTriggersPrompt(t *testing.T) {
-	setupTestConfig(t)
+	setupTestConfigEnv(t)
 
 	manager, err := NewConfigManager()
 	require.NoError(t, err)

--- a/internal/commands/config/config_actions_test.go
+++ b/internal/commands/config/config_actions_test.go
@@ -1018,3 +1018,38 @@ func TestUpdateProfile_EmptyFlagTriggersPrompt(t *testing.T) {
 	assert.Equal(t, "new-secret-from-prompt", profiles["update-test"].SecretKey)
 	assert.Equal(t, "old-access", profiles["update-test"].AccessKey)
 }
+
+func TestUpdateProfile_EmptyAccessKeyFlagTriggersPrompt(t *testing.T) {
+	setupTestConfig(t)
+
+	manager, err := NewConfigManager()
+	require.NoError(t, err)
+	require.NoError(t, manager.CreateProfile("update-test", "old-access", "old-secret", "production", ""))
+
+	orig := utils.GetSecretResourcePrompt()
+	defer utils.SetSecretResourcePrompt(orig)
+	utils.SetSecretResourcePrompt(func(_, _ string, _ bool) (string, error) {
+		return "new-access-from-prompt", nil
+	})
+
+	cmd, _ := setupTestCmd()
+	cmd.Flags().String("access-key", "", "")
+	cmd.Flags().String("secret-key", "", "")
+	cmd.Flags().String("environment", "", "")
+	cmd.Flags().String("description", "", "")
+	// Pass --access-key="" to trigger the prompt path
+	require.NoError(t, cmd.ParseFlags([]string{"--access-key="}))
+
+	outputText, err := captureOutputFromAction(func() error {
+		return UpdateProfile(cmd, []string{"update-test"}, false)
+	})
+	require.NoError(t, err)
+	assert.Contains(t, outputText, "Profile 'update-test' updated successfully")
+
+	manager, err = NewConfigManager()
+	require.NoError(t, err)
+	profiles, err := manager.ListProfiles()
+	require.NoError(t, err)
+	assert.Equal(t, "new-access-from-prompt", profiles["update-test"].AccessKey)
+	assert.Equal(t, "old-secret", profiles["update-test"].SecretKey)
+}

--- a/internal/commands/config/config_actions_test.go
+++ b/internal/commands/config/config_actions_test.go
@@ -523,7 +523,7 @@ func TestCreateProfile_CMD(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Create same profile again — should overwrite
+		// Creating the same profile name again should now fail fast before prompting
 		cmd2, _ := setupTestCmd()
 		cmd2.Flags().String("access-key", "", "")
 		cmd2.Flags().String("secret-key", "", "")
@@ -540,18 +540,19 @@ func TestCreateProfile_CMD(t *testing.T) {
 		_, err = captureOutputFromAction(func() error {
 			return CreateProfile(cmd2, []string{"dup-profile"}, false)
 		})
-		require.NoError(t, err)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
 
-		// Verify overwritten values
+		// Verify original profile is unchanged
 		manager, err := NewConfigManager()
 		require.NoError(t, err)
 		profiles, err := manager.ListProfiles()
 		require.NoError(t, err)
 		profile := profiles["dup-profile"]
-		assert.Equal(t, "key2", profile.AccessKey)
-		assert.Equal(t, "secret2", profile.SecretKey)
-		assert.Equal(t, "staging", profile.Environment)
-		assert.Equal(t, "Second", profile.Description)
+		assert.Equal(t, "key1", profile.AccessKey)
+		assert.Equal(t, "secret1", profile.SecretKey)
+		assert.Equal(t, "production", profile.Environment)
+		assert.Equal(t, "First", profile.Description)
 	})
 }
 


### PR DESCRIPTION
`create-profile` and `update-profile` previously required secrets as plain flags (`--access-key`, `--secret-key`), exposing them in shell history and process listings.

`create-profile` now omits `WithRequiredFlag` on both key flags and falls back to a masked interactive prompt (`SecretResourcePrompt`) when either flag is absent. `update-profile` triggers the same prompt when a key flag is explicitly set to empty (`--secret-key ""`), so credentials can be rotated without typing them on the command line. Both commands gain `ImportantNote` warnings pointing to env vars (`MEGAPORT_ACCESS_KEY` / `MEGAPORT_SECRET_KEY`) or interactive entry as the safer alternatives. Examples no longer model the inline-secret pattern.

**Notable changes**

- `config.go`: removed `WithRequiredFlag` on access/secret key for `create-profile`; updated flag descriptions, examples, and security notes on both commands
- `config_actions.go`: `CreateProfile` prompts for empty keys (validating each inline before proceeding to the next); `UpdateProfile` prompts when a key flag is changed but empty; prompt errors wrapped with context
- `config_actions_test.go`: six new tests covering interactive prompt, flag-bypass, empty key errors, and update-via-prompt for both access and secret keys; prompt stubs include bounds checks
- `config.md` / `README.md`: examples updated to the prompt-based pattern; non-TTY masking caveat added throughout
- `docs/`: full regen from updated command definitions — fixes stale examples and removes the incorrect `required=true` on the key flags; also picks up unrelated new command docs (nat-gateway, mcr looking-glass) that had not been regenerated since those commands were added