### PR TITLE
ESD-1323: Add missing XML format and VXC output test coverage

### DIFF
--- a/internal/commands/mcr/mcr_output_test.go
+++ b/internal/commands/mcr/mcr_output_test.go
@@ -14,6 +14,8 @@ func TestPrintMCRs_XML(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "<items>")
+	assert.Contains(t, out, "<uid>")
 	assert.Contains(t, out, "mcr-1")
 	assert.Contains(t, out, "MyMCROne")
 }

--- a/internal/commands/mcr/mcr_output_test.go
+++ b/internal/commands/mcr/mcr_output_test.go
@@ -8,6 +8,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestPrintMCRs_XML(t *testing.T) {
+	out := op.CaptureOutput(func() {
+		err := printMCRs(testMCRs, "xml", noColor)
+		assert.NoError(t, err)
+	})
+	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "mcr-1")
+	assert.Contains(t, out, "MyMCROne")
+}
+
 func TestToMCROutput_NilMCR(t *testing.T) {
 	_, err := toMCROutput(nil)
 	assert.Error(t, err)

--- a/internal/commands/mve/mve_output_test.go
+++ b/internal/commands/mve/mve_output_test.go
@@ -8,6 +8,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestPrintMVEs_XML(t *testing.T) {
+	out := op.CaptureOutput(func() {
+		err := printMVEs(testMVEs, "xml", noColor)
+		assert.NoError(t, err)
+	})
+	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "mve-1")
+	assert.Contains(t, out, "MyMVEOne")
+}
+
 func TestToMVEOutput_NilMVE(t *testing.T) {
 	_, err := toMVEOutput(nil)
 	assert.Error(t, err)

--- a/internal/commands/mve/mve_output_test.go
+++ b/internal/commands/mve/mve_output_test.go
@@ -14,6 +14,8 @@ func TestPrintMVEs_XML(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "<items>")
+	assert.Contains(t, out, "<uid>")
 	assert.Contains(t, out, "mve-1")
 	assert.Contains(t, out, "MyMVEOne")
 }

--- a/internal/commands/ports/ports_output_test.go
+++ b/internal/commands/ports/ports_output_test.go
@@ -14,6 +14,8 @@ func TestPrintPorts_XML(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "<items>")
+	assert.Contains(t, out, "<uid>")
 	assert.Contains(t, out, "port-1")
 	assert.Contains(t, out, "MyPortOne")
 }

--- a/internal/commands/ports/ports_output_test.go
+++ b/internal/commands/ports/ports_output_test.go
@@ -8,6 +8,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestPrintPorts_XML(t *testing.T) {
+	out := op.CaptureOutput(func() {
+		err := printPorts(testPorts, "xml", true)
+		assert.NoError(t, err)
+	})
+	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "port-1")
+	assert.Contains(t, out, "MyPortOne")
+}
+
 func TestDisplayPortChanges(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/internal/commands/servicekeys/servicekeys_output_test.go
+++ b/internal/commands/servicekeys/servicekeys_output_test.go
@@ -21,6 +21,8 @@ func TestServiceKeyOutput_XML(t *testing.T) {
 	})
 
 	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "<items>")
+	assert.Contains(t, out, "<key_uid>")
 	assert.Contains(t, out, "abcd-1234-efgh-5678")
 	assert.Contains(t, out, "Product One")
 }

--- a/internal/commands/servicekeys/servicekeys_output_test.go
+++ b/internal/commands/servicekeys/servicekeys_output_test.go
@@ -1,0 +1,26 @@
+package servicekeys
+
+import (
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServiceKeyOutput_XML(t *testing.T) {
+	outputs := make([]serviceKeyOutput, 0, len(mockServiceKeys))
+	for _, sk := range mockServiceKeys {
+		skOutput, err := toServiceKeyOutput(sk)
+		assert.NoError(t, err)
+		outputs = append(outputs, skOutput)
+	}
+
+	out := output.CaptureOutput(func() {
+		err := output.PrintOutput(outputs, "xml", false)
+		assert.NoError(t, err)
+	})
+
+	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "abcd-1234-efgh-5678")
+	assert.Contains(t, out, "Product One")
+}

--- a/internal/commands/users/users_output_test.go
+++ b/internal/commands/users/users_output_test.go
@@ -8,6 +8,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestPrintUsers_XML(t *testing.T) {
+	users := []*megaport.User{
+		{
+			PartyId:   1,
+			FirstName: "Alice",
+			LastName:  "Smith",
+			Email:     "alice@example.com",
+			Position:  "Admin",
+			Active:    true,
+		},
+	}
+
+	out := op.CaptureOutput(func() {
+		err := printUsers(users, "xml", true)
+		assert.NoError(t, err)
+	})
+	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "Alice")
+	assert.Contains(t, out, "alice@example.com")
+}
+
 func TestToUserOutput_NilUser(t *testing.T) {
 	_, err := toUserOutput(nil)
 	assert.Error(t, err)

--- a/internal/commands/users/users_output_test.go
+++ b/internal/commands/users/users_output_test.go
@@ -25,6 +25,8 @@ func TestPrintUsers_XML(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "<items>")
+	assert.Contains(t, out, "<employee_id>")
 	assert.Contains(t, out, "Alice")
 	assert.Contains(t, out, "alice@example.com")
 }

--- a/internal/commands/vxc/vxc_output_test.go
+++ b/internal/commands/vxc/vxc_output_test.go
@@ -53,4 +53,5 @@ func TestPrintVXCs_XML(t *testing.T) {
 
 	assert.NotEmpty(t, out)
 	assert.Contains(t, out, "vxc-xml-1")
+	assert.Contains(t, out, "XMLTestVXC")
 }

--- a/internal/commands/vxc/vxc_output_test.go
+++ b/internal/commands/vxc/vxc_output_test.go
@@ -1,0 +1,56 @@
+package vxc
+
+import (
+	"testing"
+
+	op "github.com/megaport/megaport-cli/internal/base/output"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToVXCOutput_Valid(t *testing.T) {
+	v := &megaport.VXC{
+		UID:       "vxc-abc",
+		Name:      "Test VXC",
+		RateLimit: 500,
+		AEndConfiguration: megaport.VXCEndConfiguration{
+			UID:  "port-a",
+			VLAN: 100,
+		},
+		BEndConfiguration: megaport.VXCEndConfiguration{
+			UID:  "port-b",
+			VLAN: 200,
+		},
+		ProvisioningStatus: "LIVE",
+	}
+
+	out, err := toVXCOutput(v)
+	assert.NoError(t, err)
+	assert.Equal(t, "vxc-abc", out.UID)
+	assert.Equal(t, "Test VXC", out.Name)
+	assert.Equal(t, 500, out.RateLimit)
+	assert.Equal(t, "port-a", out.AEndUID)
+	assert.Equal(t, "port-b", out.BEndUID)
+	assert.Equal(t, 100, out.AEndVLAN)
+	assert.Equal(t, 200, out.BEndVLAN)
+	assert.Equal(t, "LIVE", out.Status)
+}
+
+func TestPrintVXCs_XML(t *testing.T) {
+	vxcs := []*megaport.VXC{
+		{
+			UID:                "vxc-xml-1",
+			Name:               "XMLTestVXC",
+			RateLimit:          1000,
+			ProvisioningStatus: "LIVE",
+		},
+	}
+
+	out := op.CaptureOutput(func() {
+		err := printVXCs(vxcs, "xml", true)
+		assert.NoError(t, err)
+	})
+
+	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "vxc-xml-1")
+}

--- a/internal/commands/vxc/vxc_output_test.go
+++ b/internal/commands/vxc/vxc_output_test.go
@@ -52,6 +52,8 @@ func TestPrintVXCs_XML(t *testing.T) {
 	})
 
 	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "<items>")
+	assert.Contains(t, out, "<uid>")
 	assert.Contains(t, out, "vxc-xml-1")
 	assert.Contains(t, out, "XMLTestVXC")
 }


### PR DESCRIPTION
Add the unit test gaps identified in ESD-1323: VXC was the only gold-standard package without a dedicated output test file, and XML format was untested across all output packages.

- **`vxc/vxc_output_test.go`** (new): `TestToVXCOutput_Valid` covering full A/B-end field mapping with both ends configured, and `TestPrintVXCs_XML` for XML format
- **`servicekeys/servicekeys_output_test.go`** (new): `TestServiceKeyOutput_XML` — table, JSON, and CSV were already covered in `servicekeys_test.go`
- **`ports/ports_output_test.go`**: `TestPrintPorts_XML` added
- **`mve/mve_output_test.go`**: `TestPrintMVEs_XML` added
- **`mcr/mcr_output_test.go`**: `TestPrintMCRs_XML` added
- **`users/users_output_test.go`**: `TestPrintUsers_XML` added

All six packages pass `go test`. No production code changed.

Note: `servicekeys_inputs_test.go` was not created — there is no `servicekeys_inputs.go` and no separate input-building helper functions exist in the package to test.