### PR TITLE
ESD-1319: Add IX integration tests

### DIFF
--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -249,8 +249,6 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	})
 	require.True(t, ok, "could not extract port UID from output:\n%s", portOut)
 
-	require.True(t, ok, "could not extract port UID from output:\n%s", portOut)
-
 	// Buy the IX.
 	ixName := fmt.Sprintf("CLI-Test-IX-%s", generateUniqueID())
 	buyCmd := integrationBuyIXCmd()
@@ -296,8 +294,6 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 			}
 		})
 	})
-	require.True(t, ok, "could not extract IX UID from buy output:\n%s", buyOut)
-
 	require.True(t, ok, "could not extract IX UID from buy output:\n%s", buyOut)
 
 	// Verify IX fields via GetIX.

--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -21,11 +21,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func generateUniqueID() string {
+func generateUniqueID(t *testing.T) string {
+	t.Helper()
 	buf := make([]byte, 4)
-	if _, err := rand.Read(buf); err != nil {
-		panic(err)
-	}
+	_, err := rand.Read(buf)
+	require.NoError(t, err, "failed to read crypto/rand entropy")
 	return hex.EncodeToString(buf)
 }
 
@@ -213,11 +213,18 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	}
 
 	// Create the port that will serve as the A-end of the IX.
-	portName := fmt.Sprintf("CLI-Test-Port-IX-%s", generateUniqueID())
+	// Port speed must be >= rateLimit to pass IX order validation.
+	portSpeed := 1000
+	if rateLimit > 10000 {
+		portSpeed = 100000
+	} else if rateLimit > 1000 {
+		portSpeed = 10000
+	}
+	portName := fmt.Sprintf("CLI-Test-Port-IX-%s", generateUniqueID(t))
 	pCmd := integrationBuyPortCmd()
 	require.NoError(t, pCmd.Flags().Set("name", portName))
 	require.NoError(t, pCmd.Flags().Set("term", "1"))
-	require.NoError(t, pCmd.Flags().Set("port-speed", "1000"))
+	require.NoError(t, pCmd.Flags().Set("port-speed", fmt.Sprintf("%d", portSpeed)))
 	require.NoError(t, pCmd.Flags().Set("location-id", fmt.Sprintf("%d", locationID)))
 	require.NoError(t, pCmd.Flags().Set("marketplace-visibility", "false"))
 	require.NoError(t, pCmd.Flags().Set("yes", "true"))
@@ -252,7 +259,7 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	require.True(t, ok, "could not extract port UID from output:\n%s", portOut)
 
 	// Buy the IX.
-	ixName := fmt.Sprintf("CLI-Test-IX-%s", generateUniqueID())
+	ixName := fmt.Sprintf("CLI-Test-IX-%s", generateUniqueID(t))
 	buyCmd := integrationBuyIXCmd()
 	require.NoError(t, buyCmd.Flags().Set("product-uid", portUID))
 	require.NoError(t, buyCmd.Flags().Set("name", ixName))

--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -223,10 +223,13 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 
 	// Port cleanup runs last (registered first — t.Cleanup is LIFO).
 	t.Cleanup(func() {
+		output.SetOutputFormat("table")
 		delPortCmd := integrationDeletePortCmd()
 		_ = delPortCmd.Flags().Set("force", "true")
 		output.CaptureOutput(func() {
-			_ = ports.DeletePort(delPortCmd, []string{portUID}, true)
+			if err := ports.DeletePort(delPortCmd, []string{portUID}, true); err != nil {
+				t.Errorf("cleanup: failed to delete test port %s: %v", portUID, err)
+			}
 		})
 	})
 
@@ -260,10 +263,13 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 
 	// IX cleanup runs first (registered second — LIFO).
 	t.Cleanup(func() {
+		output.SetOutputFormat("table")
 		delCmd := integrationDeleteIXCmd()
 		_ = delCmd.Flags().Set("force", "true")
 		output.CaptureOutput(func() {
-			_ = DeleteIX(delCmd, []string{ixUID}, true)
+			if err := DeleteIX(delCmd, []string{ixUID}, true); err != nil {
+				t.Errorf("cleanup: failed to delete test IX %s: %v", ixUID, err)
+			}
 		})
 	})
 

--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -145,6 +145,10 @@ func TestIntegration_IXListAndGet(t *testing.T) {
 	})
 	require.NoError(t, listErr)
 
+	// JSON mode emits no output (not "[]") when the list is empty.
+	if strings.TrimSpace(listOut) == "" {
+		t.Skip("no IXs available on staging to test Get")
+	}
 	var ixs []map[string]interface{}
 	require.NoError(t, json.Unmarshal([]byte(listOut), &ixs), "ListIXs returned invalid JSON")
 	if len(ixs) == 0 {

--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -303,7 +303,8 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 		assert.Contains(t, statusList[0], "status")
 	})
 
-	// Update the IX name.
+	// Update the IX name. Force table format so CaptureOutput captures update messages.
+	output.SetOutputFormat("table")
 	updatedName := ixName + "-upd"
 	updCmd := integrationUpdateIXCmd()
 	require.NoError(t, updCmd.Flags().Set("name", updatedName))

--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/commands/ports"
 	"github.com/megaport/megaport-cli/internal/testutil"
+	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -219,7 +220,6 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	if networkServiceType == "" || locationID == 0 {
 		t.Skip("no IXP with a matching staging location found")
 	}
-	const rateLimit = 1000
 
 	// Create the port that will serve as the A-end of the IX.
 	const portSpeed = 1000
@@ -260,6 +260,30 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 		})
 	})
 	require.True(t, ok, "could not extract port UID from output:\n%s", portOut)
+
+	// Probe for a supported rate limit — each metro/IXP may only accept specific speeds,
+	// so validating before buy avoids environment-unrelated failures.
+	candidateRateLimits := []int{1000, 100, 500, 10000}
+	rateLimit := 0
+	probeCtx, probeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer probeCancel()
+	for _, candidate := range candidateRateLimits {
+		probeReq := &megaport.BuyIXRequest{
+			ProductUID:         portUID,
+			NetworkServiceType: networkServiceType,
+			ASN:                12345,
+			MACAddress:         "00:11:22:33:44:55",
+			RateLimit:          candidate,
+			VLAN:               100,
+		}
+		if err := client.IXService.ValidateIXOrder(probeCtx, probeReq); err == nil {
+			rateLimit = candidate
+			break
+		}
+	}
+	if rateLimit == 0 {
+		t.Skipf("no candidate rate limit validated for IX type %q at location %d", networkServiceType, locationID)
+	}
 
 	// Buy the IX.
 	ixName := fmt.Sprintf("CLI-Test-IX-%s", generateUniqueID(t))

--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -227,11 +227,12 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	require.NoError(t, portErr, "failed to create test port")
 
 	portUID, ok := extractCreatedUID(portOut, "Port")
-	// Port cleanup runs last (registered first — t.Cleanup is LIFO). Registered
-	// before the assertion so any created port is cleaned up even if UID
-	// extraction fails.
+
+	// Port cleanup runs last (registered first — t.Cleanup is LIFO).
+	// Registered before require.True so it runs even if UID extraction fails.
 	t.Cleanup(func() {
 		if portUID == "" {
+			t.Errorf("cleanup: port UID is empty, staged port may have been leaked")
 			return
 		}
 		output.SetOutputFormat("table")
@@ -246,6 +247,8 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 			}
 		})
 	})
+	require.True(t, ok, "could not extract port UID from output:\n%s", portOut)
+
 	require.True(t, ok, "could not extract port UID from output:\n%s", portOut)
 
 	// Buy the IX.
@@ -273,10 +276,12 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	}
 
 	ixUID, ok := extractCreatedUID(buyOut, "IX")
-	// IX cleanup runs first (registered second — LIFO). Registered before the
-	// assertion so any created IX is cleaned up even if UID extraction fails.
+
+	// IX cleanup runs first (registered second — LIFO).
+	// Registered before require.True so it runs even if UID extraction fails.
 	t.Cleanup(func() {
 		if ixUID == "" {
+			t.Errorf("cleanup: IX UID is empty, staged IX may have been leaked")
 			return
 		}
 		output.SetOutputFormat("table")
@@ -291,6 +296,8 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 			}
 		})
 	})
+	require.True(t, ok, "could not extract IX UID from buy output:\n%s", buyOut)
+
 	require.True(t, ok, "could not extract IX UID from buy output:\n%s", buyOut)
 
 	// Verify IX fields via GetIX.

--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -227,10 +227,13 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	require.NoError(t, portErr, "failed to create test port")
 
 	portUID, ok := extractCreatedUID(portOut, "Port")
-	require.True(t, ok, "could not extract port UID from output:\n%s", portOut)
-
-	// Port cleanup runs last (registered first — t.Cleanup is LIFO).
+	// Port cleanup runs last (registered first — t.Cleanup is LIFO). Registered
+	// before the assertion so any created port is cleaned up even if UID
+	// extraction fails.
 	t.Cleanup(func() {
+		if portUID == "" {
+			return
+		}
 		output.SetOutputFormat("table")
 		delPortCmd := integrationDeletePortCmd()
 		if err := delPortCmd.Flags().Set("force", "true"); err != nil {
@@ -243,6 +246,7 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 			}
 		})
 	})
+	require.True(t, ok, "could not extract port UID from output:\n%s", portOut)
 
 	// Buy the IX.
 	ixName := fmt.Sprintf("CLI-Test-IX-%s", generateUniqueID())
@@ -269,10 +273,12 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	}
 
 	ixUID, ok := extractCreatedUID(buyOut, "IX")
-	require.True(t, ok, "could not extract IX UID from buy output:\n%s", buyOut)
-
-	// IX cleanup runs first (registered second — LIFO).
+	// IX cleanup runs first (registered second — LIFO). Registered before the
+	// assertion so any created IX is cleaned up even if UID extraction fails.
 	t.Cleanup(func() {
+		if ixUID == "" {
+			return
+		}
 		output.SetOutputFormat("table")
 		delCmd := integrationDeleteIXCmd()
 		if err := delCmd.Flags().Set("force", "true"); err != nil {
@@ -285,6 +291,7 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 			}
 		})
 	})
+	require.True(t, ok, "could not extract IX UID from buy output:\n%s", buyOut)
 
 	// Verify IX fields via GetIX.
 	var getErr error

--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/commands/ports"
 	"github.com/megaport/megaport-cli/internal/testutil"
-	"github.com/megaport/megaport-cli/internal/utils"
-	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -180,7 +178,7 @@ func TestIntegration_IXListAndGet(t *testing.T) {
 }
 
 // TestIntegration_IXLifecycle exercises the full create → get → status → update → delete path.
-// It skips when no active IXs exist on staging (needed to discover a valid network-service-type).
+// Discovers a valid IX network-service-type from the IXP catalog and a matching location.
 // Expected runtime: up to ~25 minutes (two provisioning waits of up to 10 min each).
 func TestIntegration_IXLifecycle(t *testing.T) {
 	client := testutil.SetupIntegrationClient(t)
@@ -190,43 +188,41 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	output.SetOutputFormat("table")
 	t.Cleanup(func() { output.SetOutputFormat(origFormat) })
 
-	// Discover a valid IX network-service-type and location from existing active IXs.
+	// Discover a valid IX network-service-type from the global IXP catalog,
+	// then find a Megaport location in the same metro to host the test port.
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
-	existingIXs, err := client.IXService.ListIXs(ctx, &megaport.ListIXsRequest{IncludeInactive: false})
-	require.NoError(t, err, "failed to list IXs for type discovery")
-	var firstIX *megaport.IX
-	for _, ix := range existingIXs {
-		if ix == nil {
-			continue
-		}
-		if ix.ProvisioningStatus == megaport.STATUS_DECOMMISSIONED ||
-			ix.ProvisioningStatus == megaport.STATUS_CANCELLED ||
-			ix.ProvisioningStatus == utils.StatusDecommissioning {
-			continue
-		}
-		firstIX = ix
-		break
-	}
-	if firstIX == nil {
-		t.Skip("no usable active IXs on staging — cannot determine a valid network-service-type for lifecycle test")
-	}
-	networkServiceType := firstIX.NetworkServiceType
-	locationID := firstIX.LocationID
-	rateLimit := firstIX.RateLimit
-	if rateLimit == 0 {
-		rateLimit = 1000
+	ixps, err := client.IXService.ListIXPs(ctx, nil)
+	require.NoError(t, err, "failed to list IXPs")
+	if len(ixps) == 0 {
+		t.Skip("no IXPs available on staging")
 	}
 
-	// Create the port that will serve as the A-end of the IX.
-	// Port speed must be >= rateLimit to pass IX order validation.
-	portSpeed := 1000
-	if rateLimit > 10000 {
-		portSpeed = 100000
-	} else if rateLimit > 1000 {
-		portSpeed = 10000
+	allLocs, err := client.LocationService.ListLocationsV3(ctx)
+	require.NoError(t, err, "failed to list locations")
+
+	var networkServiceType string
+	var locationID int
+	for _, ixp := range ixps {
+		if ixp == nil || ixp.Name == "" {
+			continue
+		}
+		matching := client.LocationService.FilterLocationsByMetroV3(ctx, ixp.Metro, allLocs)
+		if len(matching) == 0 {
+			continue
+		}
+		networkServiceType = ixp.Name
+		locationID = matching[0].ID
+		break
 	}
+	if networkServiceType == "" || locationID == 0 {
+		t.Skip("no IXP with a matching staging location found")
+	}
+	const rateLimit = 1000
+
+	// Create the port that will serve as the A-end of the IX.
+	const portSpeed = 1000
 	portName := fmt.Sprintf("CLI-Test-Port-IX-%s", generateUniqueID(t))
 	pCmd := integrationBuyPortCmd()
 	require.NoError(t, pCmd.Flags().Set("name", portName))
@@ -271,7 +267,7 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	require.NoError(t, buyCmd.Flags().Set("product-uid", portUID))
 	require.NoError(t, buyCmd.Flags().Set("name", ixName))
 	require.NoError(t, buyCmd.Flags().Set("network-service-type", networkServiceType))
-	require.NoError(t, buyCmd.Flags().Set("asn", "65000"))
+	require.NoError(t, buyCmd.Flags().Set("asn", "12345"))
 	require.NoError(t, buyCmd.Flags().Set("mac-address", "00:11:22:33:44:55"))
 	require.NoError(t, buyCmd.Flags().Set("rate-limit", fmt.Sprintf("%d", rateLimit)))
 	require.NoError(t, buyCmd.Flags().Set("vlan", "100"))

--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -136,7 +136,7 @@ func integrationStatusIXCmd() *cobra.Command {
 // TestIntegration_IXListAndGet is a fast read-only smoke test against staging.
 func TestIntegration_IXListAndGet(t *testing.T) {
 	client := testutil.SetupIntegrationClient(t)
-	defer testutil.LoginWithClient(t, client)()
+	t.Cleanup(testutil.LoginWithClient(t, client))
 	t.Cleanup(func() { output.SetOutputFormat("table") })
 
 	var listErr error
@@ -182,7 +182,7 @@ func TestIntegration_IXListAndGet(t *testing.T) {
 // Expected runtime: up to ~25 minutes (two provisioning waits of up to 10 min each).
 func TestIntegration_IXLifecycle(t *testing.T) {
 	client := testutil.SetupIntegrationClient(t)
-	defer testutil.LoginWithClient(t, client)()
+	t.Cleanup(testutil.LoginWithClient(t, client))
 	// Ensure table format so PrintResourceCreated writes to stdout, not stderr.
 	output.SetOutputFormat("table")
 	t.Cleanup(func() { output.SetOutputFormat("table") })

--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -179,7 +179,7 @@ func TestIntegration_IXListAndGet(t *testing.T) {
 
 // TestIntegration_IXLifecycle exercises the full create → get → status → update → delete path.
 // Discovers a valid IX network-service-type from the IXP catalog and a matching location.
-// Expected runtime: up to ~25 minutes (two provisioning waits of up to 10 min each).
+// Expected runtime: up to ~30 minutes (three provisioning waits of up to 10 min each: port buy, IX buy, IX update).
 func TestIntegration_IXLifecycle(t *testing.T) {
 	client := testutil.SetupIntegrationClient(t)
 	t.Cleanup(testutil.LoginWithClient(t, client))

--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -146,7 +146,8 @@ func TestIntegration_IXListAndGet(t *testing.T) {
 	require.NoError(t, listErr)
 
 	var ixs []map[string]interface{}
-	if err := json.Unmarshal([]byte(listOut), &ixs); err != nil || len(ixs) == 0 {
+	require.NoError(t, json.Unmarshal([]byte(listOut), &ixs), "ListIXs returned invalid JSON")
+	if len(ixs) == 0 {
 		t.Skip("no IXs available on staging to test Get")
 	}
 
@@ -188,11 +189,18 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 
 	existingIXs, err := client.IXService.ListIXs(ctx, &megaport.ListIXsRequest{IncludeInactive: false})
 	require.NoError(t, err, "failed to list IXs for type discovery")
-	if len(existingIXs) == 0 {
-		t.Skip("no active IXs on staging — cannot determine a valid network-service-type for lifecycle test")
+	var firstIX *megaport.IX
+	for _, ix := range existingIXs {
+		if ix != nil {
+			firstIX = ix
+			break
+		}
 	}
-	networkServiceType := existingIXs[0].NetworkServiceType
-	locationID := existingIXs[0].LocationID
+	if firstIX == nil {
+		t.Skip("no usable active IXs on staging — cannot determine a valid network-service-type for lifecycle test")
+	}
+	networkServiceType := firstIX.NetworkServiceType
+	locationID := firstIX.LocationID
 
 	// Create the port that will serve as the A-end of the IX.
 	portName := fmt.Sprintf("CLI-Test-Port-IX-%s", generateUniqueID())

--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -270,6 +270,7 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	for _, candidate := range candidateRateLimits {
 		probeReq := &megaport.BuyIXRequest{
 			ProductUID:         portUID,
+			Name:               "probe",
 			NetworkServiceType: networkServiceType,
 			ASN:                12345,
 			MACAddress:         "00:11:22:33:44:55",

--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/commands/ports"
 	"github.com/megaport/megaport-cli/internal/testutil"
+	"github.com/megaport/megaport-cli/internal/utils"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -197,10 +198,16 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	require.NoError(t, err, "failed to list IXs for type discovery")
 	var firstIX *megaport.IX
 	for _, ix := range existingIXs {
-		if ix != nil {
-			firstIX = ix
-			break
+		if ix == nil {
+			continue
 		}
+		if ix.ProvisioningStatus == megaport.STATUS_DECOMMISSIONED ||
+			ix.ProvisioningStatus == megaport.STATUS_CANCELLED ||
+			ix.ProvisioningStatus == utils.StatusDecommissioning {
+			continue
+		}
+		firstIX = ix
+		break
 	}
 	if firstIX == nil {
 		t.Skip("no usable active IXs on staging — cannot determine a valid network-service-type for lifecycle test")

--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -1,0 +1,306 @@
+//go:build integration
+
+package ix
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/commands/ports"
+	"github.com/megaport/megaport-cli/internal/testutil"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func generateUniqueID() string {
+	buf := make([]byte, 4)
+	if _, err := rand.Read(buf); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(buf)
+}
+
+// extractCreatedUID parses "<ResourceType> created <uid>" from buy command output.
+func extractCreatedUID(captured, resourceType string) (string, bool) {
+	prefix := resourceType + " created "
+	for _, line := range strings.Split(captured, "\n") {
+		if idx := strings.Index(line, prefix); idx >= 0 {
+			uid := strings.TrimSpace(line[idx+len(prefix):])
+			if uid != "" {
+				return uid, true
+			}
+		}
+	}
+	return "", false
+}
+
+func integrationListIXCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "list"}
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().Int("asn", 0, "")
+	cmd.Flags().Int("vlan", 0, "")
+	cmd.Flags().String("network-service-type", "", "")
+	cmd.Flags().Int("location-id", 0, "")
+	cmd.Flags().Int("rate-limit", 0, "")
+	cmd.Flags().Bool("include-inactive", false, "")
+	cmd.Flags().Int("limit", 0, "")
+	return cmd
+}
+
+func integrationBuyIXCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "buy"}
+	cmd.Flags().BoolP("interactive", "i", false, "")
+	cmd.Flags().Bool("no-wait", false, "")
+	cmd.Flags().BoolP("yes", "y", false, "")
+	cmd.Flags().String("product-uid", "", "")
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("network-service-type", "", "")
+	cmd.Flags().Int("asn", 0, "")
+	cmd.Flags().String("mac-address", "", "")
+	cmd.Flags().Int("rate-limit", 0, "")
+	cmd.Flags().Int("vlan", 0, "")
+	cmd.Flags().Bool("shutdown", false, "")
+	cmd.Flags().String("promo-code", "", "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	return cmd
+}
+
+func integrationDeleteIXCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "delete"}
+	cmd.Flags().BoolP("force", "f", false, "")
+	cmd.Flags().Bool("later", false, "")
+	return cmd
+}
+
+func integrationUpdateIXCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().BoolP("interactive", "i", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().Int("rate-limit", 0, "")
+	cmd.Flags().String("cost-centre", "", "")
+	cmd.Flags().Int("vlan", 0, "")
+	cmd.Flags().String("mac-address", "", "")
+	cmd.Flags().Int("asn", 0, "")
+	cmd.Flags().String("password", "", "")
+	cmd.Flags().Bool("public-graph", false, "")
+	cmd.Flags().String("reverse-dns", "", "")
+	cmd.Flags().String("a-end-product-uid", "", "")
+	cmd.Flags().Bool("shutdown", false, "")
+	return cmd
+}
+
+func integrationBuyPortCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "buy"}
+	cmd.Flags().BoolP("interactive", "i", false, "")
+	cmd.Flags().Bool("no-wait", false, "")
+	cmd.Flags().BoolP("yes", "y", false, "")
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().Int("term", 0, "")
+	cmd.Flags().Int("port-speed", 0, "")
+	cmd.Flags().Int("location-id", 0, "")
+	cmd.Flags().Bool("marketplace-visibility", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	return cmd
+}
+
+func integrationDeletePortCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "delete"}
+	cmd.Flags().BoolP("force", "f", false, "")
+	cmd.Flags().Bool("safe-delete", false, "")
+	return cmd
+}
+
+// TestIntegration_IXListAndGet is a fast read-only smoke test against staging.
+func TestIntegration_IXListAndGet(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	var listErr error
+	listOut := output.CaptureOutput(func() {
+		listErr = ListIXs(integrationListIXCmd(), nil, true, "json")
+	})
+	require.NoError(t, listErr)
+
+	var ixs []map[string]interface{}
+	if err := json.Unmarshal([]byte(listOut), &ixs); err != nil || len(ixs) == 0 {
+		t.Skip("no IXs available on staging to test Get")
+	}
+
+	first := ixs[0]
+	assert.Contains(t, first, "uid", "IX should have a uid field")
+	assert.Contains(t, first, "name", "IX should have a name field")
+
+	uid, ok := first["uid"].(string)
+	require.True(t, ok && uid != "", "uid must be a non-empty string")
+
+	getCmd := &cobra.Command{Use: "get"}
+	getCmd.Flags().Bool("export", false, "")
+
+	var getErr error
+	getOut := output.CaptureOutput(func() {
+		getErr = GetIX(getCmd, []string{uid}, true, "json")
+	})
+	require.NoError(t, getErr)
+
+	var gotList []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(getOut), &gotList), "GetIX JSON output must be valid")
+	require.Len(t, gotList, 1)
+	gotIX := gotList[0]
+	assert.Equal(t, uid, gotIX["uid"])
+	assert.Contains(t, gotIX, "name")
+	assert.Contains(t, gotIX, "status")
+}
+
+// TestIntegration_IXLifecycle exercises the full create → get → status → update → delete path.
+// It skips when no active IXs exist on staging (needed to discover a valid network-service-type).
+func TestIntegration_IXLifecycle(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	// Discover a valid IX network-service-type and location from existing active IXs.
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	existingIXs, err := client.IXService.ListIXs(ctx, &megaport.ListIXsRequest{IncludeInactive: false})
+	require.NoError(t, err, "failed to list IXs for type discovery")
+	if len(existingIXs) == 0 {
+		t.Skip("no active IXs on staging — cannot determine a valid network-service-type for lifecycle test")
+	}
+	networkServiceType := existingIXs[0].NetworkServiceType
+	locationID := existingIXs[0].LocationID
+
+	// Create the port that will serve as the A-end of the IX.
+	portName := fmt.Sprintf("CLI-Test-Port-IX-%s", generateUniqueID())
+	pCmd := integrationBuyPortCmd()
+	require.NoError(t, pCmd.Flags().Set("name", portName))
+	require.NoError(t, pCmd.Flags().Set("term", "1"))
+	require.NoError(t, pCmd.Flags().Set("port-speed", "1000"))
+	require.NoError(t, pCmd.Flags().Set("location-id", fmt.Sprintf("%d", locationID)))
+	require.NoError(t, pCmd.Flags().Set("marketplace-visibility", "false"))
+	require.NoError(t, pCmd.Flags().Set("yes", "true"))
+
+	var portErr error
+	portOut := output.CaptureOutput(func() {
+		portErr = ports.BuyPort(pCmd, nil, true)
+	})
+	require.NoError(t, portErr, "failed to create test port")
+
+	portUID, ok := extractCreatedUID(portOut, "Port")
+	require.True(t, ok, "could not extract port UID from output:\n%s", portOut)
+
+	// Port cleanup runs last (registered first — t.Cleanup is LIFO).
+	t.Cleanup(func() {
+		delPortCmd := integrationDeletePortCmd()
+		_ = delPortCmd.Flags().Set("force", "true")
+		output.CaptureOutput(func() {
+			_ = ports.DeletePort(delPortCmd, []string{portUID}, true)
+		})
+	})
+
+	// Buy the IX.
+	ixName := fmt.Sprintf("CLI-Test-IX-%s", generateUniqueID())
+	buyCmd := integrationBuyIXCmd()
+	require.NoError(t, buyCmd.Flags().Set("product-uid", portUID))
+	require.NoError(t, buyCmd.Flags().Set("name", ixName))
+	require.NoError(t, buyCmd.Flags().Set("network-service-type", networkServiceType))
+	require.NoError(t, buyCmd.Flags().Set("asn", "65000"))
+	require.NoError(t, buyCmd.Flags().Set("mac-address", "00:11:22:33:44:55"))
+	require.NoError(t, buyCmd.Flags().Set("rate-limit", "1000"))
+	require.NoError(t, buyCmd.Flags().Set("vlan", "100"))
+	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
+
+	var buyErr error
+	buyOut := output.CaptureOutput(func() {
+		buyErr = BuyIX(buyCmd, nil, true)
+	})
+	if buyErr != nil {
+		errMsg := buyErr.Error()
+		if strings.Contains(errMsg, "not available") || strings.Contains(errMsg, "invalid") ||
+			strings.Contains(errMsg, "not supported") {
+			t.Skipf("IX type %q not available at location %d on staging: %v", networkServiceType, locationID, buyErr)
+		}
+		require.NoError(t, buyErr, "failed to create test IX")
+	}
+
+	ixUID, ok := extractCreatedUID(buyOut, "IX")
+	require.True(t, ok, "could not extract IX UID from buy output:\n%s", buyOut)
+
+	// IX cleanup runs first (registered second — LIFO).
+	t.Cleanup(func() {
+		delCmd := integrationDeleteIXCmd()
+		_ = delCmd.Flags().Set("force", "true")
+		output.CaptureOutput(func() {
+			_ = DeleteIX(delCmd, []string{ixUID}, true)
+		})
+	})
+
+	// Verify IX fields via GetIX.
+	getCmd := &cobra.Command{Use: "get"}
+	getCmd.Flags().Bool("export", false, "")
+	var getErr error
+	getOut := output.CaptureOutput(func() {
+		getErr = GetIX(getCmd, []string{ixUID}, true, "json")
+	})
+	require.NoError(t, getErr)
+
+	var gotList []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(getOut), &gotList))
+	require.Len(t, gotList, 1)
+	gotIX := gotList[0]
+	assert.Equal(t, ixUID, gotIX["uid"])
+	assert.Equal(t, ixName, gotIX["name"])
+	assert.Contains(t, gotIX, "status")
+
+	// Status as a sub-test to avoid an extra IX.
+	t.Run("Status", func(t *testing.T) {
+		statusCmd := &cobra.Command{Use: "status"}
+		var statusErr error
+		statusOut := output.CaptureOutput(func() {
+			statusErr = GetIXStatus(statusCmd, []string{ixUID}, true, "json")
+		})
+		require.NoError(t, statusErr)
+
+		var statusList []map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(statusOut), &statusList))
+		require.NotEmpty(t, statusList)
+		assert.Equal(t, ixUID, statusList[0]["uid"])
+		assert.Contains(t, statusList[0], "status")
+	})
+
+	// Update the IX name.
+	updatedName := ixName + "-upd"
+	updCmd := integrationUpdateIXCmd()
+	require.NoError(t, updCmd.Flags().Set("name", updatedName))
+	var updateErr error
+	output.CaptureOutput(func() {
+		updateErr = UpdateIX(updCmd, []string{ixUID}, true)
+	})
+	require.NoError(t, updateErr)
+
+	// Verify the name was updated.
+	getCmd2 := &cobra.Command{Use: "get"}
+	getCmd2.Flags().Bool("export", false, "")
+	var getErr2 error
+	getOut2 := output.CaptureOutput(func() {
+		getErr2 = GetIX(getCmd2, []string{ixUID}, true, "json")
+	})
+	require.NoError(t, getErr2)
+
+	var gotList2 []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(getOut2), &gotList2))
+	require.Len(t, gotList2, 1)
+	assert.Equal(t, updatedName, gotList2[0]["name"])
+}

--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -123,10 +123,21 @@ func integrationDeletePortCmd() *cobra.Command {
 	return cmd
 }
 
+func integrationGetIXCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "get"}
+	cmd.Flags().Bool("export", false, "")
+	return cmd
+}
+
+func integrationStatusIXCmd() *cobra.Command {
+	return &cobra.Command{Use: "status"}
+}
+
 // TestIntegration_IXListAndGet is a fast read-only smoke test against staging.
 func TestIntegration_IXListAndGet(t *testing.T) {
 	client := testutil.SetupIntegrationClient(t)
 	defer testutil.LoginWithClient(t, client)()
+	t.Cleanup(func() { output.SetOutputFormat("table") })
 
 	var listErr error
 	listOut := output.CaptureOutput(func() {
@@ -146,12 +157,9 @@ func TestIntegration_IXListAndGet(t *testing.T) {
 	uid, ok := first["uid"].(string)
 	require.True(t, ok && uid != "", "uid must be a non-empty string")
 
-	getCmd := &cobra.Command{Use: "get"}
-	getCmd.Flags().Bool("export", false, "")
-
 	var getErr error
 	getOut := output.CaptureOutput(func() {
-		getErr = GetIX(getCmd, []string{uid}, true, "json")
+		getErr = GetIX(integrationGetIXCmd(), []string{uid}, true, "json")
 	})
 	require.NoError(t, getErr)
 
@@ -166,9 +174,13 @@ func TestIntegration_IXListAndGet(t *testing.T) {
 
 // TestIntegration_IXLifecycle exercises the full create → get → status → update → delete path.
 // It skips when no active IXs exist on staging (needed to discover a valid network-service-type).
+// Expected runtime: up to ~25 minutes (two provisioning waits of up to 10 min each).
 func TestIntegration_IXLifecycle(t *testing.T) {
 	client := testutil.SetupIntegrationClient(t)
 	defer testutil.LoginWithClient(t, client)()
+	// Ensure table format so PrintResourceCreated writes to stdout, not stderr.
+	output.SetOutputFormat("table")
+	t.Cleanup(func() { output.SetOutputFormat("table") })
 
 	// Discover a valid IX network-service-type and location from existing active IXs.
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
@@ -248,11 +260,9 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	})
 
 	// Verify IX fields via GetIX.
-	getCmd := &cobra.Command{Use: "get"}
-	getCmd.Flags().Bool("export", false, "")
 	var getErr error
 	getOut := output.CaptureOutput(func() {
-		getErr = GetIX(getCmd, []string{ixUID}, true, "json")
+		getErr = GetIX(integrationGetIXCmd(), []string{ixUID}, true, "json")
 	})
 	require.NoError(t, getErr)
 
@@ -266,10 +276,9 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 
 	// Status as a sub-test to avoid an extra IX.
 	t.Run("Status", func(t *testing.T) {
-		statusCmd := &cobra.Command{Use: "status"}
 		var statusErr error
 		statusOut := output.CaptureOutput(func() {
-			statusErr = GetIXStatus(statusCmd, []string{ixUID}, true, "json")
+			statusErr = GetIXStatus(integrationStatusIXCmd(), []string{ixUID}, true, "json")
 		})
 		require.NoError(t, statusErr)
 
@@ -291,11 +300,9 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	require.NoError(t, updateErr)
 
 	// Verify the name was updated.
-	getCmd2 := &cobra.Command{Use: "get"}
-	getCmd2.Flags().Bool("export", false, "")
 	var getErr2 error
 	getOut2 := output.CaptureOutput(func() {
-		getErr2 = GetIX(getCmd2, []string{ixUID}, true, "json")
+		getErr2 = GetIX(integrationGetIXCmd(), []string{ixUID}, true, "json")
 	})
 	require.NoError(t, getErr2)
 

--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -333,7 +333,7 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 
 		var statusList []map[string]interface{}
 		require.NoError(t, json.Unmarshal([]byte(statusOut), &statusList))
-		require.NotEmpty(t, statusList)
+		require.Len(t, statusList, 1)
 		assert.Equal(t, ixUID, statusList[0]["uid"])
 		assert.Contains(t, statusList[0], "status")
 	})

--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -137,7 +137,8 @@ func integrationStatusIXCmd() *cobra.Command {
 func TestIntegration_IXListAndGet(t *testing.T) {
 	client := testutil.SetupIntegrationClient(t)
 	t.Cleanup(testutil.LoginWithClient(t, client))
-	t.Cleanup(func() { output.SetOutputFormat("table") })
+	origFormat := output.GetOutputFormat()
+	t.Cleanup(func() { output.SetOutputFormat(origFormat) })
 
 	var listErr error
 	listOut := output.CaptureOutput(func() {
@@ -183,9 +184,10 @@ func TestIntegration_IXListAndGet(t *testing.T) {
 func TestIntegration_IXLifecycle(t *testing.T) {
 	client := testutil.SetupIntegrationClient(t)
 	t.Cleanup(testutil.LoginWithClient(t, client))
+	origFormat := output.GetOutputFormat()
 	// Ensure table format so PrintResourceCreated writes to stdout, not stderr.
 	output.SetOutputFormat("table")
-	t.Cleanup(func() { output.SetOutputFormat("table") })
+	t.Cleanup(func() { output.SetOutputFormat(origFormat) })
 
 	// Discover a valid IX network-service-type and location from existing active IXs.
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)

--- a/internal/commands/ix/ix_integration_test.go
+++ b/internal/commands/ix/ix_integration_test.go
@@ -201,6 +201,10 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	}
 	networkServiceType := firstIX.NetworkServiceType
 	locationID := firstIX.LocationID
+	rateLimit := firstIX.RateLimit
+	if rateLimit == 0 {
+		rateLimit = 1000
+	}
 
 	// Create the port that will serve as the A-end of the IX.
 	portName := fmt.Sprintf("CLI-Test-Port-IX-%s", generateUniqueID())
@@ -225,7 +229,10 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	t.Cleanup(func() {
 		output.SetOutputFormat("table")
 		delPortCmd := integrationDeletePortCmd()
-		_ = delPortCmd.Flags().Set("force", "true")
+		if err := delPortCmd.Flags().Set("force", "true"); err != nil {
+			t.Errorf("cleanup: failed to set --force flag on port delete: %v", err)
+			return
+		}
 		output.CaptureOutput(func() {
 			if err := ports.DeletePort(delPortCmd, []string{portUID}, true); err != nil {
 				t.Errorf("cleanup: failed to delete test port %s: %v", portUID, err)
@@ -241,7 +248,7 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	require.NoError(t, buyCmd.Flags().Set("network-service-type", networkServiceType))
 	require.NoError(t, buyCmd.Flags().Set("asn", "65000"))
 	require.NoError(t, buyCmd.Flags().Set("mac-address", "00:11:22:33:44:55"))
-	require.NoError(t, buyCmd.Flags().Set("rate-limit", "1000"))
+	require.NoError(t, buyCmd.Flags().Set("rate-limit", fmt.Sprintf("%d", rateLimit)))
 	require.NoError(t, buyCmd.Flags().Set("vlan", "100"))
 	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
 
@@ -251,8 +258,7 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	})
 	if buyErr != nil {
 		errMsg := buyErr.Error()
-		if strings.Contains(errMsg, "not available") || strings.Contains(errMsg, "invalid") ||
-			strings.Contains(errMsg, "not supported") {
+		if strings.Contains(errMsg, "not available") || strings.Contains(errMsg, "not supported") {
 			t.Skipf("IX type %q not available at location %d on staging: %v", networkServiceType, locationID, buyErr)
 		}
 		require.NoError(t, buyErr, "failed to create test IX")
@@ -265,7 +271,10 @@ func TestIntegration_IXLifecycle(t *testing.T) {
 	t.Cleanup(func() {
 		output.SetOutputFormat("table")
 		delCmd := integrationDeleteIXCmd()
-		_ = delCmd.Flags().Set("force", "true")
+		if err := delCmd.Flags().Set("force", "true"); err != nil {
+			t.Errorf("cleanup: failed to set --force flag on IX delete: %v", err)
+			return
+		}
 		output.CaptureOutput(func() {
 			if err := DeleteIX(delCmd, []string{ixUID}, true); err != nil {
 				t.Errorf("cleanup: failed to delete test IX %s: %v", ixUID, err)


### PR DESCRIPTION
Adds `internal/commands/ix/ix_integration_test.go` — the first integration test coverage for the IX command package. Before this, IX had zero integration tests.

Three tests are included:

- `TestIntegration_IXListAndGet` — read-only smoke test that lists active IXs and fetches the first by UID. Skips gracefully if no IXs exist on staging.
- `TestIntegration_IXLifecycle` — full lifecycle (create port → buy IX → get → update name → delete). Discovers a valid `network-service-type` from the global IXP catalog (`ListIXPs`) and a matching Megaport location via `ListLocationsV3`, so the test runs even when no IXs currently exist on staging. Port and IX are cleaned up with `t.Cleanup` in LIFO order (IX deleted before port).
- `TestIntegration_IXStatus` — runs as a sub-test inside the lifecycle test to avoid provisioning an extra IX.

Run with:
```
go test -tags integration -v -timeout 30m ./internal/commands/ix/
```

Tests confirmed passing against Staging API 2026/06/03