### PR TITLE
ESD-1323: add unit tests for ix and nat_gateway inputs, outputs, and prompts

### DIFF
--- a/internal/commands/ix/ix_inputs_test.go
+++ b/internal/commands/ix/ix_inputs_test.go
@@ -1,0 +1,147 @@
+package ix
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildIXRequestFromJSON_BothEmpty(t *testing.T) {
+	req, err := buildIXRequestFromJSON("", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse JSON")
+	assert.Nil(t, req)
+}
+
+func TestBuildUpdateIXRequestFromJSON_BothEmpty(t *testing.T) {
+	req, err := buildUpdateIXRequestFromJSON("", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse JSON")
+	assert.Nil(t, req)
+}
+
+func TestBuildIXRequestFromJSON_AllFields(t *testing.T) {
+	const validJSON = `{
+		"productUid": "port-abc",
+		"productName": "My IX",
+		"networkServiceType": "Chicago IX",
+		"asn": 64512,
+		"macAddress": "DE:AD:BE:EF:00:01",
+		"rateLimit": 500,
+		"vlan": 42,
+		"shutdown": true,
+		"promoCode": "SAVE10"
+	}`
+	req, err := buildIXRequestFromJSON(validJSON, "")
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	assert.Equal(t, "port-abc", req.ProductUID)
+	assert.Equal(t, "My IX", req.Name)
+	assert.Equal(t, "Chicago IX", req.NetworkServiceType)
+	assert.Equal(t, 64512, req.ASN)
+	assert.Equal(t, "DE:AD:BE:EF:00:01", req.MACAddress)
+	assert.Equal(t, 500, req.RateLimit)
+	assert.Equal(t, 42, req.VLAN)
+	assert.True(t, req.Shutdown)
+	assert.Equal(t, "SAVE10", req.PromoCode)
+}
+
+func TestBuildIXRequestFromJSON_TempFile(t *testing.T) {
+	content := `{"productUid":"port-file","productName":"File IX","asn":65000,"rateLimit":1000,"vlan":100,"macAddress":"00:11:22:33:44:55","networkServiceType":"London IX"}`
+	tmpFile, err := os.CreateTemp("", "ix-inputs-test-*.json")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	_, err = tmpFile.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	req, err := buildIXRequestFromJSON("", tmpFile.Name())
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	assert.Equal(t, "port-file", req.ProductUID)
+	assert.Equal(t, "File IX", req.Name)
+}
+
+func TestBuildIXRequestFromJSON_FileNotFound(t *testing.T) {
+	_, err := buildIXRequestFromJSON("", filepath.Join(t.TempDir(), "missing.json"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read JSON file")
+}
+
+func TestBuildUpdateIXRequestFromJSON_PointerFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		jsonStr string
+		check   func(t *testing.T)
+	}{
+		{
+			name:    "publicGraph true",
+			jsonStr: `{"publicGraph":true}`,
+			check: func(t *testing.T) {
+				req, err := buildUpdateIXRequestFromJSON(`{"publicGraph":true}`, "")
+				require.NoError(t, err)
+				require.NotNil(t, req.PublicGraph)
+				assert.True(t, *req.PublicGraph)
+			},
+		},
+		{
+			name:    "shutdown false explicit",
+			jsonStr: `{"shutdown":false}`,
+			check: func(t *testing.T) {
+				req, err := buildUpdateIXRequestFromJSON(`{"shutdown":false}`, "")
+				require.NoError(t, err)
+				require.NotNil(t, req.Shutdown)
+				assert.False(t, *req.Shutdown)
+			},
+		},
+		{
+			name:    "aEndProductUid set",
+			jsonStr: `{"aEndProductUid":"port-new"}`,
+			check: func(t *testing.T) {
+				req, err := buildUpdateIXRequestFromJSON(`{"aEndProductUid":"port-new"}`, "")
+				require.NoError(t, err)
+				require.NotNil(t, req.AEndProductUid)
+				assert.Equal(t, "port-new", *req.AEndProductUid)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.check(t)
+		})
+	}
+}
+
+func TestBuildUpdateIXRequestFromFlags_NoopWhenUnchanged(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().Int("rate-limit", 0, "")
+	cmd.Flags().String("cost-centre", "", "")
+	cmd.Flags().Int("vlan", 0, "")
+	cmd.Flags().String("mac-address", "", "")
+	cmd.Flags().Int("asn", 0, "")
+	cmd.Flags().String("password", "", "")
+	cmd.Flags().Bool("public-graph", false, "")
+	cmd.Flags().String("reverse-dns", "", "")
+	cmd.Flags().String("a-end-product-uid", "", "")
+	cmd.Flags().Bool("shutdown", false, "")
+
+	req, err := buildUpdateIXRequestFromFlags(cmd)
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	assert.Nil(t, req.Name)
+	assert.Nil(t, req.RateLimit)
+	assert.Nil(t, req.CostCentre)
+	assert.Nil(t, req.VLAN)
+	assert.Nil(t, req.MACAddress)
+	assert.Nil(t, req.ASN)
+	assert.Nil(t, req.Password)
+	assert.Nil(t, req.PublicGraph)
+	assert.Nil(t, req.ReverseDns)
+	assert.Nil(t, req.AEndProductUid)
+	assert.Nil(t, req.Shutdown)
+}

--- a/internal/commands/ix/ix_inputs_test.go
+++ b/internal/commands/ix/ix_inputs_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -74,16 +75,14 @@ func TestBuildIXRequestFromJSON_FileNotFound(t *testing.T) {
 
 func TestBuildUpdateIXRequestFromJSON_PointerFields(t *testing.T) {
 	tests := []struct {
-		name    string
-		jsonStr string
-		check   func(t *testing.T)
+		name      string
+		jsonStr   string
+		checkFunc func(t *testing.T, req *megaport.UpdateIXRequest)
 	}{
 		{
 			name:    "publicGraph true",
 			jsonStr: `{"publicGraph":true}`,
-			check: func(t *testing.T) {
-				req, err := buildUpdateIXRequestFromJSON(`{"publicGraph":true}`, "")
-				require.NoError(t, err)
+			checkFunc: func(t *testing.T, req *megaport.UpdateIXRequest) {
 				require.NotNil(t, req.PublicGraph)
 				assert.True(t, *req.PublicGraph)
 			},
@@ -91,9 +90,7 @@ func TestBuildUpdateIXRequestFromJSON_PointerFields(t *testing.T) {
 		{
 			name:    "shutdown false explicit",
 			jsonStr: `{"shutdown":false}`,
-			check: func(t *testing.T) {
-				req, err := buildUpdateIXRequestFromJSON(`{"shutdown":false}`, "")
-				require.NoError(t, err)
+			checkFunc: func(t *testing.T, req *megaport.UpdateIXRequest) {
 				require.NotNil(t, req.Shutdown)
 				assert.False(t, *req.Shutdown)
 			},
@@ -101,9 +98,7 @@ func TestBuildUpdateIXRequestFromJSON_PointerFields(t *testing.T) {
 		{
 			name:    "aEndProductUid set",
 			jsonStr: `{"aEndProductUid":"port-new"}`,
-			check: func(t *testing.T) {
-				req, err := buildUpdateIXRequestFromJSON(`{"aEndProductUid":"port-new"}`, "")
-				require.NoError(t, err)
+			checkFunc: func(t *testing.T, req *megaport.UpdateIXRequest) {
 				require.NotNil(t, req.AEndProductUid)
 				assert.Equal(t, "port-new", *req.AEndProductUid)
 			},
@@ -111,7 +106,9 @@ func TestBuildUpdateIXRequestFromJSON_PointerFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.check(t)
+			req, err := buildUpdateIXRequestFromJSON(tt.jsonStr, "")
+			require.NoError(t, err)
+			tt.checkFunc(t, req)
 		})
 	}
 }

--- a/internal/commands/ix/ix_output_test.go
+++ b/internal/commands/ix/ix_output_test.go
@@ -1,0 +1,113 @@
+package ix
+
+import (
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintIXs_XML(t *testing.T) {
+	ixs := []*megaport.IX{
+		{
+			ProductUID:         "ix-xml-1",
+			ProductName:        "XML Test IX",
+			NetworkServiceType: "Tokyo IX",
+			ASN:                65100,
+			RateLimit:          1000,
+			VLAN:               10,
+			MACAddress:         "AA:BB:CC:DD:EE:01",
+			ProvisioningStatus: "LIVE",
+		},
+	}
+
+	out := output.CaptureOutput(func() {
+		err := printIXs(ixs, "xml", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "<items>")
+	assert.Contains(t, out, "<item>")
+	assert.Contains(t, out, "ix-xml-1")
+	assert.Contains(t, out, "XML Test IX")
+}
+
+func TestPrintIXs_XML_List(t *testing.T) {
+	ixs := []*megaport.IX{
+		{
+			ProductUID:         "ix-a",
+			ProductName:        "First IX",
+			NetworkServiceType: "London IX",
+			ProvisioningStatus: "LIVE",
+		},
+		{
+			ProductUID:         "ix-b",
+			ProductName:        "Second IX",
+			NetworkServiceType: "Paris IX",
+			ProvisioningStatus: "CONFIGURED",
+		},
+	}
+
+	out := output.CaptureOutput(func() {
+		err := printIXs(ixs, "xml", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "<items>")
+	assert.Contains(t, out, "ix-a")
+	assert.Contains(t, out, "ix-b")
+}
+
+func TestPrintIXs_XML_Empty(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printIXs([]*megaport.IX{}, "xml", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "<items>")
+}
+
+func TestToIXOutput_FieldMapping(t *testing.T) {
+	ix := &megaport.IX{
+		ProductUID:         "uid-map",
+		ProductName:        "Mapping IX",
+		NetworkServiceType: "Miami IX",
+		ASN:                65200,
+		RateLimit:          2000,
+		VLAN:               300,
+		MACAddress:         "11:22:33:44:55:66",
+		ProvisioningStatus: "CONFIGURED",
+	}
+
+	out, err := toIXOutput(ix)
+	assert.NoError(t, err)
+	assert.Equal(t, "uid-map", out.UID)
+	assert.Equal(t, "Mapping IX", out.Name)
+	assert.Equal(t, "Miami IX", out.NetworkServiceType)
+	assert.Equal(t, 65200, out.ASN)
+	assert.Equal(t, 2000, out.RateLimit)
+	assert.Equal(t, 300, out.VLAN)
+	assert.Equal(t, "11:22:33:44:55:66", out.MACAddress)
+	assert.Equal(t, "CONFIGURED", out.Status)
+}
+
+func TestDisplayIXChanges_NilSafe(t *testing.T) {
+	// Should not panic with nil inputs
+	assert.NotPanics(t, func() { displayIXChanges(nil, nil, true) })
+	assert.NotPanics(t, func() { displayIXChanges(&megaport.IX{}, nil, true) })
+	assert.NotPanics(t, func() { displayIXChanges(nil, &megaport.IX{}, true) })
+}
+
+func TestDisplayIXChanges_ShowsDiff(t *testing.T) {
+	original := &megaport.IX{ProductName: "Old IX", RateLimit: 1000, VLAN: 10, MACAddress: "00:00:00:00:00:01", ASN: 65000}
+	updated := &megaport.IX{ProductName: "New IX", RateLimit: 2000, VLAN: 20, MACAddress: "00:00:00:00:00:02", ASN: 65001}
+
+	out := output.CaptureOutput(func() {
+		displayIXChanges(original, updated, true)
+	})
+
+	assert.Contains(t, out, "Name")
+	assert.Contains(t, out, "Old IX")
+	assert.Contains(t, out, "New IX")
+}

--- a/internal/commands/ix/ix_prompts_test.go
+++ b/internal/commands/ix/ix_prompts_test.go
@@ -1,0 +1,96 @@
+package ix
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func mockIXPromptSequence(responses []string) func(string, string, bool) (string, error) {
+	idx := 0
+	return func(_, _ string, _ bool) (string, error) {
+		if idx >= len(responses) {
+			return "", fmt.Errorf("unexpected prompt call #%d", idx)
+		}
+		val := responses[idx]
+		idx++
+		if val == "ERROR" {
+			return "", fmt.Errorf("simulated prompt error")
+		}
+		return val, nil
+	}
+}
+
+func TestBuildIXRequestFromPrompt_ErrorOnNamePrompt(t *testing.T) {
+	orig := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(orig)
+
+	// First prompt (product UID) succeeds; second (name) errors
+	utils.SetResourcePrompt(mockIXPromptSequence([]string{"port-uid-1", "ERROR"}))
+
+	_, err := buildIXRequestFromPrompt(context.Background(), true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "simulated prompt error")
+}
+
+func TestBuildIXRequestFromPrompt_ErrorOnNetworkServiceTypePrompt(t *testing.T) {
+	orig := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(orig)
+
+	utils.SetResourcePrompt(mockIXPromptSequence([]string{"port-uid-1", "My IX", "ERROR"}))
+
+	_, err := buildIXRequestFromPrompt(context.Background(), true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "simulated prompt error")
+}
+
+func TestBuildIXRequestFromPrompt_ErrorOnMACPrompt(t *testing.T) {
+	orig := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(orig)
+
+	// productUID, name, networkServiceType, asn, then ERROR on mac
+	utils.SetResourcePrompt(mockIXPromptSequence([]string{
+		"port-uid-1", "My IX", "Los Angeles IX", "65000", "ERROR",
+	}))
+
+	_, err := buildIXRequestFromPrompt(context.Background(), true)
+	assert.Error(t, err)
+}
+
+func TestBuildUpdateIXRequestFromPrompt_ErrorOnRateLimitPrompt(t *testing.T) {
+	orig := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(orig)
+
+	// name prompt returns "", then rate-limit prompt errors
+	utils.SetResourcePrompt(mockIXPromptSequence([]string{"", "ERROR"}))
+
+	_, err := buildUpdateIXRequestFromPrompt("ix-123", true)
+	assert.Error(t, err)
+}
+
+func TestBuildUpdateIXRequestFromPrompt_ErrorOnCostCentrePrompt(t *testing.T) {
+	orig := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(orig)
+
+	// name="", rate-limit="", cost-centre=ERROR
+	utils.SetResourcePrompt(mockIXPromptSequence([]string{"", "", "ERROR"}))
+
+	_, err := buildUpdateIXRequestFromPrompt("ix-123", true)
+	assert.Error(t, err)
+}
+
+func TestBuildUpdateIXRequestFromPrompt_ErrorOnPasswordPrompt(t *testing.T) {
+	orig := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(orig)
+
+	// name="Updated", rate-limit="", cost-centre="", vlan="", mac="", asn="", password=ERROR
+	utils.SetResourcePrompt(mockIXPromptSequence([]string{
+		"Updated", "", "", "", "", "", "ERROR",
+	}))
+
+	_, err := buildUpdateIXRequestFromPrompt("ix-123", true)
+	assert.Error(t, err)
+}

--- a/internal/commands/nat_gateway/nat_gateway_inputs_test.go
+++ b/internal/commands/nat_gateway/nat_gateway_inputs_test.go
@@ -1,0 +1,307 @@
+package nat_gateway
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newCreateFlagsCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "create"}
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().Int("term", 0, "")
+	cmd.Flags().Int("speed", 0, "")
+	cmd.Flags().Int("location-id", 0, "")
+	cmd.Flags().Int("session-count", 0, "")
+	cmd.Flags().String("diversity-zone", "", "")
+	cmd.Flags().String("promo-code", "", "")
+	cmd.Flags().String("service-level-reference", "", "")
+	cmd.Flags().Bool("auto-renew", false, "")
+	cmd.Flags().String("resource-tags", "", "")
+	cmd.Flags().String("resource-tags-file", "", "")
+	return cmd
+}
+
+func newUpdateFlagsCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().Int("term", 0, "")
+	cmd.Flags().Int("speed", 0, "")
+	cmd.Flags().Int("location-id", 0, "")
+	cmd.Flags().Int("session-count", 0, "")
+	cmd.Flags().String("diversity-zone", "", "")
+	cmd.Flags().String("promo-code", "", "")
+	cmd.Flags().String("service-level-reference", "", "")
+	cmd.Flags().Bool("auto-renew", false, "")
+	cmd.Flags().String("resource-tags", "", "")
+	cmd.Flags().String("resource-tags-file", "", "")
+	return cmd
+}
+
+// ---- processJSONCreateNATGatewayInput ----
+
+func TestProcessJSONCreateNATGatewayInput_EmptyStrings(t *testing.T) {
+	_, err := processJSONCreateNATGatewayInput("", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse JSON")
+}
+
+func TestProcessJSONCreateNATGatewayInput_InvalidJSON(t *testing.T) {
+	_, err := processJSONCreateNATGatewayInput(`{invalid}`, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse JSON")
+}
+
+func TestProcessJSONCreateNATGatewayInput_FileNotFound(t *testing.T) {
+	_, err := processJSONCreateNATGatewayInput("", filepath.Join(t.TempDir(), "missing.json"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read JSON file")
+}
+
+func TestProcessJSONCreateNATGatewayInput_ValidFile(t *testing.T) {
+	content := `{"name":"File GW","term":12,"speed":1000,"locationId":1}`
+	tmp, err := os.CreateTemp("", "ng-create-*.json")
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	_, err = tmp.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+
+	req, err := processJSONCreateNATGatewayInput("", tmp.Name())
+	require.NoError(t, err)
+	assert.Equal(t, "File GW", req.ProductName)
+	assert.Equal(t, 12, req.Term)
+	assert.Equal(t, 1000, req.Speed)
+	assert.Equal(t, 1, req.LocationID)
+}
+
+func TestProcessJSONCreateNATGatewayInput_WithBooleanFields(t *testing.T) {
+	req, err := processJSONCreateNATGatewayInput(
+		`{"name":"GW","term":12,"speed":1000,"locationId":1,"bgpShutdownDefault":true,"autoRenewTerm":true}`, "")
+	require.NoError(t, err)
+	assert.True(t, req.Config.BGPShutdownDefault)
+	assert.True(t, req.AutoRenewTerm)
+}
+
+// ---- processFlagCreateNATGatewayInput ----
+
+func TestProcessFlagCreateNATGatewayInput_Valid(t *testing.T) {
+	cmd := newCreateFlagsCmd()
+	require.NoError(t, cmd.Flags().Set("name", "Test GW"))
+	require.NoError(t, cmd.Flags().Set("term", "12"))
+	require.NoError(t, cmd.Flags().Set("speed", "1000"))
+	require.NoError(t, cmd.Flags().Set("location-id", "1"))
+
+	req, err := processFlagCreateNATGatewayInput(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, "Test GW", req.ProductName)
+	assert.Equal(t, 12, req.Term)
+	assert.Equal(t, 1000, req.Speed)
+	assert.Equal(t, 1, req.LocationID)
+}
+
+func TestProcessFlagCreateNATGatewayInput_WithOptionalFields(t *testing.T) {
+	cmd := newCreateFlagsCmd()
+	require.NoError(t, cmd.Flags().Set("name", "Test GW"))
+	require.NoError(t, cmd.Flags().Set("term", "12"))
+	require.NoError(t, cmd.Flags().Set("speed", "1000"))
+	require.NoError(t, cmd.Flags().Set("location-id", "1"))
+	require.NoError(t, cmd.Flags().Set("session-count", "500"))
+	require.NoError(t, cmd.Flags().Set("diversity-zone", "blue"))
+	require.NoError(t, cmd.Flags().Set("promo-code", "SAVE10"))
+	require.NoError(t, cmd.Flags().Set("auto-renew", "true"))
+
+	req, err := processFlagCreateNATGatewayInput(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, 500, req.Config.SessionCount)
+	assert.Equal(t, "blue", req.Config.DiversityZone)
+	assert.Equal(t, "SAVE10", req.PromoCode)
+	assert.True(t, req.AutoRenewTerm)
+}
+
+func TestProcessFlagCreateNATGatewayInput_MissingName(t *testing.T) {
+	cmd := newCreateFlagsCmd()
+	require.NoError(t, cmd.Flags().Set("term", "12"))
+	require.NoError(t, cmd.Flags().Set("speed", "1000"))
+	require.NoError(t, cmd.Flags().Set("location-id", "1"))
+
+	_, err := processFlagCreateNATGatewayInput(cmd)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "name")
+}
+
+func TestProcessFlagCreateNATGatewayInput_InvalidResourceTagsJSON(t *testing.T) {
+	cmd := newCreateFlagsCmd()
+	require.NoError(t, cmd.Flags().Set("name", "Test GW"))
+	require.NoError(t, cmd.Flags().Set("term", "12"))
+	require.NoError(t, cmd.Flags().Set("speed", "1000"))
+	require.NoError(t, cmd.Flags().Set("location-id", "1"))
+	require.NoError(t, cmd.Flags().Set("resource-tags", `{invalid}`))
+
+	_, err := processFlagCreateNATGatewayInput(cmd)
+	assert.Error(t, err)
+}
+
+func TestProcessFlagCreateNATGatewayInput_ValidResourceTags(t *testing.T) {
+	cmd := newCreateFlagsCmd()
+	require.NoError(t, cmd.Flags().Set("name", "Tag GW"))
+	require.NoError(t, cmd.Flags().Set("term", "12"))
+	require.NoError(t, cmd.Flags().Set("speed", "1000"))
+	require.NoError(t, cmd.Flags().Set("location-id", "1"))
+	require.NoError(t, cmd.Flags().Set("resource-tags", `{"env":"prod","team":"platform"}`))
+
+	req, err := processFlagCreateNATGatewayInput(cmd)
+	require.NoError(t, err)
+	assert.Len(t, req.ResourceTags, 2)
+}
+
+// ---- processJSONUpdateNATGatewayInput ----
+
+func TestProcessJSONUpdateNATGatewayInput_Valid(t *testing.T) {
+	req, explicit, err := processJSONUpdateNATGatewayInput(
+		`{"name":"Updated GW","locationId":2,"speed":2000,"term":24}`, "", "uid-123")
+	require.NoError(t, err)
+	assert.Equal(t, "uid-123", req.ProductUID)
+	assert.Equal(t, "Updated GW", req.ProductName)
+	assert.Equal(t, 2, req.LocationID)
+	assert.Equal(t, 2000, req.Speed)
+	assert.Equal(t, 24, req.Term)
+	assert.False(t, explicit.AutoRenewTerm)
+}
+
+func TestProcessJSONUpdateNATGatewayInput_EmptyStrings(t *testing.T) {
+	_, _, err := processJSONUpdateNATGatewayInput("", "", "uid-123")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse JSON")
+}
+
+func TestProcessJSONUpdateNATGatewayInput_InvalidJSON(t *testing.T) {
+	_, _, err := processJSONUpdateNATGatewayInput(`{bad}`, "", "uid-123")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse JSON")
+}
+
+func TestProcessJSONUpdateNATGatewayInput_FileNotFound(t *testing.T) {
+	_, _, err := processJSONUpdateNATGatewayInput("", filepath.Join(t.TempDir(), "missing.json"), "uid-123")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read JSON file")
+}
+
+func TestProcessJSONUpdateNATGatewayInput_ValidFile(t *testing.T) {
+	content := `{"name":"File Update GW","speed":3000}`
+	tmp, err := os.CreateTemp("", "ng-update-*.json")
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	_, err = tmp.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+
+	req, _, err := processJSONUpdateNATGatewayInput("", tmp.Name(), "uid-file")
+	require.NoError(t, err)
+	assert.Equal(t, "uid-file", req.ProductUID)
+	assert.Equal(t, "File Update GW", req.ProductName)
+	assert.Equal(t, 3000, req.Speed)
+}
+
+func TestProcessJSONUpdateNATGatewayInput_ExplicitBoolFields(t *testing.T) {
+	tests := []struct {
+		name            string
+		json            string
+		wantAutoRenew   bool
+		wantBGPShutdown bool
+		autoRenewVal    bool
+		bgpShutdownVal  bool
+	}{
+		{
+			name:          "autoRenewTerm true",
+			json:          `{"autoRenewTerm":true}`,
+			wantAutoRenew: true,
+			autoRenewVal:  true,
+		},
+		{
+			name:            "bgpShutdownDefault true",
+			json:            `{"bgpShutdownDefault":true}`,
+			wantBGPShutdown: true,
+			bgpShutdownVal:  true,
+		},
+		{
+			name:          "autoRenewTerm false explicit",
+			json:          `{"autoRenewTerm":false}`,
+			wantAutoRenew: true,
+			autoRenewVal:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, explicit, err := processJSONUpdateNATGatewayInput(tt.json, "", "uid-bool")
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAutoRenew, explicit.AutoRenewTerm)
+			assert.Equal(t, tt.wantBGPShutdown, explicit.BGPShutdownDefault)
+			if tt.wantAutoRenew {
+				assert.Equal(t, tt.autoRenewVal, req.AutoRenewTerm)
+			}
+		})
+	}
+}
+
+func TestProcessJSONUpdateNATGatewayInput_ExplicitSessionCount(t *testing.T) {
+	req, explicit, err := processJSONUpdateNATGatewayInput(
+		`{"sessionCount":250}`, "", "uid-sc")
+	require.NoError(t, err)
+	assert.True(t, explicit.SessionCount)
+	assert.Equal(t, 250, req.Config.SessionCount)
+}
+
+func TestProcessJSONUpdateNATGatewayInput_ExplicitDiversityZone(t *testing.T) {
+	req, explicit, err := processJSONUpdateNATGatewayInput(
+		`{"diversityZone":"red"}`, "", "uid-dz")
+	require.NoError(t, err)
+	assert.True(t, explicit.DiversityZone)
+	assert.Equal(t, "red", req.Config.DiversityZone)
+}
+
+// ---- processFlagUpdateNATGatewayInput ----
+
+func TestProcessFlagUpdateNATGatewayInput_Valid(t *testing.T) {
+	cmd := newUpdateFlagsCmd()
+	require.NoError(t, cmd.Flags().Set("name", "Updated GW"))
+	require.NoError(t, cmd.Flags().Set("term", "24"))
+	require.NoError(t, cmd.Flags().Set("speed", "2000"))
+	require.NoError(t, cmd.Flags().Set("location-id", "2"))
+
+	req, err := processFlagUpdateNATGatewayInput(cmd, "uid-upd")
+	require.NoError(t, err)
+	assert.Equal(t, "uid-upd", req.ProductUID)
+	assert.Equal(t, "Updated GW", req.ProductName)
+	assert.Equal(t, 24, req.Term)
+}
+
+func TestProcessFlagUpdateNATGatewayInput_EmptyUID(t *testing.T) {
+	cmd := newUpdateFlagsCmd()
+	_, err := processFlagUpdateNATGatewayInput(cmd, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "product UID is required")
+}
+
+func TestProcessFlagUpdateNATGatewayInput_WithResourceTags(t *testing.T) {
+	cmd := newUpdateFlagsCmd()
+	require.NoError(t, cmd.Flags().Set("resource-tags", `{"env":"staging"}`))
+
+	req, err := processFlagUpdateNATGatewayInput(cmd, "uid-tags")
+	require.NoError(t, err)
+	assert.Equal(t, "uid-tags", req.ProductUID)
+	assert.Len(t, req.ResourceTags, 1)
+}
+
+func TestProcessFlagUpdateNATGatewayInput_InvalidResourceTags(t *testing.T) {
+	cmd := newUpdateFlagsCmd()
+	require.NoError(t, cmd.Flags().Set("resource-tags", `{invalid}`))
+
+	_, err := processFlagUpdateNATGatewayInput(cmd, "uid-bad")
+	assert.Error(t, err)
+}

--- a/internal/commands/nat_gateway/nat_gateway_inputs_test.go
+++ b/internal/commands/nat_gateway/nat_gateway_inputs_test.go
@@ -245,6 +245,9 @@ func TestProcessJSONUpdateNATGatewayInput_ExplicitBoolFields(t *testing.T) {
 			if tt.wantAutoRenew {
 				assert.Equal(t, tt.autoRenewVal, req.AutoRenewTerm)
 			}
+			if tt.wantBGPShutdown {
+				assert.Equal(t, tt.bgpShutdownVal, req.Config.BGPShutdownDefault)
+			}
 		})
 	}
 }

--- a/internal/commands/nat_gateway/nat_gateway_output_test.go
+++ b/internal/commands/nat_gateway/nat_gateway_output_test.go
@@ -65,8 +65,10 @@ func TestPrintNATGateways_XML(t *testing.T) {
 
 func TestPrintNATGateways_Empty(t *testing.T) {
 	for _, format := range []string{"table", "json", "csv", "xml"} {
-		err := printNATGateways([]*megaport.NATGateway{}, format, true)
-		assert.NoError(t, err)
+		output.CaptureOutput(func() {
+			err := printNATGateways([]*megaport.NATGateway{}, format, true)
+			assert.NoError(t, err)
+		})
 	}
 }
 
@@ -104,8 +106,10 @@ func TestPrintNATGatewaySessions_XML(t *testing.T) {
 
 func TestPrintNATGatewaySessions_Empty(t *testing.T) {
 	for _, format := range []string{"table", "json", "csv", "xml"} {
-		err := printNATGatewaySessions([]*megaport.NATGatewaySession{}, format, true)
-		assert.NoError(t, err)
+		output.CaptureOutput(func() {
+			err := printNATGatewaySessions([]*megaport.NATGatewaySession{}, format, true)
+			assert.NoError(t, err)
+		})
 	}
 }
 

--- a/internal/commands/nat_gateway/nat_gateway_output_test.go
+++ b/internal/commands/nat_gateway/nat_gateway_output_test.go
@@ -1,0 +1,272 @@
+package nat_gateway
+
+import (
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/stretchr/testify/assert"
+)
+
+var testGateways = []*megaport.NATGateway{
+	{
+		ProductUID:         "ng-1",
+		ProductName:        "Gateway One",
+		LocationID:         100,
+		Speed:              1000,
+		Term:               12,
+		ProvisioningStatus: "LIVE",
+		Config: megaport.NATGatewayNetworkConfig{
+			SessionCount:  500,
+			DiversityZone: "blue",
+			ASN:           65000,
+		},
+	},
+	{
+		ProductUID:         "ng-2",
+		ProductName:        "Gateway Two",
+		LocationID:         200,
+		Speed:              2000,
+		Term:               24,
+		ProvisioningStatus: "CONFIGURED",
+	},
+}
+
+// ---- printNATGateways ----
+
+func TestPrintNATGateways_Table(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printNATGateways(testGateways, "table", true)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "UID")
+	assert.Contains(t, out, "ng-1")
+	assert.Contains(t, out, "Gateway One")
+}
+
+func TestPrintNATGateways_CSV(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printNATGateways(testGateways, "csv", true)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "uid")
+	assert.Contains(t, out, "ng-1")
+	assert.Contains(t, out, "ng-2")
+}
+
+func TestPrintNATGateways_XML(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printNATGateways(testGateways, "xml", true)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "<items>")
+	assert.Contains(t, out, "ng-1")
+}
+
+func TestPrintNATGateways_Empty(t *testing.T) {
+	for _, format := range []string{"table", "json", "csv", "xml"} {
+		out := output.CaptureOutput(func() {
+			err := printNATGateways([]*megaport.NATGateway{}, format, true)
+			assert.NoError(t, err)
+		})
+		_ = out
+	}
+}
+
+// ---- printNATGatewaySessions ----
+
+var testSessions = []*megaport.NATGatewaySession{
+	{SpeedMbps: 1000, SessionCount: []int{100, 200, 300}},
+	{SpeedMbps: 2000, SessionCount: []int{50}},
+}
+
+func TestPrintNATGatewaySessions_Table(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printNATGatewaySessions(testSessions, "table", true)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "SPEED")
+}
+
+func TestPrintNATGatewaySessions_CSV(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printNATGatewaySessions(testSessions, "csv", true)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "speed_mbps")
+	assert.Contains(t, out, "1000")
+}
+
+func TestPrintNATGatewaySessions_XML(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printNATGatewaySessions(testSessions, "xml", true)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "<items>")
+}
+
+func TestPrintNATGatewaySessions_Empty(t *testing.T) {
+	for _, format := range []string{"table", "json", "csv", "xml"} {
+		out := output.CaptureOutput(func() {
+			err := printNATGatewaySessions([]*megaport.NATGatewaySession{}, format, true)
+			assert.NoError(t, err)
+		})
+		_ = out
+	}
+}
+
+func TestPrintNATGatewaySessions_NilEntries(t *testing.T) {
+	sessions := []*megaport.NATGatewaySession{nil, {SpeedMbps: 500, SessionCount: []int{10}}, nil}
+	out := output.CaptureOutput(func() {
+		err := printNATGatewaySessions(sessions, "table", true)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "500")
+}
+
+// ---- printNATGatewayTelemetry ----
+
+var testTelemetryResp = &megaport.ServiceTelemetryResponse{
+	Data: []*megaport.TelemetryMetricData{
+		{
+			Type:    "BITS",
+			Subtype: "ingress",
+			Unit:    megaport.TelemetryUnit{Name: "bps"},
+			Samples: []megaport.TelemetrySample{
+				{Timestamp: 1700000000000, Value: 1234.5},
+			},
+		},
+	},
+}
+
+func TestPrintNATGatewayTelemetry_Table(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printNATGatewayTelemetry(testTelemetryResp, "table", true)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "BITS")
+}
+
+func TestPrintNATGatewayTelemetry_CSV(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printNATGatewayTelemetry(testTelemetryResp, "csv", true)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "type")
+	assert.Contains(t, out, "BITS")
+}
+
+func TestPrintNATGatewayTelemetry_XML(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printNATGatewayTelemetry(testTelemetryResp, "xml", true)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "<items>")
+}
+
+// ---- printNATGatewayValidateResult ----
+
+var testValidateResult = &megaport.NATGatewayValidateResult{
+	ProductUID:  "uid-val-1",
+	ProductType: "NAT_GATEWAY",
+	Metro:       "Sydney",
+	Price: megaport.NATGatewayOrderPrice{
+		Currency:     "AUD",
+		MonthlyRate:  99.99,
+		HourlyRate:   0.15,
+		MonthlySetup: 0,
+	},
+}
+
+func TestPrintNATGatewayValidateResult_Nil(t *testing.T) {
+	err := printNATGatewayValidateResult(nil, "table", true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nil value")
+}
+
+func TestPrintNATGatewayValidateResult_Table(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printNATGatewayValidateResult(testValidateResult, "table", true)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "uid-val-1")
+}
+
+func TestPrintNATGatewayValidateResult_JSON(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printNATGatewayValidateResult(testValidateResult, "json", true)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "uid-val-1")
+	assert.Contains(t, out, "NAT_GATEWAY")
+}
+
+func TestPrintNATGatewayValidateResult_CSV(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printNATGatewayValidateResult(testValidateResult, "csv", true)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "uid")
+}
+
+func TestPrintNATGatewayValidateResult_XML(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printNATGatewayValidateResult(testValidateResult, "xml", true)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "<items>")
+	assert.Contains(t, out, "uid-val-1")
+}
+
+// ---- printNATGatewayBuyResult ----
+
+var testBuyResult = &megaport.NATGatewayBuyResult{
+	ProductUID:         "uid-buy-1",
+	ProductName:        "Purchased GW",
+	ServiceName:        "NAT Gateway Service",
+	ProductType:        "NAT_GATEWAY",
+	ProvisioningStatus: "LIVE",
+	RateLimit:          1000,
+	LocationID:         1,
+	ContractTermMonths: 12,
+}
+
+func TestPrintNATGatewayBuyResult_Nil(t *testing.T) {
+	err := printNATGatewayBuyResult(nil, "table", true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nil value")
+}
+
+func TestPrintNATGatewayBuyResult_Table(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printNATGatewayBuyResult(testBuyResult, "table", true)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "uid-buy-1")
+}
+
+func TestPrintNATGatewayBuyResult_JSON(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printNATGatewayBuyResult(testBuyResult, "json", true)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "uid-buy-1")
+	assert.Contains(t, out, "Purchased GW")
+}
+
+func TestPrintNATGatewayBuyResult_CSV(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printNATGatewayBuyResult(testBuyResult, "csv", true)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "uid")
+}
+
+func TestPrintNATGatewayBuyResult_XML(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printNATGatewayBuyResult(testBuyResult, "xml", true)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, out, "<items>")
+	assert.Contains(t, out, "uid-buy-1")
+}

--- a/internal/commands/nat_gateway/nat_gateway_output_test.go
+++ b/internal/commands/nat_gateway/nat_gateway_output_test.go
@@ -65,11 +65,8 @@ func TestPrintNATGateways_XML(t *testing.T) {
 
 func TestPrintNATGateways_Empty(t *testing.T) {
 	for _, format := range []string{"table", "json", "csv", "xml"} {
-		out := output.CaptureOutput(func() {
-			err := printNATGateways([]*megaport.NATGateway{}, format, true)
-			assert.NoError(t, err)
-		})
-		_ = out
+		err := printNATGateways([]*megaport.NATGateway{}, format, true)
+		assert.NoError(t, err)
 	}
 }
 
@@ -107,11 +104,8 @@ func TestPrintNATGatewaySessions_XML(t *testing.T) {
 
 func TestPrintNATGatewaySessions_Empty(t *testing.T) {
 	for _, format := range []string{"table", "json", "csv", "xml"} {
-		out := output.CaptureOutput(func() {
-			err := printNATGatewaySessions([]*megaport.NATGatewaySession{}, format, true)
-			assert.NoError(t, err)
-		})
-		_ = out
+		err := printNATGatewaySessions([]*megaport.NATGatewaySession{}, format, true)
+		assert.NoError(t, err)
 	}
 }
 

--- a/internal/commands/nat_gateway/nat_gateway_prompts_test.go
+++ b/internal/commands/nat_gateway/nat_gateway_prompts_test.go
@@ -85,12 +85,19 @@ func TestPromptForCreateNATGatewayDetails_AutoRenewNo(t *testing.T) {
 
 func TestPromptForCreateNATGatewayDetails_EmptyName(t *testing.T) {
 	origPrompt := utils.GetResourcePrompt()
-	defer utils.SetResourcePrompt(origPrompt)
+	origTags := utils.GetResourceTagsPrompt()
+	defer func() {
+		utils.SetResourcePrompt(origPrompt)
+		utils.SetResourceTagsPrompt(origTags)
+	}()
 
-	utils.SetResourcePrompt(mockNGPromptSequence([]string{""}))
+	// Provide valid responses for all prompts except name so validation can run.
+	utils.SetResourcePrompt(mockNGPromptSequence([]string{"", "1", "1000", "12", "", "", "", "", ""}))
+	utils.SetResourceTagsPrompt(noopTagsPrompt)
 
 	_, err := promptForCreateNATGatewayDetails(true)
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "name")
 }
 
 func TestPromptForCreateNATGatewayDetails_InvalidLocationID(t *testing.T) {

--- a/internal/commands/nat_gateway/nat_gateway_prompts_test.go
+++ b/internal/commands/nat_gateway/nat_gateway_prompts_test.go
@@ -1,0 +1,303 @@
+package nat_gateway
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mockNGPromptSequence(responses []string) func(string, string, bool) (string, error) {
+	idx := 0
+	return func(_, _ string, _ bool) (string, error) {
+		if idx >= len(responses) {
+			return "", fmt.Errorf("unexpected prompt call #%d", idx)
+		}
+		val := responses[idx]
+		idx++
+		if val == "ERROR" {
+			return "", fmt.Errorf("simulated prompt error")
+		}
+		return val, nil
+	}
+}
+
+func noopTagsPrompt(_ bool) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+// promptForCreateNATGatewayDetails: name, locationID, speed, term, sessionCount,
+// diversityZone, autoRenew, promoCode, serviceLevelRef, ResourceTagsPrompt.
+
+func TestPromptForCreateNATGatewayDetails_Success(t *testing.T) {
+	origPrompt := utils.GetResourcePrompt()
+	origTags := utils.GetResourceTagsPrompt()
+	defer func() {
+		utils.SetResourcePrompt(origPrompt)
+		utils.SetResourceTagsPrompt(origTags)
+	}()
+
+	utils.SetResourcePrompt(mockNGPromptSequence([]string{
+		"My NAT GW", // name
+		"1",         // locationID
+		"1000",      // speed
+		"12",        // term
+		"100",       // sessionCount
+		"blue",      // diversityZone
+		"yes",       // autoRenew
+		"PROMO",     // promoCode
+		"SLR-1",     // serviceLevelRef
+	}))
+	utils.SetResourceTagsPrompt(noopTagsPrompt)
+
+	req, err := promptForCreateNATGatewayDetails(true)
+	require.NoError(t, err)
+	assert.Equal(t, "My NAT GW", req.ProductName)
+	assert.Equal(t, 1, req.LocationID)
+	assert.Equal(t, 1000, req.Speed)
+	assert.Equal(t, 12, req.Term)
+	assert.Equal(t, 100, req.Config.SessionCount)
+	assert.Equal(t, "blue", req.Config.DiversityZone)
+	assert.True(t, req.AutoRenewTerm)
+	assert.Equal(t, "PROMO", req.PromoCode)
+	assert.Equal(t, "SLR-1", req.ServiceLevelReference)
+}
+
+func TestPromptForCreateNATGatewayDetails_AutoRenewNo(t *testing.T) {
+	origPrompt := utils.GetResourcePrompt()
+	origTags := utils.GetResourceTagsPrompt()
+	defer func() {
+		utils.SetResourcePrompt(origPrompt)
+		utils.SetResourceTagsPrompt(origTags)
+	}()
+
+	utils.SetResourcePrompt(mockNGPromptSequence([]string{
+		"GW", "1", "1000", "12", "", "", "no", "", "",
+	}))
+	utils.SetResourceTagsPrompt(noopTagsPrompt)
+
+	req, err := promptForCreateNATGatewayDetails(true)
+	require.NoError(t, err)
+	assert.False(t, req.AutoRenewTerm)
+}
+
+func TestPromptForCreateNATGatewayDetails_EmptyName(t *testing.T) {
+	origPrompt := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(origPrompt)
+
+	utils.SetResourcePrompt(mockNGPromptSequence([]string{""}))
+
+	_, err := promptForCreateNATGatewayDetails(true)
+	assert.Error(t, err)
+}
+
+func TestPromptForCreateNATGatewayDetails_InvalidLocationID(t *testing.T) {
+	origPrompt := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(origPrompt)
+
+	utils.SetResourcePrompt(mockNGPromptSequence([]string{"GW", "notanumber"}))
+
+	_, err := promptForCreateNATGatewayDetails(true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid location ID")
+}
+
+func TestPromptForCreateNATGatewayDetails_ZeroLocationID(t *testing.T) {
+	origPrompt := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(origPrompt)
+
+	utils.SetResourcePrompt(mockNGPromptSequence([]string{"GW", "0"}))
+
+	_, err := promptForCreateNATGatewayDetails(true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid location ID")
+}
+
+func TestPromptForCreateNATGatewayDetails_InvalidSpeed(t *testing.T) {
+	origPrompt := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(origPrompt)
+
+	utils.SetResourcePrompt(mockNGPromptSequence([]string{"GW", "1", "bad"}))
+
+	_, err := promptForCreateNATGatewayDetails(true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid speed")
+}
+
+func TestPromptForCreateNATGatewayDetails_ZeroSpeed(t *testing.T) {
+	origPrompt := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(origPrompt)
+
+	utils.SetResourcePrompt(mockNGPromptSequence([]string{"GW", "1", "0"}))
+
+	_, err := promptForCreateNATGatewayDetails(true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid speed")
+}
+
+func TestPromptForCreateNATGatewayDetails_InvalidTerm(t *testing.T) {
+	origPrompt := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(origPrompt)
+
+	utils.SetResourcePrompt(mockNGPromptSequence([]string{"GW", "1", "1000", "abc"}))
+
+	_, err := promptForCreateNATGatewayDetails(true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid term")
+}
+
+func TestPromptForCreateNATGatewayDetails_InvalidSessionCount(t *testing.T) {
+	origPrompt := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(origPrompt)
+
+	utils.SetResourcePrompt(mockNGPromptSequence([]string{"GW", "1", "1000", "12", "abc"}))
+
+	_, err := promptForCreateNATGatewayDetails(true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid session count")
+}
+
+func TestPromptForCreateNATGatewayDetails_TagsError(t *testing.T) {
+	origPrompt := utils.GetResourcePrompt()
+	origTags := utils.GetResourceTagsPrompt()
+	defer func() {
+		utils.SetResourcePrompt(origPrompt)
+		utils.SetResourceTagsPrompt(origTags)
+	}()
+
+	utils.SetResourcePrompt(mockNGPromptSequence([]string{
+		"GW", "1", "1000", "12", "", "", "", "", "",
+	}))
+	utils.SetResourceTagsPrompt(func(_ bool) (map[string]string, error) {
+		return nil, fmt.Errorf("tags error")
+	})
+
+	_, err := promptForCreateNATGatewayDetails(true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "tags error")
+}
+
+// promptForUpdateNATGatewayDetails: name, locationID, speed, term, sessionCount,
+// diversityZone, autoRenew, promoCode, serviceLevelRef, ResourceTagsPrompt.
+
+func TestPromptForUpdateNATGatewayDetails_Success(t *testing.T) {
+	origPrompt := utils.GetResourcePrompt()
+	origTags := utils.GetResourceTagsPrompt()
+	defer func() {
+		utils.SetResourcePrompt(origPrompt)
+		utils.SetResourceTagsPrompt(origTags)
+	}()
+
+	utils.SetResourcePrompt(mockNGPromptSequence([]string{
+		"Updated GW", // name
+		"2",          // locationID
+		"2000",       // speed
+		"24",         // term
+		"200",        // sessionCount
+		"red",        // diversityZone
+		"y",          // autoRenew
+		"SAVE",       // promoCode
+		"SLR-2",      // serviceLevelRef
+	}))
+	utils.SetResourceTagsPrompt(noopTagsPrompt)
+
+	req, explicit, err := promptForUpdateNATGatewayDetails("uid-upd", true)
+	require.NoError(t, err)
+	assert.Equal(t, "uid-upd", req.ProductUID)
+	assert.Equal(t, "Updated GW", req.ProductName)
+	assert.Equal(t, 2, req.LocationID)
+	assert.Equal(t, 2000, req.Speed)
+	assert.Equal(t, 24, req.Term)
+	assert.Equal(t, 200, req.Config.SessionCount)
+	assert.True(t, explicit.SessionCount)
+	assert.Equal(t, "red", req.Config.DiversityZone)
+	assert.True(t, explicit.DiversityZone)
+	assert.True(t, req.AutoRenewTerm)
+	assert.True(t, explicit.AutoRenewTerm)
+}
+
+func TestPromptForUpdateNATGatewayDetails_AllEmpty(t *testing.T) {
+	origPrompt := utils.GetResourcePrompt()
+	origTags := utils.GetResourceTagsPrompt()
+	defer func() {
+		utils.SetResourcePrompt(origPrompt)
+		utils.SetResourceTagsPrompt(origTags)
+	}()
+
+	utils.SetResourcePrompt(mockNGPromptSequence([]string{
+		"", "", "", "", "", "", "", "", "",
+	}))
+	utils.SetResourceTagsPrompt(noopTagsPrompt)
+
+	req, explicit, err := promptForUpdateNATGatewayDetails("uid-empty", true)
+	require.NoError(t, err)
+	assert.Equal(t, "uid-empty", req.ProductUID)
+	assert.False(t, explicit.AutoRenewTerm)
+	assert.False(t, explicit.SessionCount)
+	assert.False(t, explicit.DiversityZone)
+}
+
+func TestPromptForUpdateNATGatewayDetails_AutoRenewNo(t *testing.T) {
+	origPrompt := utils.GetResourcePrompt()
+	origTags := utils.GetResourceTagsPrompt()
+	defer func() {
+		utils.SetResourcePrompt(origPrompt)
+		utils.SetResourceTagsPrompt(origTags)
+	}()
+
+	utils.SetResourcePrompt(mockNGPromptSequence([]string{
+		"", "", "", "", "", "", "no", "", "",
+	}))
+	utils.SetResourceTagsPrompt(noopTagsPrompt)
+
+	req, explicit, err := promptForUpdateNATGatewayDetails("uid-no", true)
+	require.NoError(t, err)
+	assert.False(t, req.AutoRenewTerm)
+	assert.True(t, explicit.AutoRenewTerm)
+}
+
+func TestPromptForUpdateNATGatewayDetails_InvalidLocationID(t *testing.T) {
+	origPrompt := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(origPrompt)
+
+	utils.SetResourcePrompt(mockNGPromptSequence([]string{"", "bad"}))
+
+	_, _, err := promptForUpdateNATGatewayDetails("uid-1", true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid location ID")
+}
+
+func TestPromptForUpdateNATGatewayDetails_InvalidSpeed(t *testing.T) {
+	origPrompt := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(origPrompt)
+
+	utils.SetResourcePrompt(mockNGPromptSequence([]string{"", "", "bad"}))
+
+	_, _, err := promptForUpdateNATGatewayDetails("uid-1", true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid speed")
+}
+
+func TestPromptForUpdateNATGatewayDetails_InvalidTerm(t *testing.T) {
+	origPrompt := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(origPrompt)
+
+	utils.SetResourcePrompt(mockNGPromptSequence([]string{"", "", "", "abc"}))
+
+	_, _, err := promptForUpdateNATGatewayDetails("uid-1", true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid term")
+}
+
+func TestPromptForUpdateNATGatewayDetails_InvalidSessionCount(t *testing.T) {
+	origPrompt := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(origPrompt)
+
+	utils.SetResourcePrompt(mockNGPromptSequence([]string{"", "", "", "", "bad"}))
+
+	_, _, err := promptForUpdateNATGatewayDetails("uid-1", true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid session count")
+}


### PR DESCRIPTION
Fills unit test gaps in the `ix` and `nat_gateway` packages identified in ESD-1323.

- `ix`: adds `ix_inputs_test.go` (JSON edge cases, flag no-ops), `ix_output_test.go` (XML format, field mapping, nil safety), `ix_prompts_test.go` (error paths on each prompt beyond the first)
- `nat_gateway`: adds `nat_gateway_inputs_test.go` (flag and JSON paths for create/update, explicit-field tracking), `nat_gateway_output_test.go` (all four formats for gateways/sessions/telemetry/validate/buy, nil-safety), `nat_gateway_prompts_test.go` (create and update happy paths plus error cases)

80 new tests total.