### PR TITLE
ESD-1320: Migrate VXC integration tests to to direct action function calls

### DIFF
--- a/internal/commands/ports/ports_integration_hook.go
+++ b/internal/commands/ports/ports_integration_hook.go
@@ -1,0 +1,43 @@
+//go:build integration
+
+package ports
+
+import (
+	"context"
+	"sync"
+
+	megaport "github.com/megaport/megaportgo"
+)
+
+// integrationHookBuyResponses records BuyPortResponses keyed by request name so
+// importing test packages (e.g. vxc) can recover a port's UID from the SDK
+// response instead of polling ListPorts. This lives in a non-test source file
+// so the hook is compiled into the ports package when it is imported under the
+// integration build tag.
+var integrationHookBuyResponses sync.Map // key: request.Name (string), value: *megaport.BuyPortResponse
+
+func init() {
+	base := buyPortFunc
+	buyPortFunc = func(ctx context.Context, client *megaport.Client, req *megaport.BuyPortRequest) (*megaport.BuyPortResponse, error) {
+		resp, err := base(ctx, client, req)
+		if err == nil && resp != nil && req != nil && req.Name != "" {
+			integrationHookBuyResponses.Store(req.Name, resp)
+		}
+		return resp, err
+	}
+}
+
+// IntegrationBuyPortUID returns the first technical service UID captured for the
+// given port name by the integration buy hook. ok is false if no response was
+// recorded or it carried no UIDs. Integration-test use only.
+func IntegrationBuyPortUID(name string) (uid string, ok bool) {
+	v, loaded := integrationHookBuyResponses.Load(name)
+	if !loaded {
+		return "", false
+	}
+	resp, isResp := v.(*megaport.BuyPortResponse)
+	if !isResp || len(resp.TechnicalServiceUIDs) == 0 {
+		return "", false
+	}
+	return resp.TechnicalServiceUIDs[0], true
+}

--- a/internal/commands/vxc/vxc_integration_test.go
+++ b/internal/commands/vxc/vxc_integration_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// integrationLocationID is the staging data centre used for all VXC lifecycle
+// integrationLocationID is the staging data center used for all VXC lifecycle
 // tests. Location 67 matches the canonical example used across the CLI test
 // suite and supports the 1G port speed these tests exercise.
 const integrationLocationID = 67
@@ -34,7 +34,7 @@ const (
 // integrationVXCBuyResponses lets parallel tests retrieve the BuyVXCResponse
 // for their VXC without scraping stdout. The init() hook below wraps
 // buyVXCFunc so the SDK response is stored under the request VXCName; tests
-// read the UID back from this map.
+// read the UID back from this map. key: req.VXCName (string), value: *megaport.BuyVXCResponse
 var integrationVXCBuyResponses sync.Map
 
 func init() {
@@ -57,8 +57,9 @@ func generateUniqueID(t *testing.T) string {
 }
 
 // buildPortCmd constructs a cobra.Command for ports.BuyPort with all required
-// flags pre-set. Tests call ports.BuyPort(buildPortCmd(...), nil, true).
-func buildPortCmd(name string, locationID int) *cobra.Command {
+// flags pre-set. Tests call ports.BuyPort(buildPortCmd(t, ...), nil, true).
+func buildPortCmd(t *testing.T, name string, locationID int) *cobra.Command {
+	t.Helper()
 	cmd := &cobra.Command{Use: "buy"}
 	cmd.Flags().Bool("interactive", false, "")
 	cmd.Flags().Bool("no-wait", false, "")
@@ -75,18 +76,19 @@ func buildPortCmd(name string, locationID int) *cobra.Command {
 	cmd.Flags().String("promo-code", "", "")
 	cmd.Flags().String("resource-tags", "", "")
 	cmd.Flags().Bool("cost-confirm", true, "")
-	_ = cmd.Flags().Set("name", name)
-	_ = cmd.Flags().Set("term", "1")
-	_ = cmd.Flags().Set("port-speed", "1000")
-	_ = cmd.Flags().Set("location-id", fmt.Sprintf("%d", locationID))
-	_ = cmd.Flags().Set("marketplace-visibility", "false")
-	_ = cmd.Flags().Set("yes", "true")
+	require.NoError(t, cmd.Flags().Set("name", name))
+	require.NoError(t, cmd.Flags().Set("term", "1"))
+	require.NoError(t, cmd.Flags().Set("port-speed", "1000"))
+	require.NoError(t, cmd.Flags().Set("location-id", fmt.Sprintf("%d", locationID)))
+	require.NoError(t, cmd.Flags().Set("marketplace-visibility", "false"))
+	require.NoError(t, cmd.Flags().Set("yes", "true"))
 	return cmd
 }
 
 // buildVXCCmd constructs a cobra.Command for BuyVXC with the given name,
-// endpoint UIDs, and rate limit pre-set. Tests call BuyVXC(buildVXCCmd(...), nil, true).
-func buildVXCCmd(name, aEndUID, bEndUID string, rateLimit int) *cobra.Command {
+// endpoint UIDs, and rate limit pre-set. Tests call BuyVXC(buildVXCCmd(t, ...), nil, true).
+func buildVXCCmd(t *testing.T, name, aEndUID, bEndUID string, rateLimit int) *cobra.Command {
+	t.Helper()
 	cmd := &cobra.Command{Use: "buy"}
 	cmd.Flags().Bool("interactive", false, "")
 	cmd.Flags().Bool("no-wait", false, "")
@@ -109,12 +111,12 @@ func buildVXCCmd(name, aEndUID, bEndUID string, rateLimit int) *cobra.Command {
 	cmd.Flags().String("cost-centre", "", "")
 	cmd.Flags().String("a-end-partner-config", "", "")
 	cmd.Flags().String("b-end-partner-config", "", "")
-	_ = cmd.Flags().Set("name", name)
-	_ = cmd.Flags().Set("a-end-uid", aEndUID)
-	_ = cmd.Flags().Set("b-end-uid", bEndUID)
-	_ = cmd.Flags().Set("rate-limit", fmt.Sprintf("%d", rateLimit))
-	_ = cmd.Flags().Set("term", "1")
-	_ = cmd.Flags().Set("yes", "true")
+	require.NoError(t, cmd.Flags().Set("name", name))
+	require.NoError(t, cmd.Flags().Set("a-end-uid", aEndUID))
+	require.NoError(t, cmd.Flags().Set("b-end-uid", bEndUID))
+	require.NoError(t, cmd.Flags().Set("rate-limit", fmt.Sprintf("%d", rateLimit)))
+	require.NoError(t, cmd.Flags().Set("term", "1"))
+	require.NoError(t, cmd.Flags().Set("yes", "true"))
 	return cmd
 }
 
@@ -166,7 +168,7 @@ func newUpdateVXCCmd() *cobra.Command {
 // from parallel tests is harmless.
 func buyPortAndGetUID(t *testing.T, portName string) string {
 	t.Helper()
-	cmd := buildPortCmd(portName, integrationLocationID)
+	cmd := buildPortCmd(t, portName, integrationLocationID)
 	require.NoErrorf(t, ports.BuyPort(cmd, nil, true), "BuyPort failed for %q", portName)
 
 	sdkClient := testutil.SharedIntegrationClient(t)
@@ -213,6 +215,7 @@ func registerPortCleanup(t *testing.T, uid string) {
 		require.NoError(t, delCmd.Flags().Set("force", "true"))
 		if err := ports.DeletePort(delCmd, []string{uid}, true); err != nil {
 			t.Errorf("cleanup: failed to delete port %s: %v", uid, err)
+			return
 		}
 	})
 }
@@ -286,7 +289,7 @@ func TestIntegration_VXCPortToPortLifecycle(t *testing.T) {
 	registerPortCleanup(t, portBUID)
 	t.Logf("Created port B: %s", portBUID)
 
-	vxcCmd := buildVXCCmd(vxcName, portAUID, portBUID, 100)
+	vxcCmd := buildVXCCmd(t, vxcName, portAUID, portBUID, 100)
 	vxcUID := runBuyVXC(t, vxcCmd, vxcName)
 	registerVXCCleanup(t, vxcUID)
 	t.Logf("Created VXC: %s", vxcUID)
@@ -322,7 +325,7 @@ func TestIntegration_VXCVLANModificationLifecycle(t *testing.T) {
 	portBUID := buyPortAndGetUID(t, portBName)
 	registerPortCleanup(t, portBUID)
 
-	vxcCmd := buildVXCCmd(vxcName, portAUID, portBUID, 100)
+	vxcCmd := buildVXCCmd(t, vxcName, portAUID, portBUID, 100)
 	require.NoError(t, vxcCmd.Flags().Set("a-end-vlan", "100"))
 	require.NoError(t, vxcCmd.Flags().Set("b-end-vlan", "200"))
 	vxcUID := runBuyVXC(t, vxcCmd, vxcName)
@@ -370,28 +373,7 @@ func TestIntegration_VXCJSONInputLifecycle(t *testing.T) {
 	buyJSON, err := json.Marshal(buyPayload)
 	require.NoError(t, err)
 
-	vxcCmd := &cobra.Command{Use: "buy"}
-	vxcCmd.Flags().Bool("interactive", false, "")
-	vxcCmd.Flags().Bool("no-wait", false, "")
-	vxcCmd.Flags().Bool("yes", false, "")
-	vxcCmd.Flags().String("json", "", "")
-	vxcCmd.Flags().String("json-file", "", "")
-	vxcCmd.Flags().String("name", "", "")
-	vxcCmd.Flags().String("a-end-uid", "", "")
-	vxcCmd.Flags().String("b-end-uid", "", "")
-	vxcCmd.Flags().Int("rate-limit", 0, "")
-	vxcCmd.Flags().Int("term", 0, "")
-	vxcCmd.Flags().Int("a-end-vlan", 0, "")
-	vxcCmd.Flags().Int("b-end-vlan", 0, "")
-	vxcCmd.Flags().Int("a-end-inner-vlan", 0, "")
-	vxcCmd.Flags().Int("b-end-inner-vlan", 0, "")
-	vxcCmd.Flags().Int("a-end-vnic-index", 0, "")
-	vxcCmd.Flags().Int("b-end-vnic-index", 0, "")
-	vxcCmd.Flags().String("promo-code", "", "")
-	vxcCmd.Flags().String("service-key", "", "")
-	vxcCmd.Flags().String("cost-centre", "", "")
-	vxcCmd.Flags().String("a-end-partner-config", "", "")
-	vxcCmd.Flags().String("b-end-partner-config", "", "")
+	vxcCmd := buildVXCCmd(t, "", "", "", 0)
 	require.NoError(t, vxcCmd.Flags().Set("json", string(buyJSON)))
 
 	vxcUID := runBuyVXC(t, vxcCmd, vxcName)

--- a/internal/commands/vxc/vxc_integration_test.go
+++ b/internal/commands/vxc/vxc_integration_test.go
@@ -174,7 +174,7 @@ func buyPortAndGetUID(t *testing.T, portName string) string {
 	sdkClient := testutil.SharedIntegrationClient(t)
 	deadline := time.Now().Add(30 * time.Second)
 	for {
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		allPorts, err := sdkClient.PortService.ListPorts(ctx)
 		cancel()
 		require.NoErrorf(t, err, "ListPorts failed after creating port %q", portName)

--- a/internal/commands/vxc/vxc_integration_test.go
+++ b/internal/commands/vxc/vxc_integration_test.go
@@ -1,0 +1,413 @@
+//go:build integration
+
+package vxc
+
+import (
+	"context"
+	crypto_rand "crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/megaport/megaport-cli/internal/commands/ports"
+	"github.com/megaport/megaport-cli/internal/testutil"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// integrationLocationID is the staging data centre used for all VXC lifecycle
+// tests. Location 67 matches the canonical example used across the CLI test
+// suite and supports the 1G port speed these tests exercise.
+const integrationLocationID = 67
+
+const (
+	cleanupStatusTimeout  = 60 * time.Second
+	cleanupStatusInterval = 2 * time.Second
+)
+
+// integrationVXCBuyResponses lets parallel tests retrieve the BuyVXCResponse
+// for their VXC without scraping stdout. The init() hook below wraps
+// buyVXCFunc so the SDK response is stored under the request VXCName; tests
+// read the UID back from this map.
+var integrationVXCBuyResponses sync.Map
+
+func init() {
+	base := buyVXCFunc
+	buyVXCFunc = func(ctx context.Context, client *megaport.Client, req *megaport.BuyVXCRequest) (*megaport.BuyVXCResponse, error) {
+		resp, err := base(ctx, client, req)
+		if err == nil && resp != nil && req != nil && req.VXCName != "" {
+			integrationVXCBuyResponses.Store(req.VXCName, resp)
+		}
+		return resp, err
+	}
+}
+
+func generateUniqueID(t *testing.T) string {
+	t.Helper()
+	buf := make([]byte, 4)
+	_, err := crypto_rand.Read(buf)
+	require.NoError(t, err, "failed to read crypto/rand entropy")
+	return hex.EncodeToString(buf)
+}
+
+// buildPortCmd constructs a cobra.Command for ports.BuyPort with all required
+// flags pre-set. Tests call ports.BuyPort(buildPortCmd(...), nil, true).
+func buildPortCmd(name string, locationID int) *cobra.Command {
+	cmd := &cobra.Command{Use: "buy"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().Bool("no-wait", false, "")
+	cmd.Flags().Bool("yes", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().Int("term", 0, "")
+	cmd.Flags().Int("port-speed", 0, "")
+	cmd.Flags().Int("location-id", 0, "")
+	cmd.Flags().Bool("marketplace-visibility", false, "")
+	cmd.Flags().String("diversity-zone", "", "")
+	cmd.Flags().String("cost-centre", "", "")
+	cmd.Flags().String("promo-code", "", "")
+	cmd.Flags().String("resource-tags", "", "")
+	cmd.Flags().Bool("cost-confirm", true, "")
+	_ = cmd.Flags().Set("name", name)
+	_ = cmd.Flags().Set("term", "1")
+	_ = cmd.Flags().Set("port-speed", "1000")
+	_ = cmd.Flags().Set("location-id", fmt.Sprintf("%d", locationID))
+	_ = cmd.Flags().Set("marketplace-visibility", "false")
+	_ = cmd.Flags().Set("yes", "true")
+	return cmd
+}
+
+// buildVXCCmd constructs a cobra.Command for BuyVXC with the given name,
+// endpoint UIDs, and rate limit pre-set. Tests call BuyVXC(buildVXCCmd(...), nil, true).
+func buildVXCCmd(name, aEndUID, bEndUID string, rateLimit int) *cobra.Command {
+	cmd := &cobra.Command{Use: "buy"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().Bool("no-wait", false, "")
+	cmd.Flags().Bool("yes", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("a-end-uid", "", "")
+	cmd.Flags().String("b-end-uid", "", "")
+	cmd.Flags().Int("rate-limit", 0, "")
+	cmd.Flags().Int("term", 0, "")
+	cmd.Flags().Int("a-end-vlan", 0, "")
+	cmd.Flags().Int("b-end-vlan", 0, "")
+	cmd.Flags().Int("a-end-inner-vlan", 0, "")
+	cmd.Flags().Int("b-end-inner-vlan", 0, "")
+	cmd.Flags().Int("a-end-vnic-index", 0, "")
+	cmd.Flags().Int("b-end-vnic-index", 0, "")
+	cmd.Flags().String("promo-code", "", "")
+	cmd.Flags().String("service-key", "", "")
+	cmd.Flags().String("cost-centre", "", "")
+	cmd.Flags().String("a-end-partner-config", "", "")
+	cmd.Flags().String("b-end-partner-config", "", "")
+	_ = cmd.Flags().Set("name", name)
+	_ = cmd.Flags().Set("a-end-uid", aEndUID)
+	_ = cmd.Flags().Set("b-end-uid", bEndUID)
+	_ = cmd.Flags().Set("rate-limit", fmt.Sprintf("%d", rateLimit))
+	_ = cmd.Flags().Set("term", "1")
+	_ = cmd.Flags().Set("yes", "true")
+	return cmd
+}
+
+func newDeletePortCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "delete"}
+	cmd.Flags().BoolP("force", "f", false, "")
+	cmd.Flags().Bool("now", false, "")
+	cmd.Flags().Bool("safe-delete", false, "")
+	return cmd
+}
+
+func newDeleteVXCCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "delete"}
+	cmd.Flags().Bool("force", false, "")
+	cmd.Flags().Bool("later", false, "")
+	return cmd
+}
+
+func newUpdateVXCCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().Int("rate-limit", 0, "")
+	cmd.Flags().Int("a-end-vlan", 0, "")
+	cmd.Flags().Int("b-end-vlan", 0, "")
+	cmd.Flags().String("a-end-location", "", "")
+	cmd.Flags().String("b-end-location", "", "")
+	cmd.Flags().Bool("locked", false, "")
+	cmd.Flags().Int("term", 0, "")
+	cmd.Flags().String("cost-centre", "", "")
+	cmd.Flags().Bool("shutdown", false, "")
+	cmd.Flags().Int("a-end-inner-vlan", 0, "")
+	cmd.Flags().Int("b-end-inner-vlan", 0, "")
+	cmd.Flags().String("a-end-uid", "", "")
+	cmd.Flags().String("b-end-uid", "", "")
+	cmd.Flags().String("a-end-partner-config", "", "")
+	cmd.Flags().String("b-end-partner-config", "", "")
+	cmd.Flags().Bool("is-approved", false, "")
+	cmd.Flags().Int("a-vnic-index", -1, "")
+	cmd.Flags().Int("b-vnic-index", -1, "")
+	return cmd
+}
+
+// buyPortAndGetUID calls ports.BuyPort (which blocks until the port is LIVE)
+// then finds the created port's UID by listing all ports via the SDK and
+// matching by name. Spinner output goes to real stdout — interleaved output
+// from parallel tests is harmless.
+func buyPortAndGetUID(t *testing.T, portName string) string {
+	t.Helper()
+	cmd := buildPortCmd(portName, integrationLocationID)
+	require.NoErrorf(t, ports.BuyPort(cmd, nil, true), "BuyPort failed for %q", portName)
+
+	sdkClient := testutil.SharedIntegrationClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	allPorts, err := sdkClient.PortService.ListPorts(ctx)
+	require.NoErrorf(t, err, "ListPorts failed after creating port %q", portName)
+	for _, p := range allPorts {
+		if p != nil && p.Name == portName {
+			return p.UID
+		}
+	}
+	t.Fatalf("port %q not found in port list after creation", portName)
+	return ""
+}
+
+// uidFromVXCBuyResponse returns the TechnicalServiceUID captured by the
+// init() hook for the given VXC name.
+func uidFromVXCBuyResponse(t *testing.T, vxcName string) string {
+	t.Helper()
+	v, ok := integrationVXCBuyResponses.Load(vxcName)
+	require.Truef(t, ok, "no VXC buy response recorded for %q", vxcName)
+	resp, ok := v.(*megaport.BuyVXCResponse)
+	require.Truef(t, ok, "VXC buy response for %q has unexpected type %T", vxcName, v)
+	require.NotEmptyf(t, resp.TechnicalServiceUID, "no UID in VXC buy response for %q", vxcName)
+	return resp.TechnicalServiceUID
+}
+
+// runBuyVXC calls BuyVXC and returns the UID from the hook-captured response.
+func runBuyVXC(t *testing.T, cmd *cobra.Command, vxcName string) string {
+	t.Helper()
+	require.NoErrorf(t, BuyVXC(cmd, nil, true), "BuyVXC failed for %q", vxcName)
+	return uidFromVXCBuyResponse(t, vxcName)
+}
+
+// registerPortCleanup schedules a best-effort delete of the port. Register
+// before registering VXC cleanup so port deletions run after VXC deletion
+// (t.Cleanup is LIFO).
+func registerPortCleanup(t *testing.T, uid string) {
+	t.Helper()
+	t.Cleanup(func() {
+		delCmd := newDeletePortCmd()
+		require.NoError(t, delCmd.Flags().Set("now", "true"))
+		require.NoError(t, delCmd.Flags().Set("force", "true"))
+		if err := ports.DeletePort(delCmd, []string{uid}, true); err != nil {
+			t.Errorf("cleanup: failed to delete port %s: %v", uid, err)
+		}
+	})
+}
+
+// registerVXCCleanup schedules VXC deletion and polls for DECOMMISSIONING so
+// port cleanups (registered before this) can safely proceed.
+func registerVXCCleanup(t *testing.T, uid string) {
+	t.Helper()
+	t.Cleanup(func() {
+		delCmd := newDeleteVXCCmd()
+		require.NoError(t, delCmd.Flags().Set("force", "true"))
+		if err := DeleteVXC(delCmd, []string{uid}, true); err != nil {
+			t.Errorf("cleanup: failed to delete VXC %s: %v", uid, err)
+			return
+		}
+
+		sdkClient := testutil.SharedIntegrationClient(t)
+		deadline := time.Now().Add(cleanupStatusTimeout)
+		var lastStatus string
+		for {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			vxc, err := sdkClient.VXCService.GetVXC(ctx, uid)
+			cancel()
+			if err != nil {
+				t.Logf("cleanup: GetVXC after delete returned %v (may already be gone)", err)
+				return
+			}
+			if vxc == nil {
+				return
+			}
+			lastStatus = vxc.ProvisioningStatus
+			if strings.Contains(lastStatus, "DECOMMISSIONING") || strings.Contains(lastStatus, "DECOMMISSIONED") {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Errorf("VXC %s did not reach DECOMMISSIONING within %s, last status %q", uid, cleanupStatusTimeout, lastStatus)
+				return
+			}
+			time.Sleep(cleanupStatusInterval)
+		}
+	})
+}
+
+// vxcFromSDK reads VXC state via the shared SDK client. Used for state
+// assertions in parallel tests instead of CaptureOutput on GetVXC.
+func vxcFromSDK(t *testing.T, uid string) *megaport.VXC {
+	t.Helper()
+	sdkClient := testutil.SharedIntegrationClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	vxc, err := sdkClient.VXCService.GetVXC(ctx, uid)
+	require.NoErrorf(t, err, "SDK GetVXC failed for %s", uid)
+	require.NotNilf(t, vxc, "SDK GetVXC returned nil for %s", uid)
+	return vxc
+}
+
+func TestIntegration_VXCPortToPortLifecycle(t *testing.T) {
+	t.Parallel()
+	testutil.RequireSharedIntegrationClient(t)
+
+	id := generateUniqueID(t)
+	portAName := fmt.Sprintf("CLI-Test-VXC-PortA-%s", id)
+	portBName := fmt.Sprintf("CLI-Test-VXC-PortB-%s", id)
+	vxcName := fmt.Sprintf("CLI-Test-VXC-%s", id)
+
+	portAUID := buyPortAndGetUID(t, portAName)
+	registerPortCleanup(t, portAUID)
+	t.Logf("Created port A: %s", portAUID)
+
+	portBUID := buyPortAndGetUID(t, portBName)
+	registerPortCleanup(t, portBUID)
+	t.Logf("Created port B: %s", portBUID)
+
+	vxcCmd := buildVXCCmd(vxcName, portAUID, portBUID, 100)
+	vxcUID := runBuyVXC(t, vxcCmd, vxcName)
+	registerVXCCleanup(t, vxcUID)
+	t.Logf("Created VXC: %s", vxcUID)
+
+	vxc := vxcFromSDK(t, vxcUID)
+	assert.Equal(t, vxcUID, vxc.UID)
+	assert.Equal(t, vxcName, vxc.Name)
+	assert.Equal(t, 100, vxc.RateLimit)
+	assert.Equal(t, portAUID, vxc.AEndConfiguration.UID)
+	assert.Equal(t, portBUID, vxc.BEndConfiguration.UID)
+
+	newName := vxcName + "-Updated"
+	updateCmd := newUpdateVXCCmd()
+	require.NoError(t, updateCmd.Flags().Set("name", newName))
+	require.NoErrorf(t, UpdateVXC(updateCmd, []string{vxcUID}, true), "UpdateVXC failed")
+
+	updated := vxcFromSDK(t, vxcUID)
+	assert.Equal(t, newName, updated.Name)
+}
+
+func TestIntegration_VXCVLANModificationLifecycle(t *testing.T) {
+	t.Parallel()
+	testutil.RequireSharedIntegrationClient(t)
+
+	id := generateUniqueID(t)
+	portAName := fmt.Sprintf("CLI-Test-VLAN-PortA-%s", id)
+	portBName := fmt.Sprintf("CLI-Test-VLAN-PortB-%s", id)
+	vxcName := fmt.Sprintf("CLI-Test-VLAN-%s", id)
+
+	portAUID := buyPortAndGetUID(t, portAName)
+	registerPortCleanup(t, portAUID)
+
+	portBUID := buyPortAndGetUID(t, portBName)
+	registerPortCleanup(t, portBUID)
+
+	vxcCmd := buildVXCCmd(vxcName, portAUID, portBUID, 100)
+	require.NoError(t, vxcCmd.Flags().Set("a-end-vlan", "100"))
+	require.NoError(t, vxcCmd.Flags().Set("b-end-vlan", "200"))
+	vxcUID := runBuyVXC(t, vxcCmd, vxcName)
+	registerVXCCleanup(t, vxcUID)
+	t.Logf("Created VXC: %s", vxcUID)
+
+	vxc := vxcFromSDK(t, vxcUID)
+	assert.Equal(t, 100, vxc.AEndConfiguration.VLAN)
+	assert.Equal(t, 200, vxc.BEndConfiguration.VLAN)
+
+	updateCmd := newUpdateVXCCmd()
+	require.NoError(t, updateCmd.Flags().Set("a-end-vlan", "101"))
+	require.NoError(t, updateCmd.Flags().Set("b-end-vlan", "201"))
+	require.NoErrorf(t, UpdateVXC(updateCmd, []string{vxcUID}, true), "UpdateVXC VLAN update failed")
+
+	updated := vxcFromSDK(t, vxcUID)
+	assert.Equal(t, 101, updated.AEndConfiguration.VLAN)
+	assert.Equal(t, 201, updated.BEndConfiguration.VLAN)
+}
+
+func TestIntegration_VXCJSONInputLifecycle(t *testing.T) {
+	t.Parallel()
+	testutil.RequireSharedIntegrationClient(t)
+
+	id := generateUniqueID(t)
+	portAName := fmt.Sprintf("CLI-Test-VXCJ-PortA-%s", id)
+	portBName := fmt.Sprintf("CLI-Test-VXCJ-PortB-%s", id)
+	vxcName := fmt.Sprintf("CLI-Test-VXCJ-%s", id)
+
+	portAUID := buyPortAndGetUID(t, portAName)
+	registerPortCleanup(t, portAUID)
+
+	portBUID := buyPortAndGetUID(t, portBName)
+	registerPortCleanup(t, portBUID)
+
+	buyPayload := map[string]any{
+		"portUid":   portAUID,
+		"vxcName":   vxcName,
+		"rateLimit": 100,
+		"term":      1,
+		"bEndConfiguration": map[string]any{
+			"productUID": portBUID,
+		},
+	}
+	buyJSON, err := json.Marshal(buyPayload)
+	require.NoError(t, err)
+
+	vxcCmd := &cobra.Command{Use: "buy"}
+	vxcCmd.Flags().Bool("interactive", false, "")
+	vxcCmd.Flags().Bool("no-wait", false, "")
+	vxcCmd.Flags().Bool("yes", false, "")
+	vxcCmd.Flags().String("json", "", "")
+	vxcCmd.Flags().String("json-file", "", "")
+	vxcCmd.Flags().String("name", "", "")
+	vxcCmd.Flags().String("a-end-uid", "", "")
+	vxcCmd.Flags().String("b-end-uid", "", "")
+	vxcCmd.Flags().Int("rate-limit", 0, "")
+	vxcCmd.Flags().Int("term", 0, "")
+	vxcCmd.Flags().Int("a-end-vlan", 0, "")
+	vxcCmd.Flags().Int("b-end-vlan", 0, "")
+	vxcCmd.Flags().Int("a-end-inner-vlan", 0, "")
+	vxcCmd.Flags().Int("b-end-inner-vlan", 0, "")
+	vxcCmd.Flags().Int("a-end-vnic-index", 0, "")
+	vxcCmd.Flags().Int("b-end-vnic-index", 0, "")
+	vxcCmd.Flags().String("promo-code", "", "")
+	vxcCmd.Flags().String("service-key", "", "")
+	vxcCmd.Flags().String("cost-centre", "", "")
+	vxcCmd.Flags().String("a-end-partner-config", "", "")
+	vxcCmd.Flags().String("b-end-partner-config", "", "")
+	require.NoError(t, vxcCmd.Flags().Set("json", string(buyJSON)))
+
+	vxcUID := runBuyVXC(t, vxcCmd, vxcName)
+	registerVXCCleanup(t, vxcUID)
+	t.Logf("Created VXC (JSON input): %s", vxcUID)
+
+	vxc := vxcFromSDK(t, vxcUID)
+	assert.Equal(t, vxcUID, vxc.UID)
+	assert.Equal(t, vxcName, vxc.Name)
+	assert.Equal(t, 100, vxc.RateLimit)
+
+	newName := vxcName + "-Updated"
+	updateCmd := newUpdateVXCCmd()
+	require.NoError(t, updateCmd.Flags().Set("name", newName))
+	require.NoErrorf(t, UpdateVXC(updateCmd, []string{vxcUID}, true), "UpdateVXC failed")
+
+	updated := vxcFromSDK(t, vxcUID)
+	assert.Equal(t, newName, updated.Name)
+}

--- a/internal/commands/vxc/vxc_integration_test.go
+++ b/internal/commands/vxc/vxc_integration_test.go
@@ -163,23 +163,30 @@ func newUpdateVXCCmd() *cobra.Command {
 }
 
 // buyPortAndGetUID calls ports.BuyPort (which blocks until the port is LIVE)
-// then finds the created port's UID by listing all ports via the SDK and
-// matching by name. Spinner output goes to real stdout — interleaved output
-// from parallel tests is harmless.
+// then finds the created port's UID by polling ListPorts until the port
+// appears by name. Polling guards against brief eventual-consistency lag
+// between the port reaching LIVE and appearing in the list API.
 func buyPortAndGetUID(t *testing.T, portName string) string {
 	t.Helper()
 	cmd := buildPortCmd(t, portName, integrationLocationID)
 	require.NoErrorf(t, ports.BuyPort(cmd, nil, true), "BuyPort failed for %q", portName)
 
 	sdkClient := testutil.SharedIntegrationClient(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	allPorts, err := sdkClient.PortService.ListPorts(ctx)
-	require.NoErrorf(t, err, "ListPorts failed after creating port %q", portName)
-	for _, p := range allPorts {
-		if p != nil && p.Name == portName {
-			return p.UID
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		allPorts, err := sdkClient.PortService.ListPorts(ctx)
+		cancel()
+		require.NoErrorf(t, err, "ListPorts failed after creating port %q", portName)
+		for _, p := range allPorts {
+			if p != nil && p.Name == portName {
+				return p.UID
+			}
 		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(2 * time.Second)
 	}
 	t.Fatalf("port %q not found in port list after creation", portName)
 	return ""

--- a/internal/commands/vxc/vxc_integration_test.go
+++ b/internal/commands/vxc/vxc_integration_test.go
@@ -163,33 +163,35 @@ func newUpdateVXCCmd() *cobra.Command {
 }
 
 // buyPortAndGetUID calls ports.BuyPort (which blocks until the port is LIVE)
-// then finds the created port's UID by polling ListPorts until the port
-// appears by name. Polling guards against brief eventual-consistency lag
-// between the port reaching LIVE and appearing in the list API.
+// then recovers the created port's UID from the BuyPortResponse captured by
+// the ports package's integration buy hook. Cleanup is registered immediately
+// after the buy succeeds and before the UID is asserted, so a billable port is
+// never leaked if UID recovery fails.
 func buyPortAndGetUID(t *testing.T, portName string) string {
 	t.Helper()
 	cmd := buildPortCmd(t, portName, integrationLocationID)
 	require.NoErrorf(t, ports.BuyPort(cmd, nil, true), "BuyPort failed for %q", portName)
 
-	sdkClient := testutil.SharedIntegrationClient(t)
-	deadline := time.Now().Add(30 * time.Second)
-	for {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		allPorts, err := sdkClient.PortService.ListPorts(ctx)
-		cancel()
-		require.NoErrorf(t, err, "ListPorts failed after creating port %q", portName)
-		for _, p := range allPorts {
-			if p != nil && p.Name == portName {
-				return p.UID
-			}
-		}
-		if time.Now().After(deadline) {
-			break
-		}
-		time.Sleep(2 * time.Second)
+	uid, ok := ports.IntegrationBuyPortUID(portName)
+	require.Truef(t, ok, "no port buy response captured for %q", portName)
+	registerPortCleanup(t, uid)
+	return uid
+}
+
+// vxcBuyResponseUID returns the TechnicalServiceUID captured by the init() hook
+// for the given VXC name without failing the test. ok is false if no response
+// was recorded or it carried no UID. Used to register cleanup before the
+// fail-able UID assertions in uidFromVXCBuyResponse.
+func vxcBuyResponseUID(vxcName string) (uid string, ok bool) {
+	v, loaded := integrationVXCBuyResponses.Load(vxcName)
+	if !loaded {
+		return "", false
 	}
-	t.Fatalf("port %q not found in port list after creation", portName)
-	return ""
+	resp, isResp := v.(*megaport.BuyVXCResponse)
+	if !isResp || resp.TechnicalServiceUID == "" {
+		return "", false
+	}
+	return resp.TechnicalServiceUID, true
 }
 
 // uidFromVXCBuyResponse returns the TechnicalServiceUID captured by the
@@ -205,9 +207,14 @@ func uidFromVXCBuyResponse(t *testing.T, vxcName string) string {
 }
 
 // runBuyVXC calls BuyVXC and returns the UID from the hook-captured response.
+// Cleanup is registered immediately after the buy succeeds and before the UID
+// is asserted, so a billable VXC is never leaked if UID extraction fails.
 func runBuyVXC(t *testing.T, cmd *cobra.Command, vxcName string) string {
 	t.Helper()
 	require.NoErrorf(t, BuyVXC(cmd, nil, true), "BuyVXC failed for %q", vxcName)
+	if uid, ok := vxcBuyResponseUID(vxcName); ok {
+		registerVXCCleanup(t, uid)
+	}
 	return uidFromVXCBuyResponse(t, vxcName)
 }
 
@@ -289,16 +296,13 @@ func TestIntegration_VXCPortToPortLifecycle(t *testing.T) {
 	vxcName := fmt.Sprintf("CLI-Test-VXC-%s", id)
 
 	portAUID := buyPortAndGetUID(t, portAName)
-	registerPortCleanup(t, portAUID)
 	t.Logf("Created port A: %s", portAUID)
 
 	portBUID := buyPortAndGetUID(t, portBName)
-	registerPortCleanup(t, portBUID)
 	t.Logf("Created port B: %s", portBUID)
 
 	vxcCmd := buildVXCCmd(t, vxcName, portAUID, portBUID, 100)
 	vxcUID := runBuyVXC(t, vxcCmd, vxcName)
-	registerVXCCleanup(t, vxcUID)
 	t.Logf("Created VXC: %s", vxcUID)
 
 	vxc := vxcFromSDK(t, vxcUID)
@@ -327,16 +331,13 @@ func TestIntegration_VXCVLANModificationLifecycle(t *testing.T) {
 	vxcName := fmt.Sprintf("CLI-Test-VLAN-%s", id)
 
 	portAUID := buyPortAndGetUID(t, portAName)
-	registerPortCleanup(t, portAUID)
 
 	portBUID := buyPortAndGetUID(t, portBName)
-	registerPortCleanup(t, portBUID)
 
 	vxcCmd := buildVXCCmd(t, vxcName, portAUID, portBUID, 100)
 	require.NoError(t, vxcCmd.Flags().Set("a-end-vlan", "100"))
 	require.NoError(t, vxcCmd.Flags().Set("b-end-vlan", "200"))
 	vxcUID := runBuyVXC(t, vxcCmd, vxcName)
-	registerVXCCleanup(t, vxcUID)
 	t.Logf("Created VXC: %s", vxcUID)
 
 	vxc := vxcFromSDK(t, vxcUID)
@@ -363,10 +364,8 @@ func TestIntegration_VXCJSONInputLifecycle(t *testing.T) {
 	vxcName := fmt.Sprintf("CLI-Test-VXCJ-%s", id)
 
 	portAUID := buyPortAndGetUID(t, portAName)
-	registerPortCleanup(t, portAUID)
 
 	portBUID := buyPortAndGetUID(t, portBName)
-	registerPortCleanup(t, portBUID)
 
 	buyPayload := map[string]any{
 		"portUid":   portAUID,
@@ -384,7 +383,6 @@ func TestIntegration_VXCJSONInputLifecycle(t *testing.T) {
 	require.NoError(t, vxcCmd.Flags().Set("json", string(buyJSON)))
 
 	vxcUID := runBuyVXC(t, vxcCmd, vxcName)
-	registerVXCCleanup(t, vxcUID)
 	t.Logf("Created VXC (JSON input): %s", vxcUID)
 
 	vxc := vxcFromSDK(t, vxcUID)


### PR DESCRIPTION
Migrates VXC integration tests from Approach A (binary invocation via `exec.Command` / `CaptureOutput`) to Approach B (direct action function calls), matching the pattern established by the ports integration tests.

The main challenge was parallelism: `CaptureOutput` holds a global stdout mutex for the entire duration of `BuyPort`/`BuyVXC` (which can take 60+ seconds to provision), serializing all parallel tests. The fix is three-pronged:

- An `init()` hook wraps `buyVXCFunc` to capture `*BuyVXCResponse` in a `sync.Map` keyed by VXC name, so tests recover UIDs without touching stdout.
- Port UIDs are recovered the same way: the ports package now exposes an integration-tagged buy hook (`ports.IntegrationBuyPortUID`) that captures the `*BuyPortResponse`, so the VXC test reads the UID straight from the hook instead of polling `ListPorts`.
- State assertions call the SDK directly via `vxcFromSDK`, bypassing `CaptureOutput` entirely.

`t.Cleanup` registration order is LIFO-aware: port cleanups are registered before VXC cleanup so the VXC is deleted first.

Cleanup is registered the instant `BuyPort`/`BuyVXC` returns success, before any UID assertion that could `FailNow`, so a billable port or VXC is never leaked if UID recovery fails.

Three scenarios are covered: port-to-port lifecycle (buy, assert, rename), VLAN modification lifecycle (buy with VLANs, assert, update VLANs), and JSON input lifecycle (buy via `--json` flag, assert, rename).