### PR TITLE
ESD-1325: add --base-url flag to override the API base URL

### DIFF
--- a/cmd/megaport/megaport_common.go
+++ b/cmd/megaport/megaport_common.go
@@ -99,7 +99,7 @@ func InitializeCommon() {
 	rootCmd.PersistentFlags().BoolVar(&utils.NoRetry, "no-retry", false, "Disable automatic retry on transient API failures")
 	rootCmd.PersistentFlags().IntVar(&utils.MaxRetries, "max-retries", 3, "Maximum number of retries for transient API failures")
 	rootCmd.PersistentFlags().BoolVar(&utils.LogHTTP, "log-http", false, "Log raw HTTP requests/responses to stderr for debugging (may include sensitive data such as auth tokens)")
-	rootCmd.PersistentFlags().StringVar(&utils.BaseURL, "base-url", "", "Override the API base URL (e.g. http://localhost:8080); takes precedence over --env")
+	rootCmd.PersistentFlags().StringVar(&utils.BaseURL, "base-url", "", "Override the API base URL (e.g. http://localhost:8080); takes precedence over --env and any profile environment")
 	rootCmd.PersistentFlags().BoolVar(&noHeader, "no-header", false, "Suppress table and CSV column headers (useful for scripting)")
 	rootCmd.PersistentFlags().BoolVar(&noPager, "no-pager", false, "Disable pager for long table output")
 	rootCmd.MarkFlagsMutuallyExclusive("quiet", "verbose")

--- a/cmd/megaport/megaport_common.go
+++ b/cmd/megaport/megaport_common.go
@@ -99,6 +99,7 @@ func InitializeCommon() {
 	rootCmd.PersistentFlags().BoolVar(&utils.NoRetry, "no-retry", false, "Disable automatic retry on transient API failures")
 	rootCmd.PersistentFlags().IntVar(&utils.MaxRetries, "max-retries", 3, "Maximum number of retries for transient API failures")
 	rootCmd.PersistentFlags().BoolVar(&utils.LogHTTP, "log-http", false, "Log raw HTTP requests/responses to stderr for debugging (may include sensitive data such as auth tokens)")
+	rootCmd.PersistentFlags().StringVar(&utils.BaseURL, "base-url", "", "Override the API base URL (e.g. http://localhost:8080); takes precedence over --env")
 	rootCmd.PersistentFlags().BoolVar(&noHeader, "no-header", false, "Suppress table and CSV column headers (useful for scripting)")
 	rootCmd.PersistentFlags().BoolVar(&noPager, "no-pager", false, "Disable pager for long table output")
 	rootCmd.MarkFlagsMutuallyExclusive("quiet", "verbose")

--- a/internal/commands/config/login.go
+++ b/internal/commands/config/login.go
@@ -199,10 +199,15 @@ var loginFuncWithOutput = func(ctx context.Context, outputFormat string) (*megap
 		return nil, fmt.Errorf("megaport API secret key not provided. Configure an active profile or set MEGAPORT_SECRET_KEY environment variable")
 	}
 
-	envOpt := environmentOption(env)
 	httpClient := &http.Client{Timeout: 30 * time.Second}
 
-	opts := appendLogOpts([]megaport.ClientOpt{megaport.WithCredentials(accessKey, secretKey), envOpt, megaport.WithCustomHeaders(cliHeaders)})
+	baseOpts := []megaport.ClientOpt{megaport.WithCredentials(accessKey, secretKey), megaport.WithCustomHeaders(cliHeaders)}
+	if utils.BaseURL != "" {
+		baseOpts = append(baseOpts, megaport.WithBaseURL(utils.BaseURL))
+	} else {
+		baseOpts = append(baseOpts, environmentOption(env))
+	}
+	opts := appendLogOpts(baseOpts)
 	megaportClient, err := megaport.New(httpClient, opts...)
 	if err != nil {
 		return nil, err
@@ -229,14 +234,19 @@ var loginFuncWithOutput = func(ctx context.Context, outputFormat string) (*megap
 // newUnauthenticatedClientFunc creates a Megaport API client without authentication.
 // Used for public API endpoints (e.g., locations) that don't require credentials.
 var newUnauthenticatedClientFunc = func() (*megaport.Client, error) {
-	env, err := resolveEnvironment(true)
-	if err != nil {
-		return nil, err
-	}
-
-	envOpt := environmentOption(env)
 	httpClient := &http.Client{Timeout: 30 * time.Second}
-	opts := appendLogOpts([]megaport.ClientOpt{envOpt, megaport.WithCustomHeaders(cliHeaders)})
+
+	baseOpts := []megaport.ClientOpt{megaport.WithCustomHeaders(cliHeaders)}
+	if utils.BaseURL != "" {
+		baseOpts = append(baseOpts, megaport.WithBaseURL(utils.BaseURL))
+	} else {
+		env, err := resolveEnvironment(true)
+		if err != nil {
+			return nil, err
+		}
+		baseOpts = append(baseOpts, environmentOption(env))
+	}
+	opts := appendLogOpts(baseOpts)
 	return megaport.New(httpClient, opts...)
 }
 

--- a/internal/commands/config/login.go
+++ b/internal/commands/config/login.go
@@ -222,12 +222,13 @@ var loginFuncWithOutput = func(ctx context.Context, outputFormat string) (*megap
 		spinner.Stop()
 		return nil, err
 	} else {
-		// Capitalize the first letter of environment for display
-		envDisplay := env
-		if len(envDisplay) > 0 {
-			envDisplay = strings.ToUpper(envDisplay[:1]) + envDisplay[1:]
+		var target string
+		if utils.BaseURL != "" {
+			target = utils.BaseURL
+		} else {
+			target = strings.ToUpper(env[:1]) + env[1:]
 		}
-		spinner.StopWithSuccess(fmt.Sprintf("Successfully logged in to Megaport %s", envDisplay))
+		spinner.StopWithSuccess(fmt.Sprintf("Successfully logged in to Megaport %s", target))
 	}
 
 	return megaportClient, nil
@@ -256,7 +257,11 @@ var newUnauthenticatedClientFunc = func() (*megaport.Client, error) {
 // is not HTTPS, since credentials will be sent in cleartext.
 func warnIfInsecureBaseURL(rawURL string) {
 	u, err := url.Parse(rawURL)
-	if err != nil || u.Scheme != "https" {
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		fmt.Fprintf(os.Stderr, "Warning: invalid --base-url %q (expected an absolute URL like https://host)\n", rawURL)
+		return
+	}
+	if u.Scheme != "https" {
 		fmt.Fprintf(os.Stderr, "Warning: --base-url %q is not HTTPS; credentials will be sent in cleartext\n", rawURL)
 	}
 }

--- a/internal/commands/config/login.go
+++ b/internal/commands/config/login.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -203,6 +204,7 @@ var loginFuncWithOutput = func(ctx context.Context, outputFormat string) (*megap
 
 	baseOpts := []megaport.ClientOpt{megaport.WithCredentials(accessKey, secretKey), megaport.WithCustomHeaders(cliHeaders)}
 	if utils.BaseURL != "" {
+		warnIfInsecureBaseURL(utils.BaseURL)
 		baseOpts = append(baseOpts, megaport.WithBaseURL(utils.BaseURL))
 	} else {
 		baseOpts = append(baseOpts, environmentOption(env))
@@ -248,6 +250,15 @@ var newUnauthenticatedClientFunc = func() (*megaport.Client, error) {
 	}
 	opts := appendLogOpts(baseOpts)
 	return megaport.New(httpClient, opts...)
+}
+
+// warnIfInsecureBaseURL prints a warning to stderr when the --base-url scheme
+// is not HTTPS, since credentials will be sent in cleartext.
+func warnIfInsecureBaseURL(rawURL string) {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Scheme != "https" {
+		fmt.Fprintf(os.Stderr, "Warning: --base-url %q is not HTTPS; credentials will be sent in cleartext\n", rawURL)
+	}
 }
 
 // appendLogOpts appends HTTP debug logging options to the client option slice

--- a/internal/commands/config/login_test.go
+++ b/internal/commands/config/login_test.go
@@ -322,6 +322,33 @@ func TestProfileOverrideLogin(t *testing.T) {
 		assert.NotContains(t, err.Error(), "not found")
 	})
 
+	t.Run("--base-url overrides env and profile environment", func(t *testing.T) {
+		origEnv := utils.Env
+		defer func() { utils.Env = origEnv }()
+		origProfile := utils.ProfileOverride
+		defer func() { utils.ProfileOverride = origProfile }()
+		origBaseURL := utils.BaseURL
+		defer func() { utils.BaseURL = origBaseURL }()
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"unauthorized"}`))
+		}))
+		defer ts.Close()
+
+		utils.Env = "production"
+		utils.ProfileOverride = "staging"
+		utils.BaseURL = ts.URL
+
+		_, err := LoginWithOutput(context.Background(), "json")
+		// The call must reach the test server (not production/staging) — a
+		// credential error means it never made a network request, so fail if we
+		// see one.
+		assert.Error(t, err)
+		assert.NotContains(t, err.Error(), "access key not provided")
+		assert.NotContains(t, err.Error(), "secret key not provided")
+	})
+
 	t.Run("no profile and no env vars returns credential error", func(t *testing.T) {
 		origEnv := utils.Env
 		defer func() { utils.Env = origEnv }()
@@ -529,6 +556,24 @@ func TestNewUnauthenticatedClient(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, client)
 		assert.Contains(t, client.BaseURL.String(), "api-mpone-dev.megaport.com")
+	})
+
+	t.Run("--base-url overrides env flag", func(t *testing.T) {
+		origEnv := utils.Env
+		defer func() { utils.Env = origEnv }()
+		origProfile := utils.ProfileOverride
+		defer func() { utils.ProfileOverride = origProfile }()
+		origBaseURL := utils.BaseURL
+		defer func() { utils.BaseURL = origBaseURL }()
+
+		utils.Env = "staging"
+		utils.ProfileOverride = ""
+		utils.BaseURL = "http://localhost:9999"
+
+		client, err := NewUnauthenticatedClient()
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.Contains(t, client.BaseURL.String(), "localhost:9999")
 	})
 }
 

--- a/internal/commands/config/login_test.go
+++ b/internal/commands/config/login_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -330,7 +331,9 @@ func TestProfileOverrideLogin(t *testing.T) {
 		origBaseURL := utils.BaseURL
 		defer func() { utils.BaseURL = origBaseURL }()
 
+		var requestCount atomic.Int32
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount.Add(1)
 			w.WriteHeader(http.StatusUnauthorized)
 			_, _ = w.Write([]byte(`{"message":"unauthorized"}`))
 		}))
@@ -341,12 +344,10 @@ func TestProfileOverrideLogin(t *testing.T) {
 		utils.BaseURL = ts.URL
 
 		_, err := LoginWithOutput(context.Background(), "json")
-		// The call must reach the test server (not production/staging) — a
-		// credential error means it never made a network request, so fail if we
-		// see one.
 		assert.Error(t, err)
 		assert.NotContains(t, err.Error(), "access key not provided")
 		assert.NotContains(t, err.Error(), "secret key not provided")
+		assert.Positive(t, requestCount.Load(), "expected at least one request to reach the test server")
 	})
 
 	t.Run("no profile and no env vars returns credential error", func(t *testing.T) {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -67,6 +67,9 @@ var (
 	// LogHTTP enables raw HTTP request/response logging to stderr. Set via --log-http flag.
 	LogHTTP bool
 
+	// BaseURL overrides the API base URL (e.g. http://localhost:8080). Set via --base-url flag.
+	BaseURL string
+
 	ValidFormats = []string{FormatTable, FormatJSON, FormatCSV, FormatXML, FormatGoTemplate}
 )
 


### PR DESCRIPTION
Adds a global `--base-url` persistent flag that points the CLI at an arbitrary API endpoint (e.g. `http://localhost:8080`). When set it takes precedence over `--env` and any profile environment setting, making it easy to test against local dev environments and enabling megatest CLI integration without needing a named environment alias.

A stderr warning is emitted when the scheme is not HTTPS, since credentials are sent to whatever URL is configured.