### PR TITLE
feat(ESD-1325): add --token-url flag for authenticated custom-host login

### DIFF
--- a/cmd/megaport/megaport_common.go
+++ b/cmd/megaport/megaport_common.go
@@ -100,7 +100,7 @@ func InitializeCommon() {
 	rootCmd.PersistentFlags().IntVar(&utils.MaxRetries, "max-retries", 3, "Maximum number of retries for transient API failures")
 	rootCmd.PersistentFlags().BoolVar(&utils.LogHTTP, "log-http", false, "Log raw HTTP requests/responses to stderr for debugging (may include sensitive data such as auth tokens)")
 	rootCmd.PersistentFlags().StringVar(&utils.BaseURL, "base-url", "", "Override the API base URL (e.g. http://localhost:8080); takes precedence over --env and any profile environment")
-	rootCmd.PersistentFlags().StringVar(&utils.TokenURL, "token-url", "", "Override the OAuth token endpoint (use with --base-url when auth is served from a non-standard host)")
+	rootCmd.PersistentFlags().StringVar(&utils.TokenURL, "token-url", "", "Override the OAuth token endpoint (typically used with --base-url when auth is served from a non-standard host)")
 	rootCmd.PersistentFlags().BoolVar(&noHeader, "no-header", false, "Suppress table and CSV column headers (useful for scripting)")
 	rootCmd.PersistentFlags().BoolVar(&noPager, "no-pager", false, "Disable pager for long table output")
 	rootCmd.MarkFlagsMutuallyExclusive("quiet", "verbose")

--- a/cmd/megaport/megaport_common.go
+++ b/cmd/megaport/megaport_common.go
@@ -100,6 +100,7 @@ func InitializeCommon() {
 	rootCmd.PersistentFlags().IntVar(&utils.MaxRetries, "max-retries", 3, "Maximum number of retries for transient API failures")
 	rootCmd.PersistentFlags().BoolVar(&utils.LogHTTP, "log-http", false, "Log raw HTTP requests/responses to stderr for debugging (may include sensitive data such as auth tokens)")
 	rootCmd.PersistentFlags().StringVar(&utils.BaseURL, "base-url", "", "Override the API base URL (e.g. http://localhost:8080); takes precedence over --env and any profile environment")
+	rootCmd.PersistentFlags().StringVar(&utils.TokenURL, "token-url", "", "Override the OAuth token endpoint (use with --base-url when auth is served from a non-standard host)")
 	rootCmd.PersistentFlags().BoolVar(&noHeader, "no-header", false, "Suppress table and CSV column headers (useful for scripting)")
 	rootCmd.PersistentFlags().BoolVar(&noPager, "no-pager", false, "Disable pager for long table output")
 	rootCmd.MarkFlagsMutuallyExclusive("quiet", "verbose")

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/jedib0t/go-pretty/v6 v6.8.0
 	github.com/jmespath/go-jmespath v0.4.0
-	github.com/megaport/megaportgo v1.12.1
+	github.com/megaport/megaportgo v1.13.0
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.17 h1:78v8ZlW0bP43XfmAfPsdXcoNCelfMHsDmd/pkENfrjQ=
 github.com/mattn/go-runewidth v0.0.17/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/megaport/megaportgo v1.12.1 h1:I2pwAFlMspiN0NW2mJB275lZkUOrwsG9Gu7r3YxKDnw=
-github.com/megaport/megaportgo v1.12.1/go.mod h1:Ee2mHySrxQo3bkpib2TILCtYOL8KfhDXAD1xEVA3aeE=
+github.com/megaport/megaportgo v1.13.0 h1:+PV3Pblu6Dd0UI6+UjTOv0Fs5Qzuu1sPkxz7B6Xr05k=
+github.com/megaport/megaportgo v1.13.0/go.mod h1:Ee2mHySrxQo3bkpib2TILCtYOL8KfhDXAD1xEVA3aeE=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=

--- a/internal/commands/config/login.go
+++ b/internal/commands/config/login.go
@@ -209,6 +209,9 @@ var loginFuncWithOutput = func(ctx context.Context, outputFormat string) (*megap
 	} else {
 		baseOpts = append(baseOpts, environmentOption(env))
 	}
+	if utils.TokenURL != "" {
+		baseOpts = append(baseOpts, megaport.WithTokenURL(utils.TokenURL))
+	}
 	opts := appendLogOpts(baseOpts)
 	megaportClient, err := megaport.New(httpClient, opts...)
 	if err != nil {

--- a/internal/commands/config/login.go
+++ b/internal/commands/config/login.go
@@ -266,10 +266,10 @@ var newUnauthenticatedClientFunc = func() (*megaport.Client, error) {
 func warnIfInsecureURL(flagName, rawURL string) {
 	u, err := url.Parse(rawURL)
 	if err != nil || u.Scheme == "" || u.Host == "" {
-		fmt.Fprintf(os.Stderr, "Warning: invalid %s %q (expected an absolute URL like https://host)\n", flagName, rawURL)
+		fmt.Fprintf(os.Stderr, "Warning: invalid %s %q (expected an absolute URL like https://host/path)\n", flagName, rawURL)
 		return
 	}
-	if u.Scheme != "https" {
+	if !strings.EqualFold(u.Scheme, "https") {
 		fmt.Fprintf(os.Stderr, "Warning: %s %q is not HTTPS; credentials will be sent in cleartext\n", flagName, rawURL)
 	}
 }

--- a/internal/commands/config/login.go
+++ b/internal/commands/config/login.go
@@ -210,6 +210,10 @@ var loginFuncWithOutput = func(ctx context.Context, outputFormat string) (*megap
 		baseOpts = append(baseOpts, environmentOption(env))
 	}
 	if utils.TokenURL != "" {
+		warnIfInsecureURL("--token-url", utils.TokenURL)
+		if utils.BaseURL == "" {
+			fmt.Fprintf(os.Stderr, "Warning: --token-url is set without --base-url; credentials will be sent to %q instead of the standard auth host\n", utils.TokenURL)
+		}
 		baseOpts = append(baseOpts, megaport.WithTokenURL(utils.TokenURL))
 	}
 	opts := appendLogOpts(baseOpts)
@@ -256,18 +260,22 @@ var newUnauthenticatedClientFunc = func() (*megaport.Client, error) {
 	return megaport.New(httpClient, opts...)
 }
 
-// warnIfInsecureBaseURL prints a warning to stderr when the --base-url scheme
-// is not HTTPS, since credentials will be sent in cleartext.
-func warnIfInsecureBaseURL(rawURL string) {
+// warnIfInsecureURL prints a warning to stderr when the given URL's scheme is
+// not HTTPS, since credentials will be sent in cleartext. flagName is used in
+// the message so callers can name the flag that supplied the URL.
+func warnIfInsecureURL(flagName, rawURL string) {
 	u, err := url.Parse(rawURL)
 	if err != nil || u.Scheme == "" || u.Host == "" {
-		fmt.Fprintf(os.Stderr, "Warning: invalid --base-url %q (expected an absolute URL like https://host)\n", rawURL)
+		fmt.Fprintf(os.Stderr, "Warning: invalid %s %q (expected an absolute URL like https://host)\n", flagName, rawURL)
 		return
 	}
 	if u.Scheme != "https" {
-		fmt.Fprintf(os.Stderr, "Warning: --base-url %q is not HTTPS; credentials will be sent in cleartext\n", rawURL)
+		fmt.Fprintf(os.Stderr, "Warning: %s %q is not HTTPS; credentials will be sent in cleartext\n", flagName, rawURL)
 	}
 }
+
+// warnIfInsecureBaseURL is a convenience wrapper for the --base-url flag.
+func warnIfInsecureBaseURL(rawURL string) { warnIfInsecureURL("--base-url", rawURL) }
 
 // appendLogOpts appends HTTP debug logging options to the client option slice
 // when --log-http is enabled. Logs go to stderr at DEBUG level with sensitive

--- a/internal/commands/config/login_test.go
+++ b/internal/commands/config/login_test.go
@@ -322,12 +322,6 @@ func TestProfileOverrideLogin(t *testing.T) {
 		assert.NotContains(t, err.Error(), "not found")
 	})
 
-	// The authenticated path's --base-url branch is structurally identical to
-	// the unauthenticated path, which is covered in TestNewUnauthenticatedClient.
-	// We can't assert end-to-end auth against a custom host here because the SDK's
-	// Authorize rejects unknown hosts before making a request; real coverage will
-	// come once --base-url is paired with token injection via WithTokenProvider.
-
 	t.Run("no profile and no env vars returns credential error", func(t *testing.T) {
 		origEnv := utils.Env
 		defer func() { utils.Env = origEnv }()
@@ -553,6 +547,72 @@ func TestNewUnauthenticatedClient(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, client)
 		assert.Contains(t, client.BaseURL.String(), "localhost:9999")
+	})
+}
+
+func TestBaseURLWithTokenURL(t *testing.T) {
+	origBaseURL := utils.BaseURL
+	origTokenURL := utils.TokenURL
+	origEnv := utils.Env
+	origProfile := utils.ProfileOverride
+	defer func() {
+		utils.BaseURL = origBaseURL
+		utils.TokenURL = origTokenURL
+		utils.Env = origEnv
+		utils.ProfileOverride = origProfile
+	}()
+
+	tempDir, err := os.MkdirTemp("", "megaport-baseurl-auth-test")
+	assert.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	t.Run("authenticated login succeeds with --base-url and --token-url", func(t *testing.T) {
+		var tokenEndpointHit bool
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/oauth2/token" {
+				tokenEndpointHit = true
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`)
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		defer ts.Close()
+
+		t.Setenv("MEGAPORT_CONFIG_DIR", tempDir)
+		t.Setenv("MEGAPORT_ACCESS_KEY", "test-key")
+		t.Setenv("MEGAPORT_SECRET_KEY", "test-secret")
+
+		utils.BaseURL = ts.URL
+		utils.TokenURL = ts.URL + "/oauth2/token"
+		utils.Env = ""
+		utils.ProfileOverride = ""
+
+		client, err := LoginWithOutput(context.Background(), "")
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.True(t, tokenEndpointHit, "token endpoint should have been called")
+		assert.Contains(t, client.BaseURL.String(), ts.Listener.Addr().String())
+	})
+
+	t.Run("--base-url without --token-url fails with unknown environment", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer ts.Close()
+
+		t.Setenv("MEGAPORT_CONFIG_DIR", tempDir)
+		t.Setenv("MEGAPORT_ACCESS_KEY", "test-key")
+		t.Setenv("MEGAPORT_SECRET_KEY", "test-secret")
+
+		utils.BaseURL = ts.URL
+		utils.TokenURL = ""
+		utils.Env = ""
+		utils.ProfileOverride = ""
+
+		_, err := LoginWithOutput(context.Background(), "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown API environment")
 	})
 }
 

--- a/internal/commands/config/login_test.go
+++ b/internal/commands/config/login_test.go
@@ -595,6 +595,48 @@ func TestBaseURLWithTokenURL(t *testing.T) {
 		assert.Contains(t, client.BaseURL.String(), ts.Listener.Addr().String())
 	})
 
+	t.Run("--token-url without --base-url warns and still applies the override", func(t *testing.T) {
+		var tokenEndpointHit bool
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/oauth2/token" {
+				tokenEndpointHit = true
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`)
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		defer ts.Close()
+
+		t.Setenv("MEGAPORT_CONFIG_DIR", tempDir)
+		t.Setenv("MEGAPORT_ACCESS_KEY", "test-key")
+		t.Setenv("MEGAPORT_SECRET_KEY", "test-secret")
+		t.Setenv("MEGAPORT_ENVIRONMENT", "staging")
+
+		utils.BaseURL = ""
+		utils.TokenURL = ts.URL + "/oauth2/token"
+		utils.Env = "staging"
+		utils.ProfileOverride = ""
+
+		// Capture stderr to verify the warning is emitted.
+		origStderr := os.Stderr
+		r, w, _ := os.Pipe()
+		os.Stderr = w
+
+		client, loginErr := LoginWithOutput(context.Background(), "")
+
+		w.Close()
+		os.Stderr = origStderr
+		var stderrBuf bytes.Buffer
+		_, _ = stderrBuf.ReadFrom(r)
+		stderrOut := stderrBuf.String()
+
+		assert.NoError(t, loginErr)
+		assert.NotNil(t, client)
+		assert.True(t, tokenEndpointHit, "token endpoint should have been called")
+		assert.Contains(t, stderrOut, "--token-url is set without --base-url")
+	})
+
 	t.Run("--base-url without --token-url fails with unknown environment", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)

--- a/internal/commands/config/login_test.go
+++ b/internal/commands/config/login_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -567,10 +568,10 @@ func TestBaseURLWithTokenURL(t *testing.T) {
 	t.Cleanup(func() { os.RemoveAll(tempDir) })
 
 	t.Run("authenticated login succeeds with --base-url and --token-url", func(t *testing.T) {
-		var tokenEndpointHit bool
+		var tokenEndpointHit atomic.Bool
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/oauth2/token" {
-				tokenEndpointHit = true
+				tokenEndpointHit.Store(true)
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = fmt.Fprint(w, `{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`)
 				return
@@ -591,15 +592,13 @@ func TestBaseURLWithTokenURL(t *testing.T) {
 		client, err := LoginWithOutput(context.Background(), "")
 		assert.NoError(t, err)
 		assert.NotNil(t, client)
-		assert.True(t, tokenEndpointHit, "token endpoint should have been called")
+		assert.True(t, tokenEndpointHit.Load(), "token endpoint should have been called")
 		assert.Contains(t, client.BaseURL.String(), ts.Listener.Addr().String())
 	})
 
 	t.Run("--token-url without --base-url warns and still applies the override", func(t *testing.T) {
-		var tokenEndpointHit bool
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/oauth2/token" {
-				tokenEndpointHit = true
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = fmt.Fprint(w, `{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`)
 				return
@@ -620,21 +619,21 @@ func TestBaseURLWithTokenURL(t *testing.T) {
 
 		// Capture stderr to verify the warning is emitted.
 		origStderr := os.Stderr
-		r, w, _ := os.Pipe()
-		os.Stderr = w
+		pr, pw, err := os.Pipe()
+		assert.NoError(t, err)
+		os.Stderr = pw
 
 		client, loginErr := LoginWithOutput(context.Background(), "")
 
-		w.Close()
+		pw.Close()
 		os.Stderr = origStderr
 		var stderrBuf bytes.Buffer
-		_, _ = stderrBuf.ReadFrom(r)
-		stderrOut := stderrBuf.String()
+		_, _ = stderrBuf.ReadFrom(pr)
+		pr.Close()
 
 		assert.NoError(t, loginErr)
 		assert.NotNil(t, client)
-		assert.True(t, tokenEndpointHit, "token endpoint should have been called")
-		assert.Contains(t, stderrOut, "--token-url is set without --base-url")
+		assert.Contains(t, stderrBuf.String(), "--token-url is set without --base-url")
 	})
 
 	t.Run("--base-url without --token-url fails with unknown environment", func(t *testing.T) {

--- a/internal/commands/config/login_test.go
+++ b/internal/commands/config/login_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -589,6 +590,12 @@ func TestBaseURLWithTokenURL(t *testing.T) {
 		utils.Env = ""
 		utils.ProfileOverride = ""
 
+		origStderr := os.Stderr
+		devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+		assert.NoError(t, err)
+		os.Stderr = devNull
+		t.Cleanup(func() { os.Stderr = origStderr; _ = devNull.Close() })
+
 		client, err := LoginWithOutput(context.Background(), "")
 		assert.NoError(t, err)
 		assert.NotNil(t, client)
@@ -617,18 +624,26 @@ func TestBaseURLWithTokenURL(t *testing.T) {
 		utils.Env = "staging"
 		utils.ProfileOverride = ""
 
-		// Capture stderr to verify the warning is emitted.
+		// Capture stderr concurrently to avoid filling the pipe buffer and
+		// deadlocking LoginWithOutput if the spinner writes frequently.
 		origStderr := os.Stderr
-		pr, pw, err := os.Pipe()
-		assert.NoError(t, err)
+		pr, pw, pipeErr := os.Pipe()
+		assert.NoError(t, pipeErr)
 		os.Stderr = pw
+		t.Cleanup(func() { os.Stderr = origStderr })
+
+		var stderrBuf bytes.Buffer
+		drainDone := make(chan struct{})
+		go func() {
+			_, _ = io.Copy(&stderrBuf, pr)
+			close(drainDone)
+		}()
 
 		client, loginErr := LoginWithOutput(context.Background(), "")
 
 		pw.Close()
 		os.Stderr = origStderr
-		var stderrBuf bytes.Buffer
-		_, _ = stderrBuf.ReadFrom(pr)
+		<-drainDone
 		pr.Close()
 
 		assert.NoError(t, loginErr)
@@ -651,7 +666,13 @@ func TestBaseURLWithTokenURL(t *testing.T) {
 		utils.Env = ""
 		utils.ProfileOverride = ""
 
-		_, err := LoginWithOutput(context.Background(), "")
+		origStderr := os.Stderr
+		devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+		assert.NoError(t, err)
+		os.Stderr = devNull
+		t.Cleanup(func() { os.Stderr = origStderr; _ = devNull.Close() })
+
+		_, err = LoginWithOutput(context.Background(), "")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unknown API environment")
 	})

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -70,6 +70,10 @@ var (
 	// BaseURL overrides the API base URL (e.g. http://localhost:8080). Set via --base-url flag.
 	BaseURL string
 
+	// TokenURL overrides the OAuth token endpoint. Use with --base-url when the token server
+	// is not one of the three standard Megaport auth hosts. Set via --token-url flag.
+	TokenURL string
+
 	ValidFormats = []string{FormatTable, FormatJSON, FormatCSV, FormatXML, FormatGoTemplate}
 )
 


### PR DESCRIPTION
Adds `--token-url` as a persistent flag so authenticated commands can reach non-standard API hosts set via `--base-url`.

The SDK's `Authorize` derives the OAuth token endpoint from the base URL host. For any host outside the three known Megaport environments it returns `"unknown API environment"` before making a request, which made `--base-url` effectively read-only (unauthenticated commands only). `--token-url` passes `WithTokenURL` to the SDK client, bypassing the host switch entirely.

- `--base-url http://localhost:8080 --token-url http://localhost:8080/oauth2/token` authenticates end-to-end against a local dev server
- HTTPS scheme check (matching `--base-url`) applies to `--token-url` too — cleartext warning fires when HTTP is used
- Setting `--token-url` without `--base-url` emits an additional warning that credentials are being redirected away from the standard auth host
- `--base-url` alone still fails with `"unknown API environment"` as before
- Removes the stale comment in `TestProfileOverrideLogin` that deferred this coverage to a future PR