### PR TITLE
ci: enforce coverage targets and add e2e/html-coverage make targets

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,30 @@
+# Codecov configuration.
+#
+# Coverage is uploaded by .github/workflows/test.yml on every PR and every push
+# to main (go test -coverprofile=coverage.out -covermode=atomic ./...). This repo
+# is public, so Codecov tokenless upload currently works and no CODECOV_TOKEN is
+# required. If uploads ever start failing (e.g. a Codecov/GitHub integration or
+# policy change), add CODECOV_TOKEN as a repo Actions secret and pass it to the
+# codecov-action step in test.yml.
+#
+# The status blocks below turn measurement into enforcement so each PR proves its
+# coverage delta:
+#   - project: the floor is whatever main currently measures (target: auto) and
+#     ratchets up as new tests land; it can never silently regress.
+#   - patch:   the new/changed lines in a PR must themselves be well covered.
 coverage:
+  status:
+    project:
+      default:
+        target: auto       # floor = current coverage on main; ratchets up
+        threshold: 0.5%    # tolerance for measurement noise
+    patch:
+      default:
+        target: 80%        # new/changed lines in a PR must be >=80% covered
   ignore:
     - "**/*_mock.go"
+    - "**/*_integration_test.go"   # integration tests are not part of the unit coverage profile
+
+comment:
+  layout: "reach, diff, files"
+  require_changes: false

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-cover test-integration test-integration-readonly lint fmt vet check clean wasm
+.PHONY: build test test-cover test-cover-html test-integration test-integration-readonly e2e lint fmt vet check clean wasm
 
 # Build the CLI binary
 build:
@@ -14,6 +14,13 @@ test-cover:
 	go tool cover -func=coverage.out
 	@rm -f coverage.out
 
+# Generate an HTML coverage report for local inspection (coverage.html kept on disk)
+test-cover-html:
+	go test -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out -o coverage.html
+	@rm -f coverage.out
+	@echo "Coverage report written to coverage.html"
+
 # Run integration tests against staging API (requires credentials — see docs/INTEGRATION_TESTING.md)
 test-integration:
 	go test -tags integration -run '^TestIntegration_' -v -timeout 30m ./internal/commands/...
@@ -21,6 +28,12 @@ test-integration:
 # Run only read-only integration tests — fast, no resources provisioned
 test-integration-readonly:
 	go test -tags integration -run '^TestIntegration_' -v -timeout 5m ./internal/commands/locations/...
+
+# Run native-binary black-box e2e tests (built behind the `e2e` build tag).
+# Placeholder: the harness and specs land in a later PR. Until then this compiles
+# cleanly and reports no matching tests, so it is safe to wire into CI now.
+e2e:
+	go test -tags e2e -run '^TestE2E_' -v ./...
 
 # Run linter
 lint:
@@ -43,4 +56,4 @@ wasm:
 
 # Clean build artifacts
 clean:
-	rm -f megaport-cli cover*.out coverage*.out web/megaport.wasm
+	rm -f megaport-cli cover*.out coverage*.out coverage.html web/megaport.wasm


### PR DESCRIPTION
## Summary

Coverage is already measured and uploaded to Codecov on every PR and push to `main`, but nothing gates on it: `.codecov.yml` only ignored mock files, with no project or patch targets. This change turns that existing measurement into enforcement so each PR proves its coverage delta. The repo is public, so Codecov tokenless upload works and no token is required.

This is the first step of an effort to raise CLI test coverage (Codecov currently reports ~74% line coverage on `main`). It deliberately contains no test or product code; it only enables the gate that subsequent test PRs will be measured against.

## What changed

**`.codecov.yml`**
- `project` status uses `target: auto` (floor = current `main` coverage as measured by Codecov, ratchets up, `0.5%` noise threshold) so coverage can never silently regress.
- `patch` status requires the new/changed lines in a PR to be `>=80%` covered.
- Ignore `*_integration_test.go` (these run only under `-tags integration` and are not part of the unit coverage profile).

**`Makefile`**
- `test-cover-html` — generate a local HTML coverage report for inspection.
- `e2e` — placeholder target behind the `e2e` build tag. It compiles cleanly and reports no matching tests today, so the native-binary e2e harness can be wired into CI in a later change.

## A note on the coverage number

Go's own tooling (`go tool cover -func`, `make test-cover`) reports ~79.5% **statement** coverage, whereas Codecov converts the same profile to ~74% **line** coverage. The two differ because one source line often holds several statements and the methods count differently. The targets above are evaluated entirely on Codecov's line metric (`target: auto` floors at whatever Codecov measures), so no specific number is hardcoded; both figures come from the identical CI command.

## Testing

- `.codecov.yml` validated as well-formed YAML.
- `make -n e2e` and `make -n test-cover-html` confirm the new targets resolve.
- No Go source changed, so the unit and lint jobs behave exactly as before; the only new effect is the Codecov project/patch status checks appearing on PRs.

## Notes for reviewers

- After this lands, a quick way to confirm the gate works: a throwaway PR that deletes a covered line should show a red Codecov `project` check, and restoring it should go green.
- Codecov uploads are confirmed landing for this repo (this PR's report posted tokenless), so the gate is live: project coverage shows 73.89% and all modified lines are covered.
