### PR TITLE
fix(ESD-1379): reset slice flags via Replace in WASM flag reset

### DIFF
--- a/cmd/megaport/cobra_helpers.go
+++ b/cmd/megaport/cobra_helpers.go
@@ -10,17 +10,23 @@ import (
 // WASM invocation would appear as "Changed" in subsequent invocations even
 // when the user did not supply them.
 func resetAllFlags(cmd *cobra.Command) {
-	cmd.Flags().VisitAll(func(f *pflag.Flag) {
-		_ = f.Value.Set(f.DefValue)
-		f.Changed = false
-	})
-	cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
-		_ = f.Value.Set(f.DefValue)
-		f.Changed = false
-	})
+	cmd.Flags().VisitAll(resetFlag)
+	cmd.PersistentFlags().VisitAll(resetFlag)
 	for _, subCmd := range cmd.Commands() {
 		resetAllFlags(subCmd)
 	}
+}
+
+// resetFlag restores a single flag to its default. Slice/array flags need
+// Replace: their DefValue stringifies to "[]" and Set appends, so re-Setting
+// DefValue would inject a literal "[]" element instead of clearing them.
+func resetFlag(f *pflag.Flag) {
+	if sv, ok := f.Value.(pflag.SliceValue); ok {
+		_ = sv.Replace([]string{})
+	} else {
+		_ = f.Value.Set(f.DefValue)
+	}
+	f.Changed = false
 }
 
 // enableTraversalForAllCommands enables subcommand traversal on all commands

--- a/cmd/megaport/cobra_helpers_test.go
+++ b/cmd/megaport/cobra_helpers_test.go
@@ -164,6 +164,37 @@ func TestResetAllFlags_WithoutReset_BugReproduction(t *testing.T) {
 	assert.True(t, countryChanged, "without reset, Changed state persists (this is the bug)")
 }
 
+// TestResetAllFlags_StringArrayStaysEmpty guards against the WASM "No ports
+// found" bug: a StringArray flag's DefValue stringifies to "[]" and Set
+// appends, so the old Set(DefValue) reset injected a literal "[]" element.
+// That made an unused --tag filter non-empty, triggering tag filtering that
+// dropped every result.
+func TestResetAllFlags_StringArrayStaysEmpty(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	list := &cobra.Command{Use: "list", RunE: func(cmd *cobra.Command, args []string) error { return nil }}
+	list.Flags().StringArray("tag", nil, "filter by resource tag (repeatable)")
+	root.AddCommand(list)
+
+	// Reset on a pristine tree must not fabricate a tag value.
+	resetAllFlags(root)
+	tags, _ := list.Flags().GetStringArray("tag")
+	assert.Empty(t, tags, "tag should be empty after reset, not contain a literal \"[]\"")
+
+	// User supplies --tag once.
+	root.SetArgs([]string{"list", "--tag", "env=prod"})
+	require.NoError(t, root.Execute())
+	tags, _ = list.Flags().GetStringArray("tag")
+	assert.Equal(t, []string{"env=prod"}, tags)
+
+	// Next run without --tag must see no tags, and repeated resets must not
+	// accumulate "[]" elements.
+	resetAllFlags(root)
+	resetAllFlags(root)
+	tags, _ = list.Flags().GetStringArray("tag")
+	assert.Empty(t, tags, "tag must be empty on the next run, with no carryover or fabricated elements")
+	assert.False(t, list.Flags().Lookup("tag").Changed)
+}
+
 // TestEnableTraversalForAllCommands verifies that traversal is enabled on
 // the entire command tree recursively.
 func TestEnableTraversalForAllCommands(t *testing.T) {


### PR DESCRIPTION
The WASM/portal build returned "No ports found" (same for vxc/mcr/mve list) regardless of environment or how many active ports existed. Root cause was client-side, not the API.

WASM reuses one long-lived root command, so `resetAllFlags` clears flag state before each run. It reset every flag with `Set(DefValue)`. For a pflag `StringArray`, `DefValue` stringifies to the literal `[]` and `Set` appends rather than replaces, so the reset injected a literal `[]` element into the `--tag` filter (and grew it each run). That made the unused `--tag` filter non-empty, triggering per-resource tag filtering that kept only items with a tag key `[]` (none) and dropped everything.

- Reset slice/array flags via pflag's `SliceValue.Replace([]string{})`; keep `Set(DefValue)` for scalars.
- Add a regression test that fails on the old behavior and passes on the fix.

Verified by rebuilding the WASM binary and rerunning against staging: the full port list renders again. Covers all four list commands using `WithTagFilterFlags`.