### PR TITLE
test(ESD-1385): add output formatter unit tests for read-only command packages

### DIFF
--- a/internal/commands/auth/auth_output_test.go
+++ b/internal/commands/auth/auth_output_test.go
@@ -1,0 +1,59 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintAuthStatus_XML(t *testing.T) {
+	user := &megaport.User{
+		FirstName:   "Test",
+		LastName:    "User",
+		Email:       "test@example.com",
+		Position:    "Admin",
+		Active:      true,
+		CompanyName: "Co",
+	}
+
+	out := output.CaptureOutput(func() {
+		err := printAuthStatus(user, "profile", "production", "https://api.megaport.com/", "Co", "xml", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "<first_name>Test</first_name>")
+	assert.Contains(t, out, "<email>test@example.com</email>")
+	assert.Contains(t, out, "<environment>Production</environment>")
+	assert.Contains(t, out, "<api_endpoint>https://api.megaport.com/</api_endpoint>")
+	assert.Contains(t, out, "<active>true</active>")
+}
+
+func TestPrintAuthStatus_AllFormatsNoSecretLeak(t *testing.T) {
+	user := &megaport.User{FirstName: "Test", Email: "test@example.com"}
+
+	for _, format := range []string{"table", "json", "csv", "xml"} {
+		t.Run(format, func(t *testing.T) {
+			out := output.CaptureOutput(func() {
+				err := printAuthStatus(user, "profile", "production", "https://api.megaport.com/", "Co", format, true)
+				assert.NoError(t, err)
+			})
+
+			assert.NotContains(t, out, "access_key")
+			assert.NotContains(t, out, "secret_key")
+			assert.NotContains(t, out, "token")
+			assert.NotContains(t, out, "password")
+		})
+	}
+}
+
+func TestPrintAuthStatus_NilUser(t *testing.T) {
+	out := output.CaptureOutput(func() {
+		err := printAuthStatus(nil, "profile", "staging", "https://api-staging.megaport.com/", "Fallback Co", "csv", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "Fallback Co")
+	assert.Contains(t, out, "Staging")
+}

--- a/internal/commands/billing_market/billing_market_actions.go
+++ b/internal/commands/billing_market/billing_market_actions.go
@@ -32,16 +32,16 @@ func GetBillingMarkets(cmd *cobra.Command, args []string, noColor bool, outputFo
 		return fmt.Errorf("failed to get billing markets: %w", err)
 	}
 
-	if len(markets) == 0 {
-		output.PrintWarning("No billing markets found", noColor)
-	}
-
 	outputs := make([]billingMarketOutput, 0, len(markets))
 	for _, m := range markets {
 		if m == nil {
 			continue
 		}
 		outputs = append(outputs, toBillingMarketOutput(m))
+	}
+
+	if len(outputs) == 0 {
+		output.PrintWarning("No billing markets found", noColor)
 	}
 
 	return output.PrintOutput(outputs, outputFormat, noColor)

--- a/internal/commands/billing_market/billing_market_actions.go
+++ b/internal/commands/billing_market/billing_market_actions.go
@@ -38,6 +38,9 @@ func GetBillingMarkets(cmd *cobra.Command, args []string, noColor bool, outputFo
 
 	outputs := make([]billingMarketOutput, 0, len(markets))
 	for _, m := range markets {
+		if m == nil {
+			continue
+		}
 		outputs = append(outputs, toBillingMarketOutput(m))
 	}
 

--- a/internal/commands/billing_market/billing_market_output.go
+++ b/internal/commands/billing_market/billing_market_output.go
@@ -29,6 +29,9 @@ type billingMarketOutput struct {
 }
 
 func toBillingMarketOutput(m *megaport.BillingMarket) billingMarketOutput {
+	if m == nil {
+		return billingMarketOutput{}
+	}
 	return billingMarketOutput{
 		ID:                  m.ID,
 		SupplierName:        m.SupplierName,

--- a/internal/commands/billing_market/billing_market_output_test.go
+++ b/internal/commands/billing_market/billing_market_output_test.go
@@ -1,0 +1,73 @@
+package billing_market
+
+import (
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToBillingMarketOutput_Nil(t *testing.T) {
+	assert.NotPanics(t, func() {
+		out := toBillingMarketOutput(nil)
+		assert.Equal(t, billingMarketOutput{}, out)
+	})
+}
+
+func TestToBillingMarketOutput_AllFields(t *testing.T) {
+	m := &megaport.BillingMarket{
+		ID:                  7,
+		SupplierName:        "Megaport EU",
+		CurrencyEnum:        "EUR",
+		Country:             "DE",
+		Region:              "Europe",
+		BillingContactPhone: "+49000",
+		TaxRate:             19.5,
+		SecondPartyID:       321,
+		PaymentTermInDays:   30,
+		VATExempt:           true,
+		Active:              false,
+	}
+
+	out := toBillingMarketOutput(m)
+	assert.Equal(t, 7, out.ID)
+	assert.Equal(t, "EUR", out.CurrencyEnum)
+	assert.Equal(t, "+49000", out.BillingContactPhone)
+	assert.Equal(t, 19.5, out.TaxRate)
+	assert.Equal(t, 321, out.SecondPartyID)
+	assert.Equal(t, 30, out.PaymentTermInDays)
+	assert.True(t, out.VATExempt)
+	assert.False(t, out.Active)
+}
+
+func TestBillingMarketOutput_XML(t *testing.T) {
+	outputs := make([]billingMarketOutput, 0, len(mockBillingMarkets))
+	for _, bm := range mockBillingMarkets {
+		outputs = append(outputs, toBillingMarketOutput(bm))
+	}
+
+	out := output.CaptureOutput(func() {
+		err := output.PrintOutput(outputs, "xml", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "<id>1</id>")
+	assert.Contains(t, out, "<supplier_name>Megaport US</supplier_name>")
+	assert.Contains(t, out, "<currency>USD</currency>")
+	assert.Contains(t, out, "<billing_contact_email>john@example.com</billing_contact_email>")
+	assert.Contains(t, out, "<active>true</active>")
+	assert.Contains(t, out, "Megaport AU")
+}
+
+func TestBillingMarketOutput_EmptySlice(t *testing.T) {
+	for _, format := range []string{"table", "json", "csv", "xml"} {
+		t.Run(format, func(t *testing.T) {
+			out := output.CaptureOutput(func() {
+				err := output.PrintOutput([]billingMarketOutput{}, format, true)
+				assert.NoError(t, err)
+			})
+			assert.NotPanics(t, func() { _ = out })
+		})
+	}
+}

--- a/internal/commands/billing_market/billing_market_output_test.go
+++ b/internal/commands/billing_market/billing_market_output_test.go
@@ -61,13 +61,19 @@ func TestBillingMarketOutput_XML(t *testing.T) {
 }
 
 func TestBillingMarketOutput_EmptySlice(t *testing.T) {
-	for _, format := range []string{"table", "json", "csv", "xml"} {
+	cases := map[string]func(string){
+		"table": func(out string) { assert.Contains(t, out, "SUPPLIER NAME") },
+		"json":  func(out string) { assert.Equal(t, "[]\n", out) },
+		"csv":   func(out string) { assert.Contains(t, out, "id,supplier_name,currency") },
+		"xml":   func(out string) { assert.Contains(t, out, "<items></items>") },
+	}
+	for format, check := range cases {
 		t.Run(format, func(t *testing.T) {
 			out := output.CaptureOutput(func() {
 				err := output.PrintOutput([]billingMarketOutput{}, format, true)
 				assert.NoError(t, err)
 			})
-			assert.NotPanics(t, func() { _ = out })
+			check(out)
 		})
 	}
 }

--- a/internal/commands/billing_market/billing_market_test.go
+++ b/internal/commands/billing_market/billing_market_test.go
@@ -238,6 +238,26 @@ func TestGetBillingMarketsAction_NilEntriesSkipped(t *testing.T) {
 	})
 }
 
+func TestGetBillingMarketsAction_AllNilWarns(t *testing.T) {
+	mockSvc := &MockBillingMarketService{
+		GetBillingMarketsResult: []*megaport.BillingMarket{nil, nil},
+	}
+
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {
+		c.BillingMarketService = mockSvc
+	})
+	defer cleanup()
+
+	cmd := &cobra.Command{Use: "get"}
+
+	out := output.CaptureOutput(func() {
+		err := GetBillingMarkets(cmd, []string{}, true, "table")
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "No billing markets found")
+}
+
 func TestSetBillingMarketAction(t *testing.T) {
 	mockSvc := &MockBillingMarketService{}
 

--- a/internal/commands/billing_market/billing_market_test.go
+++ b/internal/commands/billing_market/billing_market_test.go
@@ -217,6 +217,27 @@ func TestGetBillingMarketsAction_Empty(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestGetBillingMarketsAction_NilEntriesSkipped(t *testing.T) {
+	mockSvc := &MockBillingMarketService{
+		GetBillingMarketsResult: []*megaport.BillingMarket{nil, mockBillingMarkets[0], nil},
+	}
+
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {
+		c.BillingMarketService = mockSvc
+	})
+	defer cleanup()
+
+	cmd := &cobra.Command{Use: "get"}
+
+	assert.NotPanics(t, func() {
+		out := output.CaptureOutput(func() {
+			err := GetBillingMarkets(cmd, []string{}, true, "json")
+			assert.NoError(t, err)
+		})
+		assert.Contains(t, out, "Megaport US")
+	})
+}
+
 func TestSetBillingMarketAction(t *testing.T) {
 	mockSvc := &MockBillingMarketService{}
 

--- a/internal/commands/locations/locations_output.go
+++ b/internal/commands/locations/locations_output.go
@@ -26,6 +26,9 @@ type locationOutput struct {
 }
 
 func toLocationOutput(l *megaport.LocationV3) locationOutput {
+	if l == nil {
+		return locationOutput{}
+	}
 	o := locationOutput{
 		ID:                    l.ID,
 		Name:                  l.Name,
@@ -59,6 +62,9 @@ type locationTableOutput struct {
 }
 
 func toLocationTableOutput(l *megaport.LocationV3) locationTableOutput {
+	if l == nil {
+		return locationTableOutput{}
+	}
 	return locationTableOutput{
 		ID:           l.ID,
 		Name:         l.Name,
@@ -86,6 +92,9 @@ type marketCodeOutput struct {
 func printCountries(countries []*megaport.Country, format string, noColor bool) error {
 	outputs := make([]countryOutput, 0, len(countries))
 	for _, c := range countries {
+		if c == nil {
+			continue
+		}
 		outputs = append(outputs, countryOutput{
 			Code:      c.Code,
 			Name:      c.Name,
@@ -132,6 +141,9 @@ func printLocations(locations []*megaport.LocationV3, format string, noColor boo
 	if format == utils.FormatTable {
 		tableOutputs := make([]locationTableOutput, 0, len(locations))
 		for _, loc := range locations {
+			if loc == nil {
+				continue
+			}
 			tableOutputs = append(tableOutputs, toLocationTableOutput(loc))
 		}
 		return output.PrintOutput(tableOutputs, format, noColor)
@@ -139,6 +151,9 @@ func printLocations(locations []*megaport.LocationV3, format string, noColor boo
 
 	outputs := make([]locationOutput, 0, len(locations))
 	for _, loc := range locations {
+		if loc == nil {
+			continue
+		}
 		outputs = append(outputs, toLocationOutput(loc))
 	}
 	return output.PrintOutput(outputs, format, noColor)

--- a/internal/commands/locations/locations_output_test.go
+++ b/internal/commands/locations/locations_output_test.go
@@ -76,13 +76,15 @@ func TestPrintLocations_XML(t *testing.T) {
 
 func TestPrintLocations_NilEntriesSkipped(t *testing.T) {
 	locs := []*megaport.LocationV3{nil, testLocations[0], nil}
-	assert.NotPanics(t, func() {
-		out := op.CaptureOutput(func() {
-			err := printLocations(locs, "csv", noColor)
-			assert.NoError(t, err)
+	for _, format := range []string{"csv", "table"} {
+		assert.NotPanics(t, func() {
+			out := op.CaptureOutput(func() {
+				err := printLocations(locs, format, noColor)
+				assert.NoError(t, err)
+			})
+			assert.Contains(t, out, "Sydney")
 		})
-		assert.Contains(t, out, "Sydney")
-	})
+	}
 }
 
 func TestPrintCountries_AllFormats(t *testing.T) {

--- a/internal/commands/locations/locations_output_test.go
+++ b/internal/commands/locations/locations_output_test.go
@@ -1,0 +1,165 @@
+package locations
+
+import (
+	"testing"
+
+	op "github.com/megaport/megaport-cli/internal/base/output"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToLocationOutput_Valid(t *testing.T) {
+	msg := "scheduled maintenance"
+	l := &megaport.LocationV3{
+		ID:        3,
+		Name:      "Tokyo",
+		Metro:     "Tokyo",
+		Market:    "APAC",
+		Status:    "ACTIVE",
+		Latitude:  35.6,
+		Longitude: 139.7,
+		Address:   megaport.LocationV3Address{Country: "Japan"},
+		DataCentre: megaport.LocationV3DataCentre{
+			ID:   300,
+			Name: "TYO1",
+		},
+		OrderingMessage: &msg,
+	}
+
+	out := toLocationOutput(l)
+	assert.Equal(t, 3, out.ID)
+	assert.Equal(t, "Tokyo", out.Name)
+	assert.Equal(t, "Japan", out.Country)
+	assert.Equal(t, "APAC", out.Market)
+	assert.Equal(t, 35.6, out.Latitude)
+	assert.Equal(t, "TYO1", out.DataCentreName)
+	assert.Equal(t, 300, out.DataCentreID)
+	assert.Equal(t, "scheduled maintenance", out.OrderingMessage)
+}
+
+func TestToLocationOutput_Nil(t *testing.T) {
+	assert.NotPanics(t, func() {
+		out := toLocationOutput(nil)
+		assert.Equal(t, locationOutput{}, out)
+	})
+}
+
+func TestToLocationTableOutput_Valid(t *testing.T) {
+	l := testLocations[0]
+	out := toLocationTableOutput(l)
+	assert.Equal(t, 1, out.ID)
+	assert.Equal(t, "Sydney", out.Name)
+	assert.Equal(t, "Australia", out.Country)
+	assert.Equal(t, "ACTIVE", out.Status)
+	assert.True(t, out.MVEAvailable)
+}
+
+func TestToLocationTableOutput_Nil(t *testing.T) {
+	assert.NotPanics(t, func() {
+		out := toLocationTableOutput(nil)
+		assert.Equal(t, locationTableOutput{}, out)
+	})
+}
+
+func TestPrintLocations_XML(t *testing.T) {
+	out := op.CaptureOutput(func() {
+		err := printLocations(testLocations, "xml", noColor)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "<id>1</id>")
+	assert.Contains(t, out, "<name>Sydney</name>")
+	assert.Contains(t, out, "<country>Australia</country>")
+	assert.Contains(t, out, "<market>APAC</market>")
+	assert.Contains(t, out, "London")
+}
+
+func TestPrintLocations_NilEntriesSkipped(t *testing.T) {
+	locs := []*megaport.LocationV3{nil, testLocations[0], nil}
+	assert.NotPanics(t, func() {
+		out := op.CaptureOutput(func() {
+			err := printLocations(locs, "csv", noColor)
+			assert.NoError(t, err)
+		})
+		assert.Contains(t, out, "Sydney")
+	})
+}
+
+func TestPrintCountries_AllFormats(t *testing.T) {
+	countries := []*megaport.Country{
+		{Code: "AU", Name: "Australia", Prefix: "AUS", SiteCount: 12},
+		nil,
+		{Code: "GB", Name: "United Kingdom", Prefix: "GBR", SiteCount: 8},
+	}
+
+	xmlOut := op.CaptureOutput(func() {
+		err := printCountries(countries, "xml", noColor)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, xmlOut, "<code>AU</code>")
+	assert.Contains(t, xmlOut, "<name>Australia</name>")
+	assert.Contains(t, xmlOut, "<site_count>12</site_count>")
+
+	csvOut := op.CaptureOutput(func() {
+		err := printCountries(countries, "csv", noColor)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, csvOut, "code,name,prefix,site_count")
+	assert.Contains(t, csvOut, "AU,Australia,AUS,12")
+
+	tableOut := op.CaptureOutput(func() {
+		err := printCountries(countries, "table", noColor)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, tableOut, "AU")
+
+	jsonOut := op.CaptureOutput(func() {
+		err := printCountries(countries, "json", noColor)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, jsonOut, `"code": "AU"`)
+}
+
+func TestPrintMarketCodes_AllFormats(t *testing.T) {
+	codes := []string{"AU", "US", "UK"}
+
+	xmlOut := op.CaptureOutput(func() {
+		err := printMarketCodes(codes, "xml", noColor)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, xmlOut, "<market_code>AU</market_code>")
+
+	csvOut := op.CaptureOutput(func() {
+		err := printMarketCodes(codes, "csv", noColor)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, csvOut, "market_code")
+	assert.Contains(t, csvOut, "AU")
+
+	tableOut := op.CaptureOutput(func() {
+		err := printMarketCodes(codes, "table", noColor)
+		assert.NoError(t, err)
+	})
+	assert.Contains(t, tableOut, "US")
+
+	emptyOut := op.CaptureOutput(func() {
+		err := printMarketCodes(nil, "json", noColor)
+		assert.NoError(t, err)
+	})
+	assert.Equal(t, "[]\n", emptyOut)
+}
+
+func TestPrintRoundTripTimes_XML(t *testing.T) {
+	rtts := []*megaport.RoundTripTime{
+		{SrcLocation: 1, DstLocation: 2, MedianRTT: 12.5},
+	}
+
+	out := op.CaptureOutput(func() {
+		err := printRoundTripTimes(rtts, "xml", noColor)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "<src_location_id>1</src_location_id>")
+	assert.Contains(t, out, "<dst_location_id>2</dst_location_id>")
+	assert.Contains(t, out, "<median_rtt_ms>12.5</median_rtt_ms>")
+}

--- a/internal/commands/locations/locations_test.go
+++ b/internal/commands/locations/locations_test.go
@@ -210,6 +210,13 @@ func TestFilterLocations_EmptySlice(t *testing.T) {
 	assert.Equal(t, 0, len(result), "Expected no results for empty input")
 }
 
+func TestFilterLocations_NilElementsSkipped(t *testing.T) {
+	source := []*megaport.LocationV3{nil, testLocations[0], nil}
+	result := filterLocations(source, map[string]string{})
+	assert.Len(t, result, 1)
+	assert.Equal(t, testLocations[0].ID, result[0].ID)
+}
+
 func TestPrintLocations_EmptySlice(t *testing.T) {
 	var emptyLocations []*megaport.LocationV3
 

--- a/internal/commands/locations/locations_utils.go
+++ b/internal/commands/locations/locations_utils.go
@@ -13,6 +13,9 @@ var timeNow = time.Now
 
 func filterLocations(locations []*megaport.LocationV3, filters map[string]string) []*megaport.LocationV3 {
 	return utils.Filter(locations, func(loc *megaport.LocationV3) bool {
+		if loc == nil {
+			return false
+		}
 		if metro, ok := filters["metro"]; ok && loc.Metro != metro {
 			return false
 		}

--- a/internal/commands/partners/partners_output.go
+++ b/internal/commands/partners/partners_output.go
@@ -17,6 +17,9 @@ type partnerOutput struct {
 }
 
 func toPartnerOutput(p *megaport.PartnerMegaport) partnerOutput {
+	if p == nil {
+		return partnerOutput{}
+	}
 	return partnerOutput{
 		ProductName:   p.ProductName,
 		UID:           p.ProductUID,
@@ -31,6 +34,9 @@ func toPartnerOutput(p *megaport.PartnerMegaport) partnerOutput {
 var printPartnersFunc = func(partners []*megaport.PartnerMegaport, format string, noColor bool) error {
 	outputs := make([]partnerOutput, 0, len(partners))
 	for _, partner := range partners {
+		if partner == nil {
+			continue
+		}
 		outputs = append(outputs, toPartnerOutput(partner))
 	}
 	return output.PrintOutput(outputs, format, noColor)

--- a/internal/commands/partners/partners_output_test.go
+++ b/internal/commands/partners/partners_output_test.go
@@ -1,0 +1,71 @@
+package partners
+
+import (
+	"strings"
+	"testing"
+
+	op "github.com/megaport/megaport-cli/internal/base/output"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToPartnerOutput_Valid(t *testing.T) {
+	p := &megaport.PartnerMegaport{
+		ProductUID:    "uid-1",
+		ProductName:   "Partner One",
+		ConnectType:   "AWS",
+		CompanyName:   "Acme",
+		LocationId:    42,
+		DiversityZone: "red",
+		VXCPermitted:  true,
+	}
+
+	out := toPartnerOutput(p)
+	assert.Equal(t, "Partner One", out.ProductName)
+	assert.Equal(t, "uid-1", out.UID)
+	assert.Equal(t, "AWS", out.ConnectType)
+	assert.Equal(t, "Acme", out.CompanyName)
+	assert.Equal(t, 42, out.LocationId)
+	assert.Equal(t, "red", out.DiversityZone)
+	assert.True(t, out.VXCPermitted)
+}
+
+func TestToPartnerOutput_Nil(t *testing.T) {
+	assert.NotPanics(t, func() {
+		out := toPartnerOutput(nil)
+		assert.Equal(t, partnerOutput{}, out)
+	})
+}
+
+func TestPrintPartners_XML(t *testing.T) {
+	out := op.CaptureOutput(func() {
+		err := printPartnersFunc(testPartners, "xml", noColor)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "<product_name>ProductOne</product_name>")
+	assert.Contains(t, out, "<uid>uid1</uid>")
+	assert.Contains(t, out, "<connect_type>TypeA</connect_type>")
+	assert.Contains(t, out, "<company_name>CompanyA</company_name>")
+	assert.Contains(t, out, "<location_id>1</location_id>")
+	assert.Contains(t, out, "<diversity_zone>ZoneA</diversity_zone>")
+	assert.Contains(t, out, "<vxc_permitted>true</vxc_permitted>")
+	assert.Contains(t, out, "ProductTwo")
+}
+
+func TestPrintPartners_NilEntriesSkipped(t *testing.T) {
+	partners := []*megaport.PartnerMegaport{
+		nil,
+		{ProductUID: "uid-keep", ProductName: "Keep"},
+		nil,
+	}
+
+	out := op.CaptureOutput(func() {
+		err := printPartnersFunc(partners, "csv", noColor)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "uid-keep")
+	// Only one data row beyond the header.
+	assert.Equal(t, 2, strings.Count(strings.TrimSpace(out), "\n")+1)
+}

--- a/internal/commands/partners/partners_test.go
+++ b/internal/commands/partners/partners_test.go
@@ -137,6 +137,13 @@ func TestFilterPartners(t *testing.T) {
 	}
 }
 
+func TestFilterPartners_NilElementsSkipped(t *testing.T) {
+	source := []*megaport.PartnerMegaport{nil, testPartners[0], nil}
+	result := filterPartners(source, "", "", "", 0, "")
+	assert.Len(t, result, 1)
+	assert.Equal(t, "uid1", result[0].ProductUID)
+}
+
 func TestPrintPartners_Table(t *testing.T) {
 	output := output.CaptureOutput(func() {
 		err := printPartnersFunc(testPartners, "table", noColor)

--- a/internal/commands/partners/partners_utils.go
+++ b/internal/commands/partners/partners_utils.go
@@ -14,6 +14,9 @@ func filterPartners(
 	diversityZone string,
 ) []*megaport.PartnerMegaport {
 	return utils.Filter(partners, func(partner *megaport.PartnerMegaport) bool {
+		if partner == nil {
+			return false
+		}
 		if productName != "" && !strings.EqualFold(partner.ProductName, productName) {
 			return false
 		}

--- a/internal/commands/product/product_output_test.go
+++ b/internal/commands/product/product_output_test.go
@@ -1,0 +1,127 @@
+package product
+
+import (
+	"testing"
+
+	op "github.com/megaport/megaport-cli/internal/base/output"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToProductOutput_Port(t *testing.T) {
+	port := &megaport.Port{
+		UID:                "port-1",
+		Name:               "Test Port",
+		Type:               "MEGAPORT",
+		ProvisioningStatus: "LIVE",
+		PortSpeed:          10000,
+		LocationID:         5,
+	}
+
+	o, err := toProductOutput(port)
+	assert.NoError(t, err)
+	assert.Equal(t, "port-1", o.UID)
+	assert.Equal(t, "Test Port", o.Name)
+	assert.Equal(t, "LIVE", o.ProvisioningStatus)
+	assert.Equal(t, 10000, o.Speed)
+	assert.Equal(t, 5, o.LocationID)
+}
+
+func TestToProductOutput_MVE(t *testing.T) {
+	mve := &megaport.MVE{
+		UID:                "mve-1",
+		Name:               "Test MVE",
+		ProvisioningStatus: "LIVE",
+		LocationID:         9,
+	}
+
+	o, err := toProductOutput(mve)
+	assert.NoError(t, err)
+	assert.Equal(t, "mve-1", o.UID)
+	assert.Equal(t, "Test MVE", o.Name)
+	assert.Equal(t, 9, o.LocationID)
+	assert.Equal(t, 0, o.Speed)
+}
+
+var productTestProducts = []megaport.Product{
+	&megaport.Port{
+		UID:                "port-1",
+		Name:               "Port One",
+		ProvisioningStatus: "LIVE",
+		PortSpeed:          1000,
+		LocationID:         1,
+	},
+	&megaport.MCR{
+		UID:                "mcr-1",
+		Name:               "MCR One",
+		ProvisioningStatus: "CONFIGURED",
+		PortSpeed:          5000,
+		LocationID:         2,
+	},
+}
+
+func TestPrintProducts_Table(t *testing.T) {
+	out := op.CaptureOutput(func() {
+		err := printProducts(productTestProducts, "table", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "UID")
+	assert.Contains(t, out, "STATUS")
+	assert.Contains(t, out, "port-1")
+	assert.Contains(t, out, "Port One")
+	assert.Contains(t, out, "mcr-1")
+	assert.Contains(t, out, "MCR One")
+}
+
+func TestPrintProducts_JSON(t *testing.T) {
+	out := op.CaptureOutput(func() {
+		err := printProducts(productTestProducts, "json", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, `"uid": "port-1"`)
+	assert.Contains(t, out, `"name": "Port One"`)
+	assert.Contains(t, out, `"speed": 1000`)
+	assert.Contains(t, out, `"uid": "mcr-1"`)
+}
+
+func TestPrintProducts_CSV(t *testing.T) {
+	out := op.CaptureOutput(func() {
+		err := printProducts(productTestProducts, "csv", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "uid,name,type,provisioning_status,speed,location_id")
+	assert.Contains(t, out, "port-1,Port One")
+	assert.Contains(t, out, "mcr-1,MCR One")
+}
+
+func TestPrintProducts_XML(t *testing.T) {
+	out := op.CaptureOutput(func() {
+		err := printProducts(productTestProducts, "xml", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "<uid>port-1</uid>")
+	assert.Contains(t, out, "<name>Port One</name>")
+	assert.Contains(t, out, "<speed>1000</speed>")
+	assert.Contains(t, out, "<uid>mcr-1</uid>")
+}
+
+func TestPrintProducts_Empty(t *testing.T) {
+	out := op.CaptureOutput(func() {
+		err := printProducts([]megaport.Product{}, "json", true)
+		assert.NoError(t, err)
+	})
+	assert.Equal(t, "[]\n", out)
+}
+
+func TestPrintProducts_NilProductReturnsError(t *testing.T) {
+	var err error
+	op.CaptureOutput(func() {
+		err = printProducts([]megaport.Product{nil}, "table", true)
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nil value")
+}

--- a/internal/commands/status/status_output.go
+++ b/internal/commands/status/status_output.go
@@ -12,53 +12,53 @@ import (
 
 // statusPortOutput represents a port in the status dashboard.
 type statusPortOutput struct {
-	output.Output `json:"-" header:"-"`
-	UID           string `json:"uid" header:"UID"`
-	Name          string `json:"name" header:"Name"`
-	Status        string `json:"status" header:"Status"`
-	Speed         int    `json:"speed" header:"Speed"`
-	LocationID    int    `json:"location_id" header:"Location ID"`
+	output.Output `json:"-" header:"-" xml:"-"`
+	UID           string `json:"uid" header:"UID" xml:"uid"`
+	Name          string `json:"name" header:"Name" xml:"name"`
+	Status        string `json:"status" header:"Status" xml:"status"`
+	Speed         int    `json:"speed" header:"Speed" xml:"speed"`
+	LocationID    int    `json:"location_id" header:"Location ID" xml:"location_id"`
 }
 
 // statusMCROutput represents an MCR in the status dashboard.
 type statusMCROutput struct {
-	output.Output `json:"-" header:"-"`
-	UID           string `json:"uid" header:"UID"`
-	Name          string `json:"name" header:"Name"`
-	Status        string `json:"status" header:"Status"`
-	Speed         int    `json:"speed" header:"Speed"`
-	ASN           int    `json:"asn" header:"ASN"`
+	output.Output `json:"-" header:"-" xml:"-"`
+	UID           string `json:"uid" header:"UID" xml:"uid"`
+	Name          string `json:"name" header:"Name" xml:"name"`
+	Status        string `json:"status" header:"Status" xml:"status"`
+	Speed         int    `json:"speed" header:"Speed" xml:"speed"`
+	ASN           int    `json:"asn" header:"ASN" xml:"asn"`
 }
 
 // statusMVEOutput represents an MVE in the status dashboard.
 type statusMVEOutput struct {
-	output.Output `json:"-" header:"-"`
-	UID           string `json:"uid" header:"UID"`
-	Name          string `json:"name" header:"Name"`
-	Status        string `json:"status" header:"Status"`
-	Vendor        string `json:"vendor" header:"Vendor"`
-	Size          string `json:"size" header:"Size"`
+	output.Output `json:"-" header:"-" xml:"-"`
+	UID           string `json:"uid" header:"UID" xml:"uid"`
+	Name          string `json:"name" header:"Name" xml:"name"`
+	Status        string `json:"status" header:"Status" xml:"status"`
+	Vendor        string `json:"vendor" header:"Vendor" xml:"vendor"`
+	Size          string `json:"size" header:"Size" xml:"size"`
 }
 
 // statusVXCOutput represents a VXC in the status dashboard.
 type statusVXCOutput struct {
-	output.Output `json:"-" header:"-"`
-	UID           string `json:"uid" header:"UID"`
-	Name          string `json:"name" header:"Name"`
-	Status        string `json:"status" header:"Status"`
-	RateLimit     int    `json:"rate_limit" header:"Rate Limit"`
-	AEndUID       string `json:"a_end_uid" header:"A-End UID"`
-	BEndUID       string `json:"b_end_uid" header:"B-End UID"`
+	output.Output `json:"-" header:"-" xml:"-"`
+	UID           string `json:"uid" header:"UID" xml:"uid"`
+	Name          string `json:"name" header:"Name" xml:"name"`
+	Status        string `json:"status" header:"Status" xml:"status"`
+	RateLimit     int    `json:"rate_limit" header:"Rate Limit" xml:"rate_limit"`
+	AEndUID       string `json:"a_end_uid" header:"A-End UID" xml:"a_end_uid"`
+	BEndUID       string `json:"b_end_uid" header:"B-End UID" xml:"b_end_uid"`
 }
 
 // statusIXOutput represents an IX in the status dashboard.
 type statusIXOutput struct {
-	output.Output `json:"-" header:"-"`
-	UID           string `json:"uid" header:"UID"`
-	Name          string `json:"name" header:"Name"`
-	Status        string `json:"status" header:"Status"`
-	ASN           int    `json:"asn" header:"ASN"`
-	RateLimit     int    `json:"rate_limit" header:"Rate Limit"`
+	output.Output `json:"-" header:"-" xml:"-"`
+	UID           string `json:"uid" header:"UID" xml:"uid"`
+	Name          string `json:"name" header:"Name" xml:"name"`
+	Status        string `json:"status" header:"Status" xml:"status"`
+	ASN           int    `json:"asn" header:"ASN" xml:"asn"`
+	RateLimit     int    `json:"rate_limit" header:"Rate Limit" xml:"rate_limit"`
 }
 
 // dashboardSummary holds resource counts.

--- a/internal/commands/status/status_output_test.go
+++ b/internal/commands/status/status_output_test.go
@@ -8,6 +8,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// printDashboard's helpers (PrintPlain/PrintWarning/PrintNewline) route to
+// stdout or stderr based on output's *global* format, which only StatusDashboard
+// sets. Calling printDashboard directly leaves that global state to whatever a
+// prior test set, so pin it here to keep CaptureOutput (stdout-only) reliable.
+func withOutputFormat(t *testing.T, format string) {
+	t.Helper()
+	prev := op.GetOutputFormat()
+	op.SetOutputFormat(format)
+	t.Cleanup(func() { op.SetOutputFormat(prev) })
+}
+
 func statusTestDashboard(t *testing.T) dashboardOutput {
 	t.Helper()
 	port := &megaport.Port{UID: "port-1", Name: "Port One", ProvisioningStatus: "LIVE", PortSpeed: 1000, LocationID: 1}
@@ -56,6 +67,7 @@ func TestBuildDashboard_FieldMapping(t *testing.T) {
 }
 
 func TestPrintDashboard_Table(t *testing.T) {
+	withOutputFormat(t, "table")
 	dashboard := statusTestDashboard(t)
 	out := op.CaptureOutput(func() {
 		err := printDashboard(dashboard, "table", true)
@@ -71,6 +83,7 @@ func TestPrintDashboard_Table(t *testing.T) {
 }
 
 func TestPrintDashboard_JSON(t *testing.T) {
+	withOutputFormat(t, "json")
 	dashboard := statusTestDashboard(t)
 	out := op.CaptureOutput(func() {
 		err := printDashboard(dashboard, "json", true)
@@ -84,6 +97,7 @@ func TestPrintDashboard_JSON(t *testing.T) {
 }
 
 func TestPrintDashboard_CSV(t *testing.T) {
+	withOutputFormat(t, "csv")
 	dashboard := statusTestDashboard(t)
 	out := op.CaptureOutput(func() {
 		err := printDashboard(dashboard, "csv", true)
@@ -97,6 +111,7 @@ func TestPrintDashboard_CSV(t *testing.T) {
 }
 
 func TestPrintDashboard_XML(t *testing.T) {
+	withOutputFormat(t, "xml")
 	dashboard := statusTestDashboard(t)
 	out := op.CaptureOutput(func() {
 		err := printDashboard(dashboard, "xml", true)
@@ -116,6 +131,7 @@ func TestPrintDashboard_Empty(t *testing.T) {
 
 	for _, format := range []string{"table", "json", "csv", "xml"} {
 		t.Run(format, func(t *testing.T) {
+			withOutputFormat(t, format)
 			out := op.CaptureOutput(func() {
 				err := printDashboard(dashboard, format, true)
 				assert.NoError(t, err)

--- a/internal/commands/status/status_output_test.go
+++ b/internal/commands/status/status_output_test.go
@@ -1,0 +1,126 @@
+package status
+
+import (
+	"testing"
+
+	op "github.com/megaport/megaport-cli/internal/base/output"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/stretchr/testify/assert"
+)
+
+func statusTestDashboard(t *testing.T) dashboardOutput {
+	t.Helper()
+	port := &megaport.Port{UID: "port-1", Name: "Port One", ProvisioningStatus: "LIVE", PortSpeed: 1000, LocationID: 1}
+	mcr := &megaport.MCR{UID: "mcr-1", Name: "MCR One", ProvisioningStatus: "LIVE", PortSpeed: 5000}
+	mcr.Resources.VirtualRouter.ASN = 65000
+	mve := &megaport.MVE{UID: "mve-1", Name: "MVE One", ProvisioningStatus: "LIVE", Vendor: "cisco", Size: "MEDIUM"}
+	vxc := &megaport.VXC{UID: "vxc-1", Name: "VXC One", ProvisioningStatus: "LIVE", RateLimit: 500}
+	vxc.AEndConfiguration.UID = "a-end"
+	vxc.BEndConfiguration.UID = "b-end"
+	ix := &megaport.IX{ProductUID: "ix-1", ProductName: "IX One", ProvisioningStatus: "LIVE", ASN: 64512, RateLimit: 100}
+
+	dashboard, err := buildDashboard(
+		[]*megaport.Port{port},
+		[]*megaport.MCR{mcr},
+		[]*megaport.MVE{mve},
+		[]*megaport.VXC{vxc},
+		[]*megaport.IX{ix},
+	)
+	assert.NoError(t, err)
+	return dashboard
+}
+
+func TestBuildDashboard_FieldMapping(t *testing.T) {
+	dashboard := statusTestDashboard(t)
+
+	assert.Len(t, dashboard.Ports, 1)
+	assert.Equal(t, "port-1", dashboard.Ports[0].UID)
+	assert.Equal(t, 1000, dashboard.Ports[0].Speed)
+
+	assert.Len(t, dashboard.MCRs, 1)
+	assert.Equal(t, 65000, dashboard.MCRs[0].ASN)
+
+	assert.Len(t, dashboard.MVEs, 1)
+	assert.Equal(t, "cisco", dashboard.MVEs[0].Vendor)
+	assert.Equal(t, "MEDIUM", dashboard.MVEs[0].Size)
+
+	assert.Len(t, dashboard.VXCs, 1)
+	assert.Equal(t, "a-end", dashboard.VXCs[0].AEndUID)
+	assert.Equal(t, "b-end", dashboard.VXCs[0].BEndUID)
+
+	assert.Len(t, dashboard.IXs, 1)
+	assert.Equal(t, "ix-1", dashboard.IXs[0].UID)
+	assert.Equal(t, 64512, dashboard.IXs[0].ASN)
+
+	assert.Equal(t, dashboardSummary{Ports: 1, MCRs: 1, MVEs: 1, VXCs: 1, IXs: 1}, dashboard.Summary)
+}
+
+func TestPrintDashboard_Table(t *testing.T) {
+	dashboard := statusTestDashboard(t)
+	out := op.CaptureOutput(func() {
+		err := printDashboard(dashboard, "table", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "PORTS (1)")
+	assert.Contains(t, out, "port-1")
+	assert.Contains(t, out, "MCRS (1)")
+	assert.Contains(t, out, "mcr-1")
+	assert.Contains(t, out, "ix-1")
+	assert.Contains(t, out, "Total: 1 port(s), 1 MCR(s), 1 MVE(s), 1 VXC(s), 1 IX(s)")
+}
+
+func TestPrintDashboard_JSON(t *testing.T) {
+	dashboard := statusTestDashboard(t)
+	out := op.CaptureOutput(func() {
+		err := printDashboard(dashboard, "json", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, `"uid": "port-1"`)
+	assert.Contains(t, out, `"asn": 65000`)
+	assert.Contains(t, out, `"a_end_uid": "a-end"`)
+	assert.Contains(t, out, `"summary"`)
+}
+
+func TestPrintDashboard_CSV(t *testing.T) {
+	dashboard := statusTestDashboard(t)
+	out := op.CaptureOutput(func() {
+		err := printDashboard(dashboard, "csv", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "# PORTS")
+	assert.Contains(t, out, "port-1")
+	assert.Contains(t, out, "# IXS")
+	assert.Contains(t, out, "ix-1")
+}
+
+func TestPrintDashboard_XML(t *testing.T) {
+	dashboard := statusTestDashboard(t)
+	out := op.CaptureOutput(func() {
+		err := printDashboard(dashboard, "xml", true)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "<dashboard>")
+	assert.Contains(t, out, "<uid>port-1</uid>")
+	assert.Contains(t, out, "<asn>65000</asn>")
+	assert.Contains(t, out, "<a_end_uid>a-end</a_end_uid>")
+	assert.Contains(t, out, "<summary>")
+}
+
+func TestPrintDashboard_Empty(t *testing.T) {
+	dashboard, err := buildDashboard(nil, nil, nil, nil, nil)
+	assert.NoError(t, err)
+
+	for _, format := range []string{"table", "json", "csv", "xml"} {
+		t.Run(format, func(t *testing.T) {
+			out := op.CaptureOutput(func() {
+				err := printDashboard(dashboard, format, true)
+				assert.NoError(t, err)
+			})
+			assert.NotEmpty(t, out)
+		})
+	}
+}


### PR DESCRIPTION
Adds the missing `<pkg>_output_test.go` for the six read-only command packages (`partners`, `product`, `status`, `billing_market`, `auth`, `locations`). Each now exercises the `to<Type>Output` field mapping and all four output formats (table, JSON, CSV, XML), plus a nil/empty case. XML was previously untested for every one of these.

Two real bugs surfaced while writing the tests; fixed with regressions kept:

- Nil-safety: `toPartnerOutput`, `toBillingMarketOutput`, `toLocationOutput`, `toLocationTableOutput` dereferenced their pointer args without a nil check, and the partner/location/country/billing print loops appended raw entries. A nil element from the API would panic. Added nil guards.
- Status XML element names: the status dashboard uses a bespoke XML encoder and the output structs had no `xml` tags, so it emitted Go field names (`<UID>`, `<ASN>`) instead of the snake_case names every other command and the dashboard's own JSON use. Added `xml` tags so XML matches (`<uid>`, `<asn>`).