### PR TITLE
ESD-1387: Add read-only integration tests for billing-market, product, status, topology

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,7 +19,13 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Run read-only integration tests
-        run: go test -tags integration -run '^TestIntegration_' -v -timeout 5m ./internal/commands/locations/...
+        run: |
+          go test -tags integration -run '^TestIntegration_' -v -timeout 5m \
+            ./internal/commands/billing_market/... \
+            ./internal/commands/locations/... \
+            ./internal/commands/product/... \
+            ./internal/commands/status/... \
+            ./internal/commands/topology/...
         env:
           MEGAPORT_ACCESS_KEY: ${{ secrets.MEGAPORT_ACCESS_KEY }}
           MEGAPORT_SECRET_KEY: ${{ secrets.MEGAPORT_SECRET_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,12 @@ test-integration:
 
 # Run only read-only integration tests — fast, no resources provisioned
 test-integration-readonly:
-	go test -tags integration -run '^TestIntegration_' -v -timeout 5m ./internal/commands/locations/...
+	go test -tags integration -run '^TestIntegration_' -v -timeout 5m \
+		./internal/commands/billing_market/... \
+		./internal/commands/locations/... \
+		./internal/commands/product/... \
+		./internal/commands/status/... \
+		./internal/commands/topology/...
 
 # Run linter
 lint:

--- a/docs/INTEGRATION_TESTING.md
+++ b/docs/INTEGRATION_TESTING.md
@@ -34,7 +34,7 @@ Once provisioning lifecycle tests are written (ports, VXC, MCR, MVE, IX, NAT Gat
 
 Resources will be cleaned up automatically via `t.Cleanup()` at the end of each test, even when the test fails. However, if a test run is interrupted (e.g. `Ctrl+C`), cleanup may not run. In that case, log in to the staging portal and delete any resources prefixed with `CLI-Test-`.
 
-Currently, only read-only integration tests exist (`locations`). No resources are provisioned.
+The read-only integration tests cover `billing_market`, `locations`, `product`, `status`, and `topology`. No resources are provisioned.
 
 ## Build tag
 
@@ -52,7 +52,7 @@ Running `go test ./...` (without `-tags integration`) excludes these files entir
 
 Integration tests run in CI via `.github/workflows/integration-test.yml`:
 
-- **Read-only job**: runs nightly on `main` and on manual trigger, tests `locations` (and additional packages as read-only integration tests are written). Fast, no resource cost.
+- **Read-only job**: runs nightly on `main` and on manual trigger, tests `billing_market`, `locations`, `product`, `status`, and `topology` (and additional packages as read-only integration tests are written). Fast, no resource cost.
 - **Provisioning job**: manual trigger only (`workflow_dispatch`). Runs lifecycle tests for ports, VXC, MCR, MVE, and additional resources as they are added.
 
 ## Adding a new integration test

--- a/internal/commands/billing_market/billing_market_integration_test.go
+++ b/internal/commands/billing_market/billing_market_integration_test.go
@@ -1,0 +1,40 @@
+//go:build integration
+
+package billing_market
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/testutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_GetBillingMarkets(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	cmd := &cobra.Command{Use: "get"}
+
+	var err error
+	captured := output.CaptureOutput(func() {
+		err = GetBillingMarkets(cmd, nil, true, "json")
+	})
+	require.NoError(t, err)
+
+	var markets []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(captured), &markets), "output should be valid JSON")
+
+	if len(markets) == 0 {
+		t.Skip("staging account has no billing markets configured")
+	}
+
+	for _, m := range markets {
+		assert.Contains(t, m, "id", "billing market should have an id field")
+		assert.Contains(t, m, "currency", "billing market should have a currency field")
+		assert.Contains(t, m, "country", "billing market should have a country field")
+	}
+}

--- a/internal/commands/product/product_integration_test.go
+++ b/internal/commands/product/product_integration_test.go
@@ -1,0 +1,87 @@
+//go:build integration
+
+package product
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/testutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func integrationListProductsCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "list"}
+	cmd.Flags().Bool("include-inactive", false, "")
+	cmd.Flags().Int("limit", 0, "")
+	return cmd
+}
+
+func TestIntegration_ListProducts(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	cmd := integrationListProductsCmd()
+	require.NoError(t, cmd.Flags().Set("include-inactive", "true"))
+
+	var err error
+	captured := output.CaptureOutput(func() {
+		err = ListProducts(cmd, nil, true, "json")
+	})
+	require.NoError(t, err)
+
+	var products []map[string]interface{}
+	if captured != "" {
+		require.NoError(t, json.Unmarshal([]byte(captured), &products), "output should be valid JSON")
+	}
+	if len(products) == 0 {
+		t.Skip("staging account has no products provisioned")
+	}
+
+	for _, p := range products {
+		assert.Contains(t, p, "uid", "product should have a uid field")
+		assert.Contains(t, p, "type", "product should have a type field")
+	}
+}
+
+func TestIntegration_GetProductType(t *testing.T) {
+	// List first to get a valid product UID, then resolve its type.
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	listCmd := integrationListProductsCmd()
+	require.NoError(t, listCmd.Flags().Set("include-inactive", "true"))
+
+	var listErr error
+	listOut := output.CaptureOutput(func() {
+		listErr = ListProducts(listCmd, nil, true, "json")
+	})
+	require.NoError(t, listErr)
+
+	var products []map[string]interface{}
+	if listOut != "" {
+		require.NoError(t, json.Unmarshal([]byte(listOut), &products))
+	}
+	if len(products) == 0 {
+		t.Skip("staging account has no products to resolve a type for")
+	}
+
+	uid, ok := products[0]["uid"].(string)
+	require.True(t, ok, "product uid should be a string")
+	require.NotEmpty(t, uid)
+
+	var getErr error
+	getOut := output.CaptureOutput(func() {
+		getErr = GetProductType(&cobra.Command{Use: "get-type"}, []string{uid}, true, "json")
+	})
+	require.NoError(t, getErr)
+
+	var types []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(getOut), &types), "output should be valid JSON")
+	require.NotEmpty(t, types, "get-type should return a result for a valid UID")
+	assert.Contains(t, types[0], "uid", "result should have a uid field")
+	assert.Contains(t, types[0], "type", "result should have a type field")
+}

--- a/internal/commands/status/status_integration_test.go
+++ b/internal/commands/status/status_integration_test.go
@@ -1,0 +1,50 @@
+//go:build integration
+
+package status
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/testutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func integrationStatusCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "status"}
+	cmd.Flags().Bool("include-inactive", false, "")
+	return cmd
+}
+
+func TestIntegration_StatusDashboard(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	cmd := integrationStatusCmd()
+
+	var err error
+	captured := output.CaptureOutput(func() {
+		err = StatusDashboard(cmd, nil, true, "json")
+	})
+	require.NoError(t, err)
+
+	var dashboard map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(captured), &dashboard), "output should be valid JSON")
+
+	// The dashboard always renders all resource buckets plus a summary,
+	// regardless of whether the account holds any resources.
+	assert.Contains(t, dashboard, "ports")
+	assert.Contains(t, dashboard, "mcrs")
+	assert.Contains(t, dashboard, "mves")
+	assert.Contains(t, dashboard, "vxcs")
+	assert.Contains(t, dashboard, "ixs")
+	assert.Contains(t, dashboard, "summary")
+
+	summary, ok := dashboard["summary"].(map[string]interface{})
+	require.True(t, ok, "summary should be an object")
+	assert.Contains(t, summary, "ports")
+	assert.Contains(t, summary, "vxcs")
+}

--- a/internal/commands/topology/topology_integration_test.go
+++ b/internal/commands/topology/topology_integration_test.go
@@ -1,0 +1,71 @@
+//go:build integration
+
+package topology
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/testutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func integrationTopologyCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "topology"}
+	cmd.Flags().Bool("include-inactive", false, "")
+	cmd.Flags().String("type", "", "")
+	return cmd
+}
+
+func TestIntegration_ShowTopology(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	cmd := integrationTopologyCmd()
+
+	var err error
+	captured := output.CaptureOutput(func() {
+		err = ShowTopology(cmd, nil, true, "json")
+	})
+	require.NoError(t, err)
+
+	var nodes []TopologyNode
+	require.NoError(t, json.Unmarshal([]byte(captured), &nodes), "output should be valid JSON")
+
+	if len(nodes) == 0 {
+		t.Skip("staging account has no Port/MCR/MVE resources to build a topology from")
+	}
+
+	for _, n := range nodes {
+		assert.NotEmpty(t, n.UID, "topology node should have a uid")
+		assert.NotEmpty(t, n.Type, "topology node should have a type")
+	}
+}
+
+func TestIntegration_ShowTopology_TypeFilter(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	cmd := integrationTopologyCmd()
+	require.NoError(t, cmd.Flags().Set("type", "port"))
+
+	var err error
+	captured := output.CaptureOutput(func() {
+		err = ShowTopology(cmd, nil, true, "json")
+	})
+	require.NoError(t, err)
+
+	var nodes []TopologyNode
+	require.NoError(t, json.Unmarshal([]byte(captured), &nodes), "output should be valid JSON")
+
+	if len(nodes) == 0 {
+		t.Skip("staging account has no Port resources to build a topology from")
+	}
+
+	for _, n := range nodes {
+		assert.Equal(t, "Port", n.Type, "type filter should restrict nodes to Ports")
+	}
+}


### PR DESCRIPTION
Adds read-only integration tests for the billing-market, product, status, and topology commands, filling gaps in the staging integration suite. These tests list/get/show existing resources and provision nothing, so they're safe to run nightly.

Changes:
- New integration tests: `GetBillingMarkets`, `ListProducts` + `GetProductType`, `StatusDashboard`, `ShowTopology`
- Tests skip cleanly when the staging account has no matching resources
- Wire the new packages into the read-only CI job and the Makefile
- Update `docs/INTEGRATION_TESTING.md`

All tests pass against staging (6/6).
