### PR TITLE
ESD-1389: Add read-only integration tests for MCR Looking Glass

### DIFF
--- a/docs/INTEGRATION_TESTING.md
+++ b/docs/INTEGRATION_TESTING.md
@@ -55,6 +55,14 @@ Integration tests run in CI via `.github/workflows/integration-test.yml`:
 - **Read-only job**: runs nightly on `main` and on manual trigger, tests `locations` (and additional packages as read-only integration tests are written). Fast, no resource cost.
 - **Provisioning job**: manual trigger only (`workflow_dispatch`). Runs lifecycle tests for ports, VXC, MCR, MVE, and additional resources as they are added.
 
+### MCR Looking Glass tests
+
+`internal/commands/mcr/mcr_looking_glass_integration_test.go` covers the four read-only Looking Glass diagnostics (`ip-routes`, `bgp-routes`, `bgp-sessions`, `bgp-neighbor-routes`). They are read-only but live in the `mcr` package alongside the provisioning lifecycle tests, so they run under the manual provisioning job (`mcr` is already listed there) and never run nightly. They are deliberately kept out of the nightly read-only job: that job runs `-run '^TestIntegration_'` across whole packages, and adding `mcr` there would also run the MCR provisioning lifecycle tests every night.
+
+These tests need an MCR whose Looking Glass reports at least one BGP session in the UP state. They discover one automatically by listing MCRs and probing each one's BGP-sessions endpoint; the first MCR with an active session is used and the result is cached per run. If none qualifies, all four tests `t.Skip` with a clear message rather than failing.
+
+Staging prerequisite: at the time of writing, the `/lookingGlass/*` endpoints return 404 for every MCR on staging, so these tests skip by design there. To exercise the assertions, an MCR with an active BGP peering session must exist in the target environment; the discovery step then finds it with no test changes needed.
+
 ## Adding a new integration test
 
 1. Create `internal/commands/<resource>/<resource>_integration_test.go`

--- a/docs/INTEGRATION_TESTING.md
+++ b/docs/INTEGRATION_TESTING.md
@@ -61,7 +61,7 @@ Integration tests run in CI via `.github/workflows/integration-test.yml`:
 
 These tests need an MCR whose Looking Glass reports at least one BGP session in the UP state. They discover one automatically by listing MCRs and probing each one's BGP-sessions endpoint; the first MCR with an active session is used and the result is cached per run. If none qualifies, all four tests `t.Skip` with a clear message rather than failing.
 
-Staging prerequisite: at the time of writing, the `/lookingGlass/*` endpoints return 404 for every MCR on staging, so these tests skip by design there. To exercise the assertions, an MCR with an active BGP peering session must exist in the target environment; the discovery step then finds it with no test changes needed.
+Staging prerequisite: at the time of writing, the `/lookingGlass/*` endpoints return 404 for every MCR on staging, so these tests skip by design there. To exercise the assertions, an MCR with an active BGP peering session must exist in whichever environment the suite targets (set via `MEGAPORT_ENVIRONMENT`, staging by default); the discovery step then finds it automatically.
 
 ## Adding a new integration test
 

--- a/docs/INTEGRATION_TESTING.md
+++ b/docs/INTEGRATION_TESTING.md
@@ -61,7 +61,7 @@ Integration tests run in CI via `.github/workflows/integration-test.yml`:
 
 These tests need an MCR whose Looking Glass reports at least one BGP session in the UP state. They discover one automatically by listing MCRs and probing each one's BGP-sessions endpoint; the first MCR with an active session is used and the result is cached per run. If none qualifies, all four tests `t.Skip` with a clear message rather than failing.
 
-Staging prerequisite: at the time of writing, the `/lookingGlass/*` endpoints return 404 for every MCR on staging, so these tests skip by design there. To exercise the assertions, an MCR with an active BGP peering session must exist in whichever environment the suite targets (set via `MEGAPORT_ENVIRONMENT`, staging by default); the discovery step then finds it automatically.
+Staging prerequisite: at the time of writing, the `/lookingGlass/*` endpoints return 404 for every MCR on staging, so these tests skip by design there. The test helper targets staging, so to exercise the assertions an MCR with an active BGP peering session must exist on staging; the discovery step then finds it automatically.
 
 ## Adding a new integration test
 

--- a/internal/commands/mcr/mcr_looking_glass_integration_test.go
+++ b/internal/commands/mcr/mcr_looking_glass_integration_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/testutil"
+	"github.com/megaport/megaport-cli/internal/utils"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -56,6 +57,13 @@ func discoverLookingGlassTarget(t *testing.T, client *megaport.Client) (*looking
 			if m == nil {
 				continue
 			}
+			// Skip decommissioned/cancelled MCRs, as the list commands do. Looking
+			// Glass calls against an inactive MCR can return non-404 errors that
+			// would otherwise abort discovery.
+			switch m.ProvisioningStatus {
+			case megaport.STATUS_DECOMMISSIONED, megaport.STATUS_CANCELLED, utils.StatusDecommissioning:
+				continue
+			}
 			sessions, err := client.MCRLookingGlassService.ListBGPSessions(ctx, m.UID)
 			if err != nil {
 				if megaport.IsServiceNotFoundError(err) {
@@ -71,7 +79,9 @@ func discoverLookingGlassTarget(t *testing.T, client *megaport.Client) (*looking
 				if s == nil {
 					continue
 				}
-				if s.Status == megaport.BGPSessionStatusUp {
+				// Require a usable SessionID — the bgp-neighbor-routes test needs
+				// it, so a target without one is no better than no target.
+				if s.Status == megaport.BGPSessionStatusUp && s.SessionID != "" {
 					lookingGlassTargetVal = &lookingGlassTarget{
 						mcrUID:    m.UID,
 						sessionID: s.SessionID,

--- a/internal/commands/mcr/mcr_looking_glass_integration_test.go
+++ b/internal/commands/mcr/mcr_looking_glass_integration_test.go
@@ -1,0 +1,195 @@
+//go:build integration
+
+package mcr
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/testutil"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// lookingGlassTarget holds an MCR with at least one active (UP) BGP session,
+// plus that session's ID for the bgp-neighbor-routes subcommand.
+type lookingGlassTarget struct {
+	mcrUID    string
+	sessionID string
+}
+
+var (
+	lookingGlassTargetOnce sync.Once
+	lookingGlassTargetVal  *lookingGlassTarget
+)
+
+// discoverLookingGlassTarget lists MCRs on staging and returns the first one
+// whose Looking Glass reports at least one BGP session in the UP state.
+// Returns nil when no such MCR exists (e.g. the Looking Glass endpoint is not
+// available on staging, in which case every MCR returns 404). The result is
+// cached per process so the (slow) discovery scan runs once.
+func discoverLookingGlassTarget(t *testing.T, client *megaport.Client) *lookingGlassTarget {
+	t.Helper()
+	lookingGlassTargetOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		mcrs, err := client.MCRService.ListMCRs(ctx, &megaport.ListMCRsRequest{})
+		if err != nil {
+			t.Logf("looking-glass discovery: ListMCRs failed: %v", err)
+			return
+		}
+
+		for _, m := range mcrs {
+			sessions, err := client.MCRLookingGlassService.ListBGPSessions(ctx, m.UID)
+			if err != nil {
+				// The Looking Glass endpoint may not exist for this MCR
+				// (404) or be transiently unavailable; skip and keep scanning.
+				continue
+			}
+			for _, s := range sessions {
+				if s.Status == megaport.BGPSessionStatusUp {
+					lookingGlassTargetVal = &lookingGlassTarget{
+						mcrUID:    m.UID,
+						sessionID: s.SessionID,
+					}
+					return
+				}
+			}
+		}
+	})
+	return lookingGlassTargetVal
+}
+
+// requireLookingGlassTarget returns a BGP-enabled MCR or skips the test with a
+// clear message when none is available on staging.
+func requireLookingGlassTarget(t *testing.T, client *megaport.Client) *lookingGlassTarget {
+	t.Helper()
+	target := discoverLookingGlassTarget(t, client)
+	if target == nil {
+		t.Skip("no BGP-enabled MCR available on staging (no MCR reports an active Looking Glass BGP session); skipping Looking Glass integration test")
+	}
+	return target
+}
+
+func integrationLookingGlassCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "looking-glass"}
+	cmd.Flags().String("protocol", "", "")
+	cmd.Flags().String("ip", "", "")
+	return cmd
+}
+
+func TestIntegration_LookingGlassBGPSessions(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	origFmt := output.GetOutputFormat()
+	defer output.SetOutputFormat(origFmt)
+
+	target := requireLookingGlassTarget(t, client)
+
+	var err error
+	captured := output.CaptureOutput(func() {
+		err = ListLookingGlassBGPSessions(integrationLookingGlassCmd(), []string{target.mcrUID}, true, "json")
+	})
+	require.NoError(t, err, "list BGP sessions output: %s", captured)
+
+	var sessions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(captured), &sessions), "output should be valid JSON: %s", captured)
+	require.NotEmpty(t, sessions, "discovered MCR should report at least one BGP session")
+
+	for _, s := range sessions {
+		assert.Contains(t, s, "session_id")
+		assert.Contains(t, s, "neighbor_address")
+		assert.Contains(t, s, "status")
+	}
+}
+
+func TestIntegration_LookingGlassIPRoutes(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	origFmt := output.GetOutputFormat()
+	defer output.SetOutputFormat(origFmt)
+
+	target := requireLookingGlassTarget(t, client)
+
+	var err error
+	captured := output.CaptureOutput(func() {
+		err = ListLookingGlassIPRoutes(integrationLookingGlassCmd(), []string{target.mcrUID}, true, "json")
+	})
+	require.NoError(t, err, "list IP routes output: %s", captured)
+
+	var routes []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(captured), &routes), "output should be valid JSON: %s", captured)
+
+	// An MCR with active BGP sessions may still have an empty routing table at
+	// the moment of the call; assert shape only when routes are present.
+	for _, r := range routes {
+		assert.Contains(t, r, "prefix")
+		assert.Contains(t, r, "next_hop")
+		assert.Contains(t, r, "protocol")
+	}
+}
+
+func TestIntegration_LookingGlassBGPRoutes(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	origFmt := output.GetOutputFormat()
+	defer output.SetOutputFormat(origFmt)
+
+	target := requireLookingGlassTarget(t, client)
+
+	var err error
+	captured := output.CaptureOutput(func() {
+		err = ListLookingGlassBGPRoutes(integrationLookingGlassCmd(), []string{target.mcrUID}, true, "json")
+	})
+	require.NoError(t, err, "list BGP routes output: %s", captured)
+
+	var routes []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(captured), &routes), "output should be valid JSON: %s", captured)
+
+	for _, r := range routes {
+		assert.Contains(t, r, "prefix")
+		assert.Contains(t, r, "next_hop")
+		assert.Contains(t, r, "as_path")
+	}
+}
+
+func TestIntegration_LookingGlassBGPNeighborRoutes(t *testing.T) {
+	client := testutil.SetupIntegrationClient(t)
+	defer testutil.LoginWithClient(t, client)()
+
+	origFmt := output.GetOutputFormat()
+	defer output.SetOutputFormat(origFmt)
+
+	target := requireLookingGlassTarget(t, client)
+
+	// bgp-neighbor-routes takes three positional args: MCR UID, session ID, and
+	// direction ("advertised" or "received"). Use the session ID discovered from
+	// the BGP-sessions endpoint. "received" is the safe choice — an UP session
+	// is receiving the neighbor's routes even if the MCR advertises nothing.
+	args := []string{target.mcrUID, target.sessionID, "received"}
+
+	var err error
+	captured := output.CaptureOutput(func() {
+		err = ListLookingGlassBGPNeighborRoutes(integrationLookingGlassCmd(), args, true, "json")
+	})
+	require.NoError(t, err, "list BGP neighbor routes output: %s", captured)
+
+	var routes []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(captured), &routes), "output should be valid JSON: %s", captured)
+
+	for _, r := range routes {
+		assert.Contains(t, r, "prefix")
+		assert.Contains(t, r, "next_hop")
+		assert.Contains(t, r, "as_path")
+	}
+}

--- a/internal/commands/mcr/mcr_looking_glass_integration_test.go
+++ b/internal/commands/mcr/mcr_looking_glass_integration_test.go
@@ -5,6 +5,7 @@ package mcr
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -27,14 +28,19 @@ type lookingGlassTarget struct {
 var (
 	lookingGlassTargetOnce sync.Once
 	lookingGlassTargetVal  *lookingGlassTarget
+	lookingGlassDiscErr    error
 )
 
 // discoverLookingGlassTarget lists MCRs on staging and returns the first one
 // whose Looking Glass reports at least one BGP session in the UP state.
-// Returns nil when no such MCR exists (e.g. the Looking Glass endpoint is not
-// available on staging, in which case every MCR returns 404). The result is
-// cached per process so the (slow) discovery scan runs once.
-func discoverLookingGlassTarget(t *testing.T, client *megaport.Client) *lookingGlassTarget {
+//
+// It distinguishes "no target available" (nil target, nil error — skip) from a
+// real environment problem (non-nil error — fail). A 404/not-found from the
+// Looking Glass endpoint means it isn't available for that MCR and the scan
+// continues; any other error (auth, 5xx) aborts and surfaces so CI fails rather
+// than silently skipping coverage. The result is cached per process so the
+// (slow) discovery scan runs once.
+func discoverLookingGlassTarget(t *testing.T, client *megaport.Client) (*lookingGlassTarget, error) {
 	t.Helper()
 	lookingGlassTargetOnce.Do(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -42,18 +48,29 @@ func discoverLookingGlassTarget(t *testing.T, client *megaport.Client) *lookingG
 
 		mcrs, err := client.MCRService.ListMCRs(ctx, &megaport.ListMCRsRequest{})
 		if err != nil {
-			t.Logf("looking-glass discovery: ListMCRs failed: %v", err)
+			lookingGlassDiscErr = fmt.Errorf("ListMCRs failed during looking-glass discovery: %w", err)
 			return
 		}
 
 		for _, m := range mcrs {
-			sessions, err := client.MCRLookingGlassService.ListBGPSessions(ctx, m.UID)
-			if err != nil {
-				// The Looking Glass endpoint may not exist for this MCR
-				// (404) or be transiently unavailable; skip and keep scanning.
+			if m == nil {
 				continue
 			}
+			sessions, err := client.MCRLookingGlassService.ListBGPSessions(ctx, m.UID)
+			if err != nil {
+				if megaport.IsServiceNotFoundError(err) {
+					// Looking Glass not available for this MCR; keep scanning.
+					continue
+				}
+				// Auth/5xx/etc — a real failure, not "no target". Abort so the
+				// test fails instead of skipping with a misleading message.
+				lookingGlassDiscErr = fmt.Errorf("ListBGPSessions failed for MCR %s: %w", m.UID, err)
+				return
+			}
 			for _, s := range sessions {
+				if s == nil {
+					continue
+				}
 				if s.Status == megaport.BGPSessionStatusUp {
 					lookingGlassTargetVal = &lookingGlassTarget{
 						mcrUID:    m.UID,
@@ -64,14 +81,15 @@ func discoverLookingGlassTarget(t *testing.T, client *megaport.Client) *lookingG
 			}
 		}
 	})
-	return lookingGlassTargetVal
+	return lookingGlassTargetVal, lookingGlassDiscErr
 }
 
-// requireLookingGlassTarget returns a BGP-enabled MCR or skips the test with a
-// clear message when none is available on staging.
+// requireLookingGlassTarget returns a BGP-enabled MCR, fails the test on a real
+// discovery error, or skips when staging simply has no BGP-enabled MCR.
 func requireLookingGlassTarget(t *testing.T, client *megaport.Client) *lookingGlassTarget {
 	t.Helper()
-	target := discoverLookingGlassTarget(t, client)
+	target, err := discoverLookingGlassTarget(t, client)
+	require.NoError(t, err, "looking-glass target discovery failed")
 	if target == nil {
 		t.Skip("no BGP-enabled MCR available on staging (no MCR reports an active Looking Glass BGP session); skipping Looking Glass integration test")
 	}


### PR DESCRIPTION
Adds read-only integration tests for the MCR Looking Glass commands: BGP sessions, IP routes, BGP routes, and BGP neighbor routes.

The tests discover a suitable MCR/session target on staging and skip cleanly when none exists, so they're safe to run nightly. A `sync.Once` cache avoids re-discovering the target across the four tests.

Changes:
- New Looking Glass integration tests with shared target discovery
- Update `docs/INTEGRATION_TESTING.md`

The Looking Glass endpoint currently returns 404 on staging, so these skip there for now; they'll exercise once the endpoint is live.
