### PR TITLE
ESD-1416(fix-WASM): remove SSRF-prone legacy /proxy/ endpoint and default bind to loopback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,4 @@ Thumbs.db
 
 # Claude Code
 .claude/
-server
+/server

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ Thumbs.db
 
 # Claude Code
 .claude/
+server

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ EXPOSE 8080
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:8080/ || exit 1
 
 # Run server
 CMD ["./server", "--bind", "0.0.0.0", "--port", "8080", "--dir", "web"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,4 +83,4 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1
 
 # Run server
-CMD ["./server", "--port", "8080", "--dir", "web"]
+CMD ["./server", "--bind", "0.0.0.0", "--port", "8080", "--dir", "web"]

--- a/WASM_README.md
+++ b/WASM_README.md
@@ -210,6 +210,8 @@ go build -o server ./cmd/server/server.go
 ./server --port 8080 --dir web --session-duration 1h
 ```
 
+The server binds `127.0.0.1` by default. To expose it on other interfaces (e.g. inside a container), pass `--bind 0.0.0.0`.
+
 ## Publishing to the Portal
 
 The Portal loads the WASM binary from `s3://media.megaport.com/portal/megaport-cli/`. Publishing is currently manual.

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -17,15 +17,6 @@ import (
 	"github.com/megaport/megaport-cli/internal/server"
 )
 
-// isAllowedProxyHost validates that the proxy target is a Megaport API host.
-func isAllowedProxyHost(host string) bool {
-	host = strings.ToLower(strings.TrimSpace(host))
-	return host == "api.megaport.com" ||
-		host == "api-staging.megaport.com" ||
-		host == "api-mpone-dev.megaport.com" ||
-		strings.HasSuffix(host, ".megaport.com")
-}
-
 // isAllowedOrigin checks whether the CORS origin is from localhost.
 func isAllowedOrigin(origin string) bool {
 	if origin == "" {
@@ -170,6 +161,7 @@ var optimizedHTTPClient = &http.Client{
 
 func main() {
 	port := flag.String("port", "8080", "Port to serve on")
+	bind := flag.String("bind", "127.0.0.1", "Address to bind to (use 0.0.0.0 to expose on all interfaces)")
 	webDir := flag.String("dir", "web", "Directory to serve files from")
 	sessionDuration := flag.Duration("session-duration", 1*time.Hour, "Session duration")
 	flag.Parse()
@@ -202,14 +194,12 @@ func main() {
 		authenticatedProxyHandler(w, r, srv)
 	}))
 
-	// Legacy proxy handler (backward compatible)
-	http.HandleFunc("/proxy/", withSecurityHeaders(proxyHandler))
-
 	// Static file server for everything else
 	fs := http.FileServer(http.Dir(*webDir))
 	http.Handle("/", withSecurityHeaders(addCorsHeaders(fs)))
 
-	log.Printf("Starting Megaport CLI WASM Server on http://localhost:%s", *port)
+	addr := net.JoinHostPort(*bind, *port)
+	log.Printf("Starting Megaport CLI WASM Server on http://%s", addr)
 	log.Printf("Serving files from: %s", *webDir)
 	log.Printf("Session duration: %v", *sessionDuration)
 	log.Printf("\nEndpoints:")
@@ -217,8 +207,8 @@ func main() {
 	log.Printf("  - POST /auth/logout   - Customer logout")
 	log.Printf("  - GET  /auth/check    - Check session validity")
 	log.Printf("  - *    /api/*         - Authenticated API proxy")
-	log.Printf("  - *    /proxy/*       - Legacy direct proxy")
-	log.Fatal(http.ListenAndServe(":"+*port, nil))
+	httpServer := &http.Server{Addr: addr, Handler: http.DefaultServeMux}
+	log.Fatal(httpServer.ListenAndServe())
 }
 
 func authenticatedProxyHandler(w http.ResponseWriter, r *http.Request, srv *server.Server) {
@@ -320,90 +310,6 @@ func authenticatedProxyHandler(w http.ResponseWriter, r *http.Request, srv *serv
 	if _, err := w.Write(respBody); err != nil {
 		log.Printf("Error writing response: %v", err)
 	}
-}
-
-func proxyHandler(w http.ResponseWriter, r *http.Request) {
-	// Extract the target host from query parameter
-	targetHost := r.URL.Query().Get("base")
-	if targetHost == "" {
-		http.Error(w, "Missing 'base' query parameter", http.StatusBadRequest)
-		return
-	}
-
-	// Validate target host against allowlist to prevent SSRF
-	if !isAllowedProxyHost(targetHost) {
-		log.Printf("Rejected proxy request to disallowed host: %s", targetHost)
-		http.Error(w, "Forbidden: proxy target must be a *.megaport.com host", http.StatusForbidden)
-		return
-	}
-
-	// Extract the path after /proxy/
-	path := strings.TrimPrefix(r.URL.Path, "/proxy/")
-
-	// Build the target URL with query parameters (excluding 'base')
-	targetURL := "https://" + targetHost + "/" + path
-
-	// Forward all query parameters except 'base'
-	query := r.URL.Query()
-	query.Del("base")
-	if len(query) > 0 {
-		targetURL += "?" + query.Encode()
-	}
-
-	log.Printf("Proxying %s request to: %s", r.Method, targetURL)
-
-	// Create new request
-	proxyReq, err := http.NewRequest(r.Method, targetURL, r.Body)
-	if err != nil {
-		log.Printf("Failed to create proxy request for %s %s: %v", r.Method, targetURL, err)
-		http.Error(w, "Failed to create proxy request", http.StatusInternalServerError)
-		return
-	}
-
-	// Copy headers from original request (except Host)
-	for key, values := range r.Header {
-		if key != "Host" {
-			for _, value := range values {
-				proxyReq.Header.Add(key, value)
-			}
-		}
-	}
-
-	// Set proper Content-Type for OAuth requests
-	if proxyReq.Header.Get("Content-Type") == "" && r.Method == "POST" {
-		proxyReq.Header.Set("Content-Type", "application/json")
-	}
-
-	// Make the request using optimized client with connection pooling
-	resp, err := optimizedHTTPClient.Do(proxyReq)
-	if err != nil {
-		log.Printf("Proxy request failed: %v", err)
-		http.Error(w, "Proxy request failed", http.StatusBadGateway)
-		return
-	}
-	defer resp.Body.Close()
-
-	// Copy response headers before writing status
-	for key, values := range resp.Header {
-		for _, value := range values {
-			w.Header().Add(key, value)
-		}
-	}
-
-	// Add CORS headers and re-apply security headers after upstream header copy
-	// to ensure upstream cannot override our security policy
-	setCORSHeaders(w, r, "Content-Type, Authorization")
-	setSecurityHeaders(w)
-
-	// Write status code
-	w.WriteHeader(resp.StatusCode)
-
-	// Stream response body to client, counting bytes for logging
-	bytesCopied, err := io.Copy(w, resp.Body)
-	if err != nil {
-		log.Printf("Error streaming response body: %v", err)
-	}
-	log.Printf("Proxy response status: %d, body size: %d bytes", resp.StatusCode, bytesCopied)
 }
 
 func addCorsHeaders(fs http.Handler) http.HandlerFunc {

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -207,7 +207,14 @@ func main() {
 	log.Printf("  - POST /auth/logout   - Customer logout")
 	log.Printf("  - GET  /auth/check    - Check session validity")
 	log.Printf("  - *    /api/*         - Authenticated API proxy")
-	httpServer := &http.Server{Addr: addr, Handler: http.DefaultServeMux}
+	httpServer := &http.Server{
+		Addr:              addr,
+		Handler:           http.DefaultServeMux,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		WriteTimeout:      120 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
 	log.Fatal(httpServer.ListenAndServe())
 }
 

--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -36,33 +36,6 @@ func redirectClientTo(backend *httptest.Server) *http.Client {
 	}
 }
 
-func TestIsAllowedProxyHost(t *testing.T) {
-	tests := []struct {
-		host    string
-		allowed bool
-	}{
-		{"api.megaport.com", true},
-		{"api-staging.megaport.com", true},
-		{"api-mpone-dev.megaport.com", true},
-		{"custom.megaport.com", true},
-		{"API.MEGAPORT.COM", true},   // case insensitive
-		{" api.megaport.com ", true}, // trimmed
-		{"evil.com", false},
-		{"megaport.com.evil.com", false},
-		{"api.megaport.com.evil.com", false},
-		{"", false},
-		{"localhost", false},
-		{"192.168.1.1", false},
-		{"internal-network.local", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.host, func(t *testing.T) {
-			assert.Equal(t, tt.allowed, isAllowedProxyHost(tt.host))
-		})
-	}
-}
-
 func TestIsAllowedOrigin(t *testing.T) {
 	tests := []struct {
 		origin  string
@@ -124,37 +97,6 @@ func TestSetCORSHeaders(t *testing.T) {
 	})
 }
 
-func TestProxyHandler_SSRFProtection(t *testing.T) {
-	t.Run("rejects disallowed host", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		r := httptest.NewRequest("GET", "/proxy/test?base=evil.com", nil)
-
-		proxyHandler(w, r)
-
-		assert.Equal(t, http.StatusForbidden, w.Code)
-		assert.Contains(t, w.Body.String(), "proxy target must be a *.megaport.com host")
-	})
-
-	t.Run("rejects missing base parameter", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		r := httptest.NewRequest("GET", "/proxy/test", nil)
-
-		proxyHandler(w, r)
-
-		assert.Equal(t, http.StatusBadRequest, w.Code)
-	})
-
-	t.Run("rejects internal network hosts", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		r := httptest.NewRequest("GET", "/proxy/test?base=192.168.1.1", nil)
-
-		proxyHandler(w, r)
-
-		assert.Equal(t, http.StatusForbidden, w.Code)
-	})
-}
-
-// newTestServer creates a server.Server for testing with a 1-hour session duration.
 func newTestServer() *server.Server {
 	return server.NewServer(1*time.Hour, log.New(io.Discard, "", 0))
 }
@@ -358,118 +300,6 @@ func TestAuthenticatedProxyHandler_ExpiredSession(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 	assert.Contains(t, w.Body.String(), "Invalid or expired session")
-}
-
-func TestProxyHandler_SuccessfulProxy(t *testing.T) {
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/v2/products", r.URL.Path)
-		assert.Equal(t, "10", r.URL.Query().Get("limit"))
-		// 'base' param should have been stripped
-		assert.Empty(t, r.URL.Query().Get("base"))
-		w.Header().Set("X-Backend-Header", "present")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"data":[]}`))
-	}))
-	defer backend.Close()
-
-	origClient := optimizedHTTPClient
-	defer func() { optimizedHTTPClient = origClient }()
-	optimizedHTTPClient = redirectClientTo(backend)
-
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "/proxy/v2/products?base=api.megaport.com&limit=10", nil)
-	r.Header.Set("Origin", "http://localhost:8080")
-
-	proxyHandler(w, r)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "present", w.Header().Get("X-Backend-Header"))
-	assert.Contains(t, w.Body.String(), `{"data":[]}`)
-	// CORS headers should be set
-	assert.Equal(t, "http://localhost:8080", w.Header().Get("Access-Control-Allow-Origin"))
-}
-
-func TestProxyHandler_POSTSetsContentType(t *testing.T) {
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer backend.Close()
-
-	origClient := optimizedHTTPClient
-	defer func() { optimizedHTTPClient = origClient }()
-	optimizedHTTPClient = redirectClientTo(backend)
-
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest("POST", "/proxy/v2/products?base=api.megaport.com", strings.NewReader(`{}`))
-
-	proxyHandler(w, r)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-}
-
-func TestProxyHandler_CopiesRequestHeaders(t *testing.T) {
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "Bearer mytoken", r.Header.Get("Authorization"))
-		// Host header should NOT be forwarded
-		assert.NotEqual(t, "evil-host.com", r.Host)
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer backend.Close()
-
-	origClient := optimizedHTTPClient
-	defer func() { optimizedHTTPClient = origClient }()
-	optimizedHTTPClient = redirectClientTo(backend)
-
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "/proxy/v2/products?base=api.megaport.com", nil)
-	r.Header.Set("Authorization", "Bearer mytoken")
-	r.Host = "evil-host.com"
-
-	proxyHandler(w, r)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-}
-
-func TestProxyHandler_NoQueryParamsExceptBase(t *testing.T) {
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// No extra query params — query string should be empty
-		assert.Empty(t, r.URL.RawQuery)
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer backend.Close()
-
-	origClient := optimizedHTTPClient
-	defer func() { optimizedHTTPClient = origClient }()
-	optimizedHTTPClient = redirectClientTo(backend)
-
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "/proxy/v2/test?base=api.megaport.com", nil)
-
-	proxyHandler(w, r)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-}
-
-func TestProxyHandler_ForwardsQueryParams(t *testing.T) {
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "10", r.URL.Query().Get("limit"))
-		assert.Empty(t, r.URL.Query().Get("base"))
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer backend.Close()
-
-	origClient := optimizedHTTPClient
-	defer func() { optimizedHTTPClient = origClient }()
-	optimizedHTTPClient = redirectClientTo(backend)
-
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "/proxy/v2/products?base=api.megaport.com&limit=10", nil)
-
-	proxyHandler(w, r)
-
-	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestAddCorsHeaders_OptionsPreflightReturns200(t *testing.T) {

--- a/deploy.sh
+++ b/deploy.sh
@@ -74,7 +74,7 @@ fi
 echo "🚀 Starting container..."
 docker run -d \
     --name megaport-cli-wasm \
-    -p 8080:8080 \
+    -p 127.0.0.1:8080:8080 \
     megaport-cli-wasm:latest
 
 echo ""

--- a/deploy.sh
+++ b/deploy.sh
@@ -74,14 +74,14 @@ fi
 echo "🚀 Starting container..."
 docker run -d \
     --name megaport-cli-wasm \
-    -p 127.0.0.1:8080:8080 \
+    -p "127.0.0.1:${PORT:-8080}:8080" \
     megaport-cli-wasm:latest
 
 echo ""
 echo "✅ Deployment successful!"
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "🌐 Access the Vue 3 CLI at: http://localhost:8080"
+echo "🌐 Access the Vue 3 CLI at: http://localhost:${PORT:-8080}"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 echo "📦 Frontend Build Info:"
@@ -97,7 +97,7 @@ echo "  🛑 Stop:             docker stop megaport-cli-wasm"
 echo "  🗑️  Remove:           docker rm megaport-cli-wasm"
 echo ""
 echo "To login:"
-echo "  1. Open http://localhost:8080 in your browser"
+echo "  1. Open http://localhost:${PORT:-8080} in your browser"
 echo "  2. Click 'Login' to authenticate with Megaport"
 echo "  3. Start using the CLI in your browser!"
 echo ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
           '--no-verbose',
           '--tries=1',
           '--spider',
-          'http://localhost:8080/',
+          'http://127.0.0.1:8080/',
         ]
       interval: 30s
       timeout: 3s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,15 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - '${PORT:-8080}:8080'
+      - '127.0.0.1:${PORT:-8080}:8080'
     environment:
       - TZ=${TZ:-UTC}
       - SESSION_DURATION=${SESSION_DURATION:-1h}
     command:
       [
         './server',
+        '--bind',
+        '0.0.0.0',
         '--port',
         '8080',
         '--dir',


### PR DESCRIPTION
The legacy `/proxy/` endpoint was an unauthenticated SSRF: `isAllowedProxyHost` suffix-matched the raw `?base=` value before any URL parsing, so payloads like `base=evil.com/x.megaport.com` passed the check while the request went to the attacker's host, with all client headers (including `Authorization` and `Cookie`) forwarded. The server also bound all interfaces while logging `http://localhost`.

The endpoint has no callers in `web/`, `frontend-integration/`, or the cli-tutorial wasm client, so it is deleted rather than hardened.

- Delete the `/proxy/` handler, `isAllowedProxyHost`, and their tests
- Add a `--bind` flag defaulting to `127.0.0.1`; startup log prints the real bind address
- Use an explicit `http.Server` with read/write/idle timeouts
- Docker publishes `127.0.0.1:${PORT:-8080}:8080` (compose and `deploy.sh`); the container binds `0.0.0.0` internally so the published port still works

Note: PR #371 also touches `cmd/server/server.go`; whichever merges second will need a small rebase.