### PR TITLE
fix: prevent servicekeys update from resetting active and single-use (ESD-1417)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `servicekeys update` now exits non-zero when the API reports the update was not applied (previously it warned and exited 0)
+
+### Fixed
+- `servicekeys update` no longer resets `active` and `single-use` to false when those flags are omitted
+- `servicekeys update`: passing both `--product-uid` and `--product-id` now errors instead of being sent to the SDK
+- Removed the non-functional `--description` flag from `servicekeys update`
+
 ## [v0.5.5] — 2026-04-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -516,8 +516,8 @@ megaport-cli servicekeys get SERVICE_KEY_UID --output json
 # Create a new service key
 megaport-cli servicekeys create --product-uid PRODUCT_UID --description "My Service Key" --max-speed 1000
 
-# Update an existing service key
-megaport-cli servicekeys update SERVICE_KEY_UID --description "Updated Description"
+# Deactivate an existing service key
+megaport-cli servicekeys update SERVICE_KEY_UID --active=false
 ```
 
 #### IX (Internet Exchange)

--- a/docs/megaport-cli_servicekeys.md
+++ b/docs/megaport-cli_servicekeys.md
@@ -14,7 +14,7 @@ This command groups all operations related to service keys. You can use its subc
   megaport-cli servicekeys list
   megaport-cli servicekeys get [key]
   megaport-cli servicekeys create --product-uid "product-uid" --description "My service key"
-  megaport-cli servicekeys update [key] --description "Updated description"
+  megaport-cli servicekeys update [key] --active=false
 ```
 
 ## Usage

--- a/docs/megaport-cli_servicekeys_update.md
+++ b/docs/megaport-cli_servicekeys_update.md
@@ -11,8 +11,8 @@ This command allows you to modify the details of an existing service key. You ne
 ### Example Usage
 
 ```sh
-  megaport-cli servicekeys update a1b2c3d4-e5f6-7890-1234-567890abcdef --description "Updated description"
   megaport-cli servicekeys update a1b2c3d4-e5f6-7890-1234-567890abcdef --active
+  megaport-cli servicekeys update a1b2c3d4-e5f6-7890-1234-567890abcdef --active=false
   megaport-cli servicekeys update a1b2c3d4-e5f6-7890-1234-567890abcdef --product-uid "new-product-uid"
 ```
 
@@ -30,8 +30,7 @@ megaport-cli servicekeys update [flags]
 
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
-| `--active` |  | `false` | Activate the service key | false |
-| `--description` |  |  | Description for the service key | false |
+| `--active` |  | `false` | Activate or deactivate the service key | false |
 | `--product-id` |  | `0` | Product ID for the service key | false |
 | `--product-uid` |  |  | Product UID for the service key | false |
 | `--single-use` |  | `false` | Single-use service key | false |

--- a/internal/base/cmdbuilder/servicekey_flagsets.go
+++ b/internal/base/cmdbuilder/servicekey_flagsets.go
@@ -26,10 +26,13 @@ func (b *CommandBuilder) WithServiceKeyListFlags() *CommandBuilder {
 	return b
 }
 
-// WithServiceKeyUpdateFlags adds flags for updating a service key
+// WithServiceKeyUpdateFlags adds flags for updating a service key.
+// No description flag: the update API does not support it.
 func (b *CommandBuilder) WithServiceKeyUpdateFlags() *CommandBuilder {
-	b.WithServiceKeyCommonFlags()
-	b.WithBoolFlag("active", false, "Activate the service key")
+	b.WithFlag("product-uid", "", "Product UID for the service key")
+	b.WithIntFlag("product-id", 0, "Product ID for the service key")
+	b.WithBoolFlag("single-use", false, "Single-use service key")
+	b.WithBoolFlag("active", false, "Activate or deactivate the service key")
 	return b
 }
 

--- a/internal/commands/servicekeys/servicekeys.go
+++ b/internal/commands/servicekeys/servicekeys.go
@@ -11,7 +11,7 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithExample("megaport-cli servicekeys list").
 		WithExample("megaport-cli servicekeys get [key]").
 		WithExample("megaport-cli servicekeys create --product-uid \"product-uid\" --description \"My service key\"").
-		WithExample("megaport-cli servicekeys update [key] --description \"Updated description\"").
+		WithExample("megaport-cli servicekeys update [key] --active=false").
 		WithRootCmd(rootCmd).
 		Build()
 
@@ -30,8 +30,8 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithLongDesc("Update an existing service key for the Megaport API.\n\nThis command allows you to modify the details of an existing service key. You need to specify the key identifier as an argument, and provide any updated values as flags.").
 		WithColorAwareRunFunc(UpdateServiceKey).
 		WithServiceKeyUpdateFlags().
-		WithExample("megaport-cli servicekeys update a1b2c3d4-e5f6-7890-1234-567890abcdef --description \"Updated description\"").
 		WithExample("megaport-cli servicekeys update a1b2c3d4-e5f6-7890-1234-567890abcdef --active").
+		WithExample("megaport-cli servicekeys update a1b2c3d4-e5f6-7890-1234-567890abcdef --active=false").
 		WithExample("megaport-cli servicekeys update a1b2c3d4-e5f6-7890-1234-567890abcdef --product-uid \"new-product-uid\"").
 		WithRootCmd(rootCmd).
 		Build()

--- a/internal/commands/servicekeys/servicekeys_actions.go
+++ b/internal/commands/servicekeys/servicekeys_actions.go
@@ -84,6 +84,10 @@ func CreateServiceKey(cmd *cobra.Command, args []string, noColor bool) error {
 func UpdateServiceKey(cmd *cobra.Command, args []string, noColor bool) error {
 	key := args[0]
 
+	if cmd.Flags().Changed("product-uid") && cmd.Flags().Changed("product-id") {
+		return fmt.Errorf("--product-uid and --product-id cannot both be set")
+	}
+
 	ctx, cancel, client, err := utils.LoginClient(cmd, 90*time.Second, config.Login)
 	if err != nil {
 		output.PrintError("Failed to log in: %v", noColor, err)
@@ -96,8 +100,8 @@ func UpdateServiceKey(cmd *cobra.Command, args []string, noColor bool) error {
 	// didn't ask to change.
 	current, err := client.ServiceKeyService.GetServiceKey(ctx, key)
 	if err != nil {
-		output.PrintError("Failed to get service key: %v", noColor, err)
-		return fmt.Errorf("failed to get service key: %w", err)
+		output.PrintError("Failed to fetch current service key: %v", noColor, err)
+		return fmt.Errorf("failed to fetch current service key: %w", err)
 	}
 
 	req := &megaport.UpdateServiceKeyRequest{

--- a/internal/commands/servicekeys/servicekeys_actions.go
+++ b/internal/commands/servicekeys/servicekeys_actions.go
@@ -83,10 +83,6 @@ func CreateServiceKey(cmd *cobra.Command, args []string, noColor bool) error {
 
 func UpdateServiceKey(cmd *cobra.Command, args []string, noColor bool) error {
 	key := args[0]
-	productUID, _ := cmd.Flags().GetString("product-uid")
-	productID, _ := cmd.Flags().GetInt("product-id")
-	singleUse, _ := cmd.Flags().GetBool("single-use")
-	active, _ := cmd.Flags().GetBool("active")
 
 	ctx, cancel, client, err := utils.LoginClient(cmd, 90*time.Second, config.Login)
 	if err != nil {
@@ -95,12 +91,35 @@ func UpdateServiceKey(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 	defer cancel()
 
+	// SingleUse and Active are always serialized by the SDK (no omitempty),
+	// so merge from the current key to avoid resetting fields the user
+	// didn't ask to change.
+	current, err := client.ServiceKeyService.GetServiceKey(ctx, key)
+	if err != nil {
+		output.PrintError("Failed to get service key: %v", noColor, err)
+		return fmt.Errorf("failed to get service key: %w", err)
+	}
+
 	req := &megaport.UpdateServiceKeyRequest{
-		Key:        key,
-		ProductUID: productUID,
-		ProductID:  productID,
-		SingleUse:  singleUse,
-		Active:     active,
+		Key:       key,
+		SingleUse: current.SingleUse,
+		Active:    current.Active,
+	}
+	if cmd.Flags().Changed("single-use") {
+		req.SingleUse, _ = cmd.Flags().GetBool("single-use")
+	}
+	if cmd.Flags().Changed("active") {
+		req.Active, _ = cmd.Flags().GetBool("active")
+	}
+	// The SDK rejects requests with both ProductUID and ProductID set, so
+	// preserve the current ProductUID only when the user provided neither.
+	switch {
+	case cmd.Flags().Changed("product-uid"):
+		req.ProductUID, _ = cmd.Flags().GetString("product-uid")
+	case cmd.Flags().Changed("product-id"):
+		req.ProductID, _ = cmd.Flags().GetInt("product-id")
+	default:
+		req.ProductUID = current.ProductUID
 	}
 
 	spinner := output.PrintResourceUpdating("Service Key", key, noColor)
@@ -114,11 +133,12 @@ func UpdateServiceKey(cmd *cobra.Command, args []string, noColor bool) error {
 		return fmt.Errorf("failed to update service key: %w", err)
 	}
 
-	if resp.IsUpdated {
-		output.PrintResourceUpdated("Service Key", key, noColor)
-	} else {
-		output.PrintWarning("Service key update request was not successful", noColor)
+	if !resp.IsUpdated {
+		output.PrintError("Service key update was not applied", noColor)
+		return fmt.Errorf("service key update was not applied")
 	}
+
+	output.PrintResourceUpdated("Service Key", key, noColor)
 	return nil
 }
 

--- a/internal/commands/servicekeys/servicekeys_actions_test.go
+++ b/internal/commands/servicekeys/servicekeys_actions_test.go
@@ -225,7 +225,7 @@ func TestUpdateServiceKey(t *testing.T) {
 			mockService: &MockServiceKeyService{
 				GetServiceKeyError: fmt.Errorf("key not found"),
 			},
-			expectedErr: "failed to get service key",
+			expectedErr: "failed to fetch current service key",
 		},
 		{
 			name:        "login error",
@@ -267,6 +267,29 @@ func TestUpdateServiceKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUpdateServiceKey_BothProductFlagsRejected(t *testing.T) {
+	mockService := &MockServiceKeyService{}
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {
+		c.ServiceKeyService = mockService
+	})
+	defer cleanup()
+
+	cmd := newUpdateServiceKeyCmd()
+	testutil.SetFlags(t, cmd, map[string]string{
+		"product-uid": "prod-uid",
+		"product-id":  "42",
+	})
+
+	var err error
+	output.CaptureOutput(func() {
+		err = cmd.RunE(cmd, []string{"test-key-123"})
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot both be set")
+	assert.Nil(t, mockService.CapturedUpdateServiceKeyRequest)
 }
 
 func TestUpdateServiceKey_MergesUnsetFlags(t *testing.T) {

--- a/internal/commands/servicekeys/servicekeys_actions_test.go
+++ b/internal/commands/servicekeys/servicekeys_actions_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/megaport/megaport-cli/internal/commands/config"
 	"github.com/megaport/megaport-cli/internal/testutil"
 	megaport "github.com/megaport/megaportgo"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -179,13 +180,21 @@ func TestListServiceKeys_ProductUIDFilter(t *testing.T) {
 	}
 }
 
+func newUpdateServiceKeyCmd() *cobra.Command {
+	cmd := testutil.NewCommand("update", testutil.NoColorAdapter(UpdateServiceKey))
+	cmd.Flags().String("product-uid", "", "")
+	cmd.Flags().Int("product-id", 0, "")
+	cmd.Flags().Bool("single-use", false, "")
+	cmd.Flags().Bool("active", false, "")
+	return cmd
+}
+
 func TestUpdateServiceKey(t *testing.T) {
 	tests := []struct {
 		name        string
 		mockService *MockServiceKeyService
 		loginErr    error
 		expectedErr string
-		expectWarn  bool
 	}{
 		{
 			name: "success - IsUpdated true",
@@ -196,13 +205,13 @@ func TestUpdateServiceKey(t *testing.T) {
 			},
 		},
 		{
-			name: "IsUpdated false",
+			name: "IsUpdated false returns error",
 			mockService: &MockServiceKeyService{
 				UpdateServiceKeyResult: &megaport.UpdateServiceKeyResponse{
 					IsUpdated: false,
 				},
 			},
-			expectWarn: true,
+			expectedErr: "service key update was not applied",
 		},
 		{
 			name: "API error",
@@ -210,6 +219,13 @@ func TestUpdateServiceKey(t *testing.T) {
 				UpdateServiceKeyError: fmt.Errorf("API failure"),
 			},
 			expectedErr: "failed to update service key",
+		},
+		{
+			name: "get current key error",
+			mockService: &MockServiceKeyService{
+				GetServiceKeyError: fmt.Errorf("key not found"),
+			},
+			expectedErr: "failed to get service key",
 		},
 		{
 			name:        "login error",
@@ -233,18 +249,13 @@ func TestUpdateServiceKey(t *testing.T) {
 				return client, nil
 			})
 
-			cmd := testutil.NewCommand("update", testutil.NoColorAdapter(UpdateServiceKey))
-			cmd.Flags().String("product-uid", "", "")
-			cmd.Flags().Int("product-id", 0, "")
-			cmd.Flags().Bool("single-use", false, "")
-			cmd.Flags().Bool("active", false, "")
-
+			cmd := newUpdateServiceKeyCmd()
 			testutil.SetFlags(t, cmd, map[string]string{
 				"active": "true",
 			})
 
 			var err error
-			capturedOutput := output.CaptureOutput(func() {
+			output.CaptureOutput(func() {
 				err = cmd.RunE(cmd, []string{"test-key-123"})
 			})
 
@@ -253,9 +264,91 @@ func TestUpdateServiceKey(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.expectedErr)
 			} else {
 				assert.NoError(t, err)
-				if tt.expectWarn {
-					assert.Contains(t, capturedOutput, "update request was not successful")
-				}
+			}
+		})
+	}
+}
+
+func TestUpdateServiceKey_MergesUnsetFlags(t *testing.T) {
+	currentKey := &megaport.ServiceKey{
+		Key:        "test-key-123",
+		ProductUID: "current-prod-uid",
+		SingleUse:  true,
+		Active:     true,
+	}
+
+	tests := []struct {
+		name              string
+		flags             map[string]string
+		expectedSingleUse bool
+		expectedActive    bool
+		expectedUID       string
+		expectedID        int
+	}{
+		{
+			name:              "no flags preserves current values",
+			flags:             map[string]string{},
+			expectedSingleUse: true,
+			expectedActive:    true,
+			expectedUID:       "current-prod-uid",
+		},
+		{
+			name:              "product-uid only preserves bools",
+			flags:             map[string]string{"product-uid": "new-prod-uid"},
+			expectedSingleUse: true,
+			expectedActive:    true,
+			expectedUID:       "new-prod-uid",
+		},
+		{
+			name:              "explicit active=false is honored",
+			flags:             map[string]string{"active": "false"},
+			expectedSingleUse: true,
+			expectedActive:    false,
+			expectedUID:       "current-prod-uid",
+		},
+		{
+			name:              "explicit single-use=false is honored",
+			flags:             map[string]string{"single-use": "false"},
+			expectedSingleUse: false,
+			expectedActive:    true,
+			expectedUID:       "current-prod-uid",
+		},
+		{
+			name:              "product-id replaces current product-uid",
+			flags:             map[string]string{"product-id": "42"},
+			expectedSingleUse: true,
+			expectedActive:    true,
+			expectedUID:       "",
+			expectedID:        42,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockService := &MockServiceKeyService{
+				GetServiceKeyResult: currentKey,
+			}
+			cleanup := testutil.SetupLogin(func(c *megaport.Client) {
+				c.ServiceKeyService = mockService
+			})
+			defer cleanup()
+
+			cmd := newUpdateServiceKeyCmd()
+			testutil.SetFlags(t, cmd, tt.flags)
+
+			var err error
+			output.CaptureOutput(func() {
+				err = cmd.RunE(cmd, []string{"test-key-123"})
+			})
+
+			assert.NoError(t, err)
+			req := mockService.CapturedUpdateServiceKeyRequest
+			if assert.NotNil(t, req) {
+				assert.Equal(t, "test-key-123", req.Key)
+				assert.Equal(t, tt.expectedSingleUse, req.SingleUse)
+				assert.Equal(t, tt.expectedActive, req.Active)
+				assert.Equal(t, tt.expectedUID, req.ProductUID)
+				assert.Equal(t, tt.expectedID, req.ProductID)
 			}
 		})
 	}


### PR DESCRIPTION
ESD-1417

`servicekeys update KEY --product-uid X` silently deactivated the key: the SDK serializes `singleUse` and `active` without `omitempty`, and the command sent the zero values for any flag the user didn't pass.

- `UpdateServiceKey` now fetches the current key and seeds the request from it, only overriding fields whose flags were explicitly set
- Passing both `--product-uid` and `--product-id` now errors explicitly instead of reaching the SDK
- `IsUpdated == false` now returns an error instead of warning with exit 0 (defensive; the current SDK never returns false)
- Removed the `--description` flag from `servicekeys update` since the update API has no description field; it was silently ignored
- Regenerated the affected servicekeys docs and updated README examples