### PR TITLE
ENG-31566: Document manual WASM S3 publish steps

### DIFF
--- a/WASM_README.md
+++ b/WASM_README.md
@@ -204,7 +204,7 @@ go build -o server ./cmd/server/server.go
 
 ## Publishing to the Portal
 
-The portal loads the WASM binary from `s3://media.megaport.com/portal/megaport-cli/`. Publishing is currently manual.
+The Portal loads the WASM binary from `s3://media.megaport.com/portal/megaport-cli/`. Publishing is currently manual.
 
 ### Prerequisites
 

--- a/WASM_README.md
+++ b/WASM_README.md
@@ -219,8 +219,12 @@ aws sts get-caller-identity
 # 2. Build the WASM binary
 GOOS=js GOARCH=wasm go build -tags js,wasm -o web/megaport.wasm .
 
-# 3. Upload the WASM binary and the (already checked-in) wasm_exec.js loader
-aws s3 cp web/megaport.wasm s3://media.megaport.com/portal/megaport-cli/megaport.wasm
+# 3. Upload the WASM binary and the (already checked-in) wasm_exec.js loader.
+#    `--content-type application/wasm` is required so the file isn't served as
+#    application/octet-stream — `WebAssembly.instantiateStreaming` rejects
+#    anything else, which would break the standalone loader in web/script.js.
+aws s3 cp web/megaport.wasm s3://media.megaport.com/portal/megaport-cli/megaport.wasm \
+    --content-type application/wasm
 aws s3 cp web/wasm_exec.js  s3://media.megaport.com/portal/megaport-cli/wasm_exec.js
 ```
 

--- a/WASM_README.md
+++ b/WASM_README.md
@@ -202,6 +202,27 @@ go build -o server ./cmd/server/server.go
 ./server --port 8080 --dir web --session-duration 1h
 ```
 
+## Publishing to the Portal
+
+The portal loads the WASM binary from `s3://media.megaport.com/portal/megaport-cli/`. Publishing is currently manual.
+
+### Prerequisites
+
+- AWS CLI configured with SSO for the `ProductionDeveloper` role.
+
+### Steps
+
+```bash
+# 1. Verify AWS SSO auth is active
+aws sts get-caller-identity
+
+# 2. Build the WASM binary
+GOOS=js GOARCH=wasm go build -tags js,wasm -o web/megaport.wasm .
+
+# 3. Upload the WASM binary
+aws s3 cp web/megaport.wasm s3://media.megaport.com/portal/megaport-cli/megaport.wasm
+```
+
 ## API Endpoints
 
 ### Authentication

--- a/WASM_README.md
+++ b/WASM_README.md
@@ -219,14 +219,9 @@ aws sts get-caller-identity
 # 2. Build the WASM binary
 GOOS=js GOARCH=wasm go build -tags js,wasm -o web/megaport.wasm .
 
-# 3. Copy wasm_exec.js from your Go installation
-#    (Go 1.25+ uses lib/wasm; older versions use misc/wasm)
-cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" web/wasm_exec.js \
-  || cp "$(go env GOROOT)/misc/wasm/wasm_exec.js" web/wasm_exec.js
-
-# 4. Upload both files
-aws s3 cp web/megaport.wasm   s3://media.megaport.com/portal/megaport-cli/megaport.wasm
-aws s3 cp web/wasm_exec.js    s3://media.megaport.com/portal/megaport-cli/wasm_exec.js
+# 3. Upload the WASM binary and the (already checked-in) wasm_exec.js loader
+aws s3 cp web/megaport.wasm s3://media.megaport.com/portal/megaport-cli/megaport.wasm
+aws s3 cp web/wasm_exec.js  s3://media.megaport.com/portal/megaport-cli/wasm_exec.js
 ```
 
 ## API Endpoints

--- a/WASM_README.md
+++ b/WASM_README.md
@@ -213,9 +213,9 @@ The Portal loads the WASM binary from `s3://media.megaport.com/portal/megaport-c
 ### Steps
 
 ```bash
-# 1. Verify AWS SSO auth is active
+# 1. Ensure AWS SSO auth is active (login if needed)
+aws sso login
 aws sts get-caller-identity
-
 # 2. Build the WASM binary
 GOOS=js GOARCH=wasm go build -tags js,wasm -o web/megaport.wasm .
 

--- a/WASM_README.md
+++ b/WASM_README.md
@@ -219,8 +219,14 @@ aws sts get-caller-identity
 # 2. Build the WASM binary
 GOOS=js GOARCH=wasm go build -tags js,wasm -o web/megaport.wasm .
 
-# 3. Upload the WASM binary
-aws s3 cp web/megaport.wasm s3://media.megaport.com/portal/megaport-cli/megaport.wasm
+# 3. Copy wasm_exec.js from your Go installation
+#    (Go 1.25+ uses lib/wasm; older versions use misc/wasm)
+cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" web/wasm_exec.js \
+  || cp "$(go env GOROOT)/misc/wasm/wasm_exec.js" web/wasm_exec.js
+
+# 4. Upload both files
+aws s3 cp web/megaport.wasm   s3://media.megaport.com/portal/megaport-cli/megaport.wasm
+aws s3 cp web/wasm_exec.js    s3://media.megaport.com/portal/megaport-cli/wasm_exec.js
 ```
 
 ## API Endpoints


### PR DESCRIPTION
Adds a short \"Publishing to the Portal\" section to `WASM_README.md` documenting the manual steps used to upload the WASM binary to `s3://media.megaport.com/portal/megaport-cli/` (SSO auth check, WASM build, `aws s3 cp`).

Docs-only change.