### PR TITLE
fix: dedup MinASN/MaxASN build break and bump Node 20 actions to Node 24

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Run read-only integration tests
@@ -42,8 +42,8 @@ jobs:
     timeout-minutes: 35
     if: github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: 'go.mod'
       # Add packages here as integration tests are written (see docs/INTEGRATION_TESTING.md)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,8 +14,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: 'go.mod'
           cache: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,20 +27,20 @@ jobs:
           cache: true
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3.7.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec  # v6.3.0
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd  # v7.0.0
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -48,7 +48,7 @@ jobs:
 
       - name: Mint installation token for homebrew-tap
         id: tap-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -56,8 +56,9 @@ jobs:
           repositories: homebrew-tap
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811  # v5.1.0
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7.2.2
         with:
+          version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,11 +17,11 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: 'go.mod'
           cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run Tests
         run: go test -v -coverprofile=coverage.out -covermode=atomic ./...
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238  # v4.6.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           files: coverage.out
           fail_ci_if_error: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Run Tests
@@ -30,8 +30,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Install golangci-lint

--- a/internal/validation/vxc.go
+++ b/internal/validation/vxc.go
@@ -25,9 +25,6 @@ const (
 	// MaxMED is the maximum Multi-Exit Discriminator value for BGP routing.
 	// Using int64 to avoid overflow on 32-bit platforms.
 	MaxMED int64 = 4294967295
-	// MinASN and MaxASN bound a valid 32-bit BGP autonomous system number.
-	MinASN       = 1
-	MaxASN int64 = 4294967295
 	// BGPPeerNonCloud identifies a non-cloud BGP peer type.
 	BGPPeerNonCloud = "NON_CLOUD"
 	// BGPPeerPrivCloud identifies a private cloud BGP peer type.
@@ -239,7 +236,7 @@ func ValidateAWSPartnerConfig(config *megaport.VXCPartnerConfigAWS) error {
 	if config.ASN == 0 {
 		return NewValidationError("ASN", config.ASN, "cannot be empty")
 	}
-	if config.ASN < MinASN || int64(config.ASN) > MaxASN {
+	if int64(config.ASN) < MinASN || int64(config.ASN) > MaxASN {
 		return NewValidationError("ASN", config.ASN, fmt.Sprintf("must be between %d-%d", MinASN, MaxASN))
 	}
 	return nil
@@ -518,7 +515,7 @@ func ValidateBGPConnectionConfig(conn megaport.BgpConnectionConfig, ifaceIndex, 
 	if conn.PeerAsn == 0 {
 		return NewValidationError(fmt.Sprintf("%s peer ASN", fieldPrefix), nil, "is required")
 	}
-	if conn.PeerAsn < MinASN || int64(conn.PeerAsn) > MaxASN {
+	if int64(conn.PeerAsn) < MinASN || int64(conn.PeerAsn) > MaxASN {
 		return NewValidationError(fmt.Sprintf("%s peer ASN", fieldPrefix), conn.PeerAsn, fmt.Sprintf("must be between %d-%d", MinASN, MaxASN))
 	}
 	if conn.LocalIpAddress == "" {


### PR DESCRIPTION
`main` is failing to build (Unit Tests + Lint) because `MinASN`/`MaxASN` are declared twice in the `validation` package: `common.go` already had them as `int64`, and PR #400 added a second pair in `vxc.go`. The duplicate also reintroduced an `int` vs `int64` mismatch in the two ASN comparisons.

> **Timeline:** On **2026-06-16** GitHub forces all actions onto the Node.js 24 runtime, running the Node 20 actions below under Node 24 whether or not they declare it. That clears the deprecation warnings and avoids any Node 24 incompatibility surfacing on a release tag, so it's worth merging before then.

Changes:
- Drop the duplicate `MinASN`/`MaxASN` from `vxc.go`; keep `common.go`'s `int64` versions (these back the 32-bit-safe `ValidateASN` helper).
- Cast `config.ASN` and `conn.PeerAsn` to `int64` in the two range checks so they compare cleanly against `MinASN`.
- Bump every Node 20 GitHub action to its Node 24 major: `checkout`, `setup-go`, `docker/*` (qemu/buildx/login), `ghaction-import-gpg`, `create-github-app-token` (also now SHA-pinned), `goreleaser-action`, and `codecov-action`. Inputs/outputs are unchanged per action; `goreleaser-action` v7 has its binary pinned to `~> v2` so the bump can't shift the GoReleaser line.

Verified: `go build ./...`, `go vet`, `go test ./internal/validation/`, a `js/wasm` build, the full provisioning integration suite against staging (31 pass, 0 fail), and every new action SHA resolved against its claimed upstream tag.