### PR TITLE
test(ESD-1392): resource tag lifecycle integration tests (ports/mcr/mve/vxc)

### DIFF
--- a/internal/commands/mcr/mcr_integration_test.go
+++ b/internal/commands/mcr/mcr_integration_test.go
@@ -76,6 +76,15 @@ func integrationMCRDeleteCmd() *cobra.Command {
 	return cmd
 }
 
+func integrationMCRTagCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "update-tags"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().BoolP("force", "f", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	return cmd
+}
+
 func integrationMCRPrefixFilterCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "prefix-filter-list"}
 	cmd.Flags().Bool("interactive", false, "")
@@ -191,6 +200,40 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 	require.NoError(t, updErr, "update MCR output: %s", updOut)
 
 	assert.Equal(t, newName, getMCRJSON(t, mcrUID)["name"])
+
+	// Resource tag round-trip (ESD-1392): set tags via update-tags, read them
+	// back via list-tags, then clear them. Rides on the lifecycle MCR, so no
+	// extra cleanup is needed.
+	setTagsCmd := integrationMCRTagCmd()
+	require.NoError(t, setTagsCmd.Flags().Set("json", `{"env":"cli-integration","owner":"esd-1392"}`))
+	require.NoError(t, setTagsCmd.Flags().Set("force", "true"))
+	var setTagsErr error
+	setTagsOut := captureTableOutput(func() { setTagsErr = UpdateMCRResourceTags(setTagsCmd, []string{mcrUID}, true) })
+	require.NoError(t, setTagsErr, "update MCR tags output: %s", setTagsOut)
+
+	var listTagsErr error
+	listTagsOut := output.CaptureOutput(func() {
+		listTagsErr = ListMCRResourceTags(&cobra.Command{Use: "list-tags"}, []string{mcrUID}, true, "json")
+	})
+	require.NoError(t, listTagsErr, "list MCR tags output: %s", listTagsOut)
+	assert.Contains(t, listTagsOut, "cli-integration")
+	assert.Contains(t, listTagsOut, "esd-1392")
+
+	// Clear the tags so the MCR is left clean for the steps that follow.
+	clearTagsCmd := integrationMCRTagCmd()
+	require.NoError(t, clearTagsCmd.Flags().Set("json", "{}"))
+	require.NoError(t, clearTagsCmd.Flags().Set("force", "true"))
+	var clearTagsErr error
+	clearTagsOut := captureTableOutput(func() { clearTagsErr = UpdateMCRResourceTags(clearTagsCmd, []string{mcrUID}, true) })
+	require.NoError(t, clearTagsErr, "clear MCR tags output: %s", clearTagsOut)
+
+	var verifyTagsErr error
+	verifyTagsOut := output.CaptureOutput(func() {
+		verifyTagsErr = ListMCRResourceTags(&cobra.Command{Use: "list-tags"}, []string{mcrUID}, true, "json")
+	})
+	require.NoError(t, verifyTagsErr, "list MCR tags after clear output: %s", verifyTagsOut)
+	assert.NotContains(t, verifyTagsOut, "cli-integration")
+	assert.NotContains(t, verifyTagsOut, "esd-1392")
 
 	// Prefix filter list lifecycle (create -> get -> update -> delete).
 	createPFLJSON := `{

--- a/internal/commands/mcr/mcr_integration_test.go
+++ b/internal/commands/mcr/mcr_integration_test.go
@@ -85,6 +85,20 @@ func integrationMCRTagCmd() *cobra.Command {
 	return cmd
 }
 
+// tagsFromListJSON parses the JSON output of list-tags (an array of {key,value}
+// objects) into a map, so assertions can check key->value pairs instead of
+// substring-matching the rendered blob.
+func tagsFromListJSON(t *testing.T, out string) map[string]string {
+	t.Helper()
+	var tags []output.ResourceTag
+	require.NoErrorf(t, json.Unmarshal([]byte(out), &tags), "parse list-tags JSON: %s", out)
+	m := make(map[string]string, len(tags))
+	for _, tag := range tags {
+		m[tag.Key] = tag.Value
+	}
+	return m
+}
+
 func integrationMCRPrefixFilterCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "prefix-filter-list"}
 	cmd.Flags().Bool("interactive", false, "")
@@ -204,8 +218,11 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 	// Resource tag round-trip (ESD-1392): set tags via update-tags, read them
 	// back via list-tags, then clear them. Rides on the lifecycle MCR, so no
 	// extra cleanup is needed.
+	want := map[string]string{"env": "cli-integration", "owner": "esd-1392"}
+	setTagsJSON, err := json.Marshal(want)
+	require.NoError(t, err)
 	setTagsCmd := integrationMCRTagCmd()
-	require.NoError(t, setTagsCmd.Flags().Set("json", `{"env":"cli-integration","owner":"esd-1392"}`))
+	require.NoError(t, setTagsCmd.Flags().Set("json", string(setTagsJSON)))
 	require.NoError(t, setTagsCmd.Flags().Set("force", "true"))
 	var setTagsErr error
 	setTagsOut := captureTableOutput(func() { setTagsErr = UpdateMCRResourceTags(setTagsCmd, []string{mcrUID}, true) })
@@ -216,8 +233,12 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 		listTagsErr = ListMCRResourceTags(&cobra.Command{Use: "list-tags"}, []string{mcrUID}, true, "json")
 	})
 	require.NoError(t, listTagsErr, "list MCR tags output: %s", listTagsOut)
-	assert.Contains(t, listTagsOut, "cli-integration")
-	assert.Contains(t, listTagsOut, "esd-1392")
+	// Assert our tags round-tripped without requiring the map to contain only
+	// them, so an API-injected tag can't make this flaky.
+	got := tagsFromListJSON(t, listTagsOut)
+	for k, v := range want {
+		assert.Equalf(t, v, got[k], "tag %q should round-trip", k)
+	}
 
 	// Clear the tags so the MCR is left clean for the steps that follow.
 	clearTagsCmd := integrationMCRTagCmd()
@@ -232,8 +253,10 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 		verifyTagsErr = ListMCRResourceTags(&cobra.Command{Use: "list-tags"}, []string{mcrUID}, true, "json")
 	})
 	require.NoError(t, verifyTagsErr, "list MCR tags after clear output: %s", verifyTagsOut)
-	assert.NotContains(t, verifyTagsOut, "cli-integration")
-	assert.NotContains(t, verifyTagsOut, "esd-1392")
+	cleared := tagsFromListJSON(t, verifyTagsOut)
+	for k := range want {
+		assert.NotContainsf(t, cleared, k, "tag %q should be cleared", k)
+	}
 
 	// Prefix filter list lifecycle (create -> get -> update -> delete).
 	createPFLJSON := `{

--- a/internal/commands/mve/mve_integration_test.go
+++ b/internal/commands/mve/mve_integration_test.go
@@ -78,6 +78,15 @@ func integrationMVEDeleteCmd() *cobra.Command {
 	return cmd
 }
 
+func integrationMVETagCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "update-tags"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().BoolP("force", "f", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	return cmd
+}
+
 // parseCreatedUID pulls the resource UID out of a "<resource> created <uid>"
 // success message.
 func parseCreatedUID(out, resource string) string {
@@ -227,6 +236,40 @@ func TestIntegration_MVELifecycle(t *testing.T) {
 	require.NoError(t, updErr, "update MVE output: %s", updOut)
 
 	assert.Equal(t, newName, getMVEJSON(t, mveUID)["name"])
+
+	// Resource tag round-trip (ESD-1392): set tags via update-tags, read them
+	// back via list-tags, then clear them. Rides on the lifecycle MVE, so no
+	// extra cleanup is needed.
+	setTagsCmd := integrationMVETagCmd()
+	require.NoError(t, setTagsCmd.Flags().Set("json", `{"env":"cli-integration","owner":"esd-1392"}`))
+	require.NoError(t, setTagsCmd.Flags().Set("force", "true"))
+	var setTagsErr error
+	setTagsOut := captureTableOutput(func() { setTagsErr = UpdateMVEResourceTags(setTagsCmd, []string{mveUID}, true) })
+	require.NoError(t, setTagsErr, "update MVE tags output: %s", setTagsOut)
+
+	var listTagsErr error
+	listTagsOut := output.CaptureOutput(func() {
+		listTagsErr = ListMVEResourceTags(&cobra.Command{Use: "list-tags"}, []string{mveUID}, true, "json")
+	})
+	require.NoError(t, listTagsErr, "list MVE tags output: %s", listTagsOut)
+	assert.Contains(t, listTagsOut, "cli-integration")
+	assert.Contains(t, listTagsOut, "esd-1392")
+
+	// Clear the tags so the MVE is left clean for the steps that follow.
+	clearTagsCmd := integrationMVETagCmd()
+	require.NoError(t, clearTagsCmd.Flags().Set("json", "{}"))
+	require.NoError(t, clearTagsCmd.Flags().Set("force", "true"))
+	var clearTagsErr error
+	clearTagsOut := captureTableOutput(func() { clearTagsErr = UpdateMVEResourceTags(clearTagsCmd, []string{mveUID}, true) })
+	require.NoError(t, clearTagsErr, "clear MVE tags output: %s", clearTagsOut)
+
+	var verifyTagsErr error
+	verifyTagsOut := output.CaptureOutput(func() {
+		verifyTagsErr = ListMVEResourceTags(&cobra.Command{Use: "list-tags"}, []string{mveUID}, true, "json")
+	})
+	require.NoError(t, verifyTagsErr, "list MVE tags after clear output: %s", verifyTagsOut)
+	assert.NotContains(t, verifyTagsOut, "cli-integration")
+	assert.NotContains(t, verifyTagsOut, "esd-1392")
 
 	// Update the vNIC descriptions via --vnics and verify they took effect.
 	// The count and VLANs are immutable, so the update array must have one

--- a/internal/commands/mve/mve_integration_test.go
+++ b/internal/commands/mve/mve_integration_test.go
@@ -87,6 +87,20 @@ func integrationMVETagCmd() *cobra.Command {
 	return cmd
 }
 
+// tagsFromListJSON parses the JSON output of list-tags (an array of {key,value}
+// objects) into a map, so assertions can check key->value pairs instead of
+// substring-matching the rendered blob.
+func tagsFromListJSON(t *testing.T, out string) map[string]string {
+	t.Helper()
+	var tags []output.ResourceTag
+	require.NoErrorf(t, json.Unmarshal([]byte(out), &tags), "parse list-tags JSON: %s", out)
+	m := make(map[string]string, len(tags))
+	for _, tag := range tags {
+		m[tag.Key] = tag.Value
+	}
+	return m
+}
+
 // parseCreatedUID pulls the resource UID out of a "<resource> created <uid>"
 // success message.
 func parseCreatedUID(out, resource string) string {
@@ -240,8 +254,11 @@ func TestIntegration_MVELifecycle(t *testing.T) {
 	// Resource tag round-trip (ESD-1392): set tags via update-tags, read them
 	// back via list-tags, then clear them. Rides on the lifecycle MVE, so no
 	// extra cleanup is needed.
+	want := map[string]string{"env": "cli-integration", "owner": "esd-1392"}
+	setTagsJSON, err := json.Marshal(want)
+	require.NoError(t, err)
 	setTagsCmd := integrationMVETagCmd()
-	require.NoError(t, setTagsCmd.Flags().Set("json", `{"env":"cli-integration","owner":"esd-1392"}`))
+	require.NoError(t, setTagsCmd.Flags().Set("json", string(setTagsJSON)))
 	require.NoError(t, setTagsCmd.Flags().Set("force", "true"))
 	var setTagsErr error
 	setTagsOut := captureTableOutput(func() { setTagsErr = UpdateMVEResourceTags(setTagsCmd, []string{mveUID}, true) })
@@ -252,8 +269,12 @@ func TestIntegration_MVELifecycle(t *testing.T) {
 		listTagsErr = ListMVEResourceTags(&cobra.Command{Use: "list-tags"}, []string{mveUID}, true, "json")
 	})
 	require.NoError(t, listTagsErr, "list MVE tags output: %s", listTagsOut)
-	assert.Contains(t, listTagsOut, "cli-integration")
-	assert.Contains(t, listTagsOut, "esd-1392")
+	// Assert our tags round-tripped without requiring the map to contain only
+	// them, so an API-injected tag can't make this flaky.
+	got := tagsFromListJSON(t, listTagsOut)
+	for k, v := range want {
+		assert.Equalf(t, v, got[k], "tag %q should round-trip", k)
+	}
 
 	// Clear the tags so the MVE is left clean for the steps that follow.
 	clearTagsCmd := integrationMVETagCmd()
@@ -268,8 +289,10 @@ func TestIntegration_MVELifecycle(t *testing.T) {
 		verifyTagsErr = ListMVEResourceTags(&cobra.Command{Use: "list-tags"}, []string{mveUID}, true, "json")
 	})
 	require.NoError(t, verifyTagsErr, "list MVE tags after clear output: %s", verifyTagsOut)
-	assert.NotContains(t, verifyTagsOut, "cli-integration")
-	assert.NotContains(t, verifyTagsOut, "esd-1392")
+	cleared := tagsFromListJSON(t, verifyTagsOut)
+	for k := range want {
+		assert.NotContainsf(t, cleared, k, "tag %q should be cleared", k)
+	}
 
 	// Update the vNIC descriptions via --vnics and verify they took effect.
 	// The count and VLANs are immutable, so the update array must have one

--- a/internal/commands/ports/ports_integration_test.go
+++ b/internal/commands/ports/ports_integration_test.go
@@ -114,6 +114,18 @@ func newDeletePortCmd() *cobra.Command {
 	return cmd
 }
 
+func newUpdatePortTagsCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "update-tags"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().BoolP("force", "f", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().String("tags", "", "")
+	cmd.Flags().String("tags-file", "", "")
+	cmd.Flags().String("resource-tags", "", "")
+	return cmd
+}
+
 // cleanupStatusTimeout bounds how long registerPortCleanup will poll the SDK
 // for the port to enter DECOMMISSIONING/DECOMMISSIONED after DeletePort.
 // DeletePort only submits the cancellation request; the API can take a few
@@ -290,6 +302,53 @@ func runUpdatePortWithFlag(t *testing.T, uid, flagName, flagValue string) {
 	require.NoErrorf(t, UpdatePort(cmd, []string{uid}, true), "UpdatePort failed for %s", uid)
 }
 
+// portTagsFromSDK reads a port's resource tags via the shared SDK client. This
+// is the same call the list-tags command makes underneath; it is used instead
+// of capturing the command's stdout because these tests run under t.Parallel()
+// (see the package comment on CaptureOutput).
+func portTagsFromSDK(t *testing.T, uid string) map[string]string {
+	t.Helper()
+	client := testutil.SharedIntegrationClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	tags, err := client.PortService.ListPortResourceTags(ctx, uid)
+	require.NoErrorf(t, err, "SDK ListPortResourceTags failed for %s", uid)
+	return tags
+}
+
+// runPortTagRoundTrip exercises update-tags then list-tags on an existing
+// lifecycle port: it sets two tags via the update-tags command, reads them back
+// through the SDK, then clears them and confirms they are gone. It rides on the
+// port the caller already provisioned, so it needs no separate cleanup.
+func runPortTagRoundTrip(t *testing.T, uid string) {
+	t.Helper()
+	want := map[string]string{"env": "cli-integration", "owner": "esd-1392"}
+	tagJSON, err := json.Marshal(want)
+	require.NoError(t, err)
+
+	setCmd := newUpdatePortTagsCmd()
+	require.NoError(t, setCmd.Flags().Set("json", string(tagJSON)))
+	require.NoError(t, setCmd.Flags().Set("force", "true"))
+	require.NoErrorf(t, UpdatePortResourceTags(setCmd, []string{uid}, true), "UpdatePortResourceTags failed for %s", uid)
+
+	// Assert our tags round-tripped without requiring the map to contain only
+	// them, so an API-injected tag can't make this flaky.
+	got := portTagsFromSDK(t, uid)
+	for k, v := range want {
+		assert.Equalf(t, v, got[k], "tag %q should round-trip", k)
+	}
+
+	clearCmd := newUpdatePortTagsCmd()
+	require.NoError(t, clearCmd.Flags().Set("json", "{}"))
+	require.NoError(t, clearCmd.Flags().Set("force", "true"))
+	require.NoErrorf(t, UpdatePortResourceTags(clearCmd, []string{uid}, true), "clearing port tags failed for %s", uid)
+
+	cleared := portTagsFromSDK(t, uid)
+	for k := range want {
+		assert.NotContainsf(t, cleared, k, "tag %q should be cleared", k)
+	}
+}
+
 func TestIntegration_PortLifecycle(t *testing.T) {
 	t.Parallel()
 	testutil.RequireSharedIntegrationClient(t)
@@ -328,6 +387,8 @@ func TestIntegration_PortLifecycle(t *testing.T) {
 
 	updated := portFromSDK(t, uid)
 	assert.Equal(t, newName, updated.Name)
+
+	runPortTagRoundTrip(t, uid)
 }
 
 func TestIntegration_LAGPortLifecycle(t *testing.T) {

--- a/internal/commands/vxc/vxc_integration_test.go
+++ b/internal/commands/vxc/vxc_integration_test.go
@@ -286,6 +286,61 @@ func vxcFromSDK(t *testing.T, uid string) *megaport.VXC {
 	return vxc
 }
 
+func newUpdateVXCTagsCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "update-tags"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().BoolP("force", "f", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	return cmd
+}
+
+// vxcTagsFromSDK reads a VXC's resource tags via the shared SDK client (the same
+// call the list-tags command makes underneath). Used instead of capturing the
+// command's stdout because these tests run under t.Parallel().
+func vxcTagsFromSDK(t *testing.T, uid string) map[string]string {
+	t.Helper()
+	sdkClient := testutil.SharedIntegrationClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	tags, err := sdkClient.VXCService.ListVXCResourceTags(ctx, uid)
+	require.NoErrorf(t, err, "SDK ListVXCResourceTags failed for %s", uid)
+	return tags
+}
+
+// runVXCTagRoundTrip exercises update-tags then list-tags on an existing
+// lifecycle VXC: it sets two tags via the update-tags command, reads them back
+// through the SDK, then clears them and confirms they are gone. It rides on the
+// VXC the caller already provisioned, so it needs no separate cleanup.
+func runVXCTagRoundTrip(t *testing.T, uid string) {
+	t.Helper()
+	want := map[string]string{"env": "cli-integration", "owner": "esd-1392"}
+	tagJSON, err := json.Marshal(want)
+	require.NoError(t, err)
+
+	setCmd := newUpdateVXCTagsCmd()
+	require.NoError(t, setCmd.Flags().Set("json", string(tagJSON)))
+	require.NoError(t, setCmd.Flags().Set("force", "true"))
+	require.NoErrorf(t, UpdateVXCResourceTags(setCmd, []string{uid}, true), "UpdateVXCResourceTags failed for %s", uid)
+
+	// Assert our tags round-tripped without requiring the map to contain only
+	// them, so an API-injected tag can't make this flaky.
+	got := vxcTagsFromSDK(t, uid)
+	for k, v := range want {
+		assert.Equalf(t, v, got[k], "tag %q should round-trip", k)
+	}
+
+	clearCmd := newUpdateVXCTagsCmd()
+	require.NoError(t, clearCmd.Flags().Set("json", "{}"))
+	require.NoError(t, clearCmd.Flags().Set("force", "true"))
+	require.NoErrorf(t, UpdateVXCResourceTags(clearCmd, []string{uid}, true), "clearing VXC tags failed for %s", uid)
+
+	cleared := vxcTagsFromSDK(t, uid)
+	for k := range want {
+		assert.NotContainsf(t, cleared, k, "tag %q should be cleared", k)
+	}
+}
+
 func TestIntegration_VXCPortToPortLifecycle(t *testing.T) {
 	t.Parallel()
 	testutil.RequireSharedIntegrationClient(t)
@@ -319,6 +374,8 @@ func TestIntegration_VXCPortToPortLifecycle(t *testing.T) {
 
 	updated := vxcFromSDK(t, vxcUID)
 	assert.Equal(t, newName, updated.Name)
+
+	runVXCTagRoundTrip(t, vxcUID)
 }
 
 func TestIntegration_VXCVLANModificationLifecycle(t *testing.T) {


### PR DESCRIPTION
Adds an update-tags then list-tags round-trip to the existing provisioning lifecycle tests for ports, MCR, MVE, and VXC. Each step sets two tags on the resource the lifecycle test already provisioned, reads them back, asserts they round-trip, then clears them. It rides on the existing resource, so there's no new cleanup and little added runtime.

- ports/vxc (parallel tests): exercise the update-tags command, then read tags back via the SDK for assertions. These tests can't use `CaptureOutput` under `t.Parallel()` (it swaps global stdout and races with concurrent spinners), matching the existing `portFromSDK`/`vxcFromSDK` pattern.
- mcr/mve (serial tests): exercise both the update-tags and list-tags commands, capturing the list-tags JSON and asserting it contains the tags, then clearing and asserting they're gone.
- Set/clear both pass `--force` so the confirm prompt never blocks on stdin in CI.
- Round-trip assertions check our tags are present/absent rather than requiring an exact whole-map match, so an API-injected tag can't cause flakiness.

Runs in the manual provisioning job under the `integration provisioning` build tags.

Verified by running the full `integration provisioning` suite against staging: all four lifecycle tests (Port, VXC, MCR, MVE) pass, provisioning and tearing down real resources cleanly with no failures.