### PR TITLE
ESD-1491: route AWS/BGP ASN range checks through ValidateASN

### DIFF
--- a/internal/validation/vxc.go
+++ b/internal/validation/vxc.go
@@ -236,8 +236,8 @@ func ValidateAWSPartnerConfig(config *megaport.VXCPartnerConfigAWS) error {
 	if config.ASN == 0 {
 		return NewValidationError("ASN", config.ASN, "cannot be empty")
 	}
-	if int64(config.ASN) < MinASN || int64(config.ASN) > MaxASN {
-		return NewValidationError("ASN", config.ASN, fmt.Sprintf("must be between %d-%d", MinASN, MaxASN))
+	if err := ValidateASN(config.ASN); err != nil {
+		return NewValidationError("ASN", config.ASN, fmt.Sprintf("must be between %d-%d", MinASN, maxSupportedASNForInt()))
 	}
 	return nil
 }
@@ -515,8 +515,8 @@ func ValidateBGPConnectionConfig(conn megaport.BgpConnectionConfig, ifaceIndex, 
 	if conn.PeerAsn == 0 {
 		return NewValidationError(fmt.Sprintf("%s peer ASN", fieldPrefix), nil, "is required")
 	}
-	if int64(conn.PeerAsn) < MinASN || int64(conn.PeerAsn) > MaxASN {
-		return NewValidationError(fmt.Sprintf("%s peer ASN", fieldPrefix), conn.PeerAsn, fmt.Sprintf("must be between %d-%d", MinASN, MaxASN))
+	if err := ValidateASN(conn.PeerAsn); err != nil {
+		return NewValidationError(fmt.Sprintf("%s peer ASN", fieldPrefix), conn.PeerAsn, fmt.Sprintf("must be between %d-%d", MinASN, maxSupportedASNForInt()))
 	}
 	if conn.LocalIpAddress == "" {
 		return NewValidationError(fmt.Sprintf("%s local IP address", fieldPrefix), conn.LocalIpAddress, "cannot be empty")

--- a/internal/validation/vxc.go
+++ b/internal/validation/vxc.go
@@ -236,6 +236,7 @@ func ValidateAWSPartnerConfig(config *megaport.VXCPartnerConfigAWS) error {
 	if config.ASN == 0 {
 		return NewValidationError("ASN", config.ASN, "cannot be empty")
 	}
+	// Delegate to ValidateASN for the platform-aware bound; re-wrap to keep field name and message format.
 	if err := ValidateASN(config.ASN); err != nil {
 		return NewValidationError("ASN", config.ASN, fmt.Sprintf("must be between %d-%d", MinASN, maxSupportedASNForInt()))
 	}
@@ -515,6 +516,7 @@ func ValidateBGPConnectionConfig(conn megaport.BgpConnectionConfig, ifaceIndex, 
 	if conn.PeerAsn == 0 {
 		return NewValidationError(fmt.Sprintf("%s peer ASN", fieldPrefix), nil, "is required")
 	}
+	// Delegate to ValidateASN for the platform-aware bound; re-wrap to keep field name and message format.
 	if err := ValidateASN(conn.PeerAsn); err != nil {
 		return NewValidationError(fmt.Sprintf("%s peer ASN", fieldPrefix), conn.PeerAsn, fmt.Sprintf("must be between %d-%d", MinASN, maxSupportedASNForInt()))
 	}

--- a/internal/validation/vxc_test.go
+++ b/internal/validation/vxc_test.go
@@ -631,6 +631,50 @@ func TestValidateAWSPartnerConfig(t *testing.T) {
 	}
 }
 
+// TestValidateAWSPartnerConfig_HighASN mirrors TestValidateBGPConnectionConfig_HighASN:
+// it confirms the AWS validator agrees with ValidateASN at the 32-bit max boundary.
+func TestValidateAWSPartnerConfig_HighASN(t *testing.T) {
+	if int64(math.MaxInt) < int64(math.MaxUint32) {
+		t.Skip("int is narrower than the 32-bit ASN range on this platform")
+	}
+	max64 := MaxASN
+	maxValid := int(max64)     // 4294967295
+	aboveMax := int(max64) + 1 // 4294967296
+	tests := []struct {
+		name    string
+		asn     int
+		wantErr bool
+		errText string
+	}{
+		{"ASN 4294967295 (32-bit max)", maxValid, false, ""},
+		{"ASN above 32-bit max rejected", aboveMax, true,
+			fmt.Sprintf("Invalid ASN: %d - must be between 1-4294967295", aboveMax)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			awsConfig := &megaport.VXCPartnerConfigAWS{
+				ConnectType:       "private",
+				OwnerAccount:      "123456789012",
+				ASN:               tt.asn,
+				AmazonASN:         64512,
+				CustomerIPAddress: "192.168.1.1/30",
+				AmazonIPAddress:   "192.168.1.2/30",
+				ConnectionName:    "test",
+				Type:              "private",
+			}
+			err := ValidateAWSPartnerConfig(awsConfig)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateAWSPartnerConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.wantErr {
+				assert.IsType(t, &ValidationError{}, err)
+				assert.Equal(t, tt.errText, err.Error())
+			}
+		})
+	}
+}
+
 func TestValidateGooglePartnerConfig(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
`ValidateAWSPartnerConfig` and `ValidateBGPConnectionConfig` previously hand-rolled an ASN range check against the raw `MaxASN` constant. On 32-bit targets (js/wasm), `ValidateASN` caps the upper bound at `math.MaxInt32` via `maxSupportedASNForInt()`, but the two validators bypassed that by comparing against `MaxASN` directly.

Both validators now call `ValidateASN` for the range check and re-wrap any error to preserve their existing field names and message format. `maxSupportedASNForInt()` is the single source of truth for the platform-aware bound.

- `ValidateAWSPartnerConfig`: replaces direct `> MaxASN` comparison with `ValidateASN` delegation
- `ValidateBGPConnectionConfig`: same
- Adds `TestValidateAWSPartnerConfig_HighASN` mirroring the existing BGP high-ASN boundary test

No behavior change on 64-bit targets. Error message wording is unchanged.