### PR TITLE
feat(ESD-1283): register read-only status, topology, product modules in WASM build

### DIFF
--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -57,7 +57,7 @@ var (
 				return
 			}
 			// No args - just show help
-			cmd.Help()
+			_ = cmd.Help()
 		},
 	}
 

--- a/cmd/megaport/modules_wasm.go
+++ b/cmd/megaport/modules_wasm.go
@@ -8,7 +8,10 @@ import (
 	"github.com/megaport/megaport-cli/internal/commands/mve"
 	"github.com/megaport/megaport-cli/internal/commands/partners"
 	"github.com/megaport/megaport-cli/internal/commands/ports"
+	"github.com/megaport/megaport-cli/internal/commands/product"
 	"github.com/megaport/megaport-cli/internal/commands/servicekeys"
+	"github.com/megaport/megaport-cli/internal/commands/status"
+	"github.com/megaport/megaport-cli/internal/commands/topology"
 	"github.com/megaport/megaport-cli/internal/commands/vxc"
 )
 
@@ -27,5 +30,8 @@ func registerModules() {
 	moduleRegistry.Register(mve.NewModule())
 	moduleRegistry.Register(locations.NewModule())
 	moduleRegistry.Register(partners.NewModule())
+	moduleRegistry.Register(product.NewModule())
 	moduleRegistry.Register(servicekeys.NewModule())
+	moduleRegistry.Register(status.NewModule())
+	moduleRegistry.Register(topology.NewModule())
 }

--- a/cmd/megaport/modules_wasm_test.go
+++ b/cmd/megaport/modules_wasm_test.go
@@ -1,0 +1,41 @@
+//go:build js && wasm
+
+package megaport
+
+import (
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/wasm"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestReadOnlyModulesRegistered verifies the read-only status, topology, and
+// product modules are wired into the WASM command tree (ESD-1283). Each is
+// invoked with --help so no network call is made; an unregistered command would
+// instead surface an "unknown command" error. Cases are help-only by design so
+// they share the global rootCmd without leaking flag state between subtests.
+func TestReadOnlyModulesRegistered(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		// usage is the command path cobra echoes in the "Usage:" block; it
+		// tracks the command structure rather than drift-prone help prose.
+		usage string
+	}{
+		{"status", []string{"megaport-cli", "status", "--help"}, "megaport-cli status"},
+		{"topology", []string{"megaport-cli", "topology", "--help"}, "megaport-cli topology"},
+		{"product", []string{"megaport-cli", "product", "--help"}, "megaport-cli product"},
+		{"product list", []string{"megaport-cli", "product", "list", "--help"}, "megaport-cli product list"},
+		{"product get-type", []string{"megaport-cli", "product", "get-type", "--help"}, "megaport-cli product get-type"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wasm.ResetOutputBuffers()
+			ExecuteWithArgs(tc.args)
+			out := wasm.GetCapturedOutput()
+			assert.NotContains(t, out, "unknown command", "%v should be a registered command", tc.args)
+			assert.Contains(t, out, tc.usage, "%v help should show its usage path", tc.args)
+		})
+	}
+}

--- a/internal/base/output/common.go
+++ b/internal/base/output/common.go
@@ -278,6 +278,8 @@ func PrintOutput[T OutputFields](data []T, format string, noColor bool) error {
 // Use it to compose several tables into one writer (e.g. the status dashboard)
 // so the full output is captured in order, including under the WASM transport
 // where PrintOutput("table") would otherwise only retain the last section.
+// Touching no shared globals, it needs no output-package locking; the caller
+// owns w.
 func PrintTableToWriter[T OutputFields](w io.Writer, data []T, noColor bool) error {
 	return printTableToWriter(w, data, noColor, currentPrintOptions())
 }

--- a/internal/base/output/common.go
+++ b/internal/base/output/common.go
@@ -3,6 +3,7 @@ package output
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"reflect"
 	"strings"
 	"sync"
@@ -270,6 +271,15 @@ func PrintOutput[T OutputFields](data []T, format string, noColor bool) error {
 			return printTable(data, noColor, opts)
 		})
 	}
+}
+
+// PrintTableToWriter renders data as a table directly to w with no global side
+// effects: it does not page, write to os.Stdout, or set the WASM table global.
+// Use it to compose several tables into one writer (e.g. the status dashboard)
+// so the full output is captured in order, including under the WASM transport
+// where PrintOutput("table") would otherwise only retain the last section.
+func PrintTableToWriter[T OutputFields](w io.Writer, data []T, noColor bool) error {
+	return printTableToWriter(w, data, noColor, currentPrintOptions())
 }
 
 // getStructTypeInfo extracts header names, json names, and field indices from a struct type.

--- a/internal/base/output/output_native_test.go
+++ b/internal/base/output/output_native_test.go
@@ -1,0 +1,27 @@
+//go:build !wasm
+
+package output
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// createTempFile only exists in the native build, so this test lives behind the
+// !wasm tag alongside it.
+func TestCaptureOutput_TempFileFailure(t *testing.T) {
+	orig := createTempFile
+	createTempFile = func() (*os.File, error) {
+		return nil, errors.New("temp file unavailable")
+	}
+	defer func() { createTempFile = orig }()
+
+	called := false
+	result := CaptureOutput(func() { called = true })
+
+	assert.True(t, called, "f should still be called when temp file creation fails")
+	assert.Empty(t, result, "result should be empty when temp file creation fails")
+}

--- a/internal/base/output/output_test.go
+++ b/internal/base/output/output_test.go
@@ -725,20 +725,6 @@ func TestJSONOutput_NoTrailingNewlines(t *testing.T) {
 	assert.False(t, strings.HasSuffix(output, "]\n\n"), "JSON should not have multiple trailing newlines")
 }
 
-func TestCaptureOutput_TempFileFailure(t *testing.T) {
-	orig := createTempFile
-	createTempFile = func() (*os.File, error) {
-		return nil, errors.New("temp file unavailable")
-	}
-	defer func() { createTempFile = orig }()
-
-	called := false
-	result := CaptureOutput(func() { called = true })
-
-	assert.True(t, called, "f should still be called when temp file creation fails")
-	assert.Empty(t, result, "result should be empty when temp file creation fails")
-}
-
 func TestCaptureOutputErr_RestoresStdoutOnError(t *testing.T) {
 	originalStdout := os.Stdout
 

--- a/internal/base/output/output_test.go
+++ b/internal/base/output/output_test.go
@@ -385,6 +385,38 @@ func TestPrintPrettyTable_SimpleStruct(t *testing.T) {
 	assert.Contains(t, output, " true ")
 }
 
+func TestPrintTableToWriter(t *testing.T) {
+	data := []SimpleStruct{
+		{ID: 1, Name: "Item 1", Active: true},
+		{ID: 2, Name: "Item 2", Active: false},
+	}
+
+	var buf strings.Builder
+	err := PrintTableToWriter(&buf, data, true)
+	assert.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "ID")
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "Item 1")
+	assert.Contains(t, out, "Item 2")
+}
+
+func TestPrintTableToWriter_EmptySlice(t *testing.T) {
+	var buf strings.Builder
+	err := PrintTableToWriter(&buf, []SimpleStruct{}, true)
+	assert.NoError(t, err)
+}
+
+func TestPrintTableToWriter_UnknownFieldErrors(t *testing.T) {
+	SetOutputFields([]string{"definitely_not_a_field"})
+	defer SetOutputFields(nil)
+
+	var buf strings.Builder
+	err := PrintTableToWriter(&buf, []SimpleStruct{{ID: 1, Name: "Item 1"}}, true)
+	assert.Error(t, err)
+}
+
 func TestPrintPrettyTable_ComplexStruct(t *testing.T) {
 	reference := SimpleStruct{ID: 100, Name: "Reference", Active: true}
 	now := time.Now()

--- a/internal/base/output/table.go
+++ b/internal/base/output/table.go
@@ -3,6 +3,7 @@
 package output
 
 import (
+	"io"
 	"os"
 	"reflect"
 	"strings"
@@ -64,6 +65,10 @@ func calculateDynamicWidth(termWidth int, minWidth, maxPercentage int) int {
 }
 
 func printTable[T OutputFields](data []T, noColor bool, opts printOptions) error {
+	return printTableToWriter(os.Stdout, data, noColor, opts)
+}
+
+func printTableToWriter[T OutputFields](w io.Writer, data []T, noColor bool, opts printOptions) error {
 	headers, jsonNames, fieldIndices, err := getStructTypeInfo(data)
 	if err != nil {
 		return err
@@ -78,7 +83,7 @@ func printTable[T OutputFields](data []T, noColor bool, opts printOptions) error
 		return nil
 	}
 	t := prettytable.NewWriter()
-	t.SetOutputMirror(os.Stdout)
+	t.SetOutputMirror(w)
 	termWidth := getTerminalWidth()
 	columnConfigs := make([]prettytable.ColumnConfig, len(headers))
 	for i := range headers {

--- a/internal/base/output/table_wasm.go
+++ b/internal/base/output/table_wasm.go
@@ -5,6 +5,7 @@ package output
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"reflect"
 	"strings"
 	"sync/atomic"
@@ -47,6 +48,30 @@ func calculateDynamicWidth(termWidth int, minWidth, maxPercentage int) int {
 func printTable[T OutputFields](data []T, noColor bool, opts printOptions) error {
 	wasmBufMu.Lock()
 	defer wasmBufMu.Unlock()
+
+	// In WASM, render into the global WasmTableWriter so the rendered table is
+	// available to the JS-accessible wasmTableOutput global that the web UI reads.
+	WasmTableWriter.Reset()
+	if err := printTableToWriter(WasmTableWriter, data, noColor, opts); err != nil {
+		return err
+	}
+
+	tableOutput := WasmTableWriter.String()
+
+	// Write the table output to stdout so it can be captured by wasm buffers.
+	fmt.Print(tableOutput)
+
+	// Also write to a JavaScript-accessible global variable.
+	js.Global().Set("wasmTableOutput", tableOutput)
+
+	return nil
+}
+
+// printTableToWriter renders data as a table directly to w with no global side
+// effects. printTable wraps it for the JS-global capture path; the status
+// dashboard calls it (via PrintTableToWriter) to compose several tables into one
+// writer without the per-call global being overwritten.
+func printTableToWriter[T OutputFields](w io.Writer, data []T, noColor bool, opts printOptions) error {
 	headers, jsonNames, fieldIndices, err := getStructTypeInfo(data)
 	if err != nil {
 		return err
@@ -63,11 +88,7 @@ func printTable[T OutputFields](data []T, noColor bool, opts printOptions) error
 
 	// Create table writer
 	t := prettytable.NewWriter()
-
-	// CRITICAL FIX: In WASM, write ONLY to WasmTableWriter
-	// Don't write to os.Stdout as it causes capture issues
-	WasmTableWriter.Reset() // Clear previous content
-	t.SetOutputMirror(WasmTableWriter)
+	t.SetOutputMirror(w)
 
 	// WASM-specific table configuration with improved column widths
 	// This ensures consistent, readable column distribution in the browser
@@ -192,16 +213,5 @@ func printTable[T OutputFields](data []T, noColor bool, opts printOptions) error
 	}
 
 	t.Render()
-
-	// Get the rendered table output
-	tableOutput := WasmTableWriter.String()
-
-	// Write the table output to stdout so it can be captured by wasm buffers
-	// This is the key: write the buffered content to stdout
-	fmt.Print(tableOutput)
-
-	// Also write to a JavaScript-accessible global variable
-	js.Global().Set("wasmTableOutput", tableOutput)
-
 	return nil
 }

--- a/internal/commands/status/status_actions.go
+++ b/internal/commands/status/status_actions.go
@@ -152,7 +152,7 @@ func StatusDashboard(cmd *cobra.Command, args []string, noColor bool, outputForm
 		return fmt.Errorf("failed to build dashboard: %w", err)
 	}
 
-	if err := printDashboard(dashboard, outputFormat, noColor); err != nil {
+	if err := printDashboard(cmd.OutOrStdout(), dashboard, outputFormat, noColor); err != nil {
 		output.PrintError("Failed to print dashboard: %v", noColor, err)
 		return fmt.Errorf("failed to print dashboard: %w", err)
 	}

--- a/internal/commands/status/status_output.go
+++ b/internal/commands/status/status_output.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"os"
+	"io"
 
 	"github.com/megaport/megaport-cli/internal/base/output"
 	megaport "github.com/megaport/megaportgo"
@@ -214,13 +214,15 @@ func buildDashboard(
 	return dashboard, nil
 }
 
-// printDashboard dispatches to the appropriate format printer.
-func printDashboard(dashboard dashboardOutput, format string, noColor bool) error {
+// printDashboard dispatches to the appropriate format printer. w receives the
+// JSON/XML output so it is captured by the cobra writer (the WASM output buffer
+// in the browser build); table/CSV go through the output package directly.
+func printDashboard(w io.Writer, dashboard dashboardOutput, format string, noColor bool) error {
 	switch format {
 	case "json":
-		return printDashboardJSON(dashboard)
+		return printDashboardJSON(w, dashboard)
 	case "xml":
-		return printDashboardXML(dashboard)
+		return printDashboardXML(w, dashboard)
 	case "csv":
 		return printDashboardCSV(dashboard, noColor)
 	default:
@@ -292,13 +294,13 @@ func printDashboardTable(dashboard dashboardOutput, noColor bool) error {
 	return nil
 }
 
-func printDashboardJSON(dashboard dashboardOutput) error {
-	encoder := json.NewEncoder(os.Stdout)
+func printDashboardJSON(w io.Writer, dashboard dashboardOutput) error {
+	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(dashboard)
 }
 
-func printDashboardXML(dashboard dashboardOutput) error {
+func printDashboardXML(w io.Writer, dashboard dashboardOutput) error {
 	type xmlDashboard struct {
 		XMLName xml.Name           `xml:"dashboard"`
 		Ports   []statusPortOutput `xml:"ports>port"`
@@ -316,12 +318,12 @@ func printDashboardXML(dashboard dashboardOutput) error {
 		IXs:     dashboard.IXs,
 		Summary: dashboard.Summary,
 	}
-	encoder := xml.NewEncoder(os.Stdout)
+	encoder := xml.NewEncoder(w)
 	encoder.Indent("", "  ")
 	if err := encoder.Encode(out); err != nil {
 		return err
 	}
-	fmt.Fprintln(os.Stdout)
+	fmt.Fprintln(w)
 	return nil
 }
 

--- a/internal/commands/status/status_output.go
+++ b/internal/commands/status/status_output.go
@@ -234,8 +234,13 @@ func printDashboard(w io.Writer, dashboard dashboardOutput, format string, noCol
 // printDashboardTable renders every section's table into w via
 // PrintTableToWriter rather than PrintOutput("table"). Under the WASM transport
 // PrintOutput overwrites a single per-call table global, so only the last
-// section would survive; rendering each table into w keeps them all, in order,
-// alongside the section headers (PrintPlain also targets the WASM buffer).
+// section would survive; rendering each table into w keeps them all, in order.
+//
+// w must be cmd.OutOrStdout() so it matches where the output.Print* helpers send
+// the section headers and summary (os.Stdout natively, the WASM output buffer in
+// the browser); otherwise headers and tables would land in different places. The
+// headers stay on PrintPlain/PrintWarning so they keep quiet-mode and JSON-stderr
+// gating, which a raw write to w would drop.
 func printDashboardTable(w io.Writer, dashboard dashboardOutput, noColor bool) error {
 	// PORTS
 	output.PrintNewline()

--- a/internal/commands/status/status_output.go
+++ b/internal/commands/status/status_output.go
@@ -214,9 +214,10 @@ func buildDashboard(
 	return dashboard, nil
 }
 
-// printDashboard dispatches to the appropriate format printer. w receives the
-// JSON/XML output so it is captured by the cobra writer (the WASM output buffer
-// in the browser build); table/CSV go through the output package directly.
+// printDashboard dispatches to the appropriate format printer. JSON/XML/table
+// output all go to w (the cobra writer, which is the WASM output buffer in the
+// browser build) so the full dashboard is captured in order; CSV goes through
+// the output package directly.
 func printDashboard(w io.Writer, dashboard dashboardOutput, format string, noColor bool) error {
 	switch format {
 	case "json":
@@ -226,18 +227,23 @@ func printDashboard(w io.Writer, dashboard dashboardOutput, format string, noCol
 	case "csv":
 		return printDashboardCSV(dashboard, noColor)
 	default:
-		return printDashboardTable(dashboard, noColor)
+		return printDashboardTable(w, dashboard, noColor)
 	}
 }
 
-func printDashboardTable(dashboard dashboardOutput, noColor bool) error {
+// printDashboardTable renders every section's table into w via
+// PrintTableToWriter rather than PrintOutput("table"). Under the WASM transport
+// PrintOutput overwrites a single per-call table global, so only the last
+// section would survive; rendering each table into w keeps them all, in order,
+// alongside the section headers (PrintPlain also targets the WASM buffer).
+func printDashboardTable(w io.Writer, dashboard dashboardOutput, noColor bool) error {
 	// PORTS
 	output.PrintNewline()
 	output.PrintPlain("PORTS (%d)", noColor, len(dashboard.Ports))
 	if len(dashboard.Ports) == 0 {
 		output.PrintWarning("No ports found.", noColor)
 	} else {
-		if err := output.PrintOutput(dashboard.Ports, "table", noColor); err != nil {
+		if err := output.PrintTableToWriter(w, dashboard.Ports, noColor); err != nil {
 			return err
 		}
 	}
@@ -248,7 +254,7 @@ func printDashboardTable(dashboard dashboardOutput, noColor bool) error {
 	if len(dashboard.MCRs) == 0 {
 		output.PrintWarning("No MCRs found.", noColor)
 	} else {
-		if err := output.PrintOutput(dashboard.MCRs, "table", noColor); err != nil {
+		if err := output.PrintTableToWriter(w, dashboard.MCRs, noColor); err != nil {
 			return err
 		}
 	}
@@ -259,7 +265,7 @@ func printDashboardTable(dashboard dashboardOutput, noColor bool) error {
 	if len(dashboard.MVEs) == 0 {
 		output.PrintWarning("No MVEs found.", noColor)
 	} else {
-		if err := output.PrintOutput(dashboard.MVEs, "table", noColor); err != nil {
+		if err := output.PrintTableToWriter(w, dashboard.MVEs, noColor); err != nil {
 			return err
 		}
 	}
@@ -270,7 +276,7 @@ func printDashboardTable(dashboard dashboardOutput, noColor bool) error {
 	if len(dashboard.VXCs) == 0 {
 		output.PrintWarning("No VXCs found.", noColor)
 	} else {
-		if err := output.PrintOutput(dashboard.VXCs, "table", noColor); err != nil {
+		if err := output.PrintTableToWriter(w, dashboard.VXCs, noColor); err != nil {
 			return err
 		}
 	}
@@ -281,7 +287,7 @@ func printDashboardTable(dashboard dashboardOutput, noColor bool) error {
 	if len(dashboard.IXs) == 0 {
 		output.PrintWarning("No IXs found.", noColor)
 	} else {
-		if err := output.PrintOutput(dashboard.IXs, "table", noColor); err != nil {
+		if err := output.PrintTableToWriter(w, dashboard.IXs, noColor); err != nil {
 			return err
 		}
 	}

--- a/internal/commands/status/status_output_test.go
+++ b/internal/commands/status/status_output_test.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"io"
 	"os"
 	"testing"
 
@@ -124,6 +125,48 @@ func TestPrintDashboard_XML(t *testing.T) {
 	assert.Contains(t, out, "<asn>65000</asn>")
 	assert.Contains(t, out, "<a_end_uid>a-end</a_end_uid>")
 	assert.Contains(t, out, "<summary>")
+}
+
+// TestPrintDashboardTable_SectionError verifies that a table-render failure in
+// any section is propagated. Setting an unknown --fields makes
+// PrintTableToWriter fail, and each subtest populates exactly one section so the
+// error originates from that section's render call.
+func TestPrintDashboardTable_SectionError(t *testing.T) {
+	withOutputFormat(t, "table")
+
+	port := &megaport.Port{UID: "port-1", Name: "Port One", ProvisioningStatus: "LIVE"}
+	mcr := &megaport.MCR{UID: "mcr-1", Name: "MCR One", ProvisioningStatus: "LIVE"}
+	mve := &megaport.MVE{UID: "mve-1", Name: "MVE One", ProvisioningStatus: "LIVE"}
+	vxc := &megaport.VXC{UID: "vxc-1", Name: "VXC One", ProvisioningStatus: "LIVE"}
+	ix := &megaport.IX{ProductUID: "ix-1", ProductName: "IX One", ProvisioningStatus: "LIVE"}
+
+	cases := []struct {
+		name  string
+		ports []*megaport.Port
+		mcrs  []*megaport.MCR
+		mves  []*megaport.MVE
+		vxcs  []*megaport.VXC
+		ixs   []*megaport.IX
+	}{
+		{name: "ports", ports: []*megaport.Port{port}},
+		{name: "mcrs", mcrs: []*megaport.MCR{mcr}},
+		{name: "mves", mves: []*megaport.MVE{mve}},
+		{name: "vxcs", vxcs: []*megaport.VXC{vxc}},
+		{name: "ixs", ixs: []*megaport.IX{ix}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dashboard, err := buildDashboard(tc.ports, tc.mcrs, tc.mves, tc.vxcs, tc.ixs)
+			assert.NoError(t, err)
+
+			op.SetOutputFields([]string{"definitely_not_a_field"})
+			t.Cleanup(func() { op.SetOutputFields(nil) })
+
+			err = printDashboard(io.Discard, dashboard, "table", true)
+			assert.Error(t, err)
+		})
+	}
 }
 
 func TestPrintDashboard_Empty(t *testing.T) {

--- a/internal/commands/status/status_output_test.go
+++ b/internal/commands/status/status_output_test.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"os"
 	"testing"
 
 	op "github.com/megaport/megaport-cli/internal/base/output"
@@ -70,7 +71,7 @@ func TestPrintDashboard_Table(t *testing.T) {
 	withOutputFormat(t, "table")
 	dashboard := statusTestDashboard(t)
 	out := op.CaptureOutput(func() {
-		err := printDashboard(dashboard, "table", true)
+		err := printDashboard(os.Stdout, dashboard, "table", true)
 		assert.NoError(t, err)
 	})
 
@@ -86,7 +87,7 @@ func TestPrintDashboard_JSON(t *testing.T) {
 	withOutputFormat(t, "json")
 	dashboard := statusTestDashboard(t)
 	out := op.CaptureOutput(func() {
-		err := printDashboard(dashboard, "json", true)
+		err := printDashboard(os.Stdout, dashboard, "json", true)
 		assert.NoError(t, err)
 	})
 
@@ -100,7 +101,7 @@ func TestPrintDashboard_CSV(t *testing.T) {
 	withOutputFormat(t, "csv")
 	dashboard := statusTestDashboard(t)
 	out := op.CaptureOutput(func() {
-		err := printDashboard(dashboard, "csv", true)
+		err := printDashboard(os.Stdout, dashboard, "csv", true)
 		assert.NoError(t, err)
 	})
 
@@ -114,7 +115,7 @@ func TestPrintDashboard_XML(t *testing.T) {
 	withOutputFormat(t, "xml")
 	dashboard := statusTestDashboard(t)
 	out := op.CaptureOutput(func() {
-		err := printDashboard(dashboard, "xml", true)
+		err := printDashboard(os.Stdout, dashboard, "xml", true)
 		assert.NoError(t, err)
 	})
 
@@ -133,7 +134,7 @@ func TestPrintDashboard_Empty(t *testing.T) {
 		t.Run(format, func(t *testing.T) {
 			withOutputFormat(t, format)
 			out := op.CaptureOutput(func() {
-				err := printDashboard(dashboard, format, true)
+				err := printDashboard(os.Stdout, dashboard, format, true)
 				assert.NoError(t, err)
 			})
 			assert.NotEmpty(t, out)

--- a/internal/commands/status/status_output_wasm_test.go
+++ b/internal/commands/status/status_output_wasm_test.go
@@ -1,0 +1,40 @@
+//go:build js && wasm
+
+package status
+
+import (
+	"testing"
+
+	op "github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/wasm"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPrintDashboard_TableWASMCapture guards the ESD-1283 fix: the multi-section
+// table dashboard must render in full through the WASM capture path. Routing each
+// section through PrintOutput("table") previously left only the last section in
+// the per-call wasmTableOutput global, so the browser saw a truncated dashboard.
+// PrintTableToWriter renders every section into WasmOutputBuffer instead, so
+// GetCapturedOutput returns headers, all five tables, and the summary in order.
+func TestPrintDashboard_TableWASMCapture(t *testing.T) {
+	wasm.ResetOutputBuffers()
+	op.SetOutputFormat("table")
+
+	dashboard := statusTestDashboard(t)
+	err := printDashboard(wasm.WasmOutputBuffer, dashboard, "table", true)
+	assert.NoError(t, err)
+
+	out := wasm.GetCapturedOutput()
+
+	// Every section header and its row must survive, not just the last one.
+	for _, want := range []string{
+		"PORTS (1)", "port-1",
+		"MCRS (1)", "mcr-1",
+		"MVES (1)", "mve-1",
+		"VXCS (1)", "vxc-1",
+		"IXS (1)", "ix-1",
+		"Total: 1 port(s), 1 MCR(s), 1 MVE(s), 1 VXC(s), 1 IX(s)",
+	} {
+		assert.Contains(t, out, want, "WASM dashboard capture should include %q", want)
+	}
+}

--- a/internal/commands/status/status_test.go
+++ b/internal/commands/status/status_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	op "github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/commands/config"
 	"github.com/megaport/megaport-cli/internal/testutil"
 	megaport "github.com/megaport/megaportgo"
@@ -390,6 +391,28 @@ func TestStatusDashboard_CSVOutput(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, buf.String(), "# PORTS")
 	assert.Contains(t, buf.String(), "port-1")
+}
+
+// TestStatusDashboard_PrintError verifies a print failure propagates. An unknown
+// --fields makes the table render fail, exercising the printDashboard error path.
+func TestStatusDashboard_PrintError(t *testing.T) {
+	cleanup := setupMocks(
+		&MockPortService{ListPortsResult: []*megaport.Port{
+			{UID: "port-1", Name: "P1", ProvisioningStatus: "LIVE", PortSpeed: 1000, LocationID: 1},
+		}},
+		&MockMCRService{},
+		&MockMVEService{},
+		&MockVXCService{},
+		&MockIXService{},
+	)
+	defer cleanup()
+
+	op.SetOutputFields([]string{"definitely_not_a_field"})
+	defer op.SetOutputFields(nil)
+
+	cmd := newStatusCmd()
+	err := StatusDashboard(cmd, nil, true, "table")
+	assert.Error(t, err)
 }
 
 // TestBuildDashboard_NilPort verifies buildDashboard returns an error for a nil port.

--- a/internal/commands/topology/topology_actions.go
+++ b/internal/commands/topology/topology_actions.go
@@ -107,11 +107,11 @@ func ShowTopology(cmd *cobra.Command, args []string, noColor bool, outputFormat 
 		if err != nil {
 			return fmt.Errorf("failed to marshal topology: %w", err)
 		}
-		fmt.Println(string(jsonBytes))
+		fmt.Fprintln(cmd.OutOrStdout(), string(jsonBytes))
 	case "csv", "xml":
 		return fmt.Errorf("output format %q is not supported for topology — use table (default) or json", outputFormat)
 	default:
-		fmt.Print(renderTree(nodes, noColor))
+		fmt.Fprint(cmd.OutOrStdout(), renderTree(nodes, noColor))
 	}
 
 	return nil


### PR DESCRIPTION
Registers the three read-only modules in the browser (WASM) build so they reach parity with the native CLI: `status` (account dashboard), `topology` (resource tree), and `product` (`list` / `get-type`).

Registration was the easy part. Getting them to actually render in the browser needed output-path fixes, because WASM doesn't capture `os.Stdout`: output has to go through cobra's writer (`cmd.OutOrStdout()`), which the WASM entry point points at the captured buffer.

Changes:
- Register `status`, `topology`, and `product` in the WASM `registerModules()`, ordered to match the native registration.
- Route `status` (JSON/XML) and `topology` (tree/JSON) through `cmd.OutOrStdout()` so they're captured in the browser instead of vanishing to the console.
- Add `output.PrintTableToWriter`, a side-effect-free table renderer, and use it for the status dashboard. `PrintOutput("table")` writes each table into one per-call WASM global, so the multi-section dashboard only kept its last section in the browser; rendering each section into the cobra writer keeps them all. Native output is unchanged.
- Tests: a `js,wasm` smoke test that all three resolve in the WASM command tree, plus a WASM test proving the full multi-section dashboard is captured.
- Fix an unchecked `cmd.Help()` return flagged by errcheck under the WASM build tags.

`make check`, the `js/wasm` build, and the WASM tests all pass. In-browser verification against Staging (dashboard/tree/product render) is the remaining manual check.

ESD-1283