### PR TITLE
fix(config): fail-closed credential redaction in --log-http (ESD-1418)

### DIFF
--- a/internal/commands/config/login.go
+++ b/internal/commands/config/login.go
@@ -278,8 +278,8 @@ func warnIfInsecureURL(flagName, rawURL string) {
 func warnIfInsecureBaseURL(rawURL string) { warnIfInsecureURL("--base-url", rawURL) }
 
 // appendLogOpts appends HTTP debug logging options to the client option slice
-// when --log-http is enabled. Logs go to stderr at DEBUG level with sensitive
-// fields (access keys, tokens, and all response bodies) redacted.
+// when --log-http is enabled. Logs go to stderr at DEBUG level; the
+// redactingHandler scrubs credential-bearing fields and response bodies.
 func appendLogOpts(opts []megaport.ClientOpt) []megaport.ClientOpt {
 	result := append([]megaport.ClientOpt(nil), opts...)
 	if utils.LogHTTP {
@@ -307,10 +307,20 @@ var sensitiveExactKeys = map[string]bool{
 	"response_body_base_64": true,
 }
 
+// nonSensitiveExactKeys lists keys that match a substring family but carry no
+// credential and are useful for --log-http debugging, so they stay visible.
+// token_url is the constant OAuth endpoint, not the token itself.
+var nonSensitiveExactKeys = map[string]bool{
+	"token_url": true,
+}
+
 // isSensitiveKey reports whether an slog attribute key should have its value
 // redacted, matching credential families as case-insensitive substrings.
 func isSensitiveKey(key string) bool {
 	lower := strings.ToLower(key)
+	if nonSensitiveExactKeys[lower] {
+		return false
+	}
 	if sensitiveExactKeys[lower] {
 		return true
 	}
@@ -320,6 +330,14 @@ func isSensitiveKey(key string) bool {
 		}
 	}
 	return false
+}
+
+// looksLikeAuthValue reports whether a string value carries an HTTP
+// Authorization credential. Scanning the value (not just the key) keeps
+// redaction fail-closed when a credential is logged under an unrecognized key.
+func looksLikeAuthValue(v string) bool {
+	lower := strings.ToLower(strings.TrimSpace(v))
+	return strings.HasPrefix(lower, "basic ") || strings.HasPrefix(lower, "bearer ")
 }
 
 // redactingHandler wraps an slog.Handler to replace sensitive attribute values
@@ -368,6 +386,10 @@ func redactAttr(a slog.Attr) slog.Attr {
 			cleaned[i] = redactAttr(ga)
 		}
 		return slog.Group(a.Key, attrsToAny(cleaned)...)
+	}
+	// Fail closed on credential-shaped values under unrecognized keys.
+	if a.Value.Kind() == slog.KindString && looksLikeAuthValue(a.Value.String()) {
+		return slog.String(a.Key, "[REDACTED]")
 	}
 	return a
 }

--- a/internal/commands/config/login.go
+++ b/internal/commands/config/login.go
@@ -378,9 +378,13 @@ func redactAttr(a slog.Attr) slog.Attr {
 	if isSensitiveKey(a.Key) {
 		return slog.String(a.Key, "[REDACTED]")
 	}
+	// Resolve LogValuer values so group recursion and value scanning see the
+	// real logged value rather than its unresolved wrapper, which otherwise
+	// lets a credential resolved by the inner handler slip past the scan.
+	val := a.Value.Resolve()
 	// Recurse into group attributes
-	if a.Value.Kind() == slog.KindGroup {
-		attrs := a.Value.Group()
+	if val.Kind() == slog.KindGroup {
+		attrs := val.Group()
 		cleaned := make([]slog.Attr, len(attrs))
 		for i, ga := range attrs {
 			cleaned[i] = redactAttr(ga)
@@ -388,8 +392,8 @@ func redactAttr(a slog.Attr) slog.Attr {
 		return slog.Group(a.Key, attrsToAny(cleaned)...)
 	}
 	// Fail closed on credential-shaped values under unrecognized keys,
-	// regardless of the attribute's value kind (String, Any, Stringer, ...).
-	if looksLikeAuthValue(a.Value.String()) {
+	// regardless of the attribute's value kind (String, Any, LogValuer, ...).
+	if looksLikeAuthValue(val.String()) {
 		return slog.String(a.Key, "[REDACTED]")
 	}
 	return a

--- a/internal/commands/config/login.go
+++ b/internal/commands/config/login.go
@@ -387,8 +387,9 @@ func redactAttr(a slog.Attr) slog.Attr {
 		}
 		return slog.Group(a.Key, attrsToAny(cleaned)...)
 	}
-	// Fail closed on credential-shaped values under unrecognized keys.
-	if a.Value.Kind() == slog.KindString && looksLikeAuthValue(a.Value.String()) {
+	// Fail closed on credential-shaped values under unrecognized keys,
+	// regardless of the attribute's value kind (String, Any, Stringer, ...).
+	if looksLikeAuthValue(a.Value.String()) {
 		return slog.String(a.Key, "[REDACTED]")
 	}
 	return a

--- a/internal/commands/config/login.go
+++ b/internal/commands/config/login.go
@@ -290,14 +290,36 @@ func appendLogOpts(opts []megaport.ClientOpt) []megaport.ClientOpt {
 	return result
 }
 
-// sensitiveKeys lists slog attribute keys whose values should be redacted.
-var sensitiveKeys = map[string]bool{
-	"access_key":            true,
-	"secret_key":            true,
+// sensitiveKeySubstrings are matched case-insensitively against slog attribute
+// keys. Substring matching fails closed: any current or future log key carrying
+// a credential family (authorization headers, access/secret keys, tokens) is
+// redacted even if the SDK adds a new key name we never enumerated.
+var sensitiveKeySubstrings = []string{
+	"authorization",
+	"key",
+	"token",
+	"secret",
+}
+
+// sensitiveExactKeys lists keys to redact that the substring families above
+// don't catch, such as encoded response bodies that may embed credentials.
+var sensitiveExactKeys = map[string]bool{
 	"response_body_base_64": true,
-	"authorization":         true,
-	"x-authorization":       true,
-	"access_token":          true,
+}
+
+// isSensitiveKey reports whether an slog attribute key should have its value
+// redacted, matching credential families as case-insensitive substrings.
+func isSensitiveKey(key string) bool {
+	lower := strings.ToLower(key)
+	if sensitiveExactKeys[lower] {
+		return true
+	}
+	for _, sub := range sensitiveKeySubstrings {
+		if strings.Contains(lower, sub) {
+			return true
+		}
+	}
+	return false
 }
 
 // redactingHandler wraps an slog.Handler to replace sensitive attribute values
@@ -335,7 +357,7 @@ func (h *redactingHandler) WithGroup(name string) slog.Handler {
 // For group attributes (like the SDK's "api_request" group), it recurses
 // into the group's attributes.
 func redactAttr(a slog.Attr) slog.Attr {
-	if sensitiveKeys[a.Key] {
+	if isSensitiveKey(a.Key) {
 		return slog.String(a.Key, "[REDACTED]")
 	}
 	// Recurse into group attributes

--- a/internal/commands/config/login_test.go
+++ b/internal/commands/config/login_test.go
@@ -897,6 +897,45 @@ func TestRedactingHandler(t *testing.T) {
 		assert.Contains(t, output, "[REDACTED]")
 	})
 
+	// Fail-closed: a credential key the allowlist never enumerated (the SDK's
+	// authorization_header) must still be redacted via substring matching.
+	t.Run("redacts unlisted authorization_header", func(t *testing.T) {
+		buf.Reset()
+		logger.DebugContext(context.Background(), "login request",
+			slog.String("authorization_header", "Basic YWNjZXNzOnNlY3JldA=="),
+		)
+		output := buf.String()
+		assert.NotContains(t, output, "Basic YWNjZXNzOnNlY3JldA==")
+		assert.NotContains(t, output, "YWNjZXNzOnNlY3JldA==")
+		assert.Contains(t, output, "[REDACTED]")
+	})
+
+	t.Run("redaction is case-insensitive", func(t *testing.T) {
+		for _, key := range []string{"Authorization", "X-Access-Key", "Secret_Key", "ACCESS_TOKEN"} {
+			assert.True(t, isSensitiveKey(key), "expected %q to be treated as sensitive", key)
+		}
+	})
+
+	t.Run("preserves non-credential keys", func(t *testing.T) {
+		for _, key := range []string{"method", "path", "api_host", "trace_id", "content_type", "status_code"} {
+			assert.False(t, isSensitiveKey(key), "expected %q to be preserved", key)
+		}
+	})
+
+	t.Run("redacts credential-family substrings", func(t *testing.T) {
+		buf.Reset()
+		logger.DebugContext(context.Background(), "auth",
+			slog.String("client_secret", "shh-secret"),
+			slog.String("refresh_token", "refresh-me"),
+			slog.String("api_key_id", "key-id-leak"),
+		)
+		output := buf.String()
+		assert.NotContains(t, output, "shh-secret")
+		assert.NotContains(t, output, "refresh-me")
+		assert.NotContains(t, output, "key-id-leak")
+		assert.Contains(t, output, "[REDACTED]")
+	})
+
 	t.Run("redacts inside group attributes", func(t *testing.T) {
 		buf.Reset()
 		logger.DebugContext(context.Background(), "api call",

--- a/internal/commands/config/login_test.go
+++ b/internal/commands/config/login_test.go
@@ -853,6 +853,12 @@ func TestCLIHeadersSentOnRequests(t *testing.T) {
 	assert.Equal(t, "cli", capturedHeaders.Get("x-app"))
 }
 
+// stringerValue is a fmt.Stringer so slog.Any produces a non-string (KindAny)
+// attribute value, exercising the value-level redaction path.
+type stringerValue string
+
+func (s stringerValue) String() string { return string(s) }
+
 func TestRedactingHandler(t *testing.T) {
 	var buf bytes.Buffer
 	inner := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
@@ -944,6 +950,18 @@ func TestRedactingHandler(t *testing.T) {
 		output := buf.String()
 		assert.NotContains(t, output, "YWNjZXNzOnNlY3JldA==")
 		assert.NotContains(t, output, "eyJ-token-value")
+		assert.Contains(t, output, "[REDACTED]")
+	})
+
+	// A credential carried by a non-string value (slog.Any over a Stringer)
+	// must still be caught by the value-level scan.
+	t.Run("redacts auth value from non-string attr", func(t *testing.T) {
+		buf.Reset()
+		logger.DebugContext(context.Background(), "request",
+			slog.Any("opaque", stringerValue("Bearer opaque-secret-token")),
+		)
+		output := buf.String()
+		assert.NotContains(t, output, "opaque-secret-token")
 		assert.Contains(t, output, "[REDACTED]")
 	})
 

--- a/internal/commands/config/login_test.go
+++ b/internal/commands/config/login_test.go
@@ -859,6 +859,13 @@ type stringerValue string
 
 func (s stringerValue) String() string { return string(s) }
 
+// logValuerLeak exposes its credential only through LogValue(); its plain fmt
+// form ("{...}") hides the scheme prefix, so the value scan must Resolve()
+// before inspecting or the inner handler prints the resolved credential.
+type logValuerLeak struct{ token string }
+
+func (l logValuerLeak) LogValue() slog.Value { return slog.StringValue("Bearer " + l.token) }
+
 func TestRedactingHandler(t *testing.T) {
 	var buf bytes.Buffer
 	inner := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
@@ -962,6 +969,18 @@ func TestRedactingHandler(t *testing.T) {
 		)
 		output := buf.String()
 		assert.NotContains(t, output, "opaque-secret-token")
+		assert.Contains(t, output, "[REDACTED]")
+	})
+
+	// A LogValuer's credential is only visible after Resolve(); the scan must
+	// resolve before inspecting or the inner handler prints it in cleartext.
+	t.Run("redacts auth value from LogValuer attr", func(t *testing.T) {
+		buf.Reset()
+		logger.DebugContext(context.Background(), "request",
+			slog.Any("lazy", logValuerLeak{token: "lazy-secret-token"}),
+		)
+		output := buf.String()
+		assert.NotContains(t, output, "lazy-secret-token")
 		assert.Contains(t, output, "[REDACTED]")
 	})
 

--- a/internal/commands/config/login_test.go
+++ b/internal/commands/config/login_test.go
@@ -853,8 +853,8 @@ func TestCLIHeadersSentOnRequests(t *testing.T) {
 	assert.Equal(t, "cli", capturedHeaders.Get("x-app"))
 }
 
-// stringerValue is a fmt.Stringer so slog.Any produces a non-string (KindAny)
-// attribute value, exercising the value-level redaction path.
+// stringerValue is a fmt.Stringer wrapped via slog.Any, exercising the
+// value-level redaction path for a value that isn't a plain slog string.
 type stringerValue string
 
 func (s stringerValue) String() string { return string(s) }

--- a/internal/commands/config/login_test.go
+++ b/internal/commands/config/login_test.go
@@ -922,6 +922,31 @@ func TestRedactingHandler(t *testing.T) {
 		}
 	})
 
+	// token_url is the constant OAuth endpoint, not the token, and is the most
+	// useful field when debugging --log-http auth issues; keep it visible.
+	t.Run("preserves token_url despite token substring", func(t *testing.T) {
+		buf.Reset()
+		logger.DebugContext(context.Background(), "login request",
+			slog.String("token_url", "https://auth.megaport.com/oauth2/token"),
+		)
+		output := buf.String()
+		assert.Contains(t, output, "https://auth.megaport.com/oauth2/token")
+		assert.NotContains(t, output, "[REDACTED]")
+	})
+
+	// Fail closed on a credential-shaped value even when its key is unknown.
+	t.Run("redacts auth value under unrecognized key", func(t *testing.T) {
+		buf.Reset()
+		logger.DebugContext(context.Background(), "request",
+			slog.String("custom_header", "Basic YWNjZXNzOnNlY3JldA=="),
+			slog.String("bearer_field", "Bearer eyJ-token-value"),
+		)
+		output := buf.String()
+		assert.NotContains(t, output, "YWNjZXNzOnNlY3JldA==")
+		assert.NotContains(t, output, "eyJ-token-value")
+		assert.Contains(t, output, "[REDACTED]")
+	})
+
 	t.Run("redacts credential-family substrings", func(t *testing.T) {
 		buf.Reset()
 		logger.DebugContext(context.Background(), "auth",


### PR DESCRIPTION
The `--log-http` redactingHandler scrubbed credentials using an exact slog-key allowlist. Any key it didn't enumerate printed in cleartext to stderr. The risk case is the SDK login path's `authorization_header` (the raw `Basic base64(accessKey:secretKey)` pair, trivially reversible). Users enable `--log-http` precisely when something breaks, then paste the output into support tickets and CI logs.

This switches redaction to fail closed:

- Match the `authorization`/`key`/`token`/`secret` families as case-insensitive substrings, so new SDK log keys are scrubbed by default.
- Keep `token_url` visible (it's the constant OAuth endpoint, not a credential, and the most useful field for debugging auth issues).
- Scan attribute values (any kind, not just strings) for `Basic`/`Bearer` prefixes, so a credential logged under an unrecognized key is still caught.

Note: the currently pinned `megaportgo v1.13.1` does not actually log `authorization_header` (the login path logs only `token_url` and `content_type`), so there's no active leak against today's SDK. This is defense-in-depth so a future SDK log key can't reintroduce one. MegaportGo fixed this issue previously as well. 

Unit tests cover the unlisted `authorization_header` key, case-insensitivity, the credential-family substrings, value-based redaction under unknown keys (string and non-string), and the `token_url` carve-out.