### PR TITLE
fix: failed mutations exit non-zero; usage errors return exit code 2

### DIFF
--- a/cmd/megaport/megaport.go
+++ b/cmd/megaport/megaport.go
@@ -313,9 +313,8 @@ func isCobraUsageError(msg string) bool {
 		"unknown command",
 		"unknown flag",
 		"unknown shorthand flag",
-		"accepts between",
-		"accepts at most",
-		"accepts at least",
+		"arg(s), received",
+		"arg(s), only received",
 		"required flag(s)",
 	}
 	for _, p := range cobraPatterns {

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -231,7 +231,7 @@ func TestExitCodeFromError(t *testing.T) {
 		{"cobra unknown command", errors.New(`unknown command "foo" for "megaport-cli"`), exitcodes.Usage},
 		{"cobra unknown flag", errors.New(`unknown flag: --bogus`), exitcodes.Usage},
 		{"cobra unknown shorthand flag", errors.New(`unknown shorthand flag: 'x' in -x`), exitcodes.Usage},
-		{"cobra accepts at most", errors.New(`accepts at most 1 arg(s), received 2`), exitcodes.Usage},
+		{"cobra accepts at most (MaximumNArgs)", errors.New(`accepts at most 1 arg(s), received 2`), exitcodes.Usage},
 		{"cobra accepts exact (ExactArgs)", errors.New(`accepts 1 arg(s), received 0`), exitcodes.Usage},
 		{"cobra accepts between (RangeArgs)", errors.New(`accepts between 1 and 2 arg(s), received 3`), exitcodes.Usage},
 		{"cobra requires at least (MinimumNArgs)", errors.New(`requires at least 1 arg(s), only received 0`), exitcodes.Usage},

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -232,6 +232,9 @@ func TestExitCodeFromError(t *testing.T) {
 		{"cobra unknown flag", errors.New(`unknown flag: --bogus`), exitcodes.Usage},
 		{"cobra unknown shorthand flag", errors.New(`unknown shorthand flag: 'x' in -x`), exitcodes.Usage},
 		{"cobra accepts at most", errors.New(`accepts at most 1 arg(s), received 2`), exitcodes.Usage},
+		{"cobra accepts exact (ExactArgs)", errors.New(`accepts 1 arg(s), received 0`), exitcodes.Usage},
+		{"cobra accepts between (RangeArgs)", errors.New(`accepts between 1 and 2 arg(s), received 3`), exitcodes.Usage},
+		{"cobra requires at least (MinimumNArgs)", errors.New(`requires at least 1 arg(s), only received 0`), exitcodes.Usage},
 		{"cobra required flag(s)", errors.New(`required flag(s) "name" not set`), exitcodes.Usage},
 
 		// PersistentPreRunE format validation

--- a/internal/commands/mcr/mcr_actions_manage.go
+++ b/internal/commands/mcr/mcr_actions_manage.go
@@ -63,6 +63,7 @@ func DeleteMCR(cmd *cobra.Command, args []string, noColor bool) error {
 		output.PrintResourceDeleted("MCR", mcrUID, true, noColor)
 	} else {
 		output.PrintError("MCR deletion request was not successful", noColor)
+		return fmt.Errorf("MCR deletion request was not successful")
 	}
 
 	return nil
@@ -94,6 +95,7 @@ func RestoreMCR(cmd *cobra.Command, args []string, noColor bool) error {
 		output.PrintSuccess("MCR %s restored successfully", noColor, mcrUID)
 	} else {
 		output.PrintError("MCR restoration request was not successful", noColor)
+		return fmt.Errorf("MCR restoration request was not successful")
 	}
 
 	return nil

--- a/internal/commands/mcr/mcr_actions_prefix_filter.go
+++ b/internal/commands/mcr/mcr_actions_prefix_filter.go
@@ -151,6 +151,7 @@ func UpdateMCRPrefixFilterList(cmd *cobra.Command, args []string, noColor bool) 
 		output.PrintSuccess("Prefix filter list updated successfully - ID: %d", noColor, prefixFilterListID)
 	} else {
 		output.PrintError("Prefix filter list update request was not successful", noColor)
+		return fmt.Errorf("prefix filter list update request was not successful")
 	}
 	return nil
 }
@@ -257,6 +258,7 @@ func DeleteMCRPrefixFilterList(cmd *cobra.Command, args []string, noColor bool) 
 		output.PrintSuccess("Prefix filter list deleted successfully - ID: %d", noColor, prefixFilterListID)
 	} else {
 		output.PrintError("Prefix filter list deletion request was not successful", noColor)
+		return fmt.Errorf("prefix filter list deletion request was not successful")
 	}
 
 	return nil

--- a/internal/commands/mcr/mcr_actions_test.go
+++ b/internal/commands/mcr/mcr_actions_test.go
@@ -183,6 +183,18 @@ func TestDeleteMCRCmd_WithMockClient(t *testing.T) {
 			expectDeleted:  true,
 		},
 		{
+			name:  "deletion unsuccessful",
+			mcrID: "mcr-fail",
+			force: true,
+			setupMock: func(m *MockMCRService) {
+				m.DeleteMCRResult = &megaport.DeleteMCRResponse{
+					IsDeleting: false,
+				}
+			},
+			expectedError: "MCR deletion request was not successful",
+			expectDeleted: false,
+		},
+		{
 			name:           "cancel deletion",
 			mcrID:          "mcr-keep",
 			force:          false,
@@ -304,7 +316,7 @@ func TestRestoreMCRCmd_WithMockClient(t *testing.T) {
 					IsRestored: false,
 				}
 			},
-			expectedOut: "MCR restoration request was not successful",
+			expectedError: "MCR restoration request was not successful",
 		},
 	}
 
@@ -620,6 +632,19 @@ func TestDeleteMCRPrefixFilterListCmd_WithMockClient(t *testing.T) {
 				m.DeleteMCRPrefixFilterListErr = fmt.Errorf("API error: service unavailable")
 			},
 			expectedError: "API error: service unavailable",
+		},
+		{
+			name:           "deletion unsuccessful",
+			mcrUID:         "mcr-123",
+			prefixListID:   1,
+			force:          false,
+			promptResponse: "y",
+			setupMock: func(m *MockMCRService) {
+				m.DeleteMCRPrefixFilterListResult = &megaport.DeleteMCRPrefixFilterListResponse{
+					IsDeleted: false,
+				}
+			},
+			expectedError: "prefix filter list deletion request was not successful",
 		},
 	}
 
@@ -2336,6 +2361,38 @@ func TestUpdateMCRPrefixFilterList(t *testing.T) {
 				}
 			},
 			expectedError: "API error: update failed",
+		},
+		{
+			name: "update unsuccessful",
+			args: []string{"mcr-123", "456"},
+			flags: map[string]string{
+				"description": "Updated Prefix List",
+			},
+			setupLogin: func() {
+				config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+					client := &megaport.Client{}
+					client.MCRService = &MockMCRService{}
+					return client, nil
+				})
+			},
+			setupGetPrefixFL: func() {
+				getMCRPrefixFilterListFunc = func(ctx context.Context, client *megaport.Client, mcrUID string, prefixFilterListID int) (*megaport.MCRPrefixFilterList, error) {
+					return &megaport.MCRPrefixFilterList{
+						ID:            456,
+						Description:   "Original Prefix List",
+						AddressFamily: "IPv4",
+						Entries: []*megaport.MCRPrefixListEntry{
+							{Action: "permit", Prefix: "10.0.0.0/8"},
+						},
+					}, nil
+				}
+			},
+			setupModify: func() {
+				modifyMCRPrefixFilterListFunc = func(ctx context.Context, client *megaport.Client, mcrID string, prefixFilterListID int, prefixFilterList *megaport.MCRPrefixFilterList) (*megaport.ModifyMCRPrefixFilterListResponse, error) {
+					return &megaport.ModifyMCRPrefixFilterListResponse{IsUpdated: false}, nil
+				}
+			},
+			expectedError: "prefix filter list update request was not successful",
 		},
 	}
 

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -569,7 +569,8 @@ func DeleteMVE(cmd *cobra.Command, args []string, noColor bool) error {
 	if resp.IsDeleted {
 		output.PrintResourceDeleted("MVE", mveUID, true, noColor)
 	} else {
-		output.PrintWarning("MVE delete failed", noColor)
+		output.PrintError("MVE deletion request was not successful", noColor)
+		return fmt.Errorf("MVE deletion request was not successful")
 	}
 	return nil
 }

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -342,7 +342,7 @@ func UpdateMVE(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	if !resp.MVEUpdated {
-		output.PrintWarning("MVE update request was not successful", noColor)
+		output.PrintError("MVE update request was not successful", noColor)
 		return fmt.Errorf("MVE update request was not successful")
 	}
 

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -586,6 +586,16 @@ func TestDeleteMVE(t *testing.T) {
 			expectedError: "deletion failed",
 		},
 		{
+			name: "deletion unsuccessful",
+			mockSetup: func(m *MockMVEService) {
+				m.DeleteMVEResult = &megaport.DeleteMVEResponse{
+					IsDeleted: false,
+				}
+			},
+			confirmDelete: true,
+			expectedError: "MVE deletion request was not successful",
+		},
+		{
 			name: "deletion cancelled",
 			mockSetup: func(m *MockMVEService) {
 			},

--- a/internal/commands/ports/ports_actions_manage.go
+++ b/internal/commands/ports/ports_actions_manage.go
@@ -164,7 +164,8 @@ func DeletePort(cmd *cobra.Command, args []string, noColor bool) error {
 	if resp.IsDeleting {
 		output.PrintResourceDeleted("Port", portUID, true, noColor)
 	} else {
-		output.PrintWarning("Port deletion request was not successful", noColor)
+		output.PrintError("Port deletion request was not successful", noColor)
+		return fmt.Errorf("port deletion request was not successful")
 	}
 	return nil
 }
@@ -199,7 +200,8 @@ func RestorePort(cmd *cobra.Command, args []string, noColor bool) error {
 	if resp.IsRestored {
 		output.PrintInfo("Port %s restored successfully", noColor, formattedUID)
 	} else {
-		output.PrintWarning("Port restoration request was not successful", noColor)
+		output.PrintError("Port restoration request was not successful", noColor)
+		return fmt.Errorf("port restoration request was not successful")
 	}
 	return nil
 }
@@ -234,7 +236,8 @@ func LockPort(cmd *cobra.Command, args []string, noColor bool) error {
 	if resp.IsLocking {
 		output.PrintInfo("Port %s locked successfully", noColor, formattedUID)
 	} else {
-		output.PrintWarning("Port lock request was not successful", noColor)
+		output.PrintError("Port lock request was not successful", noColor)
+		return fmt.Errorf("port lock request was not successful")
 	}
 	return nil
 }
@@ -269,7 +272,8 @@ func UnlockPort(cmd *cobra.Command, args []string, noColor bool) error {
 	if resp.IsUnlocking {
 		output.PrintInfo("Port %s unlocked successfully", noColor, formattedUID)
 	} else {
-		output.PrintWarning("Port unlock request was not successful", noColor)
+		output.PrintError("Port unlock request was not successful", noColor)
+		return fmt.Errorf("port unlock request was not successful")
 	}
 	return nil
 }

--- a/internal/commands/ports/ports_actions_test.go
+++ b/internal/commands/ports/ports_actions_test.go
@@ -1098,6 +1098,12 @@ func TestRestorePort(t *testing.T) {
 			expectedError: "restore service unavailable",
 		},
 		{
+			name:          "unsuccessful",
+			portUID:       "port-restore-fail",
+			restoreResp:   &megaport.RestorePortResponse{IsRestored: false},
+			expectedError: "restoration request was not successful",
+		},
+		{
 			name:          "login error",
 			portUID:       "port-restore-login",
 			loginErr:      fmt.Errorf("authentication failed"),
@@ -1181,6 +1187,12 @@ func TestLockPort(t *testing.T) {
 			expectedError: "lock service unavailable",
 		},
 		{
+			name:          "unsuccessful",
+			portUID:       "port-lock-fail",
+			lockResp:      &megaport.LockPortResponse{IsLocking: false},
+			expectedError: "lock request was not successful",
+		},
+		{
 			name:          "login error",
 			portUID:       "port-lock-login",
 			loginErr:      fmt.Errorf("invalid token"),
@@ -1262,6 +1274,12 @@ func TestUnlockPort(t *testing.T) {
 			portUID:       "port-unlock-err",
 			unlockErr:     fmt.Errorf("unlock service unavailable"),
 			expectedError: "unlock service unavailable",
+		},
+		{
+			name:          "unsuccessful",
+			portUID:       "port-unlock-fail",
+			unlockResp:    &megaport.UnlockPortResponse{IsUnlocking: false},
+			expectedError: "unlock request was not successful",
 		},
 		{
 			name:          "login error",
@@ -2159,10 +2177,10 @@ func TestDeletePort_Comprehensive(t *testing.T) {
 			expectedError: "API failure",
 		},
 		{
-			name:             "delete returns not deleting",
-			force:            true,
-			isDeleting:       false,
-			expectedContains: "not successful",
+			name:          "delete returns not deleting",
+			force:         true,
+			isDeleting:    false,
+			expectedError: "not successful",
 		},
 	}
 


### PR DESCRIPTION
Failed mutations were exiting 0 and usage errors were exiting 1 instead of 2, both of which break scripting against the CLI.

- Port delete/restore/lock/unlock, MCR delete/restore, MCR prefix-filter update/delete, and MVE delete now return a non-nil error when the API reports the request was not successful, so they exit non-zero instead of 0.
- `isCobraUsageError` now recognizes cobra's `ExactArgs` and `MinimumNArgs` messages (matched on the shared `arg(s), received` / `arg(s), only received` substrings), so `megaport-cli ports get` with no args exits 2.
- Tests assert the error return for each touched action and the new usage-error classifications.

ESD-1420
