### PR TITLE
feat: register nat-gateway module in WASM build

### DIFF
--- a/cmd/megaport/modules_wasm.go
+++ b/cmd/megaport/modules_wasm.go
@@ -6,6 +6,7 @@ import (
 	"github.com/megaport/megaport-cli/internal/commands/locations"
 	"github.com/megaport/megaport-cli/internal/commands/mcr"
 	"github.com/megaport/megaport-cli/internal/commands/mve"
+	"github.com/megaport/megaport-cli/internal/commands/nat_gateway"
 	"github.com/megaport/megaport-cli/internal/commands/partners"
 	"github.com/megaport/megaport-cli/internal/commands/ports"
 	"github.com/megaport/megaport-cli/internal/commands/servicekeys"
@@ -25,6 +26,7 @@ func registerModules() {
 	moduleRegistry.Register(vxc.NewModule())
 	moduleRegistry.Register(mcr.NewModule())
 	moduleRegistry.Register(mve.NewModule())
+	moduleRegistry.Register(nat_gateway.NewModule())
 	moduleRegistry.Register(locations.NewModule())
 	moduleRegistry.Register(partners.NewModule())
 	moduleRegistry.Register(servicekeys.NewModule())

--- a/cmd/megaport/nat_gateway_wasm_test.go
+++ b/cmd/megaport/nat_gateway_wasm_test.go
@@ -1,0 +1,40 @@
+//go:build js && wasm
+
+package megaport
+
+import (
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/wasm"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNATGatewayModuleRegistered verifies the nat-gateway module is wired into
+// the WASM command tree (ESD-1284). Each command is invoked with --help so no
+// network call is made; an unregistered command would instead surface an
+// "unknown command" error. Cases are help-only by design so they share the
+// global rootCmd without leaking flag state between subtests.
+func TestNATGatewayModuleRegistered(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		// usage is the command path cobra echoes in the "Usage:" block; it
+		// tracks the command structure rather than drift-prone help prose.
+		usage string
+	}{
+		{"nat-gateway", []string{"megaport-cli", "nat-gateway", "--help"}, "megaport-cli nat-gateway"},
+		{"list", []string{"megaport-cli", "nat-gateway", "list", "--help"}, "megaport-cli nat-gateway list"},
+		{"get", []string{"megaport-cli", "nat-gateway", "get", "--help"}, "megaport-cli nat-gateway get"},
+		{"list-sessions", []string{"megaport-cli", "nat-gateway", "list-sessions", "--help"}, "megaport-cli nat-gateway list-sessions"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wasm.ResetOutputBuffers()
+			ExecuteWithArgs(tc.args)
+			out := wasm.GetCapturedOutput()
+			assert.NotContains(t, out, "unknown command", "%v should be a registered command", tc.args)
+			assert.Contains(t, out, tc.usage, "%v help should show its usage path", tc.args)
+		})
+	}
+}


### PR DESCRIPTION
Registers the `nat-gateway` module in the WASM build so the full NAT Gateway command set is available in the browser, matching the native CLI.

The module already uses the standard overridable func-pointer pattern calling the SDK directly, with no filesystem, `os/exec`, or build-tag dependencies, so this is register-and-go. No `nat_gateway_actions_wasm.go` override was needed.

- Add `nat_gateway.NewModule()` to `registerModules()` in `modules_wasm.go`.
- Add a `js,wasm` smoke test asserting `nat-gateway`, `list`, `get`, and `list-sessions` resolve in the WASM command tree.

Verified against Staging via the native binary (same SDK func-pointer paths the WASM build uses): `list`, `get`, `list-sessions` return real data; `telemetry` renders both json and table (no samples on the test gateway); `validate`/`create`/`buy`/`update`/`delete` are wired. The js/wasm build compiles clean.

ESD-1284