### PR TITLE
fix(output): empty list results emit valid json/csv/xml; accept uppercase --output

### DIFF
--- a/internal/commands/config/config_actions.go
+++ b/internal/commands/config/config_actions.go
@@ -229,7 +229,7 @@ func ListProfiles(cmd *cobra.Command, args []string, noColor bool, outputFormat 
 		})
 	}
 
-	if len(profileOutputs) == 0 {
+	if len(profileOutputs) == 0 && outputFormat == utils.FormatTable {
 		output.PrintInfo("No profiles found", noColor)
 		return nil
 	}

--- a/internal/commands/config/config_actions_test.go
+++ b/internal/commands/config/config_actions_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/megaport/megaport-cli/internal/base/output"
@@ -253,6 +254,29 @@ func TestListProfiles_MasksAccessKey(t *testing.T) {
 
 	assert.NotContains(t, listOutput, "my-secret-access-key-12345", "full access key should not appear in list output")
 	assert.Contains(t, listOutput, "my-s...2345", "masked access key should appear in list output")
+}
+
+func TestListProfiles_Empty(t *testing.T) {
+	t.Run("table prints info message", func(t *testing.T) {
+		setupTestConfigEnv(t)
+		out, err := captureOutputFromAction(func() error {
+			cmd, _ := setupTestCmd()
+			return ListProfiles(cmd, nil, true, "table")
+		})
+		require.NoError(t, err)
+		assert.Contains(t, out, "No profiles found")
+	})
+
+	t.Run("json emits empty array", func(t *testing.T) {
+		setupTestConfigEnv(t)
+		defer output.SetOutputFormat("table")
+		out, err := captureOutputFromAction(func() error {
+			cmd, _ := setupTestCmd()
+			return ListProfiles(cmd, nil, true, "json")
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "[]", strings.TrimSpace(out))
+	})
 }
 
 func TestDeleteProfile_CMD(t *testing.T) {

--- a/internal/commands/locations/locations_actions.go
+++ b/internal/commands/locations/locations_actions.go
@@ -67,26 +67,8 @@ func ListLocations(cmd *cobra.Command, args []string, noColor bool, outputFormat
 	filteredLocations := filterLocations(locations, filters)
 
 	limit, _ := cmd.Flags().GetInt("limit")
-	if limit < 0 {
-		return fmt.Errorf("--limit must be a non-negative integer")
-	}
-	if limit > 0 && len(filteredLocations) > limit {
-		filteredLocations = filteredLocations[:limit]
-	}
-
-	if len(filteredLocations) == 0 {
-		if outputFormat == utils.FormatTable {
-			output.PrintInfo("No locations found matching your filters.", noColor)
-		}
-		return nil
-	}
-
-	err = printLocations(filteredLocations, outputFormat, noColor)
-	if err != nil {
-		output.PrintError("Failed to print locations: %v", noColor, err)
-		return fmt.Errorf("failed to print locations: %w", err)
-	}
-	return nil
+	return utils.ApplyLimitAndPrint(filteredLocations, limit, outputFormat, noColor,
+		"No locations found matching your filters.", printLocations)
 }
 
 func ListCountries(cmd *cobra.Command, args []string, noColor bool, outputFormat string) error {

--- a/internal/commands/managed_account/managed_account_actions.go
+++ b/internal/commands/managed_account/managed_account_actions.go
@@ -38,26 +38,8 @@ func ListManagedAccounts(cmd *cobra.Command, args []string, noColor bool, output
 	filteredAccounts := filterManagedAccounts(accounts, accountName, accountRef)
 
 	limit, _ := cmd.Flags().GetInt("limit")
-	if limit < 0 {
-		return fmt.Errorf("--limit must be a non-negative integer")
-	}
-	if limit > 0 && len(filteredAccounts) > limit {
-		filteredAccounts = filteredAccounts[:limit]
-	}
-
-	if len(filteredAccounts) == 0 {
-		if outputFormat == utils.FormatTable {
-			output.PrintInfo("No managed accounts found.", noColor)
-		}
-		return nil
-	}
-
-	err = printManagedAccounts(filteredAccounts, outputFormat, noColor)
-	if err != nil {
-		output.PrintError("Failed to print managed accounts: %v", noColor, err)
-		return fmt.Errorf("failed to print managed accounts: %w", err)
-	}
-	return nil
+	return utils.ApplyLimitAndPrint(filteredAccounts, limit, outputFormat, noColor,
+		"No managed accounts found.", printManagedAccounts)
 }
 
 func GetManagedAccount(cmd *cobra.Command, args []string, noColor bool, outputFormat string) error {

--- a/internal/commands/nat_gateway/nat_gateway_actions.go
+++ b/internal/commands/nat_gateway/nat_gateway_actions.go
@@ -396,7 +396,7 @@ func ListNATGatewaySessions(cmd *cobra.Command, args []string, noColor bool, out
 		return fmt.Errorf("failed to list NAT Gateway sessions: %w", err)
 	}
 
-	if len(sessions) == 0 {
+	if len(sessions) == 0 && outputFormat == utils.FormatTable {
 		output.PrintInfo("No NAT Gateway session options found", noColor)
 		return nil
 	}

--- a/internal/commands/nat_gateway/nat_gateway_additional_test.go
+++ b/internal/commands/nat_gateway/nat_gateway_additional_test.go
@@ -156,6 +156,7 @@ func TestListNATGatewaySessions_Empty(t *testing.T) {
 	})
 
 	t.Run("json emits empty array", func(t *testing.T) {
+		defer output.SetOutputFormat("table")
 		cmd := newTestCmd("list-sessions")
 		out := output.CaptureOutput(func() {
 			assert.NoError(t, ListNATGatewaySessions(cmd, nil, true, "json"))

--- a/internal/commands/nat_gateway/nat_gateway_additional_test.go
+++ b/internal/commands/nat_gateway/nat_gateway_additional_test.go
@@ -3,8 +3,10 @@ package nat_gateway
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/testutil"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
@@ -145,9 +147,21 @@ func TestListNATGatewaySessions_Empty(t *testing.T) {
 	}
 	defer setupMockNATGateway(mock)()
 
-	cmd := newTestCmd("list-sessions")
-	err := ListNATGatewaySessions(cmd, nil, true, "table")
-	assert.NoError(t, err)
+	t.Run("table prints info message", func(t *testing.T) {
+		cmd := newTestCmd("list-sessions")
+		out := output.CaptureOutput(func() {
+			assert.NoError(t, ListNATGatewaySessions(cmd, nil, true, "table"))
+		})
+		assert.Contains(t, out, "No NAT Gateway session options found")
+	})
+
+	t.Run("json emits empty array", func(t *testing.T) {
+		cmd := newTestCmd("list-sessions")
+		out := output.CaptureOutput(func() {
+			assert.NoError(t, ListNATGatewaySessions(cmd, nil, true, "json"))
+		})
+		assert.Equal(t, "[]", strings.TrimSpace(out))
+	})
 }
 
 func TestListNATGateways_IncludeInactive(t *testing.T) {

--- a/internal/commands/partners/partners_actions.go
+++ b/internal/commands/partners/partners_actions.go
@@ -39,26 +39,8 @@ func ListPartners(cmd *cobra.Command, args []string, noColor bool, outputFormat 
 	filteredPartners := filterPartners(partners, productName, connectType, companyName, locationID, diversityZone)
 
 	limit, _ := cmd.Flags().GetInt("limit")
-	if limit < 0 {
-		return fmt.Errorf("--limit must be a non-negative integer")
-	}
-	if limit > 0 && len(filteredPartners) > limit {
-		filteredPartners = filteredPartners[:limit]
-	}
-
-	if len(filteredPartners) == 0 {
-		if outputFormat == utils.FormatTable {
-			output.PrintInfo("No partner ports found matching your filters.", noColor)
-		}
-		return nil
-	}
-
-	err = printPartnersFunc(filteredPartners, outputFormat, noColor)
-	if err != nil {
-		output.PrintError("Failed to print partner ports: %v", noColor, err)
-		return fmt.Errorf("failed to print partners: %w", err)
-	}
-	return nil
+	return utils.ApplyLimitAndPrint(filteredPartners, limit, outputFormat, noColor,
+		"No partner ports found matching your filters.", printPartnersFunc)
 }
 
 func FindPartners(cmd *cobra.Command, args []string, noColor bool) error {

--- a/internal/commands/product/product_actions.go
+++ b/internal/commands/product/product_actions.go
@@ -46,26 +46,8 @@ func ListProducts(cmd *cobra.Command, args []string, noColor bool, outputFormat 
 	filtered := filterProducts(products, includeInactive)
 
 	limit, _ := cmd.Flags().GetInt("limit")
-	if limit < 0 {
-		return fmt.Errorf("--limit must be a non-negative integer")
-	}
-	if limit > 0 && len(filtered) > limit {
-		filtered = filtered[:limit]
-	}
-
-	if len(filtered) == 0 {
-		if outputFormat == utils.FormatTable {
-			output.PrintInfo("No products found.", noColor)
-		}
-		return nil
-	}
-
-	err = printProducts(filtered, outputFormat, noColor)
-	if err != nil {
-		output.PrintError("Failed to print products: %v", noColor, err)
-		return fmt.Errorf("failed to print products: %w", err)
-	}
-	return nil
+	return utils.ApplyLimitAndPrint(filtered, limit, outputFormat, noColor,
+		"No products found.", printProducts)
 }
 
 func GetProductType(cmd *cobra.Command, args []string, noColor bool, outputFormat string) error {

--- a/internal/commands/servicekeys/servicekeys_actions.go
+++ b/internal/commands/servicekeys/servicekeys_actions.go
@@ -158,10 +158,8 @@ func ListServiceKeys(cmd *cobra.Command, args []string, noColor bool, outputForm
 		serviceKeys = serviceKeys[:limit]
 	}
 
-	if len(serviceKeys) == 0 {
-		if outputFormat == utils.FormatTable {
-			output.PrintInfo("No service keys found.", noColor)
-		}
+	if len(serviceKeys) == 0 && outputFormat == utils.FormatTable {
+		output.PrintInfo("No service keys found.", noColor)
 		return nil
 	}
 

--- a/internal/commands/servicekeys/servicekeys_actions_test.go
+++ b/internal/commands/servicekeys/servicekeys_actions_test.go
@@ -358,9 +358,10 @@ func TestListServiceKeys_EmptyResult(t *testing.T) {
 			expectedOutput: "No service keys found.",
 		},
 		{
-			name:         "json format returns empty array without message",
-			outputFormat: "json",
-			notExpected:  "No service keys found.",
+			name:           "json format returns empty array without message",
+			outputFormat:   "json",
+			expectedOutput: "[]",
+			notExpected:    "No service keys found.",
 		},
 	}
 

--- a/internal/utils/list.go
+++ b/internal/utils/list.go
@@ -9,8 +9,10 @@ import (
 // ApplyLimitAndPrint handles the common post-filter pipeline for all List
 // commands: validate and apply --limit, check for empty results, and print.
 //
-// Returns nil (no error) when items is empty. If outputFormat is table,
-// it also prints an informational message.
+// For table output an empty result prints a human-readable message instead of
+// an empty table. For machine formats (json/csv/xml/go-template) it always
+// calls printFunc so an empty result still emits a valid document ([] for json,
+// header-only or empty for csv, <items></items> for xml) rather than zero bytes.
 func ApplyLimitAndPrint[T any](
 	items []T,
 	limit int,
@@ -26,10 +28,8 @@ func ApplyLimitAndPrint[T any](
 		items = items[:limit]
 	}
 
-	if len(items) == 0 {
-		if outputFormat == FormatTable {
-			output.PrintInfo(emptyMessage, noColor)
-		}
+	if len(items) == 0 && outputFormat == FormatTable {
+		output.PrintInfo(emptyMessage, noColor)
 		return nil
 	}
 

--- a/internal/utils/list_test.go
+++ b/internal/utils/list_test.go
@@ -2,8 +2,10 @@ package utils
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,14 +40,29 @@ func TestApplyLimitAndPrint(t *testing.T) {
 		assert.Equal(t, []string{"a", "b", "c"}, printed)
 	})
 
-	t.Run("empty items prints info for table format", func(t *testing.T) {
-		err := ApplyLimitAndPrint([]string{}, 0, FormatTable, true, "No items found.", noop)
+	t.Run("empty items prints info and skips printFunc for table format", func(t *testing.T) {
+		called := false
+		err := ApplyLimitAndPrint([]string{}, 0, FormatTable, true, "No items found.",
+			func(items []string, format string, noColor bool) error {
+				called = true
+				return nil
+			})
 		assert.NoError(t, err)
+		assert.False(t, called, "printFunc must not be called for empty table output")
 	})
 
-	t.Run("empty items returns nil for non-table format", func(t *testing.T) {
-		err := ApplyLimitAndPrint([]string{}, 0, "json", true, "No items found.", noop)
-		assert.NoError(t, err)
+	t.Run("empty items still call printFunc for non-table formats", func(t *testing.T) {
+		for _, format := range []string{FormatJSON, FormatCSV, FormatXML} {
+			called := false
+			err := ApplyLimitAndPrint([]string{}, 0, format, true, "No items found.",
+				func(items []string, f string, noColor bool) error {
+					called = true
+					assert.Empty(t, items)
+					return nil
+				})
+			assert.NoError(t, err)
+			assert.True(t, called, "printFunc must be called for empty %s output", format)
+		}
 	})
 
 	t.Run("propagates print error", func(t *testing.T) {
@@ -71,5 +88,47 @@ func TestApplyLimitAndPrint(t *testing.T) {
 	t.Run("nil slice behaves like empty", func(t *testing.T) {
 		err := ApplyLimitAndPrint[string](nil, 0, FormatTable, true, "No items.", noop)
 		assert.NoError(t, err)
+	})
+}
+
+type listItem struct {
+	UID  string `json:"uid" header:"UID" csv:"uid"`
+	Name string `json:"name" header:"Name" csv:"name"`
+}
+
+// TestApplyLimitAndPrint_EmptyOutputPerFormat verifies an empty result still
+// emits a valid document for the machine formats instead of zero bytes.
+func TestApplyLimitAndPrint_EmptyOutputPerFormat(t *testing.T) {
+	printItems := func(items []listItem, format string, noColor bool) error {
+		return output.PrintOutput(items, format, noColor)
+	}
+
+	t.Run("json emits empty array", func(t *testing.T) {
+		out := output.CaptureOutput(func() {
+			assert.NoError(t, ApplyLimitAndPrint([]listItem{}, 0, FormatJSON, true, "none", printItems))
+		})
+		assert.Equal(t, "[]", strings.TrimSpace(out))
+	})
+
+	t.Run("csv emits header only", func(t *testing.T) {
+		out := output.CaptureOutput(func() {
+			assert.NoError(t, ApplyLimitAndPrint([]listItem{}, 0, FormatCSV, true, "none", printItems))
+		})
+		assert.Equal(t, "uid,name", strings.TrimSpace(out))
+	})
+
+	t.Run("xml emits empty document", func(t *testing.T) {
+		out := output.CaptureOutput(func() {
+			assert.NoError(t, ApplyLimitAndPrint([]listItem{}, 0, FormatXML, true, "none", printItems))
+		})
+		assert.NotEmpty(t, strings.TrimSpace(out))
+		assert.Contains(t, out, "<items>")
+	})
+
+	t.Run("table prints info message and no document", func(t *testing.T) {
+		out := output.CaptureOutput(func() {
+			assert.NoError(t, ApplyLimitAndPrint([]listItem{}, 0, FormatTable, true, "No items found.", printItems))
+		})
+		assert.Contains(t, out, "No items found.")
 	})
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -241,10 +241,13 @@ func WrapOutputFormatRunE(fn func(cmd *cobra.Command, args []string, noColor boo
 		}
 
 		// Get output format value from command
-		format, err := cmd.Flags().GetString("output")
+		rawFormat, err := cmd.Flags().GetString("output")
 		if err != nil {
-			format = FormatTable // Default to table format if flag not found
+			rawFormat = FormatTable // Default to table format if flag not found
 		}
+		// Lowercase to match WrapRunE / root PersistentPreRunE, so "--output JSON"
+		// is accepted everywhere "--output json" is.
+		format := strings.ToLower(rawFormat)
 
 		// Validate format
 		validFormat := false

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/megaport/megaport-cli/internal/base/exitcodes"
@@ -452,6 +453,29 @@ func TestWrapOutputFormatRunE(t *testing.T) {
 		var cliErr *exitcodes.CLIError
 		require.True(t, errors.As(err, &cliErr))
 		assert.Equal(t, exitcodes.Usage, cliErr.Code)
+	})
+
+	t.Run("uppercase output format is accepted and lowercased", func(t *testing.T) {
+		for _, raw := range []string{"JSON", "Json", "CSV", "XML", "Table"} {
+			var capturedFormat string
+			wrapped := WrapOutputFormatRunE(func(cmd *cobra.Command, args []string, noColor bool, format string) error {
+				capturedFormat = format
+				return nil
+			})
+
+			root := &cobra.Command{Use: "root"}
+			root.PersistentFlags().Bool("no-color", false, "")
+			root.PersistentFlags().String("fields", "", "")
+			root.PersistentFlags().String("query", "", "")
+			root.PersistentFlags().String("template", "", "")
+			child := &cobra.Command{Use: "list"}
+			child.Flags().String("output", raw, "")
+			root.AddCommand(child)
+
+			err := wrapped(child, []string{})
+			assert.NoError(t, err, "format %q should be accepted", raw)
+			assert.Equal(t, strings.ToLower(raw), capturedFormat, "format %q should be lowercased", raw)
+		}
 	})
 }
 


### PR DESCRIPTION
Two output-contract fixes in the shared list helpers, both with outsized scripting impact.

- `ApplyLimitAndPrint` now always calls the print function for non-table formats when the result is empty, so `list --output json` emits `[]` (csv a header row, xml an empty document) instead of zero bytes. The table path keeps its human "No X found" message.
- Consolidate the three remaining inline copies of the empty-check pattern (product, partners, locations) onto `ApplyLimitAndPrint`.
- `WrapOutputFormatRunE` now lowercases the `--output` value before validating, so `--output JSON` / `Json` is accepted everywhere `--output json` is. Matches what `WrapRunE` and the root pre-run already do.

Tests cover empty-slice output per format (json/csv/xml/table) and case-insensitive format validation.

Fixes ESD-1498.
