### PR TITLE
fix: return errors on failed mutations and fix usage exit code (ESD-1497)

### DIFF
--- a/cmd/megaport/megaport.go
+++ b/cmd/megaport/megaport.go
@@ -313,9 +313,9 @@ func isCobraUsageError(msg string) bool {
 		"unknown command",
 		"unknown flag",
 		"unknown shorthand flag",
-		"accepts between",
-		"accepts at most",
-		"accepts at least",
+		// Covers every cobra arg-count validator: ExactArgs, MinimumNArgs,
+		// MaximumNArgs, and RangeArgs all phrase their error as "... arg(s) ...".
+		"arg(s)",
 		"required flag(s)",
 	}
 	for _, p := range cobraPatterns {

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/commands/config"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -232,6 +233,8 @@ func TestExitCodeFromError(t *testing.T) {
 		{"cobra unknown flag", errors.New(`unknown flag: --bogus`), exitcodes.Usage},
 		{"cobra unknown shorthand flag", errors.New(`unknown shorthand flag: 'x' in -x`), exitcodes.Usage},
 		{"cobra accepts at most", errors.New(`accepts at most 1 arg(s), received 2`), exitcodes.Usage},
+		{"cobra exact args", errors.New(`accepts 1 arg(s), received 0`), exitcodes.Usage},
+		{"cobra minimum n args", errors.New(`requires at least 2 arg(s), only received 1`), exitcodes.Usage},
 		{"cobra required flag(s)", errors.New(`required flag(s) "name" not set`), exitcodes.Usage},
 
 		// PersistentPreRunE format validation
@@ -244,6 +247,38 @@ func TestExitCodeFromError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.wantCode, exitCodeFromError(tt.err))
+		})
+	}
+}
+
+// TestExitCodeFromError_CobraArgValidators drives cobra's own argument
+// validators so the asserted exit code is checked against the exact error
+// strings cobra produces, not a hand-copied approximation.
+func TestExitCodeFromError_CobraArgValidators(t *testing.T) {
+	tests := []struct {
+		name string
+		args cobra.PositionalArgs
+		argv []string
+	}{
+		{"ExactArgs too few", cobra.ExactArgs(1), []string{}},
+		{"ExactArgs too many", cobra.ExactArgs(1), []string{"a", "b"}},
+		{"MinimumNArgs", cobra.MinimumNArgs(2), []string{"a"}},
+		{"MaximumNArgs", cobra.MaximumNArgs(1), []string{"a", "b"}},
+		{"RangeArgs", cobra.RangeArgs(1, 2), []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{
+				Use:           "get",
+				Args:          tt.args,
+				RunE:          func(cmd *cobra.Command, args []string) error { return nil },
+				SilenceUsage:  true,
+				SilenceErrors: true,
+			}
+			cmd.SetArgs(tt.argv)
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Equal(t, exitcodes.Usage, exitCodeFromError(err), "cobra error: %v", err)
 		})
 	}
 }

--- a/internal/commands/mcr/mcr_actions_manage.go
+++ b/internal/commands/mcr/mcr_actions_manage.go
@@ -59,12 +59,12 @@ func DeleteMCR(cmd *cobra.Command, args []string, noColor bool) error {
 		return fmt.Errorf("failed to delete MCR: %w", err)
 	}
 
-	if resp.IsDeleting {
-		output.PrintResourceDeleted("MCR", mcrUID, true, noColor)
-	} else {
-		output.PrintError("MCR deletion request was not successful", noColor)
+	if !resp.IsDeleting {
+		output.PrintError("MCR deletion request was not successful for %s", noColor, mcrUID)
+		return fmt.Errorf("MCR deletion request was not successful for %s", mcrUID)
 	}
 
+	output.PrintResourceDeleted("MCR", mcrUID, true, noColor)
 	return nil
 }
 
@@ -90,12 +90,12 @@ func RestoreMCR(cmd *cobra.Command, args []string, noColor bool) error {
 		return fmt.Errorf("failed to restore MCR: %w", err)
 	}
 
-	if resp.IsRestored {
-		output.PrintSuccess("MCR %s restored successfully", noColor, mcrUID)
-	} else {
-		output.PrintError("MCR restoration request was not successful", noColor)
+	if !resp.IsRestored {
+		output.PrintError("MCR restoration request was not successful for %s", noColor, mcrUID)
+		return fmt.Errorf("MCR restoration request was not successful for %s", mcrUID)
 	}
 
+	output.PrintSuccess("MCR %s restored successfully", noColor, mcrUID)
 	return nil
 }
 

--- a/internal/commands/mcr/mcr_actions_prefix_filter.go
+++ b/internal/commands/mcr/mcr_actions_prefix_filter.go
@@ -147,11 +147,12 @@ func UpdateMCRPrefixFilterList(cmd *cobra.Command, args []string, noColor bool) 
 		return err
 	}
 
-	if resp.IsUpdated {
-		output.PrintSuccess("Prefix filter list updated successfully - ID: %d", noColor, prefixFilterListID)
-	} else {
-		output.PrintError("Prefix filter list update request was not successful", noColor)
+	if !resp.IsUpdated {
+		output.PrintError("Prefix filter list update request was not successful for ID %d", noColor, prefixFilterListID)
+		return fmt.Errorf("prefix filter list update request was not successful for ID %d", prefixFilterListID)
 	}
+
+	output.PrintSuccess("Prefix filter list updated successfully - ID: %d", noColor, prefixFilterListID)
 	return nil
 }
 
@@ -253,11 +254,11 @@ func DeleteMCRPrefixFilterList(cmd *cobra.Command, args []string, noColor bool) 
 		return fmt.Errorf("failed to delete prefix filter list: %w", err)
 	}
 
-	if resp.IsDeleted {
-		output.PrintSuccess("Prefix filter list deleted successfully - ID: %d", noColor, prefixFilterListID)
-	} else {
-		output.PrintError("Prefix filter list deletion request was not successful", noColor)
+	if !resp.IsDeleted {
+		output.PrintError("Prefix filter list deletion request was not successful for ID %d", noColor, prefixFilterListID)
+		return fmt.Errorf("prefix filter list deletion request was not successful for ID %d", prefixFilterListID)
 	}
 
+	output.PrintSuccess("Prefix filter list deleted successfully - ID: %d", noColor, prefixFilterListID)
 	return nil
 }

--- a/internal/commands/mcr/mcr_actions_test.go
+++ b/internal/commands/mcr/mcr_actions_test.go
@@ -202,6 +202,18 @@ func TestDeleteMCRCmd_WithMockClient(t *testing.T) {
 			expectedError: "failed to delete MCR",
 			expectDeleted: false,
 		},
+		{
+			name:  "deletion not successful",
+			mcrID: "mcr-not-deleting",
+			force: true,
+			setupMock: func(m *MockMCRService) {
+				m.DeleteMCRResult = &megaport.DeleteMCRResponse{
+					IsDeleting: false,
+				}
+			},
+			expectedError: "not successful",
+			expectDeleted: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -304,7 +316,7 @@ func TestRestoreMCRCmd_WithMockClient(t *testing.T) {
 					IsRestored: false,
 				}
 			},
-			expectedOut: "MCR restoration request was not successful",
+			expectedError: "not successful",
 		},
 	}
 
@@ -620,6 +632,19 @@ func TestDeleteMCRPrefixFilterListCmd_WithMockClient(t *testing.T) {
 				m.DeleteMCRPrefixFilterListErr = fmt.Errorf("API error: service unavailable")
 			},
 			expectedError: "API error: service unavailable",
+		},
+		{
+			name:           "not successful",
+			mcrUID:         "mcr-123",
+			prefixListID:   1,
+			force:          true,
+			promptResponse: "y",
+			setupMock: func(m *MockMCRService) {
+				m.DeleteMCRPrefixFilterListResult = &megaport.DeleteMCRPrefixFilterListResponse{
+					IsDeleted: false,
+				}
+			},
+			expectedError: "not successful",
 		},
 	}
 
@@ -2336,6 +2361,38 @@ func TestUpdateMCRPrefixFilterList(t *testing.T) {
 				}
 			},
 			expectedError: "API error: update failed",
+		},
+		{
+			name: "not successful",
+			args: []string{"mcr-123", "456"},
+			flags: map[string]string{
+				"description": "Updated Prefix List",
+			},
+			setupLogin: func() {
+				config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+					client := &megaport.Client{}
+					client.MCRService = &MockMCRService{}
+					return client, nil
+				})
+			},
+			setupGetPrefixFL: func() {
+				getMCRPrefixFilterListFunc = func(ctx context.Context, client *megaport.Client, mcrUID string, prefixFilterListID int) (*megaport.MCRPrefixFilterList, error) {
+					return &megaport.MCRPrefixFilterList{
+						ID:            456,
+						Description:   "Original Prefix List",
+						AddressFamily: "IPv4",
+						Entries: []*megaport.MCRPrefixListEntry{
+							{Action: "permit", Prefix: "10.0.0.0/8"},
+						},
+					}, nil
+				}
+			},
+			setupModify: func() {
+				modifyMCRPrefixFilterListFunc = func(ctx context.Context, client *megaport.Client, mcrID string, prefixFilterListID int, prefixFilterList *megaport.MCRPrefixFilterList) (*megaport.ModifyMCRPrefixFilterListResponse, error) {
+					return &megaport.ModifyMCRPrefixFilterListResponse{IsUpdated: false}, nil
+				}
+			},
+			expectedError: "not successful",
 		},
 	}
 

--- a/internal/commands/mcr/mcr_actions_test.go
+++ b/internal/commands/mcr/mcr_actions_test.go
@@ -211,7 +211,7 @@ func TestDeleteMCRCmd_WithMockClient(t *testing.T) {
 					IsDeleting: false,
 				}
 			},
-			expectedError: "not successful",
+			expectedError: "not successful for mcr-not-deleting",
 			expectDeleted: false,
 		},
 	}
@@ -316,7 +316,7 @@ func TestRestoreMCRCmd_WithMockClient(t *testing.T) {
 					IsRestored: false,
 				}
 			},
-			expectedError: "not successful",
+			expectedError: "not successful for mcr-fail",
 		},
 	}
 
@@ -644,7 +644,7 @@ func TestDeleteMCRPrefixFilterListCmd_WithMockClient(t *testing.T) {
 					IsDeleted: false,
 				}
 			},
-			expectedError: "not successful",
+			expectedError: "not successful for ID 1",
 		},
 	}
 
@@ -2392,7 +2392,7 @@ func TestUpdateMCRPrefixFilterList(t *testing.T) {
 					return &megaport.ModifyMCRPrefixFilterListResponse{IsUpdated: false}, nil
 				}
 			},
-			expectedError: "not successful",
+			expectedError: "not successful for ID 456",
 		},
 	}
 

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -566,11 +566,12 @@ func DeleteMVE(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	// MVEs always delete immediately (SDK hardcodes DeleteNow: true).
-	if resp.IsDeleted {
-		output.PrintResourceDeleted("MVE", mveUID, true, noColor)
-	} else {
-		output.PrintWarning("MVE delete failed", noColor)
+	if !resp.IsDeleted {
+		output.PrintError("MVE deletion request was not successful for %s", noColor, mveUID)
+		return fmt.Errorf("MVE deletion request was not successful for %s", mveUID)
 	}
+
+	output.PrintResourceDeleted("MVE", mveUID, true, noColor)
 	return nil
 }
 

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -616,7 +616,7 @@ func TestDeleteMVE(t *testing.T) {
 				}
 			},
 			forceFlag:     true,
-			expectedError: "not successful",
+			expectedError: "not successful for mve-uid",
 		},
 	}
 

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -608,6 +608,16 @@ func TestDeleteMVE(t *testing.T) {
 			forceFlag:     true,
 			expectedError: "empty response from API",
 		},
+		{
+			name: "delete not successful",
+			mockSetup: func(m *MockMVEService) {
+				m.DeleteMVEResult = &megaport.DeleteMVEResponse{
+					IsDeleted: false,
+				}
+			},
+			forceFlag:     true,
+			expectedError: "not successful",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/commands/ports/ports_actions_manage.go
+++ b/internal/commands/ports/ports_actions_manage.go
@@ -198,7 +198,7 @@ func RestorePort(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	if !resp.IsRestored {
-		output.PrintError("Port restoration request was not successful for %s", noColor, formattedUID)
+		output.PrintError("Port restoration request was not successful for %s", noColor, portUID)
 		return fmt.Errorf("port restoration request was not successful for %s", portUID)
 	}
 
@@ -234,7 +234,7 @@ func LockPort(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	if !resp.IsLocking {
-		output.PrintError("Port lock request was not successful for %s", noColor, formattedUID)
+		output.PrintError("Port lock request was not successful for %s", noColor, portUID)
 		return fmt.Errorf("port lock request was not successful for %s", portUID)
 	}
 
@@ -270,7 +270,7 @@ func UnlockPort(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	if !resp.IsUnlocking {
-		output.PrintError("Port unlock request was not successful for %s", noColor, formattedUID)
+		output.PrintError("Port unlock request was not successful for %s", noColor, portUID)
 		return fmt.Errorf("port unlock request was not successful for %s", portUID)
 	}
 

--- a/internal/commands/ports/ports_actions_manage.go
+++ b/internal/commands/ports/ports_actions_manage.go
@@ -161,11 +161,12 @@ func DeletePort(cmd *cobra.Command, args []string, noColor bool) error {
 		return err
 	}
 
-	if resp.IsDeleting {
-		output.PrintResourceDeleted("Port", portUID, true, noColor)
-	} else {
-		output.PrintWarning("Port deletion request was not successful", noColor)
+	if !resp.IsDeleting {
+		output.PrintError("Port deletion request was not successful for %s", noColor, portUID)
+		return fmt.Errorf("port deletion request was not successful for %s", portUID)
 	}
+
+	output.PrintResourceDeleted("Port", portUID, true, noColor)
 	return nil
 }
 
@@ -196,11 +197,12 @@ func RestorePort(cmd *cobra.Command, args []string, noColor bool) error {
 		return err
 	}
 
-	if resp.IsRestored {
-		output.PrintInfo("Port %s restored successfully", noColor, formattedUID)
-	} else {
-		output.PrintWarning("Port restoration request was not successful", noColor)
+	if !resp.IsRestored {
+		output.PrintError("Port restoration request was not successful for %s", noColor, formattedUID)
+		return fmt.Errorf("port restoration request was not successful for %s", portUID)
 	}
+
+	output.PrintInfo("Port %s restored successfully", noColor, formattedUID)
 	return nil
 }
 
@@ -231,11 +233,12 @@ func LockPort(cmd *cobra.Command, args []string, noColor bool) error {
 		return err
 	}
 
-	if resp.IsLocking {
-		output.PrintInfo("Port %s locked successfully", noColor, formattedUID)
-	} else {
-		output.PrintWarning("Port lock request was not successful", noColor)
+	if !resp.IsLocking {
+		output.PrintError("Port lock request was not successful for %s", noColor, formattedUID)
+		return fmt.Errorf("port lock request was not successful for %s", portUID)
 	}
+
+	output.PrintInfo("Port %s locked successfully", noColor, formattedUID)
 	return nil
 }
 
@@ -266,11 +269,12 @@ func UnlockPort(cmd *cobra.Command, args []string, noColor bool) error {
 		return err
 	}
 
-	if resp.IsUnlocking {
-		output.PrintInfo("Port %s unlocked successfully", noColor, formattedUID)
-	} else {
-		output.PrintWarning("Port unlock request was not successful", noColor)
+	if !resp.IsUnlocking {
+		output.PrintError("Port unlock request was not successful for %s", noColor, formattedUID)
+		return fmt.Errorf("port unlock request was not successful for %s", portUID)
 	}
+
+	output.PrintInfo("Port %s unlocked successfully", noColor, formattedUID)
 	return nil
 }
 

--- a/internal/commands/ports/ports_actions_test.go
+++ b/internal/commands/ports/ports_actions_test.go
@@ -1103,6 +1103,12 @@ func TestRestorePort(t *testing.T) {
 			loginErr:      fmt.Errorf("authentication failed"),
 			expectedError: "authentication failed",
 		},
+		{
+			name:          "not successful",
+			portUID:       "port-restore-fail",
+			restoreResp:   &megaport.RestorePortResponse{IsRestored: false},
+			expectedError: "not successful",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1186,6 +1192,12 @@ func TestLockPort(t *testing.T) {
 			loginErr:      fmt.Errorf("invalid token"),
 			expectedError: "invalid token",
 		},
+		{
+			name:          "not successful",
+			portUID:       "port-lock-fail",
+			lockResp:      &megaport.LockPortResponse{IsLocking: false},
+			expectedError: "not successful",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1268,6 +1280,12 @@ func TestUnlockPort(t *testing.T) {
 			portUID:       "port-unlock-login",
 			loginErr:      fmt.Errorf("session expired"),
 			expectedError: "session expired",
+		},
+		{
+			name:          "not successful",
+			portUID:       "port-unlock-fail",
+			unlockResp:    &megaport.UnlockPortResponse{IsUnlocking: false},
+			expectedError: "not successful",
 		},
 	}
 
@@ -2159,10 +2177,10 @@ func TestDeletePort_Comprehensive(t *testing.T) {
 			expectedError: "API failure",
 		},
 		{
-			name:             "delete returns not deleting",
-			force:            true,
-			isDeleting:       false,
-			expectedContains: "not successful",
+			name:          "delete returns not deleting",
+			force:         true,
+			isDeleting:    false,
+			expectedError: "not successful",
 		},
 	}
 

--- a/internal/commands/ports/ports_actions_test.go
+++ b/internal/commands/ports/ports_actions_test.go
@@ -1107,7 +1107,7 @@ func TestRestorePort(t *testing.T) {
 			name:          "not successful",
 			portUID:       "port-restore-fail",
 			restoreResp:   &megaport.RestorePortResponse{IsRestored: false},
-			expectedError: "not successful",
+			expectedError: "not successful for port-restore-fail",
 		},
 	}
 
@@ -1196,7 +1196,7 @@ func TestLockPort(t *testing.T) {
 			name:          "not successful",
 			portUID:       "port-lock-fail",
 			lockResp:      &megaport.LockPortResponse{IsLocking: false},
-			expectedError: "not successful",
+			expectedError: "not successful for port-lock-fail",
 		},
 	}
 
@@ -1285,7 +1285,7 @@ func TestUnlockPort(t *testing.T) {
 			name:          "not successful",
 			portUID:       "port-unlock-fail",
 			unlockResp:    &megaport.UnlockPortResponse{IsUnlocking: false},
-			expectedError: "not successful",
+			expectedError: "not successful for port-unlock-fail",
 		},
 	}
 
@@ -2180,7 +2180,7 @@ func TestDeletePort_Comprehensive(t *testing.T) {
 			name:          "delete returns not deleting",
 			force:         true,
 			isDeleting:    false,
-			expectedError: "not successful",
+			expectedError: "not successful for port-123",
 		},
 	}
 


### PR DESCRIPTION
Fixes two exit-code correctness bugs so scripts can trust the CLI's exit status.

**Failed mutations now return an error.** Several manage commands printed a "not successful" message but still returned `nil`, so a mutation the API reported as *not* successful exited 0. Every not-successful branch now returns a non-nil error (and so exits non-zero). Affected sites:

- ports: delete, restore, lock, unlock
- mcr: delete, restore; prefix-filter-list update and delete
- mve: delete

**Usage errors now exit 2.** `isCobraUsageError` didn't recognize cobra's arg-count message ("accepts N arg(s), received M"), so e.g. `ports get` with no args exited 1 instead of the documented usage code 2. Matching on the shared `arg(s)` substring covers all four cobra arg validators (ExactArgs, MinimumNArgs, MaximumNArgs, RangeArgs).

Tests assert both the error return and the usage exit code, and the not-successful cases now check the error carries the resource UID/ID.

Notes:
- `servicekeys` is intentionally untouched: ESD-1417 (#407) is in flight over the same file.
- The existing `PrintError` + `return err` pattern (double-print under the root's `SilenceErrors: false`) is left as-is. It's a codebase-wide convention; changing it only here would diverge, and a global rework is out of scope for an exit-code fix.
