### PR TITLE
fix(ESD-1500): stop retrying buy/order calls on ambiguous errors

### DIFF
--- a/internal/commands/apply/apply_actions.go
+++ b/internal/commands/apply/apply_actions.go
@@ -143,7 +143,7 @@ func ApplyConfig(cmd *cobra.Command, _ []string, noColor bool, outputFormat stri
 
 		createSpinner := output.PrintResourceCreating("Port", p.Name, noColor)
 		var resp *megaport.BuyPortResponse
-		err = utils.WithRetry(ctx, func(ctx context.Context) error {
+		err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
 			var e error
 			resp, e = client.PortService.BuyPort(ctx, req)
 			return e
@@ -221,7 +221,7 @@ func ApplyConfig(cmd *cobra.Command, _ []string, noColor bool, outputFormat stri
 
 		createSpinner := output.PrintResourceCreating("MCR", m.Name, noColor)
 		var resp *megaport.BuyMCRResponse
-		err = utils.WithRetry(ctx, func(ctx context.Context) error {
+		err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
 			var e error
 			resp, e = client.MCRService.BuyMCR(ctx, req)
 			return e
@@ -307,7 +307,7 @@ func ApplyConfig(cmd *cobra.Command, _ []string, noColor bool, outputFormat stri
 
 		createSpinner := output.PrintResourceCreating("MVE", mv.Name, noColor)
 		var resp *megaport.BuyMVEResponse
-		err = utils.WithRetry(ctx, func(ctx context.Context) error {
+		err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
 			var e error
 			resp, e = client.MVEService.BuyMVE(ctx, req)
 			return e
@@ -400,7 +400,7 @@ func ApplyConfig(cmd *cobra.Command, _ []string, noColor bool, outputFormat stri
 
 		createSpinner := output.PrintResourceCreating("VXC", v.Name, noColor)
 		var resp *megaport.BuyVXCResponse
-		err = utils.WithRetry(ctx, func(ctx context.Context) error {
+		err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
 			var e error
 			resp, e = client.VXCService.BuyVXC(ctx, req)
 			return e

--- a/internal/commands/ix/ix_actions.go
+++ b/internal/commands/ix/ix_actions.go
@@ -1,6 +1,7 @@
 package ix
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -240,7 +241,12 @@ func BuyIX(cmd *cobra.Command, args []string, noColor bool) error {
 	} else {
 		buySpinner = output.PrintResourceCreating("IX", req.Name, noColor)
 	}
-	resp, err := buyIXFunc(ctx, client, req)
+	var resp *megaport.BuyIXResponse
+	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
+		var e error
+		resp, e = buyIXFunc(ctx, client, req)
+		return e
+	})
 	buySpinner.Stop()
 
 	if err != nil {
@@ -339,7 +345,12 @@ func UpdateIX(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	updateSpinner := output.PrintResourceUpdating("IX", ixUID, noColor)
-	updatedIX, err := updateIXFunc(ctx, client, ixUID, req)
+	var updatedIX *megaport.IX
+	err = utils.WithRetry(ctx, func(ctx context.Context) error {
+		var e error
+		updatedIX, e = updateIXFunc(ctx, client, ixUID, req)
+		return e
+	})
 	updateSpinner.Stop()
 
 	if err != nil {
@@ -386,7 +397,9 @@ func DeleteIX(cmd *cobra.Command, args []string, noColor bool) error {
 
 	spinner := output.PrintResourceDeleting("IX", ixUID, noColor)
 
-	err = deleteIXFunc(ctx, client, ixUID, deleteRequest)
+	err = utils.WithRetry(ctx, func(ctx context.Context) error {
+		return deleteIXFunc(ctx, client, ixUID, deleteRequest)
+	})
 
 	spinner.Stop()
 

--- a/internal/commands/ix/ix_actions_test.go
+++ b/internal/commands/ix/ix_actions_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 	"os"
 	"testing"
 
@@ -1996,4 +1998,71 @@ func TestMockIXServiceReset(t *testing.T) {
 	assert.Nil(t, m.getIXError)
 	assert.Nil(t, m.deleteIXError)
 	assert.False(t, m.forceNilGetIX)
+}
+
+// TestBuyIX_NoRetryOnAmbiguousError ensures a buy is never re-submitted after an
+// ambiguous 502, which could double-submit the order and duplicate billing.
+func TestBuyIX_NoRetryOnAmbiguousError(t *testing.T) {
+	originalBuyIXFunc := buyIXFunc
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
+	defer func() {
+		cleanup()
+		buyIXFunc = originalBuyIXFunc
+	}()
+	originalBuyConfirmPrompt := utils.GetBuyConfirmPrompt()
+	defer func() { utils.SetBuyConfirmPrompt(originalBuyConfirmPrompt) }()
+	utils.SetBuyConfirmPrompt(func(_ string, _ []utils.BuyConfirmDetail, _ bool) bool { return true })
+
+	config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+		client := &megaport.Client{}
+		client.IXService = &MockIXService{}
+		return client, nil
+	})
+
+	calls := 0
+	buyIXFunc = func(ctx context.Context, client *megaport.Client, req *megaport.BuyIXRequest) (*megaport.BuyIXResponse, error) {
+		calls++
+		return nil, &megaport.ErrorResponse{
+			Response: &http.Response{
+				StatusCode: http.StatusBadGateway,
+				Header:     http.Header{},
+				Request:    &http.Request{URL: &url.URL{}},
+			},
+			Message: "bad gateway",
+		}
+	}
+
+	cmd := &cobra.Command{Use: "buy", RunE: testutil.NoColorAdapter(BuyIX)}
+	cmd.Flags().BoolP("interactive", "i", false, "")
+	cmd.Flags().Bool("no-wait", false, "")
+	cmd.Flags().String("product-uid", "", "")
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("network-service-type", "", "")
+	cmd.Flags().Int("asn", 0, "")
+	cmd.Flags().String("mac-address", "", "")
+	cmd.Flags().Int("rate-limit", 0, "")
+	cmd.Flags().Int("vlan", 0, "")
+	cmd.Flags().Bool("shutdown", false, "")
+	cmd.Flags().String("promo-code", "", "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+
+	testutil.SetFlags(t, cmd, map[string]string{
+		"product-uid":          "port-uid-123",
+		"name":                 "Test IX",
+		"network-service-type": "Los Angeles IX",
+		"asn":                  "65000",
+		"mac-address":          "00:11:22:33:44:55",
+		"rate-limit":           "1000",
+		"vlan":                 "100",
+	})
+	assert.NoError(t, cmd.Flags().Set("no-wait", "true"))
+
+	var err error
+	output.CaptureOutput(func() {
+		err = cmd.RunE(cmd, nil)
+	})
+
+	assert.Error(t, err)
+	assert.Equal(t, 1, calls, "buy must not retry on an ambiguous 502")
 }

--- a/internal/commands/ix/ix_actions_test.go
+++ b/internal/commands/ix/ix_actions_test.go
@@ -2004,11 +2004,15 @@ func TestMockIXServiceReset(t *testing.T) {
 // ambiguous 502, which could double-submit the order and duplicate billing.
 func TestBuyIX_NoRetryOnAmbiguousError(t *testing.T) {
 	originalBuyIXFunc := buyIXFunc
+	originalMaxRetries := utils.MaxRetries
 	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
 	defer func() {
 		cleanup()
 		buyIXFunc = originalBuyIXFunc
+		utils.MaxRetries = originalMaxRetries
 	}()
+	// Retries are available; the order-safe policy must still refuse to use them on a 502.
+	utils.MaxRetries = 3
 	originalBuyConfirmPrompt := utils.GetBuyConfirmPrompt()
 	defer func() { utils.SetBuyConfirmPrompt(originalBuyConfirmPrompt) }()
 	utils.SetBuyConfirmPrompt(func(_ string, _ []utils.BuyConfirmDetail, _ bool) bool { return true })

--- a/internal/commands/mcr/mcr_actions.go
+++ b/internal/commands/mcr/mcr_actions.go
@@ -128,7 +128,7 @@ func BuyMCR(cmd *cobra.Command, args []string, noColor bool) error {
 		buySpinner = output.PrintResourceCreating("MCR", req.Name, noColor)
 	}
 	var resp *megaport.BuyMCRResponse
-	err = utils.WithRetry(ctx, func(ctx context.Context) error {
+	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
 		var e error
 		resp, e = buyMCRFunc(ctx, client, req)
 		return e

--- a/internal/commands/mcr/mcr_actions_ipsec_addon.go
+++ b/internal/commands/mcr/mcr_actions_ipsec_addon.go
@@ -75,7 +75,7 @@ func AddMCRIPSecAddOn(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	spinner := output.PrintResourceCreating("IPSec Add-On", mcrUID, noColor)
-	err = utils.WithRetry(ctx, func(ctx context.Context) error {
+	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
 		return updateMCRWithAddOnFunc(ctx, client, mcrUID, req)
 	})
 	spinner.Stop()

--- a/internal/commands/mcr/mcr_actions_prefix_filter.go
+++ b/internal/commands/mcr/mcr_actions_prefix_filter.go
@@ -59,7 +59,7 @@ func CreateMCRPrefixFilterList(cmd *cobra.Command, args []string, noColor bool) 
 	}
 	spinner := output.PrintResourceCreating("Prefix Filter List", req.PrefixFilterList.Description, noColor)
 	var resp *megaport.CreateMCRPrefixFilterListResponse
-	err = utils.WithRetry(ctx, func(ctx context.Context) error {
+	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
 		var e error
 		resp, e = createMCRPrefixFilterListFunc(ctx, client, req)
 		return e

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -194,7 +194,7 @@ func BuyMVE(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	var resp *megaport.BuyMVEResponse
-	err = utils.WithRetry(ctx, func(ctx context.Context) error {
+	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
 		var e error
 		resp, e = client.MVEService.BuyMVE(ctx, req)
 		return e

--- a/internal/commands/nat_gateway/nat_gateway_actions.go
+++ b/internal/commands/nat_gateway/nat_gateway_actions.go
@@ -75,7 +75,7 @@ func CreateNATGateway(cmd *cobra.Command, args []string, noColor bool) error {
 	spinner := output.PrintResourceCreating("NAT Gateway", req.ProductName, noColor)
 
 	var gw *megaport.NATGateway
-	err = utils.WithRetry(ctx, func(ctx context.Context) error {
+	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
 		var e error
 		gw, e = createNATGatewayFunc(ctx, client, req)
 		return e
@@ -460,7 +460,7 @@ func BuyNATGateway(cmd *cobra.Command, args []string, noColor bool) error {
 
 	spinner := output.PrintResourceCreating("NAT Gateway", uid, noColor)
 	var res *megaport.NATGatewayBuyResult
-	err = utils.WithRetry(ctx, func(ctx context.Context) error {
+	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
 		var e error
 		res, e = buyNATGatewayFunc(ctx, client, uid)
 		return e

--- a/internal/commands/ports/ports_actions.go
+++ b/internal/commands/ports/ports_actions.go
@@ -119,7 +119,7 @@ func BuyPort(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	var resp *megaport.BuyPortResponse
-	err = utils.WithRetry(ctx, func(ctx context.Context) error {
+	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
 		var e error
 		resp, e = buyPortFunc(ctx, client, req)
 		return e
@@ -256,7 +256,12 @@ func BuyLAGPort(cmd *cobra.Command, args []string, noColor bool) error {
 		spinner = output.PrintResourceCreating("LAG Port", req.Name, noColor)
 	}
 
-	resp, err := buyPortFunc(ctx, client, req)
+	var resp *megaport.BuyPortResponse
+	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
+		var e error
+		resp, e = buyPortFunc(ctx, client, req)
+		return e
+	})
 
 	spinner.Stop()
 

--- a/internal/commands/vxc/vxc_actions.go
+++ b/internal/commands/vxc/vxc_actions.go
@@ -301,7 +301,7 @@ func BuyVXC(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	var resp *megaport.BuyVXCResponse
-	err = utils.WithRetry(ctx, func(ctx context.Context) error {
+	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
 		var e error
 		resp, e = buyVXCFunc(ctx, client, req)
 		return e

--- a/internal/utils/retry.go
+++ b/internal/utils/retry.go
@@ -34,6 +34,10 @@ type RetryOpts struct {
 	// RetryNetworkErrors enables retrying on ambiguous network failures
 	// (connection reset, EOF, timeout). Only set this for idempotent operations.
 	RetryNetworkErrors bool
+	// OrderSafe restricts retries to errors that prove the request never reached
+	// processing (HTTP 429, connection-refused-before-send). Set this for
+	// non-idempotent buy/order calls so an ambiguous failure cannot double-submit.
+	OrderSafe bool
 }
 
 // DefaultRetryOpts returns sensible defaults for API retry behaviour.
@@ -75,6 +79,21 @@ func WithIdempotentRetry(ctx context.Context, fn func(ctx context.Context) error
 	return RetryWithBackoff(ctx, opts, fn)
 }
 
+// WithOrderRetry wraps fn with a retry policy safe for non-idempotent buy/order
+// operations. It retries ONLY when the request provably never reached
+// processing: HTTP 429, or a connection-refused error raised before the request
+// was sent. It never retries on 5xx or other ambiguous-outcome errors, which
+// could double-submit an order and cause duplicate billing.
+// If --no-retry was set globally, fn is called exactly once.
+func WithOrderRetry(ctx context.Context, fn func(ctx context.Context) error) error {
+	if NoRetry {
+		return fn(ctx)
+	}
+	opts := DefaultRetryOpts()
+	opts.OrderSafe = true
+	return RetryWithBackoff(ctx, opts, fn)
+}
+
 // RetryWithBackoff calls fn up to opts.MaxRetries+1 times with exponential
 // backoff and jitter. It respects the Retry-After header from 429 responses
 // and only retries on transient/server errors.
@@ -91,7 +110,12 @@ func RetryWithBackoff(ctx context.Context, opts RetryOpts, fn func(ctx context.C
 			return err
 		}
 
-		if !isRetryable(err, opts.RetryNetworkErrors) {
+		retryable := isRetryable(err, opts.RetryNetworkErrors)
+		if opts.OrderSafe {
+			retryable = isOrderRetryable(err)
+		}
+
+		if !retryable {
 			return err
 		}
 
@@ -191,6 +215,19 @@ func isRetryable(err error, retryNetworkErrors bool) bool {
 	}
 
 	return false
+}
+
+// isOrderRetryable returns true only for errors that prove a buy/order request
+// never reached processing: HTTP 429, or connection-refused raised during the
+// TCP handshake (the request bytes never left the client). Ambiguous outcomes
+// (5xx, connection reset, timeout, EOF) are never retried because the order may
+// already have been accepted upstream.
+func isOrderRetryable(err error) bool {
+	var apiErr *megaport.ErrorResponse
+	if errors.As(err, &apiErr) && apiErr.Response != nil {
+		return apiErr.Response.StatusCode == http.StatusTooManyRequests
+	}
+	return errors.Is(err, syscall.ECONNREFUSED)
 }
 
 // retryAfterDelay extracts the Retry-After header from a 429 response and

--- a/internal/utils/retry_test.go
+++ b/internal/utils/retry_test.go
@@ -430,6 +430,20 @@ func TestWithOrderRetry_NoRetryOn502(t *testing.T) {
 	assert.Equal(t, 1, calls, "a buy must not be retried on an ambiguous 502")
 }
 
+func TestWithOrderRetry_NoRetryFlag(t *testing.T) {
+	oldNoRetry := NoRetry
+	defer func() { NoRetry = oldNoRetry }()
+	NoRetry = true
+
+	calls := 0
+	err := WithOrderRetry(context.Background(), func(ctx context.Context) error {
+		calls++
+		return apiError(429, "")
+	})
+	assert.Error(t, err)
+	assert.Equal(t, 1, calls, "--no-retry should disable order retries")
+}
+
 func TestOrderSafeRetry_RetriesOn429ThenSucceeds(t *testing.T) {
 	opts := fastOpts()
 	opts.OrderSafe = true

--- a/internal/utils/retry_test.go
+++ b/internal/utils/retry_test.go
@@ -413,8 +413,13 @@ func TestIsOrderRetryable(t *testing.T) {
 
 func TestWithOrderRetry_NoRetryOn502(t *testing.T) {
 	oldNoRetry := NoRetry
-	defer func() { NoRetry = oldNoRetry }()
+	oldMaxRetries := MaxRetries
+	defer func() {
+		NoRetry = oldNoRetry
+		MaxRetries = oldMaxRetries
+	}()
 	NoRetry = false
+	MaxRetries = 3 // retries are available; the order-safe policy must still refuse to use them on a 502
 
 	calls := 0
 	err := WithOrderRetry(context.Background(), func(ctx context.Context) error {

--- a/internal/utils/retry_test.go
+++ b/internal/utils/retry_test.go
@@ -388,6 +388,88 @@ func TestLogRetry_NonVerboseEarlyAttempt(t *testing.T) {
 	logRetry(1, 3, 100*time.Millisecond, fmt.Errorf("test error"))
 }
 
+func TestIsOrderRetryable(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		{"429 Too Many Requests", apiError(429, ""), true},
+		{"502 Bad Gateway", apiError(502, ""), false},
+		{"503 Service Unavailable", apiError(503, ""), false},
+		{"504 Gateway Timeout", apiError(504, ""), false},
+		{"400 Bad Request", apiError(400, ""), false},
+		{"connection refused (pre-send)", fmt.Errorf("dial: %w", syscall.ECONNREFUSED), true},
+		{"connection reset (ambiguous)", fmt.Errorf("write: %w", syscall.ECONNRESET), false},
+		{"io.EOF (ambiguous)", io.EOF, false},
+		{"timeout (ambiguous)", &net.DNSError{IsTimeout: true}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.retryable, isOrderRetryable(tt.err))
+		})
+	}
+}
+
+func TestWithOrderRetry_NoRetryOn502(t *testing.T) {
+	oldNoRetry := NoRetry
+	defer func() { NoRetry = oldNoRetry }()
+	NoRetry = false
+
+	calls := 0
+	err := WithOrderRetry(context.Background(), func(ctx context.Context) error {
+		calls++
+		return apiError(502, "")
+	})
+	assert.Error(t, err)
+	assert.Equal(t, 1, calls, "a buy must not be retried on an ambiguous 502")
+}
+
+func TestOrderSafeRetry_RetriesOn429ThenSucceeds(t *testing.T) {
+	opts := fastOpts()
+	opts.OrderSafe = true
+
+	calls := 0
+	err := RetryWithBackoff(context.Background(), opts, func(ctx context.Context) error {
+		calls++
+		if calls == 1 {
+			return apiError(429, "")
+		}
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, calls, "a buy should retry once on 429 and then succeed")
+}
+
+func TestOrderSafeRetry_RetriesOnConnectionRefused(t *testing.T) {
+	opts := fastOpts()
+	opts.OrderSafe = true
+
+	calls := 0
+	err := RetryWithBackoff(context.Background(), opts, func(ctx context.Context) error {
+		calls++
+		if calls == 1 {
+			return fmt.Errorf("dial tcp: %w", syscall.ECONNREFUSED)
+		}
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, calls, "connection-refused-before-send is safe to retry")
+}
+
+func TestOrderSafeRetry_NoRetryOnAmbiguousNetworkError(t *testing.T) {
+	opts := fastOpts()
+	opts.OrderSafe = true
+
+	calls := 0
+	err := RetryWithBackoff(context.Background(), opts, func(ctx context.Context) error {
+		calls++
+		return fmt.Errorf("read tcp: %w", syscall.ECONNRESET)
+	})
+	assert.Error(t, err)
+	assert.Equal(t, 1, calls, "connection reset is ambiguous and must not retry a buy")
+}
+
 // fastOpts returns retry options with minimal delays for fast tests.
 func fastOpts() RetryOpts {
 	return RetryOpts{


### PR DESCRIPTION
`utils.WithRetry` retries on 502/504, which a gateway can return *after* an order was already accepted upstream. Buy/order calls were wrapped in it, so an ambiguous gateway error could re-submit an accepted order and double-bill.

This adds `WithOrderRetry`, which retries only when the request provably never reached processing (HTTP 429 and connection-refused-before-send), and moves every non-idempotent create/buy path onto it.

- New `WithOrderRetry` helper: retries on 429 and pre-send connection-refused only, never on 5xx or other ambiguous errors.
- Switched all non-idempotent creates/buys: port, LAG port, VXC, MCR, MVE, NAT gateway create/buy, IX buy, MCR prefix filter list create, MCR IPSec add-on add, and the apply order paths.
- Fixed inconsistent outliers: LAG buy and IX buy previously had no retry; IX update/delete now use the standard mutation retry like their port/MCR peers.
- Reads and idempotent updates (update/delete/modify) keep their existing helpers.
- Tests: unit tests verified load-bearing via mutation check, `--no-retry` path covered, plus a package-level test wiring a mock IX buy through the new path.

Closes ESD-1500.
