### PR TITLE
fix: route CLI status and error output to stderr (ESD-1421)

### DIFF
--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -66,6 +66,36 @@ func SetOutputFormat(format string) {
 	updateOutputConfig(func(c *OutputConfig) { c.Format = format })
 }
 
+var (
+	errorPrintedMu sync.Mutex
+	errorPrinted   bool
+)
+
+// markErrorPrinted records that PrintError emitted a human-readable error line
+// during the current command. The RunE wrappers consult this so they don't
+// print the same error a second time.
+func markErrorPrinted() {
+	errorPrintedMu.Lock()
+	errorPrinted = true
+	errorPrintedMu.Unlock()
+}
+
+// ErrorWasPrinted reports whether an action already printed an error this
+// invocation.
+func ErrorWasPrinted() bool {
+	errorPrintedMu.Lock()
+	defer errorPrintedMu.Unlock()
+	return errorPrinted
+}
+
+// ResetErrorPrinted clears the printed-error flag. Called at the start of each
+// command (and on every re-entry in the long-lived WASM process).
+func ResetErrorPrinted() {
+	errorPrintedMu.Lock()
+	errorPrinted = false
+	errorPrintedMu.Unlock()
+}
+
 // GetOutputFormat returns the currently active output format (e.g. "table", "json").
 func GetOutputFormat() string {
 	outputCfgMu.RLock()

--- a/internal/base/output/messages_native.go
+++ b/internal/base/output/messages_native.go
@@ -29,44 +29,46 @@ func PrintErrorJSON(code int, message string) {
 
 // Native (non-WASM) implementations that write to stdout/stderr directly
 
+// All status messages go to stderr so stdout carries only formatted data.
+
 func PrintSuccess(format string, noColor bool, args ...interface{}) {
 	if IsQuiet() {
 		return
 	}
 	msg := fmt.Sprintf(format, args...)
-	if GetOutputFormat() == "json" {
-		if noColor {
-			fmt.Fprintf(os.Stderr, "✓ %s\n", msg)
-		} else {
-			fmt.Fprint(os.Stderr, color.GreenString("✓ "))
-			fmt.Fprintln(os.Stderr, msg)
-		}
+	if noColor {
+		fmt.Fprintf(os.Stderr, "✓ %s\n", msg)
 	} else {
-		if noColor {
-			fmt.Printf("✓ %s\n", msg)
-		} else {
-			fmt.Print(color.GreenString("✓ "))
-			fmt.Println(msg)
-		}
+		fmt.Fprint(os.Stderr, color.GreenString("✓ "))
+		fmt.Fprintln(os.Stderr, msg)
 	}
 }
 
 func PrintError(format string, noColor bool, args ...interface{}) {
-	msg := fmt.Sprintf(format, args...)
+	markErrorPrinted()
+	// In JSON mode the structured envelope (PrintErrorJSON) is the single error
+	// representation, so the human line is suppressed to avoid double output.
 	if GetOutputFormat() == "json" {
-		if noColor {
-			fmt.Fprintf(os.Stderr, "✗ %s\n", msg)
-		} else {
-			fmt.Fprint(os.Stderr, color.RedString("✗ "))
-			fmt.Fprintln(os.Stderr, msg)
-		}
+		return
+	}
+	msg := fmt.Sprintf(format, args...)
+	if noColor {
+		fmt.Fprintf(os.Stderr, "✗ %s\n", msg)
 	} else {
-		if noColor {
-			fmt.Printf("✗ %s\n", msg)
-		} else {
-			fmt.Print(color.RedString("✗ "))
-			fmt.Println(msg)
-		}
+		fmt.Fprint(os.Stderr, color.RedString("✗ "))
+		fmt.Fprintln(os.Stderr, msg)
+	}
+}
+
+// PrintErrorPlain writes a human-readable error line to stderr unconditionally,
+// regardless of output format. The RunE wrappers use it to surface a failure
+// the action did not print itself; it does not mark the printed-error flag.
+func PrintErrorPlain(message string, noColor bool) {
+	if noColor {
+		fmt.Fprintf(os.Stderr, "✗ %s\n", message)
+	} else {
+		fmt.Fprint(os.Stderr, color.RedString("✗ "))
+		fmt.Fprintln(os.Stderr, message)
 	}
 }
 
@@ -75,20 +77,11 @@ func PrintWarning(format string, noColor bool, args ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf(format, args...)
-	if GetOutputFormat() == "json" {
-		if noColor {
-			fmt.Fprintf(os.Stderr, "⚠ %s\n", msg)
-		} else {
-			fmt.Fprint(os.Stderr, color.YellowString("⚠ "))
-			fmt.Fprintln(os.Stderr, msg)
-		}
+	if noColor {
+		fmt.Fprintf(os.Stderr, "⚠ %s\n", msg)
 	} else {
-		if noColor {
-			fmt.Printf("⚠ %s\n", msg)
-		} else {
-			fmt.Print(color.YellowString("⚠ "))
-			fmt.Println(msg)
-		}
+		fmt.Fprint(os.Stderr, color.YellowString("⚠ "))
+		fmt.Fprintln(os.Stderr, msg)
 	}
 }
 
@@ -97,20 +90,11 @@ func PrintInfo(format string, noColor bool, args ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf(format, args...)
-	if GetOutputFormat() == "json" {
-		if noColor {
-			fmt.Fprintf(os.Stderr, "ℹ %s\n", msg)
-		} else {
-			fmt.Fprint(os.Stderr, color.BlueString("ℹ "))
-			fmt.Fprintln(os.Stderr, msg)
-		}
+	if noColor {
+		fmt.Fprintf(os.Stderr, "ℹ %s\n", msg)
 	} else {
-		if noColor {
-			fmt.Printf("ℹ %s\n", msg)
-		} else {
-			fmt.Print(color.BlueString("ℹ "))
-			fmt.Println(msg)
-		}
+		fmt.Fprint(os.Stderr, color.BlueString("ℹ "))
+		fmt.Fprintln(os.Stderr, msg)
 	}
 }
 

--- a/internal/base/output/messages_native_test.go
+++ b/internal/base/output/messages_native_test.go
@@ -55,3 +55,61 @@ func TestPrintErrorJSON_UsageError(t *testing.T) {
 	assert.Equal(t, 2, env.Error.Code)
 	assert.Equal(t, "usage_error", env.Error.Type)
 }
+
+func TestPrintErrorSuppressedInJSON(t *testing.T) {
+	saveOutputFormat(t)
+	SetOutputFormat("json")
+	ResetErrorPrinted()
+
+	stdout := captureStdout(t, func() {
+		stderr := captureStderr(t, func() {
+			PrintError("boom %d", true, 1)
+		})
+		// Human line is suppressed in JSON mode; the wrapper emits the
+		// structured envelope instead.
+		assert.Empty(t, stderr)
+	})
+	assert.Empty(t, stdout)
+	// The flag is still set so the wrapper knows an error was reported.
+	assert.True(t, ErrorWasPrinted())
+}
+
+func TestPrintErrorMarksAndRoutesToStderrForTable(t *testing.T) {
+	saveOutputFormat(t)
+	SetOutputFormat("table")
+	ResetErrorPrinted()
+	assert.False(t, ErrorWasPrinted())
+
+	stdout := captureStdout(t, func() {
+		stderr := captureStderr(t, func() {
+			PrintError("boom", true)
+		})
+		assert.Contains(t, stderr, "✗ boom")
+	})
+	assert.Empty(t, stdout, "PrintError must not pollute stdout")
+	assert.True(t, ErrorWasPrinted())
+}
+
+func TestPrintErrorPlainAlwaysWritesStderr(t *testing.T) {
+	saveOutputFormat(t)
+	// Even with the global format set to json, PrintErrorPlain writes
+	// unconditionally: it must not consult the output format.
+	SetOutputFormat("json")
+	ResetErrorPrinted()
+
+	stderr := captureStderr(t, func() {
+		PrintErrorPlain("invalid output format: JSON", true)
+	})
+	assert.Equal(t, "✗ invalid output format: JSON\n", stderr)
+	// PrintErrorPlain does not mark the printed-error flag.
+	assert.False(t, ErrorWasPrinted())
+}
+
+func TestResetErrorPrinted(t *testing.T) {
+	saveOutputFormat(t)
+	SetOutputFormat("table")
+	markErrorPrinted()
+	assert.True(t, ErrorWasPrinted())
+	ResetErrorPrinted()
+	assert.False(t, ErrorWasPrinted())
+}

--- a/internal/base/output/messages_native_test.go
+++ b/internal/base/output/messages_native_test.go
@@ -105,6 +105,21 @@ func TestPrintErrorPlainAlwaysWritesStderr(t *testing.T) {
 	assert.False(t, ErrorWasPrinted())
 }
 
+func TestPrintErrorPlainColorWritesStderr(t *testing.T) {
+	saveOutputFormat(t)
+	SetOutputFormat("table")
+	ResetErrorPrinted()
+
+	stderr := captureStderr(t, func() {
+		PrintErrorPlain("something broke", false)
+	})
+	// The colored branch may emit ANSI escapes depending on the terminal, so
+	// assert on the message content rather than an exact byte match.
+	assert.Contains(t, stderr, "✗ ")
+	assert.Contains(t, stderr, "something broke")
+	assert.False(t, ErrorWasPrinted())
+}
+
 func TestResetErrorPrinted(t *testing.T) {
 	saveOutputFormat(t)
 	SetOutputFormat("table")

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -32,6 +32,25 @@ func captureOutput(f func()) string {
 	return buf.String()
 }
 
+// captureMessages captures stderr, where the Print* status helpers now write.
+func captureMessages(f func()) string {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	f()
+
+	w.Close()
+	os.Stderr = old
+
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, r)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to copy from pipe: %v", err))
+	}
+	return buf.String()
+}
+
 func TestPrintSuccess(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -58,7 +77,7 @@ func TestPrintSuccess(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := captureOutput(func() {
+			output := captureMessages(func() {
 				PrintSuccess(tt.format, tt.noColor, tt.args...)
 			})
 			assert.Contains(t, output, tt.expectedContains)
@@ -107,7 +126,7 @@ func TestPrintResourceSuccess(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := captureOutput(func() {
+			output := captureMessages(func() {
 				PrintResourceSuccess(tt.resourceType, tt.action, tt.uid, tt.noColor)
 			})
 			assert.Equal(t, tt.expected, output)
@@ -116,14 +135,14 @@ func TestPrintResourceSuccess(t *testing.T) {
 }
 
 func TestPrintResourceCreated(t *testing.T) {
-	output := captureOutput(func() {
+	output := captureMessages(func() {
 		PrintResourceCreated("Port", "port-123", true)
 	})
 	assert.Equal(t, "✓ Port created port-123\n", output)
 }
 
 func TestPrintResourceUpdated(t *testing.T) {
-	output := captureOutput(func() {
+	output := captureMessages(func() {
 		PrintResourceUpdated("Port", "port-123", true)
 	})
 	assert.Equal(t, "✓ Port updated port-123\n", output)
@@ -158,7 +177,7 @@ func TestPrintResourceDeleted(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := captureOutput(func() {
+			output := captureMessages(func() {
 				PrintResourceDeleted(tt.resourceType, tt.uid, tt.immediate, tt.noColor)
 			})
 			assert.Equal(t, tt.expected, output)
@@ -266,36 +285,36 @@ func TestPrintResourceListing(t *testing.T) {
 }
 
 func TestPrintError(t *testing.T) {
-	output := captureOutput(func() {
+	output := captureMessages(func() {
 		PrintError("Test %s message", true, "error")
 	})
 	assert.Equal(t, "✗ Test error message\n", output)
 
-	output = captureOutput(func() {
+	output = captureMessages(func() {
 		PrintError("Test %s message", false, "error")
 	})
 	assert.Contains(t, output, "Test error message")
 }
 
 func TestPrintWarning(t *testing.T) {
-	output := captureOutput(func() {
+	output := captureMessages(func() {
 		PrintWarning("Test %s message", true, "warning")
 	})
 	assert.Equal(t, "⚠ Test warning message\n", output)
 
-	output = captureOutput(func() {
+	output = captureMessages(func() {
 		PrintWarning("Test %s message", false, "warning")
 	})
 	assert.Contains(t, output, "Test warning message")
 }
 
 func TestPrintInfo(t *testing.T) {
-	output := captureOutput(func() {
+	output := captureMessages(func() {
 		PrintInfo("Test %s message", true, "info")
 	})
 	assert.Equal(t, "ℹ Test info message\n", output)
 
-	output = captureOutput(func() {
+	output = captureMessages(func() {
 		PrintInfo("Test %s message", false, "info")
 	})
 	assert.Contains(t, output, "Test info message")

--- a/internal/base/output/messages_wasm.go
+++ b/internal/base/output/messages_wasm.go
@@ -214,6 +214,11 @@ func PrintSuccess(format string, noColor bool, args ...interface{}) {
 
 // PrintError overrides the base function for WASM to capture output
 func PrintError(format string, noColor bool, args ...interface{}) {
+	markErrorPrinted()
+	// In JSON mode the structured envelope is the single error representation.
+	if GetOutputFormat() == "json" {
+		return
+	}
 	msg := fmt.Sprintf(format, args...)
 	var output string
 	if noColor {
@@ -222,6 +227,19 @@ func PrintError(format string, noColor bool, args ...interface{}) {
 		output = color.RedString("✗ ") + msg + "\n"
 	}
 	wasm.WasmOutputBuffer.Write([]byte(output))
+}
+
+// PrintErrorPlain writes a human-readable error line unconditionally,
+// regardless of output format. Used by the RunE wrappers to surface a failure
+// the action did not print itself; it does not mark the printed-error flag.
+func PrintErrorPlain(message string, noColor bool) {
+	var out string
+	if noColor {
+		out = fmt.Sprintf("✗ %s\n", message)
+	} else {
+		out = color.RedString("✗ ") + message + "\n"
+	}
+	wasm.WasmOutputBuffer.Write([]byte(out))
 }
 
 // PrintWarning overrides the base function for WASM to capture output

--- a/internal/base/output/output.go
+++ b/internal/base/output/output.go
@@ -176,11 +176,44 @@ var createTempFile = func() (*os.File, error) {
 	return os.CreateTemp("", "capture-stdout-*")
 }
 
-// CaptureOutput runs f and returns everything it writes to stdout.
+// CaptureOutput runs f and returns everything it writes to stdout and stderr
+// combined. Status messages route to stderr and data to stdout, so a test that
+// wants all user-facing output captures both. Use CaptureStdout when asserting
+// that the data stream alone is clean.
 // Uses a temporary file instead of an OS pipe to avoid deadlocking when
 // f() produces more output than the pipe buffer can hold.
 // Must not be called reentrantly (the global stdoutMu is not reentrant).
 func CaptureOutput(f func()) string {
+	stdoutMu.Lock()
+	defer stdoutMu.Unlock()
+
+	oldOut, oldErr := os.Stdout, os.Stderr
+	tmp, err := createTempFile()
+	if err != nil {
+		f()
+		return ""
+	}
+	defer os.Remove(tmp.Name())
+	defer tmp.Close()
+
+	os.Stdout = tmp
+	os.Stderr = tmp
+	defer func() { os.Stdout = oldOut; os.Stderr = oldErr }()
+
+	f()
+
+	// Read back captured output.
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		return ""
+	}
+	data, _ := io.ReadAll(tmp)
+	return string(data)
+}
+
+// CaptureStdout runs f and returns only what it writes to stdout. Use this when
+// a test needs the clean data stream (for example parsing exported JSON/CSV)
+// without the status messages that route to stderr.
+func CaptureStdout(f func()) string {
 	stdoutMu.Lock()
 	defer stdoutMu.Unlock()
 
@@ -198,7 +231,6 @@ func CaptureOutput(f func()) string {
 
 	f()
 
-	// Read back captured output.
 	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
 		return ""
 	}
@@ -206,11 +238,13 @@ func CaptureOutput(f func()) string {
 	return string(data)
 }
 
+// CaptureOutputErr is the error-returning counterpart to CaptureOutput: it
+// captures both stdout and stderr.
 func CaptureOutputErr(f func() error) (string, error) {
 	stdoutMu.Lock()
 	defer stdoutMu.Unlock()
 
-	old := os.Stdout
+	oldOut, oldErr := os.Stdout, os.Stderr
 	tmp, err := createTempFile()
 	if err != nil {
 		runErr := f()
@@ -220,7 +254,8 @@ func CaptureOutputErr(f func() error) (string, error) {
 	defer tmp.Close()
 
 	os.Stdout = tmp
-	defer func() { os.Stdout = old }()
+	os.Stderr = tmp
+	defer func() { os.Stdout = oldOut; os.Stderr = oldErr }()
 
 	runErr := f()
 

--- a/internal/base/output/output_test.go
+++ b/internal/base/output/output_test.go
@@ -707,6 +707,41 @@ func TestCaptureOutput_TempFileFailure(t *testing.T) {
 	assert.Empty(t, result, "result should be empty when temp file creation fails")
 }
 
+func TestCaptureStdout_CapturesStdoutExcludesStderr(t *testing.T) {
+	out := CaptureStdout(func() {
+		fmt.Fprint(os.Stdout, "data-line")
+		fmt.Fprint(os.Stderr, "status-line")
+	})
+
+	assert.Equal(t, "data-line", out, "CaptureStdout should return only stdout")
+	assert.NotContains(t, out, "status-line", "stderr must not leak into the captured data stream")
+}
+
+func TestCaptureStdout_RestoresStdout(t *testing.T) {
+	originalStdout := os.Stdout
+
+	out := CaptureStdout(func() {
+		fmt.Print("hello")
+	})
+
+	assert.Equal(t, "hello", out)
+	assert.Equal(t, originalStdout, os.Stdout, "os.Stdout should be restored after CaptureStdout returns")
+}
+
+func TestCaptureStdout_TempFileFailure(t *testing.T) {
+	orig := createTempFile
+	createTempFile = func() (*os.File, error) {
+		return nil, errors.New("temp file unavailable")
+	}
+	defer func() { createTempFile = orig }()
+
+	called := false
+	result := CaptureStdout(func() { called = true })
+
+	assert.True(t, called, "f should still be called when temp file creation fails")
+	assert.Empty(t, result, "result should be empty when temp file creation fails")
+}
+
 func TestCaptureOutputErr_RestoresStdoutOnError(t *testing.T) {
 	originalStdout := os.Stdout
 

--- a/internal/base/output/output_wasm.go
+++ b/internal/base/output/output_wasm.go
@@ -396,6 +396,12 @@ func CaptureOutput(f func()) string {
 	return string(out)
 }
 
+// CaptureStdout mirrors the native helper. In WASM all output already flows
+// through a single buffer, so there is no separate data stream to isolate.
+func CaptureStdout(f func()) string {
+	return CaptureOutput(f)
+}
+
 // CaptureOutputErr runs a function and captures its stdout output, also returning any error.
 // Must not be called reentrantly (the global stdoutMu is not reentrant).
 func CaptureOutputErr(f func() error) (string, error) {

--- a/internal/base/output/verbosity_test.go
+++ b/internal/base/output/verbosity_test.go
@@ -113,7 +113,7 @@ func TestQuietDoesNotSuppressPrintError(t *testing.T) {
 	resetVerbosity(t)
 	SetVerbosity("quiet")
 
-	out := captureStdout(t, func() {
+	out := captureStderr(t, func() {
 		PrintError("error message", true)
 	})
 	assert.Contains(t, out, "error message", "PrintError should still produce output in quiet mode")
@@ -205,22 +205,22 @@ func TestQuietSuppressesPrintVerbose(t *testing.T) {
 func TestNormalModeShowsAllMessages(t *testing.T) {
 	resetVerbosity(t)
 
-	infoOut := captureStdout(t, func() {
+	infoOut := captureStderr(t, func() {
 		PrintInfo("info message", true)
 	})
 	assert.Contains(t, infoOut, "info message", "PrintInfo should produce output in normal mode")
 
-	successOut := captureStdout(t, func() {
+	successOut := captureStderr(t, func() {
 		PrintSuccess("success message", true)
 	})
 	assert.Contains(t, successOut, "success message", "PrintSuccess should produce output in normal mode")
 
-	warningOut := captureStdout(t, func() {
+	warningOut := captureStderr(t, func() {
 		PrintWarning("warning message", true)
 	})
 	assert.Contains(t, warningOut, "warning message", "PrintWarning should produce output in normal mode")
 
-	errorOut := captureStdout(t, func() {
+	errorOut := captureStderr(t, func() {
 		PrintError("error message", true)
 	})
 	assert.Contains(t, errorOut, "error message", "PrintError should produce output in normal mode")

--- a/internal/commands/ix/ix_actions_test.go
+++ b/internal/commands/ix/ix_actions_test.go
@@ -1819,7 +1819,7 @@ func TestGetIX_Export(t *testing.T) {
 	assert.NoError(t, cmd.Flags().Set("export", "true"))
 
 	var err error
-	capturedOutput := output.CaptureOutput(func() {
+	capturedOutput := output.CaptureStdout(func() {
 		err = GetIX(cmd, []string{"ix-export-123"}, true, "table")
 	})
 

--- a/internal/commands/locations/locations_actions_test.go
+++ b/internal/commands/locations/locations_actions_test.go
@@ -402,7 +402,7 @@ func TestGetLocation(t *testing.T) {
 			defer output.SetOutputFormat("table")
 
 			var err error
-			capturedOutput := output.CaptureOutput(func() {
+			capturedOutput := output.CaptureStdout(func() {
 				err = GetLocation(cmd, tt.args, true, "json")
 			})
 

--- a/internal/commands/mcr/mcr_actions_test.go
+++ b/internal/commands/mcr/mcr_actions_test.go
@@ -2732,7 +2732,7 @@ func TestGetMCR_Export(t *testing.T) {
 	assert.NoError(t, cmd.Flags().Set("export", "true"))
 
 	var err error
-	capturedOutput := output.CaptureOutput(func() {
+	capturedOutput := output.CaptureStdout(func() {
 		err = GetMCR(cmd, []string{"mcr-export-123"}, true, "table")
 	})
 

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -2433,7 +2433,7 @@ func TestGetMVE_Export(t *testing.T) {
 	assert.NoError(t, cmd.Flags().Set("export", "true"))
 
 	var err error
-	capturedOutput := output.CaptureOutput(func() {
+	capturedOutput := output.CaptureStdout(func() {
 		err = GetMVE(cmd, []string{"mve-export-123"}, true, "table")
 	})
 

--- a/internal/commands/ports/ports_actions_test.go
+++ b/internal/commands/ports/ports_actions_test.go
@@ -2331,7 +2331,7 @@ func TestGetPort_Export(t *testing.T) {
 	require.NoError(t, cmd.Flags().Set("export", "true"))
 
 	var err error
-	capturedOutput := output.CaptureOutput(func() {
+	capturedOutput := output.CaptureStdout(func() {
 		err = testutil.OutputAdapter(GetPort)(cmd, []string{"port-export-123"})
 	})
 

--- a/internal/commands/vxc/vxc_actions_test.go
+++ b/internal/commands/vxc/vxc_actions_test.go
@@ -2333,7 +2333,7 @@ func TestGetVXC_Export(t *testing.T) {
 	assert.NoError(t, cmd.Flags().Set("export", "true"))
 
 	var err error
-	capturedOutput := output.CaptureOutput(func() {
+	capturedOutput := output.CaptureStdout(func() {
 		err = GetVXC(cmd, []string{"vxc-export-123"}, true, "table")
 	})
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -157,32 +157,62 @@ func applyFieldsFilter(cmd *cobra.Command) {
 	}
 }
 
+// emitError reports a command failure on the correct stream and returns the
+// resolved exit code. JSON output emits only the structured envelope; other
+// formats print a human line to stderr, but only when the action did not
+// already print the error itself, so nothing is shown twice and no failure is
+// silent.
+func emitError(cmd *cobra.Command, format string, err error) int {
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	code := classifyError(err)
+	if format == FormatJSON {
+		output.PrintErrorJSON(code, err.Error())
+		cmd.Root().SilenceErrors = true
+		return code
+	}
+	if !output.ErrorWasPrinted() {
+		noColor, _ := cmd.Root().PersistentFlags().GetBool("no-color")
+		output.PrintErrorPlain(err.Error(), noColor)
+	}
+	return code
+}
+
+// reportGuardError surfaces a pre-run guard failure (invalid flag combination)
+// and returns it unchanged so callers keep the original usage error and code.
+func reportGuardError(cmd *cobra.Command, format string, err error) error {
+	emitError(cmd, format, err)
+	return err
+}
+
+// reportActionError surfaces a failed action. The returned error keeps the
+// verbose, help-pointing wording for non-JSON formats; JSON returns the bare
+// error so the envelope stays the single representation.
+func reportActionError(cmd *cobra.Command, args []string, format string, err error) error {
+	code := emitError(cmd, format, err)
+	if format == FormatJSON {
+		return exitcodes.New(code, err)
+	}
+	wrapped := fmt.Errorf("error running %s command\n\nError: %v\nCommand: %s\nArguments: %v\n\nFor more information, use the --help flag", cmd.Name(), err, cmd.Name(), args)
+	return exitcodes.New(code, wrapped)
+}
+
 // WrapRunE wraps a RunE function to set SilenceUsage to true if an error occurs and formats the error message.
 func WrapRunE(runE func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		output.ResetErrorPrinted()
 		applyFieldsFilter(cmd)
 		applyTemplateFilter(cmd)
 		rawFormat, _ := cmd.Root().PersistentFlags().GetString("output")
 		format := strings.ToLower(rawFormat)
 		if format == FormatGoTemplate && output.GetTemplateString() == "" {
-			cmd.SilenceUsage = true
-			return exitcodes.NewUsageError(fmt.Errorf("--template is required when --output go-template is used"))
+			return reportGuardError(cmd, format, exitcodes.NewUsageError(fmt.Errorf("--template is required when --output go-template is used")))
 		}
 		if err := enforceQueryFormatGuard(cmd, applyQueryFilter(cmd), format); err != nil {
-			return err
+			return reportGuardError(cmd, format, err)
 		}
-		err := runE(cmd, args)
-		if err != nil {
-			cmd.SilenceUsage = true
-			cmd.SilenceErrors = true
-			code := classifyError(err)
-			if format == FormatJSON {
-				output.PrintErrorJSON(code, err.Error())
-				cmd.Root().SilenceErrors = true
-				return exitcodes.New(code, err)
-			}
-			wrapped := fmt.Errorf("error running %s command\n\nError: %v\nCommand: %s\nArguments: %v\n\nFor more information, use the --help flag", cmd.Name(), err, cmd.Name(), args)
-			return exitcodes.New(code, wrapped)
+		if err := runE(cmd, args); err != nil {
+			return reportActionError(cmd, args, format, err)
 		}
 		return nil
 	}
@@ -192,16 +222,16 @@ func WrapRunE(runE func(cmd *cobra.Command, args []string) error) func(cmd *cobr
 // and passing the noColor flag to command functions.
 func WrapColorAwareRunE(fn func(cmd *cobra.Command, args []string, noColor bool) error) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		output.ResetErrorPrinted()
 		applyFieldsFilter(cmd)
 		applyTemplateFilter(cmd)
 		rawFormat, _ := cmd.Root().PersistentFlags().GetString("output")
 		format := strings.ToLower(rawFormat)
 		if format == FormatGoTemplate && output.GetTemplateString() == "" {
-			cmd.SilenceUsage = true
-			return exitcodes.NewUsageError(fmt.Errorf("--template is required when --output go-template is used"))
+			return reportGuardError(cmd, format, exitcodes.NewUsageError(fmt.Errorf("--template is required when --output go-template is used")))
 		}
 		if err := enforceQueryFormatGuard(cmd, applyQueryFilter(cmd), format); err != nil {
-			return err
+			return reportGuardError(cmd, format, err)
 		}
 		// Get noColor value from root command
 		noColor, err := cmd.Root().PersistentFlags().GetBool("no-color")
@@ -209,22 +239,8 @@ func WrapColorAwareRunE(fn func(cmd *cobra.Command, args []string, noColor bool)
 			noColor = false // Default to color if flag not found
 		}
 
-		// Call the function with the noColor parameter
-		err = fn(cmd, args, noColor)
-
-		// Error handling from WrapRunE
-		if err != nil {
-			cmd.SilenceUsage = true
-			cmd.SilenceErrors = true
-			code := classifyError(err)
-			if format == FormatJSON {
-				output.PrintErrorJSON(code, err.Error())
-				cmd.Root().SilenceErrors = true
-				return exitcodes.New(code, err)
-			}
-			wrapped := fmt.Errorf("error running %s command\n\nError: %v\nCommand: %s\nArguments: %v\n\nFor more information, use the --help flag",
-				cmd.Name(), err, cmd.Name(), args)
-			return exitcodes.New(code, wrapped)
+		if err := fn(cmd, args, noColor); err != nil {
+			return reportActionError(cmd, args, format, err)
 		}
 		return nil
 	}
@@ -234,6 +250,7 @@ func WrapColorAwareRunE(fn func(cmd *cobra.Command, args []string, noColor bool)
 // This wrapper takes a function that needs both output format and noColor parameters.
 func WrapOutputFormatRunE(fn func(cmd *cobra.Command, args []string, noColor bool, format string) error) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		output.ResetErrorPrinted()
 		// Get noColor value from root command
 		noColor, err := cmd.Root().PersistentFlags().GetBool("no-color")
 		if err != nil {
@@ -255,17 +272,12 @@ func WrapOutputFormatRunE(fn func(cmd *cobra.Command, args []string, noColor boo
 			}
 		}
 		if !validFormat {
-			// If an invalid format is provided, return an error
-			cmd.SilenceUsage = true
-			cmd.SilenceErrors = true
-			return exitcodes.NewUsageError(fmt.Errorf("invalid output format: %s. Must be one of: %v", format, ValidFormats))
+			return reportGuardError(cmd, format, exitcodes.NewUsageError(fmt.Errorf("invalid output format: %s. Must be one of: %v", format, ValidFormats)))
 		}
 
 		applyTemplateFilter(cmd)
 		if format == FormatGoTemplate && output.GetTemplateString() == "" {
-			cmd.SilenceUsage = true
-			cmd.SilenceErrors = true
-			return exitcodes.NewUsageError(fmt.Errorf("--template is required when --output go-template is used"))
+			return reportGuardError(cmd, format, exitcodes.NewUsageError(fmt.Errorf("--template is required when --output go-template is used")))
 		}
 
 		applyFieldsFilter(cmd)
@@ -273,25 +285,11 @@ func WrapOutputFormatRunE(fn func(cmd *cobra.Command, args []string, noColor boo
 		// re-read --output from the root persistent flags (which could differ
 		// if the subcommand defines its own local --output override).
 		if err := enforceQueryFormatGuard(cmd, applyQueryFilter(cmd), format); err != nil {
-			return err
+			return reportGuardError(cmd, format, err)
 		}
 
-		// Call the function with both parameters
-		err = fn(cmd, args, noColor, format)
-
-		// Error handling from WrapRunE
-		if err != nil {
-			cmd.SilenceUsage = true
-			cmd.SilenceErrors = true
-			code := classifyError(err)
-			if format == FormatJSON {
-				output.PrintErrorJSON(code, err.Error())
-				cmd.Root().SilenceErrors = true
-				return exitcodes.New(code, err)
-			}
-			wrapped := fmt.Errorf("error running %s command\n\nError: %v\nCommand: %s\nArguments: %v\n\nFor more information, use the --help flag",
-				cmd.Name(), err, cmd.Name(), args)
-			return exitcodes.New(code, wrapped)
+		if err := fn(cmd, args, noColor, format); err != nil {
+			return reportActionError(cmd, args, format, err)
 		}
 		return nil
 	}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/megaport/megaport-cli/internal/base/exitcodes"
+	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,6 +44,34 @@ func captureStderr(t *testing.T, fn func()) (result string) {
 	defer func() {
 		_ = w.Close() // signal EOF to the goroutine
 		<-done        // wait for all data to be read
+		_ = r.Close()
+		result = buf.String()
+	}()
+
+	fn()
+	return
+}
+
+// captureStdout captures what the function writes to os.Stdout.
+// Not parallel-safe: it redirects the global os.Stdout via os.Pipe.
+func captureStdout(t *testing.T, fn func()) (result string) {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = io.Copy(&buf, r)
+	}()
+
+	defer func() {
+		_ = w.Close()
+		<-done
 		_ = r.Close()
 		result = buf.String()
 	}()
@@ -671,4 +701,64 @@ func TestWrapOutputFormatRunE_JSONErrorOutput(t *testing.T) {
 	assert.Equal(t, exitcodes.API, code)
 	assert.Equal(t, "api_error", errType)
 	assert.Equal(t, "failed to get port: not found", msg)
+}
+
+// ESD-1421 repro: an action that returns an error without printing anything
+// itself must still surface that error to stderr in a non-JSON format.
+func TestWrapOutputFormatRunE_SilentActionPrintsToStderr(t *testing.T) {
+	output.ResetErrorPrinted()
+	wrapped := WrapOutputFormatRunE(func(cmd *cobra.Command, args []string, noColor bool, format string) error {
+		return errors.New("strconv.Atoi: parsing \"notanumber\": invalid syntax")
+	})
+	child := buildJSONChild("table")
+
+	var stdout string
+	stderr := captureStderr(t, func() {
+		stdout = captureStdout(t, func() {
+			err := wrapped(child, []string{})
+			require.Error(t, err)
+		})
+	})
+
+	assert.Contains(t, stderr, "invalid syntax", "silent action error must reach stderr")
+	assert.Empty(t, stdout, "error output must not pollute stdout")
+}
+
+// AC4: when the action already printed the error via output.PrintError, the
+// wrapper must not print it a second time.
+func TestWrapOutputFormatRunE_DoesNotDoublePrintWhenActionPrinted(t *testing.T) {
+	output.ResetErrorPrinted()
+	wrapped := WrapOutputFormatRunE(func(cmd *cobra.Command, args []string, noColor bool, format string) error {
+		output.PrintError("action said boom", true)
+		return errors.New("action said boom")
+	})
+	child := buildJSONChild("table")
+
+	stderr := captureStderr(t, func() {
+		err := wrapped(child, []string{})
+		require.Error(t, err)
+	})
+
+	assert.Equal(t, 1, strings.Count(stderr, "✗"), "error must be printed exactly once")
+}
+
+// ESD-1421 repro: `--output JSON` (uppercase) is an invalid format. The guard
+// error must reach stderr rather than exiting silently.
+func TestWrapOutputFormatRunE_UppercaseInvalidFormatPrintsToStderr(t *testing.T) {
+	output.ResetErrorPrinted()
+	wrapped := WrapOutputFormatRunE(func(cmd *cobra.Command, args []string, noColor bool, format string) error {
+		return nil
+	})
+	child := buildJSONChild("JSON")
+
+	var stdout string
+	stderr := captureStderr(t, func() {
+		stdout = captureStdout(t, func() {
+			err := wrapped(child, []string{})
+			require.Error(t, err)
+		})
+	})
+
+	assert.Contains(t, stderr, "invalid output format: JSON", "invalid-format guard must print to stderr")
+	assert.Empty(t, stdout, "guard error must not pollute stdout")
 }


### PR DESCRIPTION
Failing commands could exit with no output at all, and status messages (success, info, warnings) were written to stdout, polluting redirected data files.

This routes all status and error messages to stderr and guarantees a failing command always says why it failed.

- Every failing command now prints a useful error to stderr, even when the action returned an error without printing one itself. A printed-error flag lets the RunE wrappers cover that gap without double-printing when the action already reported it.
- `PrintError`, `PrintWarning`, `PrintInfo`, `PrintSuccess` always write to stderr in every output format, so `--output csv > file` (and json/xml) leaves the file clean.
- JSON mode emits exactly one structured error envelope; the human-readable line is suppressed.
- Test helper split: `CaptureOutput`/`CaptureOutputErr` capture both streams (all user-facing output); `CaptureStdout` captures stdout alone for tests asserting clean data.

Verified the two empirical repros now print to stderr with a non-zero exit, and that csv/json redirects produce clean data files.