### PR TITLE
ci: add GitHub Action to build and publish WASM to S3 (ESD-1506)

### DIFF
--- a/.github/workflows/wasm-publish.yaml
+++ b/.github/workflows/wasm-publish.yaml
@@ -8,8 +8,10 @@ name: Publish WASM to S3
 #   megaport/megaport-cli to github_repo_to_s3_prod_deploy_role_mappings granting the
 #   media.megaport.com bucket. That provisions this repo's standard
 #   AWS_S3_PROD_DEPLOY_ROLE. Then set this repo config:
-#     secrets.AWS_S3_PROD_DEPLOY_ROLE  role ARN to assume (a secret only to keep the AWS
-#                                      account id out of the plaintext variables list)
+#     secrets.AWS_S3_PROD_DEPLOY_ROLE  role ARN to assume (a secret so the embedded AWS
+#                                      account id stays masked in this public repo's
+#                                      world-readable Actions logs; OIDC trust is the real
+#                                      guard, this is just defense in depth)
 #     vars.AWS_S3_PROD_DEPLOY_REGION   e.g. ap-southeast-2 (org-standard name)
 #     vars.WASM_S3_BUCKET              target bucket (media.megaport.com)
 #     vars.WASM_S3_PREFIX             key prefix within the bucket (portal/megaport-cli)

--- a/.github/workflows/wasm-publish.yaml
+++ b/.github/workflows/wasm-publish.yaml
@@ -6,15 +6,23 @@ name: Publish WASM to S3
 #   The repository has no AWS access yet. Set these before this workflow can run:
 #     secrets.AWS_ROLE_ARN              OIDC role to assume (trust policy must allow this repo)
 #     vars.AWS_REGION                   e.g. ap-southeast-2
-#     vars.WASM_S3_BUCKET               target bucket
-#     vars.WASM_S3_PREFIX               key prefix within the bucket (e.g. portal/megaport-cli)
-#     vars.WASM_CLOUDFRONT_DISTRIBUTION_ID   distribution to invalidate
+#     vars.WASM_S3_BUCKET               target bucket (media.megaport.com)
+#     vars.WASM_S3_PREFIX               key prefix within the bucket (portal/megaport-cli)
+#   Optional:
+#     vars.WASM_CLOUDFRONT_DISTRIBUTION_ID   if set, the latest/ + version paths are
+#                                            invalidated; if unset, latest/ self-refreshes
+#                                            within its short TTL.
 #   See the "Check required configuration" step, which fails early with a clear message.
 #
-# WASM FILENAME:
-#   cmd/wasmhash content-hashes the wasm binary (megaport.<hash>.wasm) and injects
-#   window.__MEGAPORT_WASM_URL__ into index.html so the CDN can serve it immutable.
-#   The portal config URL must be updated to the new path after each release.
+# WHAT GETS PUBLISHED:
+#   Stable filenames under each prefix: megaport.wasm (brotli, Content-Encoding: br),
+#   wasm_exec.js, and the rest of the static site. The portal references megaport.wasm
+#   and wasm_exec.js by URL, so the names are kept stable rather than content-hashed;
+#   the version/latest prefix provides the cache-busting instead.
+#
+# PORTAL INTEGRATION:
+#   Point the portal's wasmUrl/wasmExecUrl at the latest/ alias while iterating, then
+#   pin to a specific <version>/ prefix once the integration is stable.
 
 on:
   workflow_dispatch:
@@ -50,13 +58,13 @@ jobs:
           AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
           AWS_REGION: ${{ vars.AWS_REGION }}
           WASM_S3_BUCKET: ${{ vars.WASM_S3_BUCKET }}
-          WASM_CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.WASM_CLOUDFRONT_DISTRIBUTION_ID }}
+          WASM_S3_PREFIX: ${{ vars.WASM_S3_PREFIX }}
         run: |
           missing=()
           [ -z "$AWS_ROLE_ARN" ] && missing+=("secrets.AWS_ROLE_ARN")
           [ -z "$AWS_REGION" ] && missing+=("vars.AWS_REGION")
           [ -z "$WASM_S3_BUCKET" ] && missing+=("vars.WASM_S3_BUCKET")
-          [ -z "$WASM_CLOUDFRONT_DISTRIBUTION_ID" ] && missing+=("vars.WASM_CLOUDFRONT_DISTRIBUTION_ID")
+          [ -z "$WASM_S3_PREFIX" ] && missing+=("vars.WASM_S3_PREFIX")
           if [ ${#missing[@]} -ne 0 ]; then
             echo "::error::Missing required configuration: ${missing[*]}. See ESD-1506 / the header comment in this workflow."
             exit 1
@@ -104,22 +112,13 @@ jobs:
       - name: Build static site
         run: make web-static
 
-      - name: Content-hash WASM filename
-        id: wasmhash
-        run: |
-          set -euo pipefail
-          # Renames megaport.wasm -> megaport.<hash>.wasm and injects
-          # window.__MEGAPORT_WASM_URL__ into index.html (ESD-1272).
-          hashed=$(GOWORK=off go run ./cmd/wasmhash web/vue-demo/megaport.wasm web/vue-demo/index.html)
-          echo "path=$hashed" >> "$GITHUB_OUTPUT"
-          echo "Hashed WASM: $hashed"
-
       - name: Compress WASM
         run: |
           set -euo pipefail
-          # cmd/wasmcompress writes .br and .gz next to the source file (ESD-1268).
-          # CloudFront auto-compression caps at 10 MB; the raw wasm is well over that.
-          GOWORK=off go run ./cmd/wasmcompress "${{ steps.wasmhash.outputs.path }}"
+          # cmd/wasmcompress writes .br (and .gz) next to the source file (ESD-1268).
+          # CloudFront auto-compression caps at 10 MB; the raw wasm is well over that,
+          # so it must be pre-compressed at origin and served with Content-Encoding: br.
+          GOWORK=off go run ./cmd/wasmcompress web/vue-demo/megaport.wasm
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4.3.1
@@ -132,31 +131,29 @@ jobs:
           BUCKET: ${{ vars.WASM_S3_BUCKET }}
           PREFIX: ${{ vars.WASM_S3_PREFIX }}
           VERSION: ${{ steps.version.outputs.version }}
-          HASHED_WASM_PATH: ${{ steps.wasmhash.outputs.path }}
           PUBLISH_LATEST: ${{ github.event_name == 'push' || inputs.publish_latest }}
         run: |
           set -euo pipefail
           src=web/vue-demo
-          wasm_base="$(basename "$HASHED_WASM_PATH")"
 
           publish() {
             local dest="s3://${BUCKET}/${PREFIX}/$1"
             local cache="$2"
             echo "==> Publishing to ${dest}"
-            # Sync non-wasm assets; wasm variants uploaded separately to set correct headers.
+            # Sync the site (incl. wasm_exec.js); the wasm is uploaded separately below
+            # so we can set Content-Encoding on the brotli copy.
             aws s3 sync "$src/" "$dest/" --delete \
-              --exclude "${wasm_base}" \
-              --exclude "${wasm_base}.br" \
-              --exclude "${wasm_base}.gz" \
+              --exclude 'megaport.wasm' \
+              --exclude 'megaport.wasm.br' \
+              --exclude 'megaport.wasm.gz' \
               --cache-control "$cache"
-            # Serve the brotli-compressed wasm under the hashed key with Content-Encoding: br.
-            aws s3 cp "$src/${wasm_base}.br" "$dest/${wasm_base}" \
+            aws s3 cp "$src/megaport.wasm.br" "$dest/megaport.wasm" \
               --content-type application/wasm \
               --content-encoding br \
               --cache-control "$cache"
           }
 
-          # Versioned prefix is immutable; latest is short-lived so index.html is always fresh.
+          # Versioned prefix is immutable; latest is short-lived so the portal picks up rebuilds.
           publish "$VERSION" 'public, max-age=31536000, immutable'
           if [ "$PUBLISH_LATEST" = "true" ]; then
             publish latest 'public, max-age=300'
@@ -170,6 +167,10 @@ jobs:
           PUBLISH_LATEST: ${{ github.event_name == 'push' || inputs.publish_latest }}
         run: |
           set -euo pipefail
+          if [ -z "$DISTRIBUTION_ID" ]; then
+            echo "WASM_CLOUDFRONT_DISTRIBUTION_ID not set; skipping invalidation (latest/ self-refreshes within its TTL)."
+            exit 0
+          fi
           paths="/${PREFIX}/${VERSION}/*"
           if [ "$PUBLISH_LATEST" = "true" ]; then
             paths="$paths /${PREFIX}/latest/*"
@@ -181,13 +182,12 @@ jobs:
         env:
           PREFIX: ${{ vars.WASM_S3_PREFIX }}
           VERSION: ${{ steps.version.outputs.version }}
-          HASHED_WASM_PATH: ${{ steps.wasmhash.outputs.path }}
           PUBLISH_LATEST: ${{ github.event_name == 'push' || inputs.publish_latest }}
         run: |
           {
             echo "### WASM published"
             echo ""
             echo "- Version prefix: \`${PREFIX}/${VERSION}/\`"
-            echo "- WASM key: \`$(basename "$HASHED_WASM_PATH")\`"
+            echo "- Files: \`megaport.wasm\`, \`wasm_exec.js\`"
             [ "$PUBLISH_LATEST" = "true" ] && echo "- Latest alias: \`${PREFIX}/latest/\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/wasm-publish.yaml
+++ b/.github/workflows/wasm-publish.yaml
@@ -3,11 +3,15 @@ name: Publish WASM to S3
 # Builds the browser/WASM CLI static site and publishes it to S3 + CloudFront.
 #
 # CONFIGURATION REQUIRED BEFORE MERGE (ESD-1506):
-#   The repository has no AWS access yet. Set these before this workflow can run:
-#     secrets.AWS_ROLE_ARN              OIDC role to assume (trust policy must allow this repo)
-#     vars.AWS_REGION                   e.g. ap-southeast-2
-#     vars.WASM_S3_BUCKET               target bucket (media.megaport.com)
-#     vars.WASM_S3_PREFIX               key prefix within the bucket (portal/megaport-cli)
+#   AWS access is provisioned via the shared github_runners_iam Terraform module in
+#   megaport/aws-infrastructure (production-legacy/github_runners_iam.tf): add
+#   megaport/megaport-cli to github_repo_to_s3_prod_deploy_role_mappings granting the
+#   media.megaport.com bucket (model on aws-infrastructure PR #951). That provisions
+#   this repo's standard AWS_S3_PROD_DEPLOY_ROLE. Then set as repo variables:
+#     vars.AWS_S3_PROD_DEPLOY_ROLE     role ARN to assume (org-standard name)
+#     vars.AWS_S3_PROD_DEPLOY_REGION   e.g. ap-southeast-2 (org-standard name)
+#     vars.WASM_S3_BUCKET              target bucket (media.megaport.com)
+#     vars.WASM_S3_PREFIX             key prefix within the bucket (portal/megaport-cli)
 #   Optional:
 #     vars.WASM_CLOUDFRONT_DISTRIBUTION_ID   if set, the latest/ + version paths are
 #                                            invalidated; if unset, latest/ self-refreshes
@@ -26,8 +30,9 @@ name: Publish WASM to S3
 #
 # SAFETY:
 #   A v* tag push auto-publishes to the production bucket. The job runs in the
-#   `production` GitHub environment; add required reviewers there to gate deploys,
-#   and scope the OIDC role's trust policy to that environment.
+#   `production` GitHub environment, so add required reviewers there to gate the
+#   auto-deploy. The shared deploy role trusts the whole repo, so this GitHub-side
+#   approval is what guards production.
 
 on:
   workflow_dispatch:
@@ -61,15 +66,15 @@ jobs:
     steps:
       - name: Check required configuration
         env:
-          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
-          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_ROLE_ARN: ${{ vars.AWS_S3_PROD_DEPLOY_ROLE }}
+          AWS_REGION: ${{ vars.AWS_S3_PROD_DEPLOY_REGION }}
           WASM_S3_BUCKET: ${{ vars.WASM_S3_BUCKET }}
           WASM_S3_PREFIX: ${{ vars.WASM_S3_PREFIX }}
         run: |
           set -euo pipefail
           missing=()
-          [ -z "$AWS_ROLE_ARN" ] && missing+=("secrets.AWS_ROLE_ARN")
-          [ -z "$AWS_REGION" ] && missing+=("vars.AWS_REGION")
+          [ -z "$AWS_ROLE_ARN" ] && missing+=("vars.AWS_S3_PROD_DEPLOY_ROLE")
+          [ -z "$AWS_REGION" ] && missing+=("vars.AWS_S3_PROD_DEPLOY_REGION")
           [ -z "$WASM_S3_BUCKET" ] && missing+=("vars.WASM_S3_BUCKET")
           [ -z "$WASM_S3_PREFIX" ] && missing+=("vars.WASM_S3_PREFIX")
           if [ ${#missing[@]} -ne 0 ]; then
@@ -130,8 +135,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4.3.1
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: ${{ vars.AWS_S3_PROD_DEPLOY_ROLE }}
+          aws-region: ${{ vars.AWS_S3_PROD_DEPLOY_REGION }}
 
       - name: Publish to S3
         env:

--- a/.github/workflows/wasm-publish.yaml
+++ b/.github/workflows/wasm-publish.yaml
@@ -6,8 +6,8 @@ name: Publish WASM to S3
 #   AWS access is provisioned via the shared github_runners_iam Terraform module in
 #   megaport/aws-infrastructure (production-legacy/github_runners_iam.tf): add
 #   megaport/megaport-cli to github_repo_to_s3_prod_deploy_role_mappings granting the
-#   media.megaport.com bucket (model on aws-infrastructure PR #951). That provisions
-#   this repo's standard AWS_S3_PROD_DEPLOY_ROLE. Then set as repo variables:
+#   media.megaport.com bucket. That provisions this repo's standard
+#   AWS_S3_PROD_DEPLOY_ROLE. Then set as repo variables:
 #     vars.AWS_S3_PROD_DEPLOY_ROLE     role ARN to assume (org-standard name)
 #     vars.AWS_S3_PROD_DEPLOY_REGION   e.g. ap-southeast-2 (org-standard name)
 #     vars.WASM_S3_BUCKET              target bucket (media.megaport.com)

--- a/.github/workflows/wasm-publish.yaml
+++ b/.github/workflows/wasm-publish.yaml
@@ -7,9 +7,14 @@ name: Publish WASM to S3
 #     secrets.AWS_ROLE_ARN              OIDC role to assume (trust policy must allow this repo)
 #     vars.AWS_REGION                   e.g. ap-southeast-2
 #     vars.WASM_S3_BUCKET               target bucket
-#     vars.WASM_S3_PREFIX               key prefix (default: megaport-cli-wasm)
+#     vars.WASM_S3_PREFIX               key prefix within the bucket (e.g. portal/megaport-cli)
 #     vars.WASM_CLOUDFRONT_DISTRIBUTION_ID   distribution to invalidate
 #   See the "Check required configuration" step, which fails early with a clear message.
+#
+# WASM FILENAME:
+#   cmd/wasmhash content-hashes the wasm binary (megaport.<hash>.wasm) and injects
+#   window.__MEGAPORT_WASM_URL__ into index.html so the CDN can serve it immutable.
+#   The portal config URL must be updated to the new path after each release.
 
 on:
   workflow_dispatch:
@@ -96,20 +101,25 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Publishing version: $version"
 
-      - name: Install brotli
-        run: sudo apt-get update && sudo apt-get install -y brotli
-
       - name: Build static site
         run: make web-static
 
-      - name: Pre-compress WASM (brotli)
+      - name: Content-hash WASM filename
+        id: wasmhash
         run: |
           set -euo pipefail
-          # CloudFront auto-compression caps at 10 MB and the raw .wasm is well over
-          # that, so it must be compressed at origin and served with Content-Encoding: br.
-          brotli --version
-          brotli -q 11 -f -o web/vue-demo/megaport.wasm.br web/vue-demo/megaport.wasm
-          ls -lh web/vue-demo/megaport.wasm web/vue-demo/megaport.wasm.br
+          # Renames megaport.wasm -> megaport.<hash>.wasm and injects
+          # window.__MEGAPORT_WASM_URL__ into index.html (ESD-1272).
+          hashed=$(GOWORK=off go run ./cmd/wasmhash web/vue-demo/megaport.wasm web/vue-demo/index.html)
+          echo "path=$hashed" >> "$GITHUB_OUTPUT"
+          echo "Hashed WASM: $hashed"
+
+      - name: Compress WASM
+        run: |
+          set -euo pipefail
+          # cmd/wasmcompress writes .br and .gz next to the source file (ESD-1268).
+          # CloudFront auto-compression caps at 10 MB; the raw wasm is well over that.
+          GOWORK=off go run ./cmd/wasmcompress "${{ steps.wasmhash.outputs.path }}"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4.3.1
@@ -120,29 +130,33 @@ jobs:
       - name: Publish to S3
         env:
           BUCKET: ${{ vars.WASM_S3_BUCKET }}
-          PREFIX: ${{ vars.WASM_S3_PREFIX || 'megaport-cli-wasm' }}
+          PREFIX: ${{ vars.WASM_S3_PREFIX }}
           VERSION: ${{ steps.version.outputs.version }}
+          HASHED_WASM_PATH: ${{ steps.wasmhash.outputs.path }}
           PUBLISH_LATEST: ${{ github.event_name == 'push' || inputs.publish_latest }}
         run: |
           set -euo pipefail
           src=web/vue-demo
+          wasm_base="$(basename "$HASHED_WASM_PATH")"
 
           publish() {
             local dest="s3://${BUCKET}/${PREFIX}/$1"
             local cache="$2"
             echo "==> Publishing to ${dest}"
-            # Sync everything except the wasm; the brotli copy is uploaded separately
-            # so we can set Content-Encoding on it.
+            # Sync non-wasm assets; wasm variants uploaded separately to set correct headers.
             aws s3 sync "$src/" "$dest/" --delete \
-              --exclude 'megaport.wasm' --exclude 'megaport.wasm.br' \
+              --exclude "${wasm_base}" \
+              --exclude "${wasm_base}.br" \
+              --exclude "${wasm_base}.gz" \
               --cache-control "$cache"
-            aws s3 cp "$src/megaport.wasm.br" "$dest/megaport.wasm" \
+            # Serve the brotli-compressed wasm under the hashed key with Content-Encoding: br.
+            aws s3 cp "$src/${wasm_base}.br" "$dest/${wasm_base}" \
               --content-type application/wasm \
               --content-encoding br \
               --cache-control "$cache"
           }
 
-          # Versioned prefix is immutable; latest is short-lived so the portal picks up rebuilds.
+          # Versioned prefix is immutable; latest is short-lived so index.html is always fresh.
           publish "$VERSION" 'public, max-age=31536000, immutable'
           if [ "$PUBLISH_LATEST" = "true" ]; then
             publish latest 'public, max-age=300'
@@ -151,7 +165,7 @@ jobs:
       - name: Invalidate CloudFront
         env:
           DISTRIBUTION_ID: ${{ vars.WASM_CLOUDFRONT_DISTRIBUTION_ID }}
-          PREFIX: ${{ vars.WASM_S3_PREFIX || 'megaport-cli-wasm' }}
+          PREFIX: ${{ vars.WASM_S3_PREFIX }}
           VERSION: ${{ steps.version.outputs.version }}
           PUBLISH_LATEST: ${{ github.event_name == 'push' || inputs.publish_latest }}
         run: |
@@ -165,13 +179,15 @@ jobs:
 
       - name: Summary
         env:
-          PREFIX: ${{ vars.WASM_S3_PREFIX || 'megaport-cli-wasm' }}
+          PREFIX: ${{ vars.WASM_S3_PREFIX }}
           VERSION: ${{ steps.version.outputs.version }}
+          HASHED_WASM_PATH: ${{ steps.wasmhash.outputs.path }}
           PUBLISH_LATEST: ${{ github.event_name == 'push' || inputs.publish_latest }}
         run: |
           {
             echo "### WASM published"
             echo ""
             echo "- Version prefix: \`${PREFIX}/${VERSION}/\`"
+            echo "- WASM key: \`$(basename "$HASHED_WASM_PATH")\`"
             [ "$PUBLISH_LATEST" = "true" ] && echo "- Latest alias: \`${PREFIX}/latest/\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/wasm-publish.yaml
+++ b/.github/workflows/wasm-publish.yaml
@@ -121,9 +121,13 @@ jobs:
           else
             version="$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)"
           fi
-          # version becomes an S3 key and a CloudFront invalidation path, so keep it strict.
-          if ! printf '%s' "$version" | grep -Eq '^[A-Za-z0-9._-]+$'; then
-            echo "::error::Invalid version label '$version'; must match [A-Za-z0-9._-]+"
+          # version becomes an S3 key and a CloudFront invalidation path, so keep it strict:
+          # leading alphanumeric, only [A-Za-z0-9._-], and no '..' segment.
+          case "$version" in
+            *..*) echo "::error::Invalid version label '$version'; must not contain '..'"; exit 1 ;;
+          esac
+          if ! printf '%s' "$version" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._-]*$'; then
+            echo "::error::Invalid version label '$version'; must start with an alphanumeric and match [A-Za-z0-9._-]"
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
@@ -160,12 +164,14 @@ jobs:
             local dest="s3://${BUCKET}/${PREFIX}/$1"
             local cache="$2"
             echo "==> Publishing to ${dest}"
-            # Sync the site (incl. wasm_exec.js); the wasm is uploaded separately below
-            # so we can set Content-Encoding on the brotli copy.
+            # Sync the static site; the wasm and wasm_exec.js are uploaded separately below
+            # so we can pin their Content-Type/Content-Encoding instead of relying on
+            # aws s3 sync's MIME inference.
             aws s3 sync "$src/" "$dest/" --delete \
               --exclude 'megaport.wasm' \
               --exclude 'megaport.wasm.br' \
               --exclude 'megaport.wasm.gz' \
+              --exclude 'wasm_exec.js' \
               --cache-control "$cache"
             # Brotli only: the portal's browser audience always sends Accept-Encoding: br,
             # so we don't upload a gzip/identity fallback (unlike the general guidance in
@@ -173,6 +179,11 @@ jobs:
             aws s3 cp "$src/megaport.wasm.br" "$dest/megaport.wasm" \
               --content-type application/wasm \
               --content-encoding br \
+              --cache-control "$cache"
+            # Pin the JS MIME type so a strict CDN (X-Content-Type-Options: nosniff) can't
+            # reject the <script src> load over a misinferred content-type.
+            aws s3 cp "$src/wasm_exec.js" "$dest/wasm_exec.js" \
+              --content-type text/javascript \
               --cache-control "$cache"
           }
 

--- a/.github/workflows/wasm-publish.yaml
+++ b/.github/workflows/wasm-publish.yaml
@@ -23,6 +23,11 @@ name: Publish WASM to S3
 # PORTAL INTEGRATION:
 #   Point the portal's wasmUrl/wasmExecUrl at the latest/ alias while iterating, then
 #   pin to a specific <version>/ prefix once the integration is stable.
+#
+# SAFETY:
+#   A v* tag push auto-publishes to the production bucket. The job runs in the
+#   `production` GitHub environment; add required reviewers there to gate deploys,
+#   and scope the OIDC role's trust policy to that environment.
 
 on:
   workflow_dispatch:
@@ -52,6 +57,7 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - name: Check required configuration
         env:
@@ -60,6 +66,7 @@ jobs:
           WASM_S3_BUCKET: ${{ vars.WASM_S3_BUCKET }}
           WASM_S3_PREFIX: ${{ vars.WASM_S3_PREFIX }}
         run: |
+          set -euo pipefail
           missing=()
           [ -z "$AWS_ROLE_ARN" ] && missing+=("secrets.AWS_ROLE_ARN")
           [ -z "$AWS_REGION" ] && missing+=("vars.AWS_REGION")
@@ -147,6 +154,9 @@ jobs:
               --exclude 'megaport.wasm.br' \
               --exclude 'megaport.wasm.gz' \
               --cache-control "$cache"
+            # Brotli only: the portal's browser audience always sends Accept-Encoding: br,
+            # so we don't upload a gzip/identity fallback (unlike the general guidance in
+            # web/README.md, which serves .br/.gz/identity as separate objects).
             aws s3 cp "$src/megaport.wasm.br" "$dest/megaport.wasm" \
               --content-type application/wasm \
               --content-encoding br \

--- a/.github/workflows/wasm-publish.yaml
+++ b/.github/workflows/wasm-publish.yaml
@@ -34,11 +34,13 @@ name: Publish WASM to S3
 #   pin to a specific <version>/ prefix once the integration is stable.
 #
 # SAFETY:
-#   A v* tag push auto-publishes to the production bucket. The job runs in the
-#   `production` GitHub environment, so add required reviewers there to gate the
-#   auto-deploy. The shared deploy role trusts the whole repo, so this GitHub-side
-#   approval is what guards production.
+#   This deploys to the production bucket, so it is manual-only (workflow_dispatch),
+#   never an automatic tag push: a deploy is always a deliberate action by someone with
+#   write access. The shared deploy role trusts the whole repo, so to add a required-
+#   reviewers approval gate, move this job into a `production` GitHub environment (needs a
+#   repo admin to create it) and re-add `environment: production` to the job.
 
+# Manual-only by design: do not add an automatic tag-push trigger (see SAFETY above).
 on:
   workflow_dispatch:
     inputs:
@@ -51,17 +53,14 @@ on:
         required: false
         default: true
         type: boolean
-  push:
-    tags:
-      - 'v*'
 
 permissions:
   contents: read
   id-token: write  # required for AWS OIDC
 
 # One constant group serializes every publish, so two runs can't race a --delete sync
-# against the shared latest/ prefix (e.g. a v* tag push and a manual dispatch on a branch
-# land on different refs but the same bucket). cancel-in-progress: false queues them.
+# against the shared latest/ prefix (two manual dispatches on different refs would
+# otherwise land on the same bucket). cancel-in-progress: false queues them.
 concurrency:
   group: wasm-publish
   cancel-in-progress: false
@@ -69,7 +68,6 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: production
     steps:
       - name: Check required configuration
         env:
@@ -150,7 +148,7 @@ jobs:
           BUCKET: ${{ vars.WASM_S3_BUCKET }}
           PREFIX: ${{ vars.WASM_S3_PREFIX }}
           VERSION: ${{ steps.version.outputs.version }}
-          PUBLISH_LATEST: ${{ github.event_name == 'push' || inputs.publish_latest }}
+          PUBLISH_LATEST: ${{ inputs.publish_latest }}
         run: |
           set -euo pipefail
           src=web/vue-demo
@@ -188,7 +186,7 @@ jobs:
           DISTRIBUTION_ID: ${{ vars.WASM_CLOUDFRONT_DISTRIBUTION_ID }}
           PREFIX: ${{ vars.WASM_S3_PREFIX }}
           VERSION: ${{ steps.version.outputs.version }}
-          PUBLISH_LATEST: ${{ github.event_name == 'push' || inputs.publish_latest }}
+          PUBLISH_LATEST: ${{ inputs.publish_latest }}
         run: |
           set -euo pipefail
           # The shared s3-prod-deploy role has no cloudfront:* permission; setting
@@ -209,7 +207,7 @@ jobs:
         env:
           PREFIX: ${{ vars.WASM_S3_PREFIX }}
           VERSION: ${{ steps.version.outputs.version }}
-          PUBLISH_LATEST: ${{ github.event_name == 'push' || inputs.publish_latest }}
+          PUBLISH_LATEST: ${{ inputs.publish_latest }}
         run: |
           {
             echo "### WASM published"

--- a/.github/workflows/wasm-publish.yaml
+++ b/.github/workflows/wasm-publish.yaml
@@ -1,0 +1,177 @@
+name: Publish WASM to S3
+
+# Builds the browser/WASM CLI static site and publishes it to S3 + CloudFront.
+#
+# CONFIGURATION REQUIRED BEFORE MERGE (ESD-1506):
+#   The repository has no AWS access yet. Set these before this workflow can run:
+#     secrets.AWS_ROLE_ARN              OIDC role to assume (trust policy must allow this repo)
+#     vars.AWS_REGION                   e.g. ap-southeast-2
+#     vars.WASM_S3_BUCKET               target bucket
+#     vars.WASM_S3_PREFIX               key prefix (default: megaport-cli-wasm)
+#     vars.WASM_CLOUDFRONT_DISTRIBUTION_ID   distribution to invalidate
+#   See the "Check required configuration" step, which fails early with a clear message.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version label for the S3 prefix (default: git describe / short SHA)'
+        required: false
+        type: string
+      publish_latest:
+        description: 'Also update the moving latest/ alias'
+        required: false
+        default: true
+        type: boolean
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  id-token: write  # required for AWS OIDC
+
+# Don't let two publishes race a --delete sync / invalidation against the same ref.
+concurrency:
+  group: wasm-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check required configuration
+        env:
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          WASM_S3_BUCKET: ${{ vars.WASM_S3_BUCKET }}
+          WASM_CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.WASM_CLOUDFRONT_DISTRIBUTION_ID }}
+        run: |
+          missing=()
+          [ -z "$AWS_ROLE_ARN" ] && missing+=("secrets.AWS_ROLE_ARN")
+          [ -z "$AWS_REGION" ] && missing+=("vars.AWS_REGION")
+          [ -z "$WASM_S3_BUCKET" ] && missing+=("vars.WASM_S3_BUCKET")
+          [ -z "$WASM_CLOUDFRONT_DISTRIBUTION_ID" ] && missing+=("vars.WASM_CLOUDFRONT_DISTRIBUTION_ID")
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing required configuration: ${missing[*]}. See ESD-1506 / the header comment in this workflow."
+            exit 1
+          fi
+
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        with:
+          fetch-depth: 0  # need tags for `git describe` version fallback
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend-integration/package-lock.json
+
+      - name: Resolve version label
+        id: version
+        env:
+          # Passed via env (not inlined into the script) to avoid expression injection.
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ "$REF_TYPE" = "tag" ]; then
+            version="$REF_NAME"
+          elif [ -n "$INPUT_VERSION" ]; then
+            version="$INPUT_VERSION"
+          else
+            version="$(git describe --tags --always --dirty 2>/dev/null || git rev-parse --short HEAD)"
+          fi
+          # version becomes an S3 key and a CloudFront invalidation path, so keep it strict.
+          if ! printf '%s' "$version" | grep -Eq '^[A-Za-z0-9._-]+$'; then
+            echo "::error::Invalid version label '$version'; must match [A-Za-z0-9._-]+"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Publishing version: $version"
+
+      - name: Install brotli
+        run: sudo apt-get update && sudo apt-get install -y brotli
+
+      - name: Build static site
+        run: make web-static
+
+      - name: Pre-compress WASM (brotli)
+        run: |
+          set -euo pipefail
+          # CloudFront auto-compression caps at 10 MB and the raw .wasm is well over
+          # that, so it must be compressed at origin and served with Content-Encoding: br.
+          brotli --version
+          brotli -q 11 -f -o web/vue-demo/megaport.wasm.br web/vue-demo/megaport.wasm
+          ls -lh web/vue-demo/megaport.wasm web/vue-demo/megaport.wasm.br
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4.3.1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Publish to S3
+        env:
+          BUCKET: ${{ vars.WASM_S3_BUCKET }}
+          PREFIX: ${{ vars.WASM_S3_PREFIX || 'megaport-cli-wasm' }}
+          VERSION: ${{ steps.version.outputs.version }}
+          PUBLISH_LATEST: ${{ github.event_name == 'push' || inputs.publish_latest }}
+        run: |
+          set -euo pipefail
+          src=web/vue-demo
+
+          publish() {
+            local dest="s3://${BUCKET}/${PREFIX}/$1"
+            local cache="$2"
+            echo "==> Publishing to ${dest}"
+            # Sync everything except the wasm; the brotli copy is uploaded separately
+            # so we can set Content-Encoding on it.
+            aws s3 sync "$src/" "$dest/" --delete \
+              --exclude 'megaport.wasm' --exclude 'megaport.wasm.br' \
+              --cache-control "$cache"
+            aws s3 cp "$src/megaport.wasm.br" "$dest/megaport.wasm" \
+              --content-type application/wasm \
+              --content-encoding br \
+              --cache-control "$cache"
+          }
+
+          # Versioned prefix is immutable; latest is short-lived so the portal picks up rebuilds.
+          publish "$VERSION" 'public, max-age=31536000, immutable'
+          if [ "$PUBLISH_LATEST" = "true" ]; then
+            publish latest 'public, max-age=300'
+          fi
+
+      - name: Invalidate CloudFront
+        env:
+          DISTRIBUTION_ID: ${{ vars.WASM_CLOUDFRONT_DISTRIBUTION_ID }}
+          PREFIX: ${{ vars.WASM_S3_PREFIX || 'megaport-cli-wasm' }}
+          VERSION: ${{ steps.version.outputs.version }}
+          PUBLISH_LATEST: ${{ github.event_name == 'push' || inputs.publish_latest }}
+        run: |
+          set -euo pipefail
+          paths="/${PREFIX}/${VERSION}/*"
+          if [ "$PUBLISH_LATEST" = "true" ]; then
+            paths="$paths /${PREFIX}/latest/*"
+          fi
+          # shellcheck disable=SC2086
+          aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION_ID" --paths $paths
+
+      - name: Summary
+        env:
+          PREFIX: ${{ vars.WASM_S3_PREFIX || 'megaport-cli-wasm' }}
+          VERSION: ${{ steps.version.outputs.version }}
+          PUBLISH_LATEST: ${{ github.event_name == 'push' || inputs.publish_latest }}
+        run: |
+          {
+            echo "### WASM published"
+            echo ""
+            echo "- Version prefix: \`${PREFIX}/${VERSION}/\`"
+            [ "$PUBLISH_LATEST" = "true" ] && echo "- Latest alias: \`${PREFIX}/latest/\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/wasm-publish.yaml
+++ b/.github/workflows/wasm-publish.yaml
@@ -7,8 +7,9 @@ name: Publish WASM to S3
 #   megaport/aws-infrastructure (production-legacy/github_runners_iam.tf): add
 #   megaport/megaport-cli to github_repo_to_s3_prod_deploy_role_mappings granting the
 #   media.megaport.com bucket. That provisions this repo's standard
-#   AWS_S3_PROD_DEPLOY_ROLE. Then set as repo variables:
-#     vars.AWS_S3_PROD_DEPLOY_ROLE     role ARN to assume (org-standard name)
+#   AWS_S3_PROD_DEPLOY_ROLE. Then set this repo config:
+#     secrets.AWS_S3_PROD_DEPLOY_ROLE  role ARN to assume (a secret only to keep the AWS
+#                                      account id out of the plaintext variables list)
 #     vars.AWS_S3_PROD_DEPLOY_REGION   e.g. ap-southeast-2 (org-standard name)
 #     vars.WASM_S3_BUCKET              target bucket (media.megaport.com)
 #     vars.WASM_S3_PREFIX             key prefix within the bucket (portal/megaport-cli)
@@ -71,14 +72,14 @@ jobs:
     steps:
       - name: Check required configuration
         env:
-          AWS_ROLE_ARN: ${{ vars.AWS_S3_PROD_DEPLOY_ROLE }}
+          AWS_ROLE_ARN: ${{ secrets.AWS_S3_PROD_DEPLOY_ROLE }}
           AWS_REGION: ${{ vars.AWS_S3_PROD_DEPLOY_REGION }}
           WASM_S3_BUCKET: ${{ vars.WASM_S3_BUCKET }}
           WASM_S3_PREFIX: ${{ vars.WASM_S3_PREFIX }}
         run: |
           set -euo pipefail
           missing=()
-          [ -z "$AWS_ROLE_ARN" ] && missing+=("vars.AWS_S3_PROD_DEPLOY_ROLE")
+          [ -z "$AWS_ROLE_ARN" ] && missing+=("secrets.AWS_S3_PROD_DEPLOY_ROLE")
           [ -z "$AWS_REGION" ] && missing+=("vars.AWS_S3_PROD_DEPLOY_REGION")
           [ -z "$WASM_S3_BUCKET" ] && missing+=("vars.WASM_S3_BUCKET")
           [ -z "$WASM_S3_PREFIX" ] && missing+=("vars.WASM_S3_PREFIX")
@@ -140,7 +141,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4.3.1
         with:
-          role-to-assume: ${{ vars.AWS_S3_PROD_DEPLOY_ROLE }}
+          role-to-assume: ${{ secrets.AWS_S3_PROD_DEPLOY_ROLE }}
           aws-region: ${{ vars.AWS_S3_PROD_DEPLOY_REGION }}
 
       - name: Publish to S3

--- a/.github/workflows/wasm-publish.yaml
+++ b/.github/workflows/wasm-publish.yaml
@@ -15,7 +15,12 @@ name: Publish WASM to S3
 #   Optional:
 #     vars.WASM_CLOUDFRONT_DISTRIBUTION_ID   if set, the latest/ + version paths are
 #                                            invalidated; if unset, latest/ self-refreshes
-#                                            within its short TTL.
+#                                            within its short TTL. WARNING: the shared
+#                                            s3-prod-deploy role has NO CloudFront
+#                                            permissions, so do not set this until that IAM
+#                                            policy is extended with cloudfront:CreateInvalidation,
+#                                            or the job fails with AccessDenied after the
+#                                            S3 upload has already run.
 #   See the "Check required configuration" step, which fails early with a clear message.
 #
 # WHAT GETS PUBLISHED:
@@ -54,9 +59,11 @@ permissions:
   contents: read
   id-token: write  # required for AWS OIDC
 
-# Don't let two publishes race a --delete sync / invalidation against the same ref.
+# One constant group serializes every publish, so two runs can't race a --delete sync
+# against the shared latest/ prefix (e.g. a v* tag push and a manual dispatch on a branch
+# land on different refs but the same bucket). cancel-in-progress: false queues them.
 concurrency:
-  group: wasm-publish-${{ github.ref }}
+  group: wasm-publish
   cancel-in-progress: false
 
 jobs:
@@ -111,7 +118,7 @@ jobs:
           elif [ -n "$INPUT_VERSION" ]; then
             version="$INPUT_VERSION"
           else
-            version="$(git describe --tags --always --dirty 2>/dev/null || git rev-parse --short HEAD)"
+            version="$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)"
           fi
           # version becomes an S3 key and a CloudFront invalidation path, so keep it strict.
           if ! printf '%s' "$version" | grep -Eq '^[A-Za-z0-9._-]+$'; then
@@ -169,6 +176,8 @@ jobs:
           }
 
           # Versioned prefix is immutable; latest is short-lived so the portal picks up rebuilds.
+          # Never reuse a version label for different content: the immutable objects can be
+          # cached ~forever, so re-publishing the same <version>/ would serve stale bytes.
           publish "$VERSION" 'public, max-age=31536000, immutable'
           if [ "$PUBLISH_LATEST" = "true" ]; then
             publish latest 'public, max-age=300'
@@ -182,6 +191,9 @@ jobs:
           PUBLISH_LATEST: ${{ github.event_name == 'push' || inputs.publish_latest }}
         run: |
           set -euo pipefail
+          # The shared s3-prod-deploy role has no cloudfront:* permission; setting
+          # WASM_CLOUDFRONT_DISTRIBUTION_ID without first extending that IAM policy will
+          # fail this step with AccessDenied (the S3 publish above has already run).
           if [ -z "$DISTRIBUTION_ID" ]; then
             echo "WASM_CLOUDFRONT_DISTRIBUTION_ID not set; skipping invalidation (latest/ self-refreshes within its TTL)."
             exit 0

--- a/web/README.md
+++ b/web/README.md
@@ -107,6 +107,10 @@ Each run publishes the whole static site under two prefixes inside `portal/megap
   version comes from the tag, a manual input, or `git describe`.
 - `portal/megaport-cli/latest/`: short TTL (`max-age=300`), refreshed on every run.
 
+Treat a `<version>` label as write-once: its objects can be cached ~forever, so
+re-publishing the same label with different content would serve stale bytes. Use a fresh
+tag or `version` input per release.
+
 Every file under a prefix (including `wasm_exec.js`) inherits that prefix's cache
 lifetime. This differs from the fixed-path `cmd/server` model in the Caching section
 above, where `wasm_exec.js` is `no-cache`: here the `<version>/` path is unique so
@@ -159,7 +163,11 @@ The workflow then fails early until these repo variables are set:
 | `AWS_S3_PROD_DEPLOY_REGION` | var | `ap-southeast-2` |
 | `WASM_S3_BUCKET` | var | `media.megaport.com` |
 | `WASM_S3_PREFIX` | var | `portal/megaport-cli` |
-| `WASM_CLOUDFRONT_DISTRIBUTION_ID` | var | optional; if set, published paths are invalidated, otherwise `latest/` self-refreshes within its TTL |
+| `WASM_CLOUDFRONT_DISTRIBUTION_ID` | var | optional; if set, published paths are invalidated, otherwise `latest/` self-refreshes within its TTL. The shared deploy role has no CloudFront permission, so do not set this until that IAM policy is extended with `cloudfront:CreateInvalidation`, or the publish job fails with `AccessDenied` after the upload. |
+
+The publish job runs in the `production` GitHub environment. Add required reviewers to
+that environment so a `v*` tag push cannot auto-deploy unreviewed: the deploy role trusts
+the whole repo, so this GitHub-side approval is the gate that guards production.
 
 ## Development
 

--- a/web/README.md
+++ b/web/README.md
@@ -93,98 +93,26 @@ path. (The S3 publish flow below does serve an unhashed `megaport.wasm`, but onl
 a per-version prefix where the path itself is unique, so immutable caching is safe
 there.)
 
-## Publishing to S3 (CDN) and portal integration
+## Publishing to S3 (CDN)
 
-`.github/workflows/wasm-publish.yaml` builds the static site and publishes it to the
-`media.megaport.com` S3 bucket (fronted by CloudFront). It is manual-only: trigger it
-from the Actions tab (`workflow_dispatch`), optionally selecting a tag to run from. There
-is deliberately no automatic tag-push trigger, since this writes to a production bucket.
+`.github/workflows/wasm-publish.yaml` builds the static site and publishes it to a
+CloudFront-fronted S3 bucket. It is manual-only (`workflow_dispatch`): a production
+publish is always a deliberate action, never an automatic tag push.
 
-### Layout
+Each run uploads the whole static site under two prefixes:
 
-Each run publishes the whole static site under two prefixes inside `portal/megaport-cli/`:
+- `<version>/`: immutable, long-lived cache. Treat a version label as write-once, so use
+  a fresh tag or `version` input per release.
+- `latest/`: short TTL, refreshed on every run.
 
-- `portal/megaport-cli/<version>/`: immutable (`max-age=31536000, immutable`). The
-  version comes from the `version` input, the ref the run was dispatched from (e.g. a
-  tag), or `git describe`.
-- `portal/megaport-cli/latest/`: short TTL (`max-age=300`), refreshed on every run.
+The portal loads `megaport.wasm` (brotli, served with `Content-Encoding: br`) and
+`wasm_exec.js` by static config URL, so unlike the `cmd/server` flow above these
+filenames are kept stable rather than content-hashed; the version/latest prefix is the
+cache-buster instead.
 
-Treat a `<version>` label as write-once: its objects can be cached ~forever, so
-re-publishing the same label with different content would serve stale bytes. Use a fresh
-tag or `version` input per release.
-
-Every file under a prefix (including `wasm_exec.js`) inherits that prefix's cache
-lifetime. This differs from the fixed-path `cmd/server` model in the Caching section
-above, where `wasm_exec.js` is `no-cache`: here the `<version>/` path is unique so
-immutable caching is safe, and `latest/`'s short TTL gives the same freshness `no-cache`
-would.
-
-### Stable filenames, not content-hashed
-
-Unlike the `cmd/server` / Docker flow above, this flow does NOT run `cmd/wasmhash`. The
-portal loads `megaport.wasm` and `wasm_exec.js` by static config URL and does not read
-our `index.html`, so a changing filename would break it. The `<version>/` and `latest/`
-prefixes provide the cache-busting instead: a given versioned URL never changes content,
-so it is safe to serve immutable.
-
-### What gets uploaded
-
-The whole static site is synced, but the portal only loads two files by URL:
-`megaport.wasm` (brotli-compressed, served with `Content-Encoding: br`) and `wasm_exec.js`.
-`index.html` and the Vue `assets/` are uploaded as a byproduct of the sync, not as a
-browsable site: the built `index.html` references its assets with absolute `/assets/...`
-paths, which do not resolve under a versioned prefix.
-
-Only the brotli copy is published as `megaport.wasm` (with `Content-Encoding: br`); no
-gzip or identity fallback is uploaded, because the portal's browser audience always
-accepts brotli.
-
-### Portal integration
-
-The portal's `wasmUrl` / `wasmExecUrl` point at the `latest/` prefix while the
-integration is evolving, then pin to a specific `<version>/` prefix once it is stable:
-
-```js
-megaportCli: {
-  wasmUrl:     'https://media.megaport.com/portal/megaport-cli/latest/megaport.wasm',
-  wasmExecUrl: 'https://media.megaport.com/portal/megaport-cli/latest/wasm_exec.js',
-}
-```
-
-The portal loads the wasm with a cross-origin `fetch().arrayBuffer()`, so the
-`media.megaport.com` bucket/CloudFront must return `Access-Control-Allow-Origin` for the
-portal's origin. CORS is bucket-level config owned by infra, not something this workflow
-sets; the bucket already serves the portal's existing assets, so this is normally already
-in place, but confirm it before treating the integration as ready. (`wasm_exec.js` is
-loaded via `<script src>` and does not need CORS.)
-
-### Required GitHub config
-
-The workflow authenticates to AWS via OIDC (no long-lived keys) using the shared prod
-S3 deploy role. That role is provisioned by adding `megaport/megaport-cli` to the
-`github_repo_to_s3_prod_deploy_role_mappings` map in `megaport/aws-infrastructure`
-(`production-legacy/github_runners_iam.tf`), granting the `media.megaport.com` bucket.
-The workflow then fails early until these repo settings are present. The role ARN is
-stored as a secret so its embedded AWS account id stays masked in this public repo's
-world-readable Actions logs (OIDC trust is the real guard, so this is just defense in
-depth); the rest are plain variables:
-
-| Setting | Kind | Value |
-|---|---|---|
-| `AWS_S3_PROD_DEPLOY_ROLE` | secret | ARN of the shared prod S3 deploy role (from `megaport/aws-infrastructure`) |
-| `AWS_S3_PROD_DEPLOY_REGION` | var | `ap-southeast-2` |
-| `WASM_S3_BUCKET` | var | `media.megaport.com` |
-| `WASM_S3_PREFIX` | var | `portal/megaport-cli` |
-| `WASM_CLOUDFRONT_DISTRIBUTION_ID` | var | optional; if set, published paths are invalidated, otherwise `latest/` self-refreshes within its TTL. The shared deploy role has no CloudFront permission, so do not set this until that IAM policy is extended with `cloudfront:CreateInvalidation`, or the publish job fails with `AccessDenied` after the upload. |
-
-### Deploy safety
-
-The deploy role trusts the whole repo, so anyone with write access who can run the
-workflow can publish to the production bucket. The workflow is therefore manual-only
-(`workflow_dispatch`, no automatic tag-push trigger), so a deploy is always a deliberate
-action by a known user. To add a stronger required-reviewers approval gate, a repo admin
-can create a `production` GitHub environment with required reviewers, after which adding
-`environment: production` back to the publish job makes every run wait for approval.
+Authentication uses GitHub OIDC (no long-lived keys). The workflow fails fast with a
+clear message if its required repo configuration is missing; see the workflow file for
+the expected secrets and variables.
 
 ## Development
 

--- a/web/README.md
+++ b/web/README.md
@@ -147,13 +147,16 @@ megaportCli: {
 
 ### Required GitHub config
 
-The workflow authenticates to AWS via OIDC (no long-lived keys) and fails early until
-these are set:
+The workflow authenticates to AWS via OIDC (no long-lived keys) using the shared prod
+S3 deploy role. That role is provisioned by adding `megaport/megaport-cli` to the
+`github_repo_to_s3_prod_deploy_role_mappings` map in `megaport/aws-infrastructure`
+(`production-legacy/github_runners_iam.tf`), granting the `media.megaport.com` bucket.
+The workflow then fails early until these repo variables are set:
 
 | Setting | Kind | Value |
 |---|---|---|
-| `AWS_ROLE_ARN` | secret | OIDC role with write access to the bucket prefix |
-| `AWS_REGION` | var | `ap-southeast-2` |
+| `AWS_S3_PROD_DEPLOY_ROLE` | var | ARN of the shared prod S3 deploy role (from `megaport/aws-infrastructure`) |
+| `AWS_S3_PROD_DEPLOY_REGION` | var | `ap-southeast-2` |
 | `WASM_S3_BUCKET` | var | `media.megaport.com` |
 | `WASM_S3_PREFIX` | var | `portal/megaport-cli` |
 | `WASM_CLOUDFRONT_DISTRIBUTION_ID` | var | optional; if set, published paths are invalidated, otherwise `latest/` self-refreshes within its TTL |

--- a/web/README.md
+++ b/web/README.md
@@ -88,7 +88,62 @@ works if the CDN respects the right cache lifetimes, so the origin server
 - `wasm_exec.js`: `no-cache` — it is served from a fixed unhashed path, so it must
   revalidate to stay paired with the wasm's Go runtime after a toolchain upgrade.
 
-A plain unhashed `megaport.wasm` must NOT be served immutable.
+A plain unhashed `megaport.wasm` must NOT be served immutable at a flat, unversioned
+path. (The S3 publish flow below does serve an unhashed `megaport.wasm`, but only under
+a per-version prefix where the path itself is unique, so immutable caching is safe
+there.)
+
+## Publishing to S3 (CDN) and portal integration
+
+`.github/workflows/wasm-publish.yaml` builds the static site and publishes it to the
+`media.megaport.com` S3 bucket (fronted by CloudFront). Trigger it manually
+(`workflow_dispatch`) or by pushing a `v*` tag.
+
+### Layout
+
+Each run publishes the whole static site under two prefixes inside `portal/megaport-cli/`:
+
+- `portal/megaport-cli/<version>/`: immutable (`max-age=31536000, immutable`). The
+  version comes from the tag, a manual input, or `git describe`.
+- `portal/megaport-cli/latest/`: short TTL (`max-age=300`), refreshed on every run.
+
+### Stable filenames, not content-hashed
+
+Unlike the `cmd/server` / Docker flow above, this flow does NOT run `cmd/wasmhash`. The
+portal loads `megaport.wasm` and `wasm_exec.js` by static config URL and does not read
+our `index.html`, so a changing filename would break it. The `<version>/` and `latest/`
+prefixes provide the cache-busting instead: a given versioned URL never changes content,
+so it is safe to serve immutable.
+
+### What gets uploaded
+
+`megaport.wasm` (brotli-compressed, served with `Content-Encoding: br`), `wasm_exec.js`,
+`index.html`, and the Vue assets.
+
+### Portal integration
+
+The portal's `wasmUrl` / `wasmExecUrl` point at the `latest/` prefix while the
+integration is evolving, then pin to a specific `<version>/` prefix once it is stable:
+
+```js
+megaportCli: {
+  wasmUrl:     'https://media.megaport.com/portal/megaport-cli/latest/megaport.wasm',
+  wasmExecUrl: 'https://media.megaport.com/portal/megaport-cli/latest/wasm_exec.js',
+}
+```
+
+### Required GitHub config
+
+The workflow authenticates to AWS via OIDC (no long-lived keys) and fails early until
+these are set:
+
+| Setting | Kind | Value |
+|---|---|---|
+| `AWS_ROLE_ARN` | secret | OIDC role with write access to the bucket prefix |
+| `AWS_REGION` | var | `ap-southeast-2` |
+| `WASM_S3_BUCKET` | var | `media.megaport.com` |
+| `WASM_S3_PREFIX` | var | `portal/megaport-cli` |
+| `WASM_CLOUDFRONT_DISTRIBUTION_ID` | var | optional; if set, published paths are invalidated, otherwise `latest/` self-refreshes within its TTL |
 
 ## Development
 

--- a/web/README.md
+++ b/web/README.md
@@ -157,11 +157,13 @@ The workflow authenticates to AWS via OIDC (no long-lived keys) using the shared
 S3 deploy role. That role is provisioned by adding `megaport/megaport-cli` to the
 `github_repo_to_s3_prod_deploy_role_mappings` map in `megaport/aws-infrastructure`
 (`production-legacy/github_runners_iam.tf`), granting the `media.megaport.com` bucket.
-The workflow then fails early until these repo variables are set:
+The workflow then fails early until these repo settings are present (the role ARN is
+stored as a secret to keep the AWS account id out of the plaintext variables list; the
+rest are plain variables):
 
 | Setting | Kind | Value |
 |---|---|---|
-| `AWS_S3_PROD_DEPLOY_ROLE` | var | ARN of the shared prod S3 deploy role (from `megaport/aws-infrastructure`) |
+| `AWS_S3_PROD_DEPLOY_ROLE` | secret | ARN of the shared prod S3 deploy role (from `megaport/aws-infrastructure`) |
 | `AWS_S3_PROD_DEPLOY_REGION` | var | `ap-southeast-2` |
 | `WASM_S3_BUCKET` | var | `media.megaport.com` |
 | `WASM_S3_PREFIX` | var | `portal/megaport-cli` |

--- a/web/README.md
+++ b/web/README.md
@@ -151,6 +151,13 @@ megaportCli: {
 }
 ```
 
+The portal loads the wasm with a cross-origin `fetch().arrayBuffer()`, so the
+`media.megaport.com` bucket/CloudFront must return `Access-Control-Allow-Origin` for the
+portal's origin. CORS is bucket-level config owned by infra, not something this workflow
+sets; the bucket already serves the portal's existing assets, so this is normally already
+in place, but confirm it before treating the integration as ready. (`wasm_exec.js` is
+loaded via `<script src>` and does not need CORS.)
+
 ### Required GitHub config
 
 The workflow authenticates to AWS via OIDC (no long-lived keys) using the shared prod

--- a/web/README.md
+++ b/web/README.md
@@ -96,15 +96,17 @@ there.)
 ## Publishing to S3 (CDN) and portal integration
 
 `.github/workflows/wasm-publish.yaml` builds the static site and publishes it to the
-`media.megaport.com` S3 bucket (fronted by CloudFront). Trigger it manually
-(`workflow_dispatch`) or by pushing a `v*` tag.
+`media.megaport.com` S3 bucket (fronted by CloudFront). It is manual-only: trigger it
+from the Actions tab (`workflow_dispatch`), optionally selecting a tag to run from. There
+is deliberately no automatic tag-push trigger, since this writes to a production bucket.
 
 ### Layout
 
 Each run publishes the whole static site under two prefixes inside `portal/megaport-cli/`:
 
 - `portal/megaport-cli/<version>/`: immutable (`max-age=31536000, immutable`). The
-  version comes from the tag, a manual input, or `git describe`.
+  version comes from the `version` input, the ref the run was dispatched from (e.g. a
+  tag), or `git describe`.
 - `portal/megaport-cli/latest/`: short TTL (`max-age=300`), refreshed on every run.
 
 Treat a `<version>` label as write-once: its objects can be cached ~forever, so
@@ -165,9 +167,14 @@ The workflow then fails early until these repo variables are set:
 | `WASM_S3_PREFIX` | var | `portal/megaport-cli` |
 | `WASM_CLOUDFRONT_DISTRIBUTION_ID` | var | optional; if set, published paths are invalidated, otherwise `latest/` self-refreshes within its TTL. The shared deploy role has no CloudFront permission, so do not set this until that IAM policy is extended with `cloudfront:CreateInvalidation`, or the publish job fails with `AccessDenied` after the upload. |
 
-The publish job runs in the `production` GitHub environment. Add required reviewers to
-that environment so a `v*` tag push cannot auto-deploy unreviewed: the deploy role trusts
-the whole repo, so this GitHub-side approval is the gate that guards production.
+### Deploy safety
+
+The deploy role trusts the whole repo, so anyone with write access who can run the
+workflow can publish to the production bucket. The workflow is therefore manual-only
+(`workflow_dispatch`, no automatic tag-push trigger), so a deploy is always a deliberate
+action by a known user. To add a stronger required-reviewers approval gate, a repo admin
+can create a `production` GitHub environment with required reviewers, after which adding
+`environment: production` back to the publish job makes every run wait for approval.
 
 ## Development
 

--- a/web/README.md
+++ b/web/README.md
@@ -157,9 +157,10 @@ The workflow authenticates to AWS via OIDC (no long-lived keys) using the shared
 S3 deploy role. That role is provisioned by adding `megaport/megaport-cli` to the
 `github_repo_to_s3_prod_deploy_role_mappings` map in `megaport/aws-infrastructure`
 (`production-legacy/github_runners_iam.tf`), granting the `media.megaport.com` bucket.
-The workflow then fails early until these repo settings are present (the role ARN is
-stored as a secret to keep the AWS account id out of the plaintext variables list; the
-rest are plain variables):
+The workflow then fails early until these repo settings are present. The role ARN is
+stored as a secret so its embedded AWS account id stays masked in this public repo's
+world-readable Actions logs (OIDC trust is the real guard, so this is just defense in
+depth); the rest are plain variables:
 
 | Setting | Kind | Value |
 |---|---|---|

--- a/web/README.md
+++ b/web/README.md
@@ -107,6 +107,12 @@ Each run publishes the whole static site under two prefixes inside `portal/megap
   version comes from the tag, a manual input, or `git describe`.
 - `portal/megaport-cli/latest/`: short TTL (`max-age=300`), refreshed on every run.
 
+Every file under a prefix (including `wasm_exec.js`) inherits that prefix's cache
+lifetime. This differs from the fixed-path `cmd/server` model in the Caching section
+above, where `wasm_exec.js` is `no-cache`: here the `<version>/` path is unique so
+immutable caching is safe, and `latest/`'s short TTL gives the same freshness `no-cache`
+would.
+
 ### Stable filenames, not content-hashed
 
 Unlike the `cmd/server` / Docker flow above, this flow does NOT run `cmd/wasmhash`. The
@@ -117,8 +123,15 @@ so it is safe to serve immutable.
 
 ### What gets uploaded
 
-`megaport.wasm` (brotli-compressed, served with `Content-Encoding: br`), `wasm_exec.js`,
-`index.html`, and the Vue assets.
+The whole static site is synced, but the portal only loads two files by URL:
+`megaport.wasm` (brotli-compressed, served with `Content-Encoding: br`) and `wasm_exec.js`.
+`index.html` and the Vue `assets/` are uploaded as a byproduct of the sync, not as a
+browsable site: the built `index.html` references its assets with absolute `/assets/...`
+paths, which do not resolve under a versioned prefix.
+
+Only the brotli copy is published as `megaport.wasm` (with `Content-Encoding: br`); no
+gzip or identity fallback is uploaded, because the portal's browser audience always
+accepts brotli.
 
 ### Portal integration
 


### PR DESCRIPTION
Adds a GitHub Action that builds the browser/WASM CLI static site and publishes it to a CloudFront-fronted S3 bucket, replacing the manual upload step.

**What it does**
- Manual-only (`workflow_dispatch`): a production publish is always a deliberate action, never an automatic tag push.
- Builds the static site with `make web-static`, then pre-compresses the wasm to brotli (CloudFront auto-compression caps at 10 MB; the raw wasm is larger).
- Publishes stable filenames (`megaport.wasm` served with `Content-Encoding: br`, `wasm_exec.js`, and the rest of the site) under a versioned prefix plus a short-cached `latest/` alias.
- Authenticates via AWS OIDC (no long-lived keys); pins all actions to commit SHAs.

Filenames are kept stable (not content-hashed) because the portal references them by static config URL; the version/latest prefix is the cache-buster instead.

Required repo config (secrets and variables) is provisioned out of band and validated by the workflow's config-check step, which fails fast with a clear message if anything is missing.

ESD-1506
