### PR TITLE
fix(locations): drop blank market codes from list-market-codes

### DIFF
--- a/internal/commands/locations/locations_actions.go
+++ b/internal/commands/locations/locations_actions.go
@@ -3,6 +3,7 @@ package locations
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/commands/config"
@@ -148,6 +149,16 @@ func ListMarketCodes(cmd *cobra.Command, args []string, noColor bool, outputForm
 		output.PrintError("Failed to retrieve market codes: %v", noColor, err)
 		return fmt.Errorf("failed to list market codes: %w", err)
 	}
+
+	// The API includes countries with no (or whitespace-only) market prefix;
+	// drop them so the list doesn't render a blank entry.
+	filtered := make([]string, 0, len(marketCodes))
+	for _, mc := range marketCodes {
+		if strings.TrimSpace(mc) != "" {
+			filtered = append(filtered, mc)
+		}
+	}
+	marketCodes = filtered
 
 	if len(marketCodes) == 0 {
 		output.PrintWarning("No market codes found", noColor)

--- a/internal/commands/locations/locations_actions_test.go
+++ b/internal/commands/locations/locations_actions_test.go
@@ -541,6 +541,20 @@ func TestListMarketCodes(t *testing.T) {
 			expectedOutput: "[]",
 		},
 		{
+			name: "filters blank market codes",
+			setupMock: func(m *MockLocationsService) {
+				m.ListMarketCodesResult = []string{"AU", "", "  ", "US"}
+			},
+			expectedOutput: `[
+  {
+    "market_code": "AU"
+  },
+  {
+    "market_code": "US"
+  }
+]`,
+		},
+		{
 			name:        "client creation error",
 			setupMock:   func(m *MockLocationsService) {},
 			clientErr:   fmt.Errorf("config error"),


### PR DESCRIPTION
`locations list-market-codes` rendered an `<empty>` row (and counted it in the total). The network regions API returns some countries with an empty market prefix, and the SDK passes those straight through.

This filters out blank/whitespace market codes in the `ListMarketCodes` action, before the count message and the output, so both stay consistent.

- Drop blank/whitespace codes returned by the SDK
- Add a `TestListMarketCodes` case covering empty and whitespace-only entries

ESD-1509