### PR TITLE
fix(cli): show friendly errors for invalid integer arguments

### DIFF
--- a/internal/commands/ix/ix_prompts.go
+++ b/internal/commands/ix/ix_prompts.go
@@ -3,7 +3,6 @@ package ix
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/megaport/megaport-cli/internal/utils"
 	"github.com/megaport/megaport-cli/internal/validation"
@@ -39,9 +38,9 @@ func buildIXRequestFromPrompt(_ context.Context, noColor bool) (*megaport.BuyIXR
 	if err != nil {
 		return nil, err
 	}
-	asn, err := strconv.Atoi(asnStr)
+	asn, err := validation.ParseInt("ASN", asnStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid ASN: %w", err)
+		return nil, err
 	}
 	if err := validation.ValidateASN(asn); err != nil {
 		return nil, err
@@ -59,9 +58,9 @@ func buildIXRequestFromPrompt(_ context.Context, noColor bool) (*megaport.BuyIXR
 	if err != nil {
 		return nil, err
 	}
-	rateLimit, err := strconv.Atoi(rateLimitStr)
+	rateLimit, err := validation.ParseInt("rate limit", rateLimitStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid rate limit: %w", err)
+		return nil, err
 	}
 	if err := validation.ValidateRateLimit(rateLimit); err != nil {
 		return nil, err
@@ -71,9 +70,9 @@ func buildIXRequestFromPrompt(_ context.Context, noColor bool) (*megaport.BuyIXR
 	if err != nil {
 		return nil, err
 	}
-	vlan, err := strconv.Atoi(vlanStr)
+	vlan, err := validation.ParseInt("VLAN", vlanStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid VLAN: %w", err)
+		return nil, err
 	}
 	if err := validation.ValidateVLAN(vlan); err != nil {
 		return nil, err
@@ -116,9 +115,9 @@ func buildUpdateIXRequestFromPrompt(_ string, noColor bool) (*megaport.UpdateIXR
 		return nil, err
 	}
 	if rateLimitStr != "" {
-		rateLimit, err := strconv.Atoi(rateLimitStr)
+		rateLimit, err := validation.ParseInt("rate limit", rateLimitStr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid rate limit: %w", err)
+			return nil, err
 		}
 		if err := validation.ValidateRateLimit(rateLimit); err != nil {
 			return nil, err
@@ -141,9 +140,9 @@ func buildUpdateIXRequestFromPrompt(_ string, noColor bool) (*megaport.UpdateIXR
 		return nil, err
 	}
 	if vlanStr != "" {
-		vlan, err := strconv.Atoi(vlanStr)
+		vlan, err := validation.ParseInt("VLAN", vlanStr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid VLAN: %w", err)
+			return nil, err
 		}
 		if err := validation.ValidateVLAN(vlan); err != nil {
 			return nil, err
@@ -169,9 +168,9 @@ func buildUpdateIXRequestFromPrompt(_ string, noColor bool) (*megaport.UpdateIXR
 		return nil, err
 	}
 	if asnStr != "" {
-		asn, err := strconv.Atoi(asnStr)
+		asn, err := validation.ParseInt("ASN", asnStr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid ASN: %w", err)
+			return nil, err
 		}
 		if err := validation.ValidateASN(asn); err != nil {
 			return nil, err

--- a/internal/commands/locations/locations_actions.go
+++ b/internal/commands/locations/locations_actions.go
@@ -2,11 +2,11 @@ package locations
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/commands/config"
 	"github.com/megaport/megaport-cli/internal/utils"
+	"github.com/megaport/megaport-cli/internal/validation"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 )
@@ -311,10 +311,10 @@ func GetLocation(cmd *cobra.Command, args []string, noColor bool, outputFormat s
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
-	locationID, err := strconv.Atoi(args[0])
+	locationID, err := validation.ParseInt("location ID", args[0])
 	if err != nil {
-		output.PrintError("Invalid location ID: %v", noColor, err)
-		return fmt.Errorf("invalid location ID: %w", err)
+		output.PrintError("%v", noColor, err)
+		return err
 	}
 
 	spinner := output.PrintResourceGetting("Location", fmt.Sprintf("%d", locationID), noColor)

--- a/internal/commands/locations/locations_actions_test.go
+++ b/internal/commands/locations/locations_actions_test.go
@@ -409,6 +409,9 @@ func TestGetLocation(t *testing.T) {
 			if tt.expectedErr != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedErr)
+				// Parse failures must not leak strconv internals to the user.
+				assert.NotContains(t, err.Error(), "strconv")
+				assert.NotContains(t, capturedOutput, "strconv")
 			} else {
 				assert.NoError(t, err)
 				var parsed []map[string]interface{}

--- a/internal/commands/mcr/mcr_actions_prefix_filter.go
+++ b/internal/commands/mcr/mcr_actions_prefix_filter.go
@@ -3,12 +3,12 @@ package mcr
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/commands/config"
 	"github.com/megaport/megaport-cli/internal/utils"
+	"github.com/megaport/megaport-cli/internal/validation"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 )
@@ -77,9 +77,9 @@ func CreateMCRPrefixFilterList(cmd *cobra.Command, args []string, noColor bool) 
 
 func UpdateMCRPrefixFilterList(cmd *cobra.Command, args []string, noColor bool) error {
 	mcrUID := args[0]
-	prefixFilterListID, err := strconv.Atoi(args[1])
+	prefixFilterListID, err := validation.ParseInt("prefix filter list ID", args[1])
 	if err != nil {
-		return fmt.Errorf("invalid prefix filter list ID: %w", err)
+		return err
 	}
 
 	interactive, _ := cmd.Flags().GetBool("interactive")
@@ -197,9 +197,9 @@ func GetMCRPrefixFilterList(cmd *cobra.Command, args []string, noColor bool, out
 	defer cancel()
 
 	mcrUID := args[0]
-	prefixFilterListID, err := strconv.Atoi(args[1])
+	prefixFilterListID, err := validation.ParseInt("prefix filter list ID", args[1])
 	if err != nil {
-		return fmt.Errorf("invalid prefix filter list ID: %w", err)
+		return err
 	}
 
 	spinner := output.PrintResourceGetting("Prefix filter list", fmt.Sprintf("%d", prefixFilterListID), noColor)
@@ -233,9 +233,9 @@ func DeleteMCRPrefixFilterList(cmd *cobra.Command, args []string, noColor bool) 
 	defer cancel()
 
 	mcrUID := args[0]
-	prefixFilterListID, err := strconv.Atoi(args[1])
+	prefixFilterListID, err := validation.ParseInt("prefix filter list ID", args[1])
 	if err != nil {
-		return fmt.Errorf("invalid prefix filter list ID: %w", err)
+		return err
 	}
 
 	spinner := output.PrintResourceDeleting("Prefix filter list", fmt.Sprintf("%d", prefixFilterListID), noColor)

--- a/internal/commands/mcr/mcr_actions_test.go
+++ b/internal/commands/mcr/mcr_actions_test.go
@@ -527,13 +527,13 @@ func TestGetMCRPrefixFilterListCmd_WithMockClient(t *testing.T) {
 	defer cleanup()
 
 	tests := []struct {
-		name              string
-		mcrUID            string
-		prefixListID      int
-		rawPrefixListID   string
-		setupMock         func(*MockMCRService)
-		expectedError     string
-		expectedOutput    string
+		name            string
+		mcrUID          string
+		prefixListID    int
+		rawPrefixListID string
+		setupMock       func(*MockMCRService)
+		expectedError   string
+		expectedOutput  string
 	}{
 		{
 			name:         "successful get prefix filter list",

--- a/internal/commands/mcr/mcr_actions_test.go
+++ b/internal/commands/mcr/mcr_actions_test.go
@@ -527,12 +527,13 @@ func TestGetMCRPrefixFilterListCmd_WithMockClient(t *testing.T) {
 	defer cleanup()
 
 	tests := []struct {
-		name           string
-		mcrUID         string
-		prefixListID   int
-		setupMock      func(*MockMCRService)
-		expectedError  string
-		expectedOutput string
+		name              string
+		mcrUID            string
+		prefixListID      int
+		rawPrefixListID   string
+		setupMock         func(*MockMCRService)
+		expectedError     string
+		expectedOutput    string
 	}{
 		{
 			name:         "successful get prefix filter list",
@@ -555,6 +556,13 @@ func TestGetMCRPrefixFilterListCmd_WithMockClient(t *testing.T) {
 			},
 			expectedError: "API error: service unavailable",
 		},
+		{
+			name:            "invalid prefix filter list ID",
+			mcrUID:          "mcr-123",
+			rawPrefixListID: "abc",
+			setupMock:       func(m *MockMCRService) {},
+			expectedError:   "invalid prefix filter list ID",
+		},
 	}
 
 	for _, tt := range tests {
@@ -568,6 +576,11 @@ func TestGetMCRPrefixFilterListCmd_WithMockClient(t *testing.T) {
 				return client, nil
 			})
 
+			idStr := tt.rawPrefixListID
+			if idStr == "" {
+				idStr = fmt.Sprintf("%d", tt.prefixListID)
+			}
+
 			cmd := &cobra.Command{
 				Use:  "get-mcr-prefix-filter-list [mcrUID] [prefixListID]",
 				Args: cobra.ExactArgs(2),
@@ -577,7 +590,7 @@ func TestGetMCRPrefixFilterListCmd_WithMockClient(t *testing.T) {
 			}
 			var err error
 			output := output.CaptureOutput(func() {
-				err = cmd.RunE(cmd, []string{tt.mcrUID, fmt.Sprintf("%d", tt.prefixListID)})
+				err = cmd.RunE(cmd, []string{tt.mcrUID, idStr})
 			})
 
 			if tt.expectedError != "" {
@@ -600,14 +613,15 @@ func TestDeleteMCRPrefixFilterListCmd_WithMockClient(t *testing.T) {
 	}()
 
 	tests := []struct {
-		name           string
-		mcrUID         string
-		prefixListID   int
-		force          bool
-		promptResponse string
-		setupMock      func(*MockMCRService)
-		expectedError  string
-		expectedOutput string
+		name            string
+		mcrUID          string
+		prefixListID    int
+		rawPrefixListID string
+		force           bool
+		promptResponse  string
+		setupMock       func(*MockMCRService)
+		expectedError   string
+		expectedOutput  string
 	}{
 		{
 			name:           "successful delete prefix filter list",
@@ -646,6 +660,14 @@ func TestDeleteMCRPrefixFilterListCmd_WithMockClient(t *testing.T) {
 			},
 			expectedError: "not successful for ID 1",
 		},
+		{
+			name:            "invalid prefix filter list ID",
+			mcrUID:          "mcr-123",
+			rawPrefixListID: "abc",
+			force:           true,
+			setupMock:       func(m *MockMCRService) {},
+			expectedError:   "invalid prefix filter list ID",
+		},
 	}
 
 	for _, tt := range tests {
@@ -663,6 +685,11 @@ func TestDeleteMCRPrefixFilterListCmd_WithMockClient(t *testing.T) {
 				return tt.promptResponse, nil
 			})
 
+			idStr := tt.rawPrefixListID
+			if idStr == "" {
+				idStr = fmt.Sprintf("%d", tt.prefixListID)
+			}
+
 			cmd := &cobra.Command{
 				Use: "delete-mcr-prefix-filter-list [mcrUID] [prefixListID]",
 				RunE: func(cmd *cobra.Command, args []string) error {
@@ -678,7 +705,7 @@ func TestDeleteMCRPrefixFilterListCmd_WithMockClient(t *testing.T) {
 
 			var err error
 			output := output.CaptureOutput(func() {
-				err = cmd.RunE(cmd, []string{tt.mcrUID, fmt.Sprintf("%d", tt.prefixListID)})
+				err = cmd.RunE(cmd, []string{tt.mcrUID, idStr})
 			})
 
 			if tt.expectedError != "" {

--- a/internal/commands/mcr/mcr_prompts.go
+++ b/internal/commands/mcr/mcr_prompts.go
@@ -120,9 +120,9 @@ func promptForUpdateMCRDetails(mcrUID string, noColor bool) (*megaport.ModifyMCR
 	}
 	asnStr = strings.TrimSpace(asnStr)
 	if asnStr != "" {
-		asn, err := strconv.Atoi(asnStr)
+		asn, err := validation.ParseInt("ASN", asnStr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid ASN: %w", err)
+			return nil, err
 		}
 		if err := validation.ValidateMCRASN(int64(asn)); err != nil {
 			return nil, err

--- a/internal/commands/mcr/mcr_prompts.go
+++ b/internal/commands/mcr/mcr_prompts.go
@@ -24,9 +24,9 @@ func promptForIPSecTunnelCount(noColor bool) (int, error) {
 	if input == "" {
 		return 0, nil
 	}
-	count, err := strconv.Atoi(strings.TrimSpace(input))
+	count, err := validation.ParseInt("tunnel count", strings.TrimSpace(input))
 	if err != nil {
-		return 0, fmt.Errorf("invalid tunnel count: %w", err)
+		return 0, err
 	}
 	return count, nil
 }
@@ -43,9 +43,9 @@ func promptForIPSecTunnelCountUpdate(noColor bool) (int, error) {
 	if input == "" {
 		return 0, fmt.Errorf("tunnel count is required for update (use 0 to disable IPSec)")
 	}
-	count, err := strconv.Atoi(input)
+	count, err := validation.ParseInt("tunnel count", input)
 	if err != nil {
-		return 0, fmt.Errorf("invalid tunnel count: %w", err)
+		return 0, err
 	}
 	return count, nil
 }
@@ -100,9 +100,9 @@ func promptForUpdateMCRDetails(mcrUID string, noColor bool) (*megaport.ModifyMCR
 		return nil, err
 	}
 	if termStr != "" {
-		term, err := strconv.Atoi(termStr)
+		term, err := validation.ParseInt("term", termStr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid term: %w", err)
+			return nil, err
 		}
 
 		if err := validation.ValidateContractTerm(term); err != nil {
@@ -136,18 +136,18 @@ func promptForMCRDetails(noColor bool) (*megaport.BuyMCRRequest, error) {
 	if err != nil {
 		return nil, err
 	}
-	term, err := strconv.Atoi(termStr)
+	term, err := validation.ParseInt("term", termStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid term: %w", err)
+		return nil, err
 	}
 
 	portSpeedStr, err := utils.ResourcePrompt("mcr", fmt.Sprintf("Enter port speed - valid port speeds are %s Mbps (required): ", validation.FormatIntSlice(validation.ValidMCRPortSpeeds)), noColor)
 	if err != nil {
 		return nil, err
 	}
-	portSpeed, err := strconv.Atoi(portSpeedStr)
+	portSpeed, err := validation.ParseInt("port speed", portSpeedStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid port speed: %w", err)
+		return nil, err
 	}
 	if err := validation.ValidateMCRPortSpeed(portSpeed); err != nil {
 		return nil, err
@@ -156,9 +156,9 @@ func promptForMCRDetails(noColor bool) (*megaport.BuyMCRRequest, error) {
 	if err != nil {
 		return nil, err
 	}
-	locationID, err := strconv.Atoi(locationIDStr)
+	locationID, err := validation.ParseInt("location ID", locationIDStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid location ID: %w", err)
+		return nil, err
 	}
 
 	asnStr, err := utils.ResourcePrompt("mcr", "Enter MCR ASN (optional): ", noColor)
@@ -168,9 +168,9 @@ func promptForMCRDetails(noColor bool) (*megaport.BuyMCRRequest, error) {
 
 	var asn int
 	if asnStr != "" {
-		asnValue, err := strconv.Atoi(asnStr)
+		asnValue, err := validation.ParseInt("ASN", asnStr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid ASN: %w", err)
+			return nil, err
 		}
 		asn = asnValue
 	}

--- a/internal/commands/mcr/mcr_prompts_test.go
+++ b/internal/commands/mcr/mcr_prompts_test.go
@@ -103,6 +103,7 @@ func TestPromptForMCRDetails_InvalidPortSpeedNotNumeric(t *testing.T) {
 	_, err := promptForMCRDetails(true)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid port speed")
+	assert.NotContains(t, err.Error(), "strconv")
 }
 
 func TestPromptForMCRDetails_InvalidASN(t *testing.T) {
@@ -114,6 +115,7 @@ func TestPromptForMCRDetails_InvalidASN(t *testing.T) {
 	_, err := promptForMCRDetails(true)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid ASN")
+	assert.NotContains(t, err.Error(), "strconv")
 }
 
 func TestPromptForUpdateMCRDetails_Success(t *testing.T) {
@@ -169,6 +171,7 @@ func TestPromptForUpdateMCRDetails_InvalidTermNotNumeric(t *testing.T) {
 	_, err := promptForUpdateMCRDetails("mcr-123", true)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid term")
+	assert.NotContains(t, err.Error(), "strconv")
 }
 
 func TestPromptForUpdateMCRDetails_ASNOnly(t *testing.T) {
@@ -218,6 +221,7 @@ func TestPromptForUpdateMCRDetails_InvalidASN(t *testing.T) {
 	_, err := promptForUpdateMCRDetails("mcr-123", true)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid ASN")
+	assert.NotContains(t, err.Error(), "strconv")
 }
 
 func TestPromptForUpdateMCRDetails_ASNPromptError(t *testing.T) {

--- a/internal/commands/mcr/mcr_prompts_test.go
+++ b/internal/commands/mcr/mcr_prompts_test.go
@@ -94,6 +94,28 @@ func TestPromptForMCRDetails_InvalidLocationID(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid location ID")
 }
 
+func TestPromptForMCRDetails_InvalidPortSpeedNotNumeric(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+	utils.SetResourcePrompt(mockPromptSequence([]string{"MCR", "12", "abc"}))
+
+	_, err := promptForMCRDetails(true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid port speed")
+}
+
+func TestPromptForMCRDetails_InvalidASN(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+	utils.SetResourcePrompt(mockPromptSequence([]string{"MCR", "12", "5000", "1", "abc"}))
+
+	_, err := promptForMCRDetails(true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid ASN")
+}
+
 func TestPromptForUpdateMCRDetails_Success(t *testing.T) {
 	originalPrompt := utils.GetResourcePrompt()
 	defer func() { utils.SetResourcePrompt(originalPrompt) }()
@@ -136,6 +158,17 @@ func TestPromptForUpdateMCRDetails_InvalidTerm(t *testing.T) {
 	_, err := promptForUpdateMCRDetails("mcr-123", true)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "contract term")
+}
+
+func TestPromptForUpdateMCRDetails_InvalidTermNotNumeric(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+	utils.SetResourcePrompt(mockPromptSequence([]string{"", "", "", "abc"}))
+
+	_, err := promptForUpdateMCRDetails("mcr-123", true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid term")
 }
 
 func TestPromptForUpdateMCRDetails_ASNOnly(t *testing.T) {

--- a/internal/commands/mve/mve_prompts.go
+++ b/internal/commands/mve/mve_prompts.go
@@ -2,7 +2,6 @@ package mve
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/megaport/megaport-cli/internal/utils"
@@ -51,9 +50,9 @@ func promptMVEBaseDetails(noColor bool) (*megaport.BuyMVERequest, string, int, s
 	if err != nil {
 		return nil, "", 0, "", "", err
 	}
-	term, err := strconv.Atoi(termStr)
+	term, err := validation.ParseInt("term", termStr)
 	if err != nil {
-		return nil, "", 0, "", "", fmt.Errorf("invalid term: %w", err)
+		return nil, "", 0, "", "", err
 	}
 	req.Term = term
 
@@ -61,9 +60,9 @@ func promptMVEBaseDetails(noColor bool) (*megaport.BuyMVERequest, string, int, s
 	if err != nil {
 		return nil, "", 0, "", "", err
 	}
-	locationID, err := strconv.Atoi(locationIDStr)
+	locationID, err := validation.ParseInt("location ID", locationIDStr)
 	if err != nil {
-		return nil, "", 0, "", "", fmt.Errorf("invalid location ID: %w", err)
+		return nil, "", 0, "", "", err
 	}
 	req.LocationID = locationID
 
@@ -97,9 +96,9 @@ func promptMVEBaseDetails(noColor bool) (*megaport.BuyMVERequest, string, int, s
 	if err != nil {
 		return nil, "", 0, "", "", err
 	}
-	imageID, err := strconv.Atoi(imageIDStr)
+	imageID, err := validation.ParseInt("image ID", imageIDStr)
 	if err != nil {
-		return nil, "", 0, "", "", fmt.Errorf("invalid image ID: %w", err)
+		return nil, "", 0, "", "", err
 	}
 
 	productSize, err := utils.ResourcePrompt("mve", "Enter product size (required): ", noColor)
@@ -378,9 +377,9 @@ func promptMVEVnics(noColor bool) ([]megaport.MVENetworkInterface, error) {
 		}
 		vlan := 0
 		if vlanStr != "" {
-			vlan, err = strconv.Atoi(vlanStr)
+			vlan, err = validation.ParseInt("VLAN ID", vlanStr)
 			if err != nil {
-				return nil, fmt.Errorf("invalid VLAN ID: %w", err)
+				return nil, err
 			}
 		}
 
@@ -423,9 +422,9 @@ func promptForUpdateMVEDetails(mveUID string, currentVnics []*megaport.MVENetwor
 		return nil, err
 	}
 	if contractTermStr != "" {
-		contractTerm, err := strconv.Atoi(contractTermStr)
+		contractTerm, err := validation.ParseInt("contract term", contractTermStr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid contract term: %w", err)
+			return nil, err
 		}
 		req.ContractTermMonths = &contractTerm
 	}

--- a/internal/commands/partners/partners_actions.go
+++ b/internal/commands/partners/partners_actions.go
@@ -6,6 +6,7 @@ import (
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/commands/config"
 	"github.com/megaport/megaport-cli/internal/utils"
+	"github.com/megaport/megaport-cli/internal/validation"
 	"github.com/spf13/cobra"
 )
 
@@ -110,9 +111,10 @@ func FindPartners(cmd *cobra.Command, args []string, noColor bool) error {
 		return err
 	}
 	if locationIDStr != "" {
-		if _, err := fmt.Sscanf(locationIDStr, "%d", &locationID); err != nil {
-			output.PrintError("Invalid location ID format: %v", noColor, err)
-			return fmt.Errorf("invalid location ID format: %w", err)
+		locationID, err = validation.ParseInt("location ID", locationIDStr)
+		if err != nil {
+			output.PrintError("%v", noColor, err)
+			return err
 		}
 	}
 

--- a/internal/commands/partners/partners_actions_test.go
+++ b/internal/commands/partners/partners_actions_test.go
@@ -106,7 +106,7 @@ func TestFindPartners(t *testing.T) {
 				"",
 				"table",
 			},
-			expectedError: "invalid location ID format",
+			expectedError: "invalid location ID",
 			setupMock: func(t *testing.T, m *MockPartnerService) {
 				m.listPartnersResponse = []*megaport.PartnerMegaport{}
 				m.listPartnersErr = nil

--- a/internal/commands/ports/ports_actions_manage.go
+++ b/internal/commands/ports/ports_actions_manage.go
@@ -3,7 +3,6 @@ package ports
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/megaport/megaport-cli/internal/base/output"
@@ -279,10 +278,10 @@ func CheckPortVLANAvailability(cmd *cobra.Command, args []string, noColor bool) 
 	defer cancel()
 
 	portUID := args[0]
-	vlan, err := strconv.Atoi(args[1])
+	vlan, err := validation.ParseInt("VLAN ID", args[1])
 	if err != nil {
-		output.PrintError("Invalid VLAN ID: %v", noColor, err)
-		return fmt.Errorf("invalid VLAN ID")
+		output.PrintError("%v", noColor, err)
+		return err
 	}
 	if err := validation.ValidatePortVLANAvailability(vlan); err != nil {
 		output.PrintError("Invalid VLAN ID: %v", noColor, err)

--- a/internal/commands/ports/ports_prompts.go
+++ b/internal/commands/ports/ports_prompts.go
@@ -26,9 +26,9 @@ func promptForPortDetails(noColor bool) (*megaport.BuyPortRequest, error) {
 	if err != nil {
 		return nil, err
 	}
-	term, err := strconv.Atoi(termStr)
+	term, err := validation.ParseInt("term", termStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid term: %w", err)
+		return nil, err
 	}
 	if err := validation.ValidateContractTerm(term); err != nil {
 		return nil, err
@@ -108,9 +108,9 @@ func promptForLAGPortDetails(noColor bool) (*megaport.BuyPortRequest, error) {
 	if err != nil {
 		return nil, err
 	}
-	term, err := strconv.Atoi(termStr)
+	term, err := validation.ParseInt("term", termStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid term: %w", err)
+		return nil, err
 	}
 	if err := validation.ValidateContractTerm(term); err != nil {
 		return nil, err
@@ -221,9 +221,9 @@ func promptForUpdatePortDetails(portUID string, noColor bool) (*megaport.ModifyP
 		return nil, err
 	}
 	if termStr != "" {
-		term, err := strconv.Atoi(termStr)
+		term, err := validation.ParseInt("term", termStr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid term: %w", err)
+			return nil, err
 		}
 		if err := validation.ValidateContractTerm(term); err != nil {
 			return nil, err

--- a/internal/commands/ports/ports_prompts.go
+++ b/internal/commands/ports/ports_prompts.go
@@ -49,9 +49,9 @@ func promptForPortDetails(noColor bool) (*megaport.BuyPortRequest, error) {
 	if err != nil {
 		return nil, err
 	}
-	locationID, err := strconv.Atoi(locationIDStr)
+	locationID, err := validation.ParseInt("location ID", locationIDStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid location ID")
+		return nil, err
 	}
 	req.LocationId = locationID
 
@@ -131,9 +131,9 @@ func promptForLAGPortDetails(noColor bool) (*megaport.BuyPortRequest, error) {
 	if err != nil {
 		return nil, err
 	}
-	locationID, err := strconv.Atoi(locationIDStr)
+	locationID, err := validation.ParseInt("location ID", locationIDStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid location ID")
+		return nil, err
 	}
 	req.LocationId = locationID
 

--- a/internal/commands/ports/ports_prompts_test.go
+++ b/internal/commands/ports/ports_prompts_test.go
@@ -218,6 +218,7 @@ func TestPromptForUpdatePortDetails_InvalidTermNotNumeric(t *testing.T) {
 	_, err := promptForUpdatePortDetails("port-123", true)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid term")
+	assert.NotContains(t, err.Error(), "strconv")
 }
 
 func TestPromptForLAGPortDetails_InvalidTerm(t *testing.T) {
@@ -229,6 +230,7 @@ func TestPromptForLAGPortDetails_InvalidTerm(t *testing.T) {
 	_, err := promptForLAGPortDetails(true)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid term")
+	assert.NotContains(t, err.Error(), "strconv")
 }
 
 func TestPromptForLAGPortDetails_InvalidLocationID(t *testing.T) {
@@ -240,4 +242,5 @@ func TestPromptForLAGPortDetails_InvalidLocationID(t *testing.T) {
 	_, err := promptForLAGPortDetails(true)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid location ID")
+	assert.NotContains(t, err.Error(), "strconv")
 }

--- a/internal/commands/ports/ports_prompts_test.go
+++ b/internal/commands/ports/ports_prompts_test.go
@@ -208,3 +208,36 @@ func TestPromptForUpdatePortDetails_NoChanges(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "at least one field must be updated")
 }
+
+func TestPromptForUpdatePortDetails_InvalidTermNotNumeric(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+	utils.SetResourcePrompt(mockPromptSequence([]string{"Updated Name", "true", "IT-Updated", "abc"}))
+
+	_, err := promptForUpdatePortDetails("port-123", true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid term")
+}
+
+func TestPromptForLAGPortDetails_InvalidTerm(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+	utils.SetResourcePrompt(mockPromptSequence([]string{"LAG", "abc"}))
+
+	_, err := promptForLAGPortDetails(true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid term")
+}
+
+func TestPromptForLAGPortDetails_InvalidLocationID(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+	utils.SetResourcePrompt(mockPromptSequence([]string{"LAG", "12", "10000", "abc"}))
+
+	_, err := promptForLAGPortDetails(true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid location ID")
+}

--- a/internal/commands/users/users_actions.go
+++ b/internal/commands/users/users_actions.go
@@ -9,6 +9,7 @@ import (
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/commands/config"
 	"github.com/megaport/megaport-cli/internal/utils"
+	"github.com/megaport/megaport-cli/internal/validation"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 )
@@ -122,10 +123,10 @@ func ListUsers(cmd *cobra.Command, args []string, noColor bool, outputFormat str
 func GetUser(cmd *cobra.Command, args []string, noColor bool, outputFormat string) error {
 	output.SetOutputFormat(outputFormat)
 
-	employeeID, err := strconv.Atoi(args[0])
+	employeeID, err := validation.ParseInt("employee ID", args[0])
 	if err != nil {
-		output.PrintError("Invalid employee ID: %v", noColor, err)
-		return fmt.Errorf("invalid employee ID: %w", err)
+		output.PrintError("%v", noColor, err)
+		return err
 	}
 
 	ctx, cancel, client, err := utils.LoginClient(cmd, 90*time.Second, config.Login)
@@ -186,10 +187,10 @@ func UpdateUser(cmd *cobra.Command, args []string, noColor bool) error {
 	ctx, cancel := utils.ContextFromCmd(cmd)
 	defer cancel()
 
-	employeeID, err := strconv.Atoi(args[0])
+	employeeID, err := validation.ParseInt("employee ID", args[0])
 	if err != nil {
-		output.PrintError("Invalid employee ID: %v", noColor, err)
-		return fmt.Errorf("invalid employee ID: %w", err)
+		output.PrintError("%v", noColor, err)
+		return err
 	}
 
 	req, err := buildUpdateUserRequest(cmd, noColor)
@@ -233,10 +234,10 @@ func DeleteUser(cmd *cobra.Command, args []string, noColor bool) error {
 	ctx, cancel := utils.ContextFromCmd(cmd)
 	defer cancel()
 
-	employeeID, err := strconv.Atoi(args[0])
+	employeeID, err := validation.ParseInt("employee ID", args[0])
 	if err != nil {
-		output.PrintError("Invalid employee ID: %v", noColor, err)
-		return fmt.Errorf("invalid employee ID: %w", err)
+		output.PrintError("%v", noColor, err)
+		return err
 	}
 
 	force, _ := cmd.Flags().GetBool("force")
@@ -273,10 +274,10 @@ func DeactivateUser(cmd *cobra.Command, args []string, noColor bool) error {
 	ctx, cancel := utils.ContextFromCmd(cmd)
 	defer cancel()
 
-	employeeID, err := strconv.Atoi(args[0])
+	employeeID, err := validation.ParseInt("employee ID", args[0])
 	if err != nil {
-		output.PrintError("Invalid employee ID: %v", noColor, err)
-		return fmt.Errorf("invalid employee ID: %w", err)
+		output.PrintError("%v", noColor, err)
+		return err
 	}
 
 	force, _ := cmd.Flags().GetBool("force")

--- a/internal/commands/users/users_actions_test.go
+++ b/internal/commands/users/users_actions_test.go
@@ -269,6 +269,7 @@ func TestCreateUser(t *testing.T) {
 			if tt.expectedError != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.NotContains(t, err.Error(), "strconv")
 			} else {
 				assert.NoError(t, err)
 				if tt.expectedContains != "" {
@@ -373,6 +374,7 @@ func TestUpdateUser(t *testing.T) {
 			if tt.expectedError != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.NotContains(t, err.Error(), "strconv")
 			} else {
 				assert.NoError(t, err)
 				if tt.expectedContains != "" {
@@ -470,6 +472,7 @@ func TestDeleteUser(t *testing.T) {
 			if tt.expectedError != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.NotContains(t, err.Error(), "strconv")
 			} else {
 				assert.NoError(t, err)
 				if tt.expectedContains != "" {
@@ -560,6 +563,7 @@ func TestDeactivateUser(t *testing.T) {
 			if tt.expectedError != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.NotContains(t, err.Error(), "strconv")
 			} else {
 				assert.NoError(t, err)
 				if tt.expectedContains != "" {

--- a/internal/commands/users/users_actions_test.go
+++ b/internal/commands/users/users_actions_test.go
@@ -285,6 +285,7 @@ func TestUpdateUser(t *testing.T) {
 
 	tests := []struct {
 		name             string
+		args             []string
 		flags            map[string]string
 		jsonInput        string
 		setupMock        func(*MockUserManagementService)
@@ -321,6 +322,12 @@ func TestUpdateUser(t *testing.T) {
 			},
 			expectedError: "update failed",
 		},
+		{
+			name:          "invalid employee ID",
+			args:          []string{"abc"},
+			setupMock:     func(m *MockUserManagementService) {},
+			expectedError: "invalid employee ID",
+		},
 	}
 
 	for _, tt := range tests {
@@ -353,9 +360,14 @@ func TestUpdateUser(t *testing.T) {
 				require.NoError(t, cmd.Flags().Set(k, v))
 			}
 
+			args := tt.args
+			if len(args) == 0 {
+				args = []string{"12345"}
+			}
+
 			var err error
 			capturedOutput := output.CaptureOutput(func() {
-				err = UpdateUser(cmd, []string{"12345"}, true)
+				err = UpdateUser(cmd, args, true)
 			})
 
 			if tt.expectedError != "" {
@@ -380,6 +392,7 @@ func TestDeleteUser(t *testing.T) {
 
 	tests := []struct {
 		name             string
+		args             []string
 		force            bool
 		confirmResult    bool
 		setupMock        func(*MockUserManagementService)
@@ -414,6 +427,13 @@ func TestDeleteUser(t *testing.T) {
 			},
 			expectedError: "delete failed",
 		},
+		{
+			name:          "invalid employee ID",
+			args:          []string{"abc"},
+			force:         true,
+			setupMock:     func(m *MockUserManagementService) {},
+			expectedError: "invalid employee ID",
+		},
 	}
 
 	for _, tt := range tests {
@@ -437,9 +457,14 @@ func TestDeleteUser(t *testing.T) {
 				require.NoError(t, cmd.Flags().Set("force", "true"))
 			}
 
+			args := tt.args
+			if len(args) == 0 {
+				args = []string{"12345"}
+			}
+
 			var err error
 			capturedOutput := output.CaptureOutput(func() {
-				err = DeleteUser(cmd, []string{"12345"}, true)
+				err = DeleteUser(cmd, args, true)
 			})
 
 			if tt.expectedError != "" {
@@ -464,6 +489,7 @@ func TestDeactivateUser(t *testing.T) {
 
 	tests := []struct {
 		name             string
+		args             []string
 		force            bool
 		confirmResult    bool
 		setupMock        func(*MockUserManagementService)
@@ -491,6 +517,13 @@ func TestDeactivateUser(t *testing.T) {
 			},
 			expectedError: "deactivation failed",
 		},
+		{
+			name:          "invalid employee ID",
+			args:          []string{"abc"},
+			force:         true,
+			setupMock:     func(m *MockUserManagementService) {},
+			expectedError: "invalid employee ID",
+		},
 	}
 
 	for _, tt := range tests {
@@ -514,9 +547,14 @@ func TestDeactivateUser(t *testing.T) {
 				require.NoError(t, cmd.Flags().Set("force", "true"))
 			}
 
+			args := tt.args
+			if len(args) == 0 {
+				args = []string{"12345"}
+			}
+
 			var err error
 			capturedOutput := output.CaptureOutput(func() {
-				err = DeactivateUser(cmd, []string{"12345"}, true)
+				err = DeactivateUser(cmd, args, true)
 			})
 
 			if tt.expectedError != "" {

--- a/internal/commands/vxc/vxc_prompts_partner.go
+++ b/internal/commands/vxc/vxc_prompts_partner.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/megaport/megaport-cli/internal/utils"
+	"github.com/megaport/megaport-cli/internal/validation"
 	megaport "github.com/megaport/megaportgo"
 )
 
@@ -109,7 +110,7 @@ func promptAWSConfig(noColor bool) (*megaport.VXCPartnerConfigAWS, error) {
 	}
 	var asn int
 	if asnStr != "" {
-		asn, err = strconv.Atoi(asnStr)
+		asn, err = validation.ParseInt("ASN", asnStr)
 		if err != nil {
 			return nil, err
 		}
@@ -121,7 +122,7 @@ func promptAWSConfig(noColor bool) (*megaport.VXCPartnerConfigAWS, error) {
 	}
 	var amazonASN int
 	if amazonASNStr != "" {
-		amazonASN, err = strconv.Atoi(amazonASNStr)
+		amazonASN, err = validation.ParseInt("Amazon ASN", amazonASNStr)
 		if err != nil {
 			return nil, err
 		}
@@ -337,7 +338,7 @@ func promptIBMConfig(noColor bool) (*megaport.VXCPartnerConfigIBM, error) {
 	if err != nil {
 		return nil, err
 	}
-	customerASN, err = strconv.Atoi(customerASNStr)
+	customerASN, err = validation.ParseInt("customer ASN", customerASNStr)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/validation/parse.go
+++ b/internal/validation/parse.go
@@ -9,9 +9,9 @@ import (
 // friendly error naming the field and the offending value, instead of leaking
 // strconv internals like `strconv.Atoi: parsing "x": invalid syntax`.
 //
-// The message stays lowercase ("invalid <field>: ...") so existing exit-code
-// classification (which matches a lowercase "invalid"/"ID" substring) and error
-// wrapping keep working.
+// The message keeps the lowercase "invalid <field>" prefix so exit-code
+// classification still tags it as a usage error. For ID arguments the field
+// should contain "ID" (e.g. "location ID") so that classification holds.
 func ParseInt(field, value string) (int, error) {
 	n, err := strconv.Atoi(value)
 	if err != nil {

--- a/internal/validation/parse.go
+++ b/internal/validation/parse.go
@@ -1,0 +1,21 @@
+package validation
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// ParseInt converts a user-supplied string into an int. On failure it returns a
+// friendly error naming the field and the offending value, instead of leaking
+// strconv internals like `strconv.Atoi: parsing "x": invalid syntax`.
+//
+// The message stays lowercase ("invalid <field>: ...") so existing exit-code
+// classification (which matches a lowercase "invalid"/"ID" substring) and error
+// wrapping keep working.
+func ParseInt(field, value string) (int, error) {
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s: %q is not a valid whole number", field, value)
+	}
+	return n, nil
+}

--- a/internal/validation/parse_test.go
+++ b/internal/validation/parse_test.go
@@ -1,0 +1,71 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseInt(t *testing.T) {
+	tests := []struct {
+		name      string
+		field     string
+		value     string
+		want      int
+		wantErr   bool
+		errSubstr []string
+	}{
+		{name: "valid positive", field: "location ID", value: "123", want: 123},
+		{name: "valid negative", field: "ASN", value: "-5", want: -5},
+		{name: "valid zero", field: "VLAN ID", value: "0", want: 0},
+		{
+			name:    "non-numeric",
+			field:   "location ID",
+			value:   "bad-location",
+			wantErr: true,
+			// Friendly message: names the field and value, no strconv internals.
+			errSubstr: []string{"invalid location ID", "bad-location"},
+		},
+		{
+			name:      "empty string",
+			field:     "employee ID",
+			value:     "",
+			wantErr:   true,
+			errSubstr: []string{"invalid employee ID"},
+		},
+		{
+			name:      "float string",
+			field:     "term",
+			value:     "1.5",
+			wantErr:   true,
+			errSubstr: []string{"invalid term"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseInt(tt.field, tt.value)
+			if tt.wantErr {
+				assert.Error(t, err)
+				for _, s := range tt.errSubstr {
+					assert.Contains(t, err.Error(), s)
+				}
+				// Must not leak strconv internals to the user.
+				assert.NotContains(t, err.Error(), "strconv")
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// classifyError keys off a lowercase "invalid" + "ID" substring, so the helper
+// must keep that wording for ID fields to preserve the Usage exit code.
+func TestParseIntPreservesUsageClassification(t *testing.T) {
+	_, err := ParseInt("location ID", "abc")
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "invalid"))
+	assert.True(t, strings.Contains(err.Error(), "ID"))
+}


### PR DESCRIPTION
Fixes the confusing parse errors where the CLI leaked `strconv` internals to the user, e.g. `Invalid location ID: strconv.Atoi: parsing "bad-location": invalid syntax`.

- Add `validation.ParseInt(field, value)` returning a friendly message: `invalid location ID: "bad-location" is not a valid whole number`.
- Route every leaking call site through it: `locations get`, `users` (get/update/delete/deactivate), `ports` VLAN check, `partners`, and the `mcr`/`mve`/`ix`/`ports`/`vxc` interactive prompts.
- Message stays lowercase on purpose so the existing Usage exit-code classification still matches.
- Left already-friendly sites (port speed, LAG count, marketplace bool, GE/LE values) untouched.

Tests: new unit tests for the helper (assert no `strconv` leak) plus a regression guard on `locations get`.

ESD-1507
