### PR TITLE
refactor(ESD-1500): rename order-retry symbols to OrderOnce

### DIFF
--- a/internal/commands/apply/apply_actions.go
+++ b/internal/commands/apply/apply_actions.go
@@ -157,7 +157,7 @@ func ApplyConfig(cmd *cobra.Command, _ []string, noColor bool, outputFormat stri
 
 		createSpinner := output.PrintResourceCreating("Port", p.Name, noColor)
 		var resp *megaport.BuyPortResponse
-		err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
+		err = utils.WithOrderOnceRetry(ctx, func(ctx context.Context) error {
 			var e error
 			resp, e = client.PortService.BuyPort(ctx, req)
 			return e
@@ -235,7 +235,7 @@ func ApplyConfig(cmd *cobra.Command, _ []string, noColor bool, outputFormat stri
 
 		createSpinner := output.PrintResourceCreating("MCR", m.Name, noColor)
 		var resp *megaport.BuyMCRResponse
-		err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
+		err = utils.WithOrderOnceRetry(ctx, func(ctx context.Context) error {
 			var e error
 			resp, e = client.MCRService.BuyMCR(ctx, req)
 			return e
@@ -321,7 +321,7 @@ func ApplyConfig(cmd *cobra.Command, _ []string, noColor bool, outputFormat stri
 
 		createSpinner := output.PrintResourceCreating("MVE", mv.Name, noColor)
 		var resp *megaport.BuyMVEResponse
-		err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
+		err = utils.WithOrderOnceRetry(ctx, func(ctx context.Context) error {
 			var e error
 			resp, e = client.MVEService.BuyMVE(ctx, req)
 			return e
@@ -414,7 +414,7 @@ func ApplyConfig(cmd *cobra.Command, _ []string, noColor bool, outputFormat stri
 
 		createSpinner := output.PrintResourceCreating("VXC", v.Name, noColor)
 		var resp *megaport.BuyVXCResponse
-		err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
+		err = utils.WithOrderOnceRetry(ctx, func(ctx context.Context) error {
 			var e error
 			resp, e = client.VXCService.BuyVXC(ctx, req)
 			return e

--- a/internal/commands/ix/ix_actions.go
+++ b/internal/commands/ix/ix_actions.go
@@ -242,7 +242,7 @@ func BuyIX(cmd *cobra.Command, args []string, noColor bool) error {
 		buySpinner = output.PrintResourceCreating("IX", req.Name, noColor)
 	}
 	var resp *megaport.BuyIXResponse
-	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
+	err = utils.WithOrderOnceRetry(ctx, func(ctx context.Context) error {
 		var e error
 		resp, e = buyIXFunc(ctx, client, req)
 		return e

--- a/internal/commands/mcr/mcr_actions.go
+++ b/internal/commands/mcr/mcr_actions.go
@@ -128,7 +128,7 @@ func BuyMCR(cmd *cobra.Command, args []string, noColor bool) error {
 		buySpinner = output.PrintResourceCreating("MCR", req.Name, noColor)
 	}
 	var resp *megaport.BuyMCRResponse
-	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
+	err = utils.WithOrderOnceRetry(ctx, func(ctx context.Context) error {
 		var e error
 		resp, e = buyMCRFunc(ctx, client, req)
 		return e

--- a/internal/commands/mcr/mcr_actions_ipsec_addon.go
+++ b/internal/commands/mcr/mcr_actions_ipsec_addon.go
@@ -75,7 +75,7 @@ func AddMCRIPSecAddOn(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	spinner := output.PrintResourceCreating("IPSec Add-On", mcrUID, noColor)
-	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
+	err = utils.WithOrderOnceRetry(ctx, func(ctx context.Context) error {
 		return updateMCRWithAddOnFunc(ctx, client, mcrUID, req)
 	})
 	spinner.Stop()

--- a/internal/commands/mcr/mcr_actions_prefix_filter.go
+++ b/internal/commands/mcr/mcr_actions_prefix_filter.go
@@ -59,7 +59,7 @@ func CreateMCRPrefixFilterList(cmd *cobra.Command, args []string, noColor bool) 
 	}
 	spinner := output.PrintResourceCreating("Prefix Filter List", req.PrefixFilterList.Description, noColor)
 	var resp *megaport.CreateMCRPrefixFilterListResponse
-	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
+	err = utils.WithOrderOnceRetry(ctx, func(ctx context.Context) error {
 		var e error
 		resp, e = createMCRPrefixFilterListFunc(ctx, client, req)
 		return e

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -194,7 +194,7 @@ func BuyMVE(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	var resp *megaport.BuyMVEResponse
-	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
+	err = utils.WithOrderOnceRetry(ctx, func(ctx context.Context) error {
 		var e error
 		resp, e = client.MVEService.BuyMVE(ctx, req)
 		return e

--- a/internal/commands/nat_gateway/nat_gateway_actions.go
+++ b/internal/commands/nat_gateway/nat_gateway_actions.go
@@ -75,7 +75,7 @@ func CreateNATGateway(cmd *cobra.Command, args []string, noColor bool) error {
 	spinner := output.PrintResourceCreating("NAT Gateway", req.ProductName, noColor)
 
 	var gw *megaport.NATGateway
-	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
+	err = utils.WithOrderOnceRetry(ctx, func(ctx context.Context) error {
 		var e error
 		gw, e = createNATGatewayFunc(ctx, client, req)
 		return e
@@ -460,7 +460,7 @@ func BuyNATGateway(cmd *cobra.Command, args []string, noColor bool) error {
 
 	spinner := output.PrintResourceCreating("NAT Gateway", uid, noColor)
 	var res *megaport.NATGatewayBuyResult
-	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
+	err = utils.WithOrderOnceRetry(ctx, func(ctx context.Context) error {
 		var e error
 		res, e = buyNATGatewayFunc(ctx, client, uid)
 		return e

--- a/internal/commands/ports/ports_actions.go
+++ b/internal/commands/ports/ports_actions.go
@@ -119,7 +119,7 @@ func BuyPort(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	var resp *megaport.BuyPortResponse
-	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
+	err = utils.WithOrderOnceRetry(ctx, func(ctx context.Context) error {
 		var e error
 		resp, e = buyPortFunc(ctx, client, req)
 		return e
@@ -257,7 +257,7 @@ func BuyLAGPort(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	var resp *megaport.BuyPortResponse
-	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
+	err = utils.WithOrderOnceRetry(ctx, func(ctx context.Context) error {
 		var e error
 		resp, e = buyPortFunc(ctx, client, req)
 		return e

--- a/internal/commands/vxc/vxc_actions.go
+++ b/internal/commands/vxc/vxc_actions.go
@@ -301,7 +301,7 @@ func BuyVXC(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 
 	var resp *megaport.BuyVXCResponse
-	err = utils.WithOrderRetry(ctx, func(ctx context.Context) error {
+	err = utils.WithOrderOnceRetry(ctx, func(ctx context.Context) error {
 		var e error
 		resp, e = buyVXCFunc(ctx, client, req)
 		return e

--- a/internal/utils/retry.go
+++ b/internal/utils/retry.go
@@ -34,10 +34,10 @@ type RetryOpts struct {
 	// RetryNetworkErrors enables retrying on ambiguous network failures
 	// (connection reset, EOF, timeout). Only set this for idempotent operations.
 	RetryNetworkErrors bool
-	// OrderSafe restricts retries to errors that prove the request never reached
+	// OrderOnce restricts retries to errors that prove the request never reached
 	// processing (HTTP 429, connection-refused-before-send). Set this for
 	// non-idempotent buy/order calls so an ambiguous failure cannot double-submit.
-	OrderSafe bool
+	OrderOnce bool
 }
 
 // DefaultRetryOpts returns sensible defaults for API retry behaviour.
@@ -79,18 +79,18 @@ func WithIdempotentRetry(ctx context.Context, fn func(ctx context.Context) error
 	return RetryWithBackoff(ctx, opts, fn)
 }
 
-// WithOrderRetry wraps fn with a retry policy safe for non-idempotent buy/order
+// WithOrderOnceRetry wraps fn with a retry policy safe for non-idempotent buy/order
 // operations. It retries ONLY when the request provably never reached
 // processing: HTTP 429, or a connection-refused error raised before the request
 // was sent. It never retries on 5xx or other ambiguous-outcome errors, which
 // could double-submit an order and cause duplicate billing.
 // If --no-retry was set globally, fn is called exactly once.
-func WithOrderRetry(ctx context.Context, fn func(ctx context.Context) error) error {
+func WithOrderOnceRetry(ctx context.Context, fn func(ctx context.Context) error) error {
 	if NoRetry {
 		return fn(ctx)
 	}
 	opts := DefaultRetryOpts()
-	opts.OrderSafe = true
+	opts.OrderOnce = true
 	return RetryWithBackoff(ctx, opts, fn)
 }
 
@@ -111,8 +111,8 @@ func RetryWithBackoff(ctx context.Context, opts RetryOpts, fn func(ctx context.C
 		}
 
 		retryable := isRetryable(err, opts.RetryNetworkErrors)
-		if opts.OrderSafe {
-			retryable = isOrderRetryable(err)
+		if opts.OrderOnce {
+			retryable = isRetryableOrderOnce(err)
 		}
 
 		if !retryable {
@@ -217,12 +217,12 @@ func isRetryable(err error, retryNetworkErrors bool) bool {
 	return false
 }
 
-// isOrderRetryable returns true only for errors that prove a buy/order request
+// isRetryableOrderOnce returns true only for errors that prove a buy/order request
 // never reached processing: HTTP 429, or connection-refused raised during the
 // TCP handshake (the request bytes never left the client). Ambiguous outcomes
 // (5xx, connection reset, timeout, EOF) are never retried because the order may
 // already have been accepted upstream.
-func isOrderRetryable(err error) bool {
+func isRetryableOrderOnce(err error) bool {
 	var apiErr *megaport.ErrorResponse
 	if errors.As(err, &apiErr) && apiErr.Response != nil {
 		return apiErr.Response.StatusCode == http.StatusTooManyRequests

--- a/internal/utils/retry_test.go
+++ b/internal/utils/retry_test.go
@@ -406,7 +406,7 @@ func TestIsOrderRetryable(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.retryable, isOrderRetryable(tt.err))
+			assert.Equal(t, tt.retryable, isRetryableOrderOnce(tt.err))
 		})
 	}
 }
@@ -422,7 +422,7 @@ func TestWithOrderRetry_NoRetryOn502(t *testing.T) {
 	MaxRetries = 3 // retries are available; the order-safe policy must still refuse to use them on a 502
 
 	calls := 0
-	err := WithOrderRetry(context.Background(), func(ctx context.Context) error {
+	err := WithOrderOnceRetry(context.Background(), func(ctx context.Context) error {
 		calls++
 		return apiError(502, "")
 	})
@@ -436,7 +436,7 @@ func TestWithOrderRetry_NoRetryFlag(t *testing.T) {
 	NoRetry = true
 
 	calls := 0
-	err := WithOrderRetry(context.Background(), func(ctx context.Context) error {
+	err := WithOrderOnceRetry(context.Background(), func(ctx context.Context) error {
 		calls++
 		return apiError(429, "")
 	})
@@ -446,7 +446,7 @@ func TestWithOrderRetry_NoRetryFlag(t *testing.T) {
 
 func TestOrderSafeRetry_RetriesOn429ThenSucceeds(t *testing.T) {
 	opts := fastOpts()
-	opts.OrderSafe = true
+	opts.OrderOnce = true
 
 	calls := 0
 	err := RetryWithBackoff(context.Background(), opts, func(ctx context.Context) error {
@@ -462,7 +462,7 @@ func TestOrderSafeRetry_RetriesOn429ThenSucceeds(t *testing.T) {
 
 func TestOrderSafeRetry_RetriesOnConnectionRefused(t *testing.T) {
 	opts := fastOpts()
-	opts.OrderSafe = true
+	opts.OrderOnce = true
 
 	calls := 0
 	err := RetryWithBackoff(context.Background(), opts, func(ctx context.Context) error {
@@ -478,7 +478,7 @@ func TestOrderSafeRetry_RetriesOnConnectionRefused(t *testing.T) {
 
 func TestOrderSafeRetry_NoRetryOnAmbiguousNetworkError(t *testing.T) {
 	opts := fastOpts()
-	opts.OrderSafe = true
+	opts.OrderOnce = true
 
 	calls := 0
 	err := RetryWithBackoff(context.Background(), opts, func(ctx context.Context) error {


### PR DESCRIPTION
Follow-up to #425 addressing @ianb-mp's naming feedback. Renames the order-retry symbols so they read as "at most once" intent:

- `OrderSafe` field → `OrderOnce`
- `WithOrderRetry` → `WithOrderOnceRetry`
- `isOrderRetryable` → `isRetryableOrderOnce`

Pure mechanical rename, no behavior change.