### PR TITLE
test (ESD-1494): add hermetic native-binary e2e contract tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ test-integration-readonly:
 # Run the hermetic native-binary e2e tests (built behind the `e2e` build tag).
 # Builds the CLI binary and drives it via argv; no credentials needed.
 e2e:
-	go test -tags e2e -run '^TestE2E_' -skip 'Staging' -v ./e2e/...
+	go test -tags e2e -run '^TestE2E_' -skip '^TestE2E_Staging_' -v ./e2e/...
 
 # Run the live staging e2e tests (read-only, requires MEGAPORT_* credentials).
 e2e-staging:

--- a/e2e/contract_test.go
+++ b/e2e/contract_test.go
@@ -122,7 +122,7 @@ func TestE2E_JSONErrorEnvelope(t *testing.T) {
 
 	res := Run(t, "ports", "buy", "--json", "this-is-not-json", "--output", "json")
 
-	require.NotEqualf(t, exitcodes.Success, res.Exit, "expected a non-zero exit\nstderr: %s", res.Stderr)
+	require.Equalf(t, exitcodes.Usage, res.Exit, "invalid JSON payload should be a usage error (exit 2)\nstderr: %s", res.Stderr)
 	assert.NotContains(t, res.Stderr, "Logging in", "should fail before any login attempt")
 
 	start := strings.Index(res.Stderr, "{")

--- a/e2e/contract_test.go
+++ b/e2e/contract_test.go
@@ -28,10 +28,10 @@ func TestE2E_Contract(t *testing.T) {
 		stderrAbsent   []string
 	}{
 		{
-			name:           "version exits zero with a version line",
+			name:           "version subcommand exits zero with a version line",
 			args:           []string{"version"},
 			wantExit:       exitcodes.Success,
-			stdoutContains: []string{"Version"},
+			stdoutContains: []string{"Megaport CLI Version:"},
 		},
 		{
 			name:           "root help lists usage and known subcommands",
@@ -40,10 +40,10 @@ func TestE2E_Contract(t *testing.T) {
 			stdoutContains: []string{"Usage:", "ports", "vxc", "mcr", "mve", "completion", "version"},
 		},
 		{
-			name:           "subcommand help exits zero",
+			name:           "subcommand help exits zero with a full help page",
 			args:           []string{"ports", "--help"},
 			wantExit:       exitcodes.Success,
-			stdoutContains: []string{"ports"},
+			stdoutContains: []string{"Usage:", "ports"},
 		},
 		{
 			name:           "completion bash emits the bash marker",
@@ -56,6 +56,12 @@ func TestE2E_Contract(t *testing.T) {
 			args:           []string{"completion", "zsh"},
 			wantExit:       exitcodes.Success,
 			stdoutContains: []string{"#compdef megaport-cli"},
+		},
+		{
+			name:           "completion fish emits the fish marker",
+			args:           []string{"completion", "fish"},
+			wantExit:       exitcodes.Success,
+			stdoutContains: []string{"fish completion for megaport-cli"},
 		},
 		{
 			name:           "unknown command is a usage error",
@@ -76,12 +82,14 @@ func TestE2E_Contract(t *testing.T) {
 			stderrContains: []string{"arg(s)"},
 		},
 		{
-			// Buy enforces required flags only when not interactive and not --json,
-			// so this must fail at flag validation before any login is attempted.
-			name:           "buy without flags fails at validation before login",
-			args:           []string{"ports", "buy"},
-			wantExit:       exitcodes.Usage,
-			stderrContains: []string{"required flag", "interactive or JSON input"},
+			// The purchase command enforces required flags only when not interactive
+			// and not --json, so it must fail at flag validation before any login.
+			name:     "purchase without flags fails at validation before login",
+			args:     []string{"ports", "buy"},
+			wantExit: exitcodes.Usage,
+			// Match the full composite message to avoid false positives from two
+			// independent substrings accidentally both appearing in unrelated output.
+			stderrContains: []string{"not set when not using interactive or JSON input"},
 			stderrAbsent:   []string{"Logging in"},
 		},
 		{
@@ -97,7 +105,9 @@ func TestE2E_Contract(t *testing.T) {
 			t.Parallel()
 			res := Run(t, tc.args...)
 
-			assert.Equalf(t, tc.wantExit, res.Exit,
+			// Use require so a wrong exit code stops the subtest immediately
+			// rather than cascading into confusing stdout/stderr failures.
+			require.Equalf(t, tc.wantExit, res.Exit,
 				"exit code\nstdout: %s\nstderr: %s", res.Stdout, res.Stderr)
 			for _, want := range tc.stdoutContains {
 				assert.Containsf(t, res.Stdout, want, "stdout missing %q\nstdout: %s", want, res.Stdout)
@@ -113,10 +123,9 @@ func TestE2E_Contract(t *testing.T) {
 }
 
 // TestE2E_JSONErrorEnvelope verifies that under --output json an erroring command
-// emits a structured JSON envelope on stderr whose type matches the exit code.
-// ports buy parses --json before any login, so an unparseable payload triggers
-// the envelope hermetically. Human progress lines precede the JSON on stderr, so
-// the envelope is decoded starting at the first brace.
+// emits a structured JSON envelope on stderr whose code and type reflect a usage
+// error. The purchase command parses --json before any login, so an unparseable
+// payload triggers the envelope hermetically.
 func TestE2E_JSONErrorEnvelope(t *testing.T) {
 	t.Parallel()
 
@@ -125,8 +134,12 @@ func TestE2E_JSONErrorEnvelope(t *testing.T) {
 	require.Equalf(t, exitcodes.Usage, res.Exit, "invalid JSON payload should be a usage error (exit 2)\nstderr: %s", res.Stderr)
 	assert.NotContains(t, res.Stderr, "Logging in", "should fail before any login attempt")
 
-	start := strings.Index(res.Stderr, "{")
-	require.GreaterOrEqualf(t, start, 0, "no JSON object found on stderr: %s", res.Stderr)
+	// The JSON encoder uses SetIndent so the envelope opens with a bare {
+	// on its own line. Anchoring on \n{ rather than a bare { guards against
+	// a future progress line whose text happens to contain a { character.
+	idx := strings.Index(res.Stderr, "\n{")
+	require.NotEqualf(t, -1, idx, "no JSON envelope found on stderr: %s", res.Stderr)
+	start := idx + 1 // skip past the newline to the opening {
 
 	var envelope struct {
 		Error struct {
@@ -138,7 +151,7 @@ func TestE2E_JSONErrorEnvelope(t *testing.T) {
 	dec := json.NewDecoder(strings.NewReader(res.Stderr[start:]))
 	require.NoErrorf(t, dec.Decode(&envelope), "envelope should be valid JSON: %s", res.Stderr[start:])
 
-	assert.Equal(t, res.Exit, envelope.Error.Code, "envelope code should match the process exit code")
-	assert.Equal(t, exitcodes.TypeName(res.Exit), envelope.Error.Type, "envelope type should match TypeName(exit code)")
+	assert.Equal(t, exitcodes.Usage, envelope.Error.Code, "envelope code should be 2 (usage error)")
+	assert.Equal(t, "usage_error", envelope.Error.Type, "envelope type should be usage_error")
 	assert.NotEmpty(t, envelope.Error.Message, "envelope should carry an error message")
 }

--- a/e2e/contract_test.go
+++ b/e2e/contract_test.go
@@ -1,0 +1,144 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestE2E_Contract drives the compiled binary via argv and asserts its CLI
+// contract: exit codes plus stdout/stderr substrings. Every case is hermetic
+// (no network, no credentials) and runs in its own process. Substrings are
+// asserted rather than full output snapshots, which would be too brittle.
+func TestE2E_Contract(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		args           []string
+		wantExit       int
+		stdoutContains []string
+		stderrContains []string
+		stderrAbsent   []string
+	}{
+		{
+			name:           "version exits zero with a version line",
+			args:           []string{"version"},
+			wantExit:       exitcodes.Success,
+			stdoutContains: []string{"Version"},
+		},
+		{
+			name:           "root help lists usage and known subcommands",
+			args:           []string{"--help"},
+			wantExit:       exitcodes.Success,
+			stdoutContains: []string{"Usage:", "ports", "vxc", "mcr", "mve", "completion", "version"},
+		},
+		{
+			name:           "subcommand help exits zero",
+			args:           []string{"ports", "--help"},
+			wantExit:       exitcodes.Success,
+			stdoutContains: []string{"ports"},
+		},
+		{
+			name:           "completion bash emits the bash marker",
+			args:           []string{"completion", "bash"},
+			wantExit:       exitcodes.Success,
+			stdoutContains: []string{"bash completion for megaport-cli"},
+		},
+		{
+			name:           "completion zsh emits the zsh marker",
+			args:           []string{"completion", "zsh"},
+			wantExit:       exitcodes.Success,
+			stdoutContains: []string{"#compdef megaport-cli"},
+		},
+		{
+			name:           "unknown command is a usage error",
+			args:           []string{"boguscommand"},
+			wantExit:       exitcodes.Usage,
+			stderrContains: []string{"unknown command"},
+		},
+		{
+			name:           "unknown flag is a usage error",
+			args:           []string{"ports", "list", "--nope"},
+			wantExit:       exitcodes.Usage,
+			stderrContains: []string{"unknown flag"},
+		},
+		{
+			name:           "wrong arg count is a usage error",
+			args:           []string{"ports", "get"},
+			wantExit:       exitcodes.Usage,
+			stderrContains: []string{"arg(s)"},
+		},
+		{
+			// Buy enforces required flags only when not interactive and not --json,
+			// so this must fail at flag validation before any login is attempted.
+			name:           "buy without flags fails at validation before login",
+			args:           []string{"ports", "buy"},
+			wantExit:       exitcodes.Usage,
+			stderrContains: []string{"required flag", "interactive or JSON input"},
+			stderrAbsent:   []string{"Logging in"},
+		},
+		{
+			name:           "invalid output format is a usage error",
+			args:           []string{"version", "--output", "bogus"},
+			wantExit:       exitcodes.Usage,
+			stderrContains: []string{"invalid output format"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res := Run(t, tc.args...)
+
+			assert.Equalf(t, tc.wantExit, res.Exit,
+				"exit code\nstdout: %s\nstderr: %s", res.Stdout, res.Stderr)
+			for _, want := range tc.stdoutContains {
+				assert.Containsf(t, res.Stdout, want, "stdout missing %q\nstdout: %s", want, res.Stdout)
+			}
+			for _, want := range tc.stderrContains {
+				assert.Containsf(t, res.Stderr, want, "stderr missing %q\nstderr: %s", want, res.Stderr)
+			}
+			for _, absent := range tc.stderrAbsent {
+				assert.NotContainsf(t, res.Stderr, absent, "stderr unexpectedly contains %q\nstderr: %s", absent, res.Stderr)
+			}
+		})
+	}
+}
+
+// TestE2E_JSONErrorEnvelope verifies that under --output json an erroring command
+// emits a structured JSON envelope on stderr whose type matches the exit code.
+// ports buy parses --json before any login, so an unparseable payload triggers
+// the envelope hermetically. Human progress lines precede the JSON on stderr, so
+// the envelope is decoded starting at the first brace.
+func TestE2E_JSONErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	res := Run(t, "ports", "buy", "--json", "this-is-not-json", "--output", "json")
+
+	require.NotEqualf(t, exitcodes.Success, res.Exit, "expected a non-zero exit\nstderr: %s", res.Stderr)
+	assert.NotContains(t, res.Stderr, "Logging in", "should fail before any login attempt")
+
+	start := strings.Index(res.Stderr, "{")
+	require.GreaterOrEqualf(t, start, 0, "no JSON object found on stderr: %s", res.Stderr)
+
+	var envelope struct {
+		Error struct {
+			Code    int    `json:"code"`
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	dec := json.NewDecoder(strings.NewReader(res.Stderr[start:]))
+	require.NoErrorf(t, dec.Decode(&envelope), "envelope should be valid JSON: %s", res.Stderr[start:])
+
+	assert.Equal(t, res.Exit, envelope.Error.Code, "envelope code should match the process exit code")
+	assert.Equal(t, exitcodes.TypeName(res.Exit), envelope.Error.Type, "envelope type should match TypeName(exit code)")
+	assert.NotEmpty(t, envelope.Error.Message, "envelope should carry an error message")
+}

--- a/e2e/harness_test.go
+++ b/e2e/harness_test.go
@@ -88,6 +88,9 @@ func sandboxEnv(t *testing.T, passthrough []string) []string {
 	env := []string{
 		"HOME=" + t.TempDir(),
 		"PATH=/usr/bin:/bin",
+		// Suppress the GitHub update-check HTTP call so hermetic tests remain
+		// network-free even when MEGAPORT_CLI_E2E_BIN points at a versioned binary.
+		"NO_UPDATE_CHECK=1",
 	}
 	for _, name := range passthrough {
 		if v, ok := os.LookupEnv(name); ok {

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -10,6 +10,7 @@ import (
 
 // TestE2E_Smoke proves the harness end to end: build, exec, capture, exit code.
 func TestE2E_Smoke(t *testing.T) {
+	t.Parallel()
 	res := Run(t, "version")
 
 	assert.Equal(t, 0, res.Exit, "version should exit 0; stderr: %s", res.Stderr)

--- a/internal/commands/version/update_check.go
+++ b/internal/commands/version/update_check.go
@@ -18,9 +18,13 @@ type updateCheckCache struct {
 }
 
 // checkForUpdate returns the latest version and whether it differs from currentVersion.
-// Fails silently — never returns an error. Returns ("", false) for "dev" builds.
+// Fails silently — never returns an error. Returns ("", false) for "dev" builds or when
+// NO_UPDATE_CHECK is set (used by the e2e hermetic sandbox).
 func checkForUpdate(currentVersion string, client *http.Client, cacheDir string) (string, bool) {
 	if currentVersion == "dev" || currentVersion == "" {
+		return "", false
+	}
+	if os.Getenv("NO_UPDATE_CHECK") != "" {
 		return "", false
 	}
 	cacheFile := filepath.Join(cacheDir, "update-check.json")

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -343,6 +343,9 @@ func classifyError(err error) int {
 		"at least one field must be updated",
 		"at least one of these flags",
 		"invalid location ID",
+		// A malformed --json argument is caller error, not an API failure.
+		// Matched before the "failed to parse" API pattern below.
+		"failed to parse JSON",
 	}
 	for _, p := range usagePatterns {
 		if strings.Contains(msg, p) {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -500,6 +500,8 @@ func TestClassifyError(t *testing.T) {
 		{"usage - at least one of these flags", "at least one of these flags must be set: name, term", exitcodes.Usage},
 		{"usage - invalid location ID", "invalid location ID: abc", exitcodes.Usage},
 		{"usage - invalid ID combo", "invalid port ID provided", exitcodes.Usage},
+		{"usage - failed to parse JSON", "failed to parse JSON: invalid character 'h' in literal true", exitcodes.Usage},
+		{"usage - failed to parse JSON file", "failed to parse JSON file: unexpected end of JSON input", exitcodes.Usage},
 
 		// API patterns
 		{"api - error listing", "failed to list ports", exitcodes.API},


### PR DESCRIPTION
Adds `TestE2E_*` cases that drive the compiled binary via argv and assert its CLI contract: exit codes, help/version/completion output, and flag plus output-format validation. No network, no credentials, so these run on every PR. Builds on the E1 harness (`e2e/` package, `Run` helper, `make e2e`).

Covered (each case is its own process, `t.Parallel()`):
- `version` exits 0 with a version line.
- Root `--help` and `ports --help` exit 0; root help lists usage and known subcommands.
- `completion bash`/`zsh` exit 0 with the expected shell markers.
- Unknown command, unknown flag, wrong arg count, and `--output bogus` all exit 2 (Usage).
- A purchase command with no flags, no `--json`, non-interactive exits 2 at flag validation before any login attempt.

Also folds in ESD-1514: `--json` parse failures were exiting 4 (`api_error`) instead of 2 (`usage_error`). Fixed by promoting `"failed to parse JSON"` to the usage patterns in `classifyError` (checked before the broader `"failed to parse"` API pattern). Covers all user-input JSON parse sites across every command package. The envelope test now asserts `exitcodes.Usage` explicitly.

JSON error envelope: the native binary emits a structured JSON envelope on stderr under `--output json` via `PrintErrorJSON` in the `Wrap*RunE` paths. The envelope test uses an invalid `--json` payload, which is parsed before any login, making it hermetic.
