### PR TITLE
ci: add govulncheck workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,24 @@
+name: govulncheck
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: 'go.mod'
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.4.0  # Pin to avoid CI drift
+      - name: Run govulncheck
+        run: govulncheck ./...


### PR DESCRIPTION
Adds a `govulncheck` CI job so we get alerted to known vulnerabilities in the Go stdlib and our dependencies, on every push to main and PR.

It mirrors the existing lint/test workflows: pinned action SHAs, `go-version-file`, read-only permissions, and a pinned govulncheck version to avoid CI drift.

Ran it locally against the current tree under the CI toolchain (go1.26.4): **no vulnerabilities found**, so this lands green. govulncheck is call-graph aware, so it only flags vulns our code actually reaches.