### PR TITLE
test: add live-staging read-only native-binary e2e tests

### DIFF
--- a/e2e/harness_test.go
+++ b/e2e/harness_test.go
@@ -32,22 +32,24 @@ func Run(t *testing.T, args ...string) Result {
 	return run(t, nil, args)
 }
 
-// RunWithEnv is like Run but also forwards the named host environment variables
-// into the sandbox when they are set. The staging tier uses it to pass the
-// MEGAPORT_* credentials through; hermetic tests do not.
-func RunWithEnv(t *testing.T, passthrough []string, args ...string) Result {
+// RunWithEnv is like Run but also seeds the sandbox from the given environment
+// spec. Each entry is either a bare NAME, forwarded from the host only when it
+// is set, or an explicit NAME=value, set verbatim. The staging tier uses it to
+// forward the MEGAPORT_* credentials and to pin MEGAPORT_ENVIRONMENT; hermetic
+// tests do not.
+func RunWithEnv(t *testing.T, envSpec []string, args ...string) Result {
 	t.Helper()
-	return run(t, passthrough, args)
+	return run(t, envSpec, args)
 }
 
-func run(t *testing.T, passthrough []string, args []string) Result {
+func run(t *testing.T, envSpec []string, args []string) Result {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), runTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, cliBinary, args...)
-	cmd.Env = sandboxEnv(t, passthrough)
+	cmd.Env = sandboxEnv(t, envSpec)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -75,11 +77,10 @@ func run(t *testing.T, passthrough []string, args []string) Result {
 }
 
 // sandboxEnv builds the subprocess environment: an isolated HOME so the CLI
-// never reads the developer's ~/.megaport/config.json, a minimal PATH, and any
-// requested passthrough variables that are actually set on the host. Everything
-// else, including all MEGAPORT_* config, is dropped so tests are hermetic by
-// default.
-func sandboxEnv(t *testing.T, passthrough []string) []string {
+// never reads the developer's ~/.megaport/config.json, a minimal PATH, and the
+// requested environment spec applied on top. Everything else, including all
+// MEGAPORT_* config, is dropped so tests are hermetic by default.
+func sandboxEnv(t *testing.T, envSpec []string) []string {
 	t.Helper()
 	// A fixed minimal PATH keeps the sandbox hermetic. The standard system dirs
 	// cover the few tools the CLI may shell out to on its darwin and linux build
@@ -92,9 +93,15 @@ func sandboxEnv(t *testing.T, passthrough []string) []string {
 		// network-free even when MEGAPORT_CLI_E2E_BIN points at a versioned binary.
 		"NO_UPDATE_CHECK=1",
 	}
-	for _, name := range passthrough {
-		if v, ok := os.LookupEnv(name); ok {
-			env = append(env, name+"="+v)
+	for _, entry := range envSpec {
+		// An explicit NAME=value entry is set verbatim; a bare NAME is forwarded
+		// from the host only when it is actually set.
+		if strings.Contains(entry, "=") {
+			env = append(env, entry)
+			continue
+		}
+		if v, ok := os.LookupEnv(entry); ok {
+			env = append(env, entry+"="+v)
 		}
 	}
 	return env

--- a/e2e/staging_test.go
+++ b/e2e/staging_test.go
@@ -1,0 +1,184 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"encoding/xml"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file holds the live-staging tier: black-box tests that drive the compiled
+// binary against the real staging API and parse its stdout. They build on the
+// hermetic harness in this package but, unlike the hermetic tests, forward the
+// MEGAPORT_* credentials into the subprocess. Every case is read-only (only list
+// commands) and runs in its own process, so the suite is safe under t.Parallel()
+// and never creates, updates, or deletes anything on staging.
+//
+// Cases skip when credentials are absent, mirroring the SDK-side gate in
+// testutil.SetupIntegrationClient, so the whole tier shares one "needs staging
+// access" gate. locations list reaches a public endpoint and does not strictly
+// require credentials, but it is gated with the rest for a uniform contract;
+// partners list is the case that actually authenticates. The tests reach staging
+// only through the binary and never import command internals or the SDK.
+
+// requireStagingCreds skips the test unless both API credentials are present in
+// the host environment, mirroring testutil.SetupIntegrationClient's gate.
+func requireStagingCreds(t *testing.T) {
+	t.Helper()
+	if os.Getenv("MEGAPORT_ACCESS_KEY") == "" || os.Getenv("MEGAPORT_SECRET_KEY") == "" {
+		t.Skip("MEGAPORT_ACCESS_KEY and MEGAPORT_SECRET_KEY required for live staging e2e tests")
+	}
+}
+
+// stagingEnv is the environment spec forwarded into each CLI subprocess. The
+// credentials are forwarded from the host by name, while MEGAPORT_ENVIRONMENT is
+// pinned to an explicit, normalized value so the binary targets the intended
+// environment instead of falling back to its production default.
+func stagingEnv() []string {
+	return []string{
+		"MEGAPORT_ACCESS_KEY",
+		"MEGAPORT_SECRET_KEY",
+		"MEGAPORT_ENVIRONMENT=" + stagingEnvironment(),
+	}
+}
+
+// stagingEnvironment resolves the target environment from the host
+// MEGAPORT_ENVIRONMENT, failing safe to staging on an empty or unrecognized
+// value. This mirrors testutil.IntegrationEnvironment so a typo cannot silently
+// retarget the tests at production, which is where the CLI itself maps any
+// value it does not recognize.
+func stagingEnvironment() string {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("MEGAPORT_ENVIRONMENT"))) {
+	case "production", "prod":
+		return "production"
+	case "development", "dev":
+		return "development"
+	default:
+		return "staging"
+	}
+}
+
+// TestE2E_Staging_LocationsListJSON drives `locations list --output json` against
+// staging and asserts the binary renders a real, non-empty JSON array. The
+// locations endpoint is public, so this case exercises reachability and rendering
+// rather than authentication; TestE2E_Staging_PartnersListJSON covers the
+// authenticated path.
+func TestE2E_Staging_LocationsListJSON(t *testing.T) {
+	requireStagingCreds(t)
+	t.Parallel()
+
+	res := RunWithEnv(t, stagingEnv(), "locations", "list", "--output", "json")
+
+	require.Equalf(t, 0, res.Exit, "locations list should exit 0\nstdout: %s\nstderr: %s", res.Stdout, res.Stderr)
+
+	var locations []json.RawMessage
+	require.NoErrorf(t, json.Unmarshal([]byte(res.Stdout), &locations),
+		"stdout should be a JSON array\nstdout: %s", res.Stdout)
+	assert.NotEmpty(t, locations, "staging should always return at least one location")
+}
+
+// TestE2E_Staging_PartnersListJSON drives `partners list --output json`, which
+// authenticates against staging before listing, and checks the decoded structure
+// has the partner-port shape. This is the canonical authentication check for the
+// tier.
+func TestE2E_Staging_PartnersListJSON(t *testing.T) {
+	requireStagingCreds(t)
+	t.Parallel()
+
+	res := RunWithEnv(t, stagingEnv(), "partners", "list", "--output", "json")
+
+	require.Equalf(t, 0, res.Exit, "partners list should exit 0\nstdout: %s\nstderr: %s", res.Stdout, res.Stderr)
+
+	// A populated UID proves at least one element carries real partner data rather
+	// than the decode silently yielding a slice of empty objects.
+	var partners []struct {
+		ProductName string `json:"product_name"`
+		UID         string `json:"uid"`
+		CompanyName string `json:"company_name"`
+		ConnectType string `json:"connect_type"`
+	}
+	require.NoErrorf(t, json.Unmarshal([]byte(res.Stdout), &partners),
+		"stdout should decode into the partner shape\nstdout: %s", res.Stdout)
+	require.NotEmpty(t, partners, "staging should always return at least one partner port")
+
+	withUID := 0
+	for _, p := range partners {
+		if p.UID != "" {
+			withUID++
+		}
+	}
+	assert.Positivef(t, withUID, "at least one partner should carry a UID\nstdout: %s", res.Stdout)
+}
+
+// TestE2E_Staging_LocationsListFormats runs the same read command across every
+// output format and asserts each exits 0 and produces output the format's parser
+// accepts. Each format runs in its own subtest, hence its own process.
+func TestE2E_Staging_LocationsListFormats(t *testing.T) {
+	requireStagingCreds(t)
+	t.Parallel()
+
+	cases := []struct {
+		format string
+		check  func(t *testing.T, stdout string)
+	}{
+		{"json", checkParsesAsJSONArray},
+		{"csv", checkParsesAsCSV},
+		{"xml", checkParsesAsXML},
+		{"table", checkNonEmptyTable},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.format, func(t *testing.T) {
+			t.Parallel()
+
+			res := RunWithEnv(t, stagingEnv(), "locations", "list", "--output", tc.format)
+
+			require.Equalf(t, 0, res.Exit, "locations list --output %s should exit 0\nstdout: %s\nstderr: %s",
+				tc.format, res.Stdout, res.Stderr)
+			tc.check(t, res.Stdout)
+		})
+	}
+}
+
+func checkParsesAsJSONArray(t *testing.T, stdout string) {
+	t.Helper()
+	var arr []json.RawMessage
+	require.NoErrorf(t, json.Unmarshal([]byte(stdout), &arr), "stdout should be a JSON array\nstdout: %s", stdout)
+	assert.NotEmpty(t, arr, "JSON array should be non-empty")
+}
+
+func checkParsesAsCSV(t *testing.T, stdout string) {
+	t.Helper()
+	records, err := csv.NewReader(strings.NewReader(stdout)).ReadAll()
+	require.NoErrorf(t, err, "stdout should be valid CSV\nstdout: %s", stdout)
+	// Require a header plus at least one data row. An empty result set still emits
+	// a header-only CSV, so checking the header alone would pass on no data and be
+	// weaker than the json/xml/table checks, which all require real content.
+	require.Greaterf(t, len(records), 1, "CSV should have a header and at least one data row\nstdout: %s", stdout)
+	assert.NotEmpty(t, records[0], "CSV header row should have columns")
+}
+
+func checkParsesAsXML(t *testing.T, stdout string) {
+	t.Helper()
+	var doc struct {
+		XMLName xml.Name   `xml:"items"`
+		Items   []struct{} `xml:"item"`
+	}
+	require.NoErrorf(t, xml.Unmarshal([]byte(stdout), &doc), "stdout should be valid XML\nstdout: %s", stdout)
+	assert.NotEmpty(t, doc.Items, "XML should contain at least one <item>")
+}
+
+func checkNonEmptyTable(t *testing.T, stdout string) {
+	t.Helper()
+	require.NotEmpty(t, strings.TrimSpace(stdout), "table output should be non-empty")
+	// A rendered table is a header plus at least one data row, so it always spans
+	// more than one line; a single line would signal an empty or malformed table.
+	assert.Greater(t, strings.Count(strings.TrimSpace(stdout), "\n"), 0, "table should span multiple lines")
+}


### PR DESCRIPTION
Adds a live-staging e2e tier on top of the existing hermetic harness: `TestE2E_Staging_*` cases that run the compiled binary against real staging and parse its stdout. Credential-gated, so they skip without creds and are meant for nightly and manual runs.

- `locations list --output json` exits 0 and stdout is a non-empty JSON array
- `partners list --output json` exits 0 and decodes to the partner-port shape (this is the case that actually authenticates)
- `locations list` across `json`, `csv`, `xml`, and `table`, each exiting 0 and parsing for its format
- Skips cleanly when `MEGAPORT_ACCESS_KEY` / `MEGAPORT_SECRET_KEY` are unset; otherwise forwards the credentials plus `MEGAPORT_ENVIRONMENT` (fail-safe to staging, so a typo cannot retarget production) into the subprocess
- Read-only only; nothing is created or mutated on staging

Run with `make e2e-staging`. Plain `go test ./...` is unaffected (the tier is behind the `e2e` build tag).

The harness env spec now also accepts explicit `NAME=value` entries so the environment can be pinned, rather than relying on the binary's production default.
