### PR TITLE
fix(output): stop spinner animating into non-TTY logs

### DIFF
--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -239,6 +239,14 @@ func (s *Spinner) renderFrame(i int) string {
 	return color.CyanString(frame)
 }
 
+// nonInteractive reports whether the spinner's sink is non-interactive: a
+// machine-readable output format, or output not attached to a TTY. In those
+// sinks the carriage-return/clear-line escapes don't collapse anything, so the
+// spinner emits a single plain status line rather than animating frame-by-frame.
+func (s *Spinner) nonInteractive() bool {
+	return (s.outputFormat != "" && s.outputFormat != "table") || !IsTerminal()
+}
+
 // runLoop is the shared spinner goroutine logic. If startTime is non-nil,
 // an elapsed duration is appended to the message on each tick.
 func (s *Spinner) runLoop(prefix string, startTime *time.Time) {
@@ -254,6 +262,11 @@ func (s *Spinner) runLoop(prefix string, startTime *time.Time) {
 		return
 	}
 	s.mu.Unlock()
+
+	if s.nonInteractive() {
+		fmt.Fprintf(os.Stderr, "%s\n", prefix)
+		return
+	}
 
 	go func() {
 		for i := 0; ; i++ {
@@ -275,11 +288,7 @@ func (s *Spinner) runLoop(prefix string, startTime *time.Time) {
 					msg = fmt.Sprintf("%s (%s elapsed)", prefix, elapsed)
 				}
 
-				if (s.outputFormat != "" && s.outputFormat != "table") || !IsTerminal() {
-					fmt.Fprintf(os.Stderr, "\r\033[K%s %s", styledFrame, msg)
-				} else {
-					fmt.Printf("\r\033[K%s %s", styledFrame, msg)
-				}
+				fmt.Printf("\r\033[K%s %s", styledFrame, msg)
 				s.mu.Unlock()
 				time.Sleep(s.frameRate)
 			}
@@ -306,9 +315,9 @@ func (s *Spinner) Stop() {
 	s.stopped = true
 	s.mu.Unlock()
 	s.stop <- true
-	if (s.outputFormat != "" && s.outputFormat != "table") || !IsTerminal() {
-		fmt.Fprint(os.Stderr, "\r\033[K")
-	} else {
+	// Only the animated TTY path leaves a frame on stdout to clear; in a
+	// non-interactive sink a bare clear sequence would just be junk in logs.
+	if !s.nonInteractive() {
 		fmt.Print("\r\033[K")
 	}
 }
@@ -318,9 +327,9 @@ func (s *Spinner) StopWithSuccess(msg string) {
 	if IsQuiet() {
 		return
 	}
-	// Write success message to stderr for non-table formats to avoid corrupting
-	// machine-readable output streams.
-	if (s.outputFormat != "" && s.outputFormat != "table") || !IsTerminal() {
+	// Write success message to stderr for non-interactive sinks to avoid
+	// corrupting machine-readable output streams.
+	if s.nonInteractive() {
 		if s.noColor {
 			fmt.Fprintf(os.Stderr, "✓ %s\n", msg)
 		} else {

--- a/internal/base/output/messages_native_test.go
+++ b/internal/base/output/messages_native_test.go
@@ -4,7 +4,9 @@ package output
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -54,4 +56,43 @@ func TestPrintErrorJSON_UsageError(t *testing.T) {
 	assert.NoError(t, json.Unmarshal([]byte(out), &env))
 	assert.Equal(t, 2, env.Error.Code)
 	assert.Equal(t, "usage_error", env.Error.Type)
+}
+
+// TestSpinnerNonTTYDoesNotAnimate guards ESD-1515: in a non-TTY sink the spinner
+// must print its status message once with no per-frame animation and no bare
+// carriage-return / clear-line escapes that would litter CI logs.
+func TestSpinnerNonTTYDoesNotAnimate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping timing-sensitive spinner test")
+	}
+	origTerm := isTerminalCached.Load()
+	t.Cleanup(func() { SetIsTerminal(origTerm) })
+	SetIsTerminal(false)
+
+	const msg = "Validating Port order..."
+
+	t.Run("Stop", func(t *testing.T) {
+		out := captureStderr(t, func() {
+			s := NewSpinner(true)
+			s.Start(msg)
+			time.Sleep(500 * time.Millisecond)
+			s.Stop()
+		})
+		assert.Equal(t, 1, strings.Count(out, msg), "status message should appear exactly once, got: %q", out)
+		assert.NotContains(t, out, "\r", "non-TTY output must not contain carriage returns")
+		assert.NotContains(t, out, "\x1b[K", "non-TTY output must not contain clear-line escapes")
+	})
+
+	t.Run("StopWithSuccess", func(t *testing.T) {
+		out := captureStderr(t, func() {
+			s := NewSpinner(true)
+			s.Start(msg)
+			time.Sleep(500 * time.Millisecond)
+			s.StopWithSuccess("Port order valid")
+		})
+		assert.Equal(t, 1, strings.Count(out, msg), "status message should appear exactly once, got: %q", out)
+		assert.Contains(t, out, "✓ Port order valid", "final success line should still be emitted")
+		assert.NotContains(t, out, "\r", "non-TTY output must not contain carriage returns")
+		assert.NotContains(t, out, "\x1b[K", "non-TTY output must not contain clear-line escapes")
+	})
 }

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -572,7 +572,7 @@ func TestStartWithElapsed(t *testing.T) {
 		assert.Contains(t, output, "elapsed")
 	})
 
-	t.Run("json output format writes to stderr", func(t *testing.T) {
+	t.Run("non-table format writes a single plain line to stderr", func(t *testing.T) {
 		spinner := NewSpinnerWithOutput(true, "json")
 		// Capture stderr by redirecting os.Stderr
 		r, w, _ := os.Pipe()
@@ -585,7 +585,11 @@ func TestStartWithElapsed(t *testing.T) {
 		os.Stderr = oldStderr
 		var buf bytes.Buffer
 		_, _ = io.Copy(&buf, r)
-		assert.Contains(t, buf.String(), "elapsed")
+		out := buf.String()
+		assert.Contains(t, out, "Provisioning...")
+		assert.NotContains(t, out, "elapsed", "non-interactive sink must not animate the elapsed counter")
+		assert.NotContains(t, out, "\r", "non-interactive sink must not emit carriage returns")
+		assert.NotContains(t, out, "\x1b[K", "non-interactive sink must not emit clear-line escapes")
 	})
 }
 


### PR DESCRIPTION
When output is not a terminal (CI logs, pipes, file redirects), the spinner kept animating: it wrote a `\r\033[K<frame> <msg>` line every ~100ms, and since the carriage-return/clear-line escapes don't collapse in a non-TTY sink, every frame became a fresh line (the hundreds of `Validating Port order...` lines in the provisioning integration logs). The `!IsTerminal()` check only chose stderr vs stdout; it never stopped the animation.

Now the spinner detects a non-interactive sink (non-table machine format, or not a TTY) and prints its status message once to stderr instead of starting the ticking goroutine. `Stop()` only emits the bare clear-line escape on the interactive path, so it no longer leaves junk in logs.

- Add `(*Spinner).nonInteractive()` and use it in `runLoop`, `Stop`, `StopWithSuccess`.
- Non-interactive `runLoop` prints the prefix once to stderr and skips the goroutine.
- Interactive TTY behavior (in-place animated spinner) is unchanged. WASM path untouched.
- New `TestSpinnerNonTTYDoesNotAnimate` (forces `IsTerminal()` false) asserts the message appears once with no `\r` / `\033[K` spam.

Verified: `go test ./...`, `go build ./...`, native + WASM build, and `golangci-lint run` all clean. Sanity-checked by piping a spinner command to `cat`: one static status line, zero CR / clear-line bytes on stdout.

Fixes ESD-1515.
