### PR TITLE
feat(wasm): register users, managed-account, billing-market modules

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,29 @@
+name: wasm
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  wasm:
+    name: WASM Build & Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: 'go.mod'
+      - name: Build WASM binary
+        run: GOOS=js GOARCH=wasm go build -tags js,wasm -o web/megaport.wasm .
+      - name: Run WASM unit tests
+        # Only ./cmd/megaport runs under the bare go_js_wasm_exec (node) runtime.
+        # The other WASM test packages need a browser host (fetch, JS bridge
+        # globals, stdin pipes) and are verified manually in-browser.
+        run: |
+          export PATH="$PATH:$(go env GOROOT)/lib/wasm"
+          GOOS=js GOARCH=wasm go test -v -tags js,wasm ./cmd/megaport

--- a/cmd/megaport/modules_wasm.go
+++ b/cmd/megaport/modules_wasm.go
@@ -3,7 +3,9 @@
 package megaport
 
 import (
+	"github.com/megaport/megaport-cli/internal/commands/billing_market"
 	"github.com/megaport/megaport-cli/internal/commands/locations"
+	"github.com/megaport/megaport-cli/internal/commands/managed_account"
 	"github.com/megaport/megaport-cli/internal/commands/mcr"
 	"github.com/megaport/megaport-cli/internal/commands/mve"
 	"github.com/megaport/megaport-cli/internal/commands/nat_gateway"
@@ -13,6 +15,7 @@ import (
 	"github.com/megaport/megaport-cli/internal/commands/servicekeys"
 	"github.com/megaport/megaport-cli/internal/commands/status"
 	"github.com/megaport/megaport-cli/internal/commands/topology"
+	"github.com/megaport/megaport-cli/internal/commands/users"
 	"github.com/megaport/megaport-cli/internal/commands/vxc"
 )
 
@@ -36,4 +39,7 @@ func registerModules() {
 	moduleRegistry.Register(servicekeys.NewModule())
 	moduleRegistry.Register(status.NewModule())
 	moduleRegistry.Register(topology.NewModule())
+	moduleRegistry.Register(users.NewModule())
+	moduleRegistry.Register(managed_account.NewModule())
+	moduleRegistry.Register(billing_market.NewModule())
 }

--- a/cmd/megaport/modules_wasm_test.go
+++ b/cmd/megaport/modules_wasm_test.go
@@ -39,3 +39,35 @@ func TestReadOnlyModulesRegistered(t *testing.T) {
 		})
 	}
 }
+
+// TestAccountPartnerAdminModulesRegistered verifies the users, managed-account,
+// and billing-market modules are wired into the WASM command tree (ESD-1287).
+// Like the read-only check above, each case is help-only so no network call is
+// made and subtests can share the global rootCmd without leaking flag state.
+func TestAccountPartnerAdminModulesRegistered(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		// usage anchors on the "Usage:" block so a parent's "Example usage"
+		// prose can't satisfy the match for a removed subcommand.
+		usage string
+	}{
+		{"users", []string{"megaport-cli", "users", "--help"}, "Usage:\n  megaport-cli users"},
+		{"users list", []string{"megaport-cli", "users", "list", "--help"}, "Usage:\n  megaport-cli users list"},
+		{"managed-account", []string{"megaport-cli", "managed-account", "--help"}, "Usage:\n  megaport-cli managed-account"},
+		{"managed-account list", []string{"megaport-cli", "managed-account", "list", "--help"}, "Usage:\n  megaport-cli managed-account list"},
+		{"billing-market", []string{"megaport-cli", "billing-market", "--help"}, "Usage:\n  megaport-cli billing-market"},
+		{"billing-market get", []string{"megaport-cli", "billing-market", "get", "--help"}, "Usage:\n  megaport-cli billing-market get"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wasm.ResetOutputBuffers()
+			ExecuteWithArgs(tc.args)
+			out := wasm.GetCapturedOutput()
+			// An unregistered command falls back to root help, which lacks
+			// this command's Usage: block, so Contains is the real check.
+			assert.Contains(t, out, tc.usage, "%v should be registered and show its usage path", tc.args)
+		})
+	}
+}


### PR DESCRIPTION
Registers the `users`, `managed-account`, and `billing-market` command modules in the WASM browser build so it reaches parity with the native CLI (ESD-1287). All three already use SDK-direct calls with no filesystem or `os/exec` dependencies, so this is a register-and-go change with no `_wasm.go` override needed.

Changes:
- Add the three modules to `registerModules()` in `cmd/megaport/modules_wasm.go`.
- Add `TestAccountPartnerAdminModulesRegistered`, a help-only smoke test asserting each module (plus one read-only subcommand each) is wired into the WASM command tree.
- Add a `wasm` CI workflow that builds the browser artifact and runs the WASM unit tests for `./cmd/megaport` under the node runtime.

CI now compiles the js/wasm build and runs the `./cmd/megaport` WASM tests (including the new smoke test). The other WASM test packages need a real browser host (fetch, JS bridge globals, stdin pipes), so they stay out of CI for now. The in-browser checks against Staging called out in the ticket (each command working, a non-partner key on managed-account behaving sensibly rather than crashing, and mutating commands confirmed with no prod side effects) remain manual.
