### PR TITLE
ci: wire e2e tests into CI and make the sandbox cross-platform

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -92,3 +92,22 @@ jobs:
           MEGAPORT_ACCESS_KEY: ${{ secrets.MEGAPORT_ACCESS_KEY }}
           MEGAPORT_SECRET_KEY: ${{ secrets.MEGAPORT_SECRET_KEY }}
           MEGAPORT_ENVIRONMENT: staging
+
+  # Live staging e2e tests. Runs on schedule and manual trigger.
+  # The tests self-skip when MEGAPORT_* secrets are absent.
+  e2e-staging:
+    name: E2E Tests (Staging)
+    runs-on: ubuntu-latest
+    # Test step has a 15m go-test timeout; allow headroom for checkout/setup-go.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: 'go.mod'
+      - name: Run staging e2e tests
+        run: make e2e-staging
+        env:
+          MEGAPORT_ACCESS_KEY: ${{ secrets.MEGAPORT_ACCESS_KEY }}
+          MEGAPORT_SECRET_KEY: ${{ secrets.MEGAPORT_SECRET_KEY }}
+          MEGAPORT_ENVIRONMENT: staging

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,14 @@ jobs:
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
       - name: Run golangci-lint
         run: golangci-lint run --timeout=5m
+
+  e2e-hermetic:
+    name: E2E Tests (Hermetic)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: 'go.mod'
+      - name: Run hermetic e2e tests
+        run: make e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,11 +41,21 @@ jobs:
 
   e2e-hermetic:
     name: E2E Tests (Hermetic)
-    runs-on: ubuntu-latest
+    # Run on Unix and Windows so OS-specific regressions in the cross-platform
+    # sandbox are caught.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: 'go.mod'
+      # Call go test directly rather than `make e2e`: make is absent on the
+      # windows-latest runner, and bash keeps the argument quoting identical on
+      # both OSes.
       - name: Run hermetic e2e tests
-        run: make e2e
+        shell: bash
+        run: go test -tags e2e -run '^TestE2E_' -skip '^TestE2E_Staging_' -v ./e2e/...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    # Caps a stuck build or run; the suite itself finishes in well under a minute.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0

--- a/e2e/harness_test.go
+++ b/e2e/harness_test.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -76,23 +78,17 @@ func run(t *testing.T, envSpec []string, args []string) Result {
 	return Result{Stdout: stdout.String(), Stderr: stderr.String(), Exit: exit}
 }
 
-// sandboxEnv builds the subprocess environment: an isolated HOME so the CLI
+// sandboxEnv builds the subprocess environment: an isolated home dir so the CLI
 // never reads the developer's ~/.megaport/config.json, a minimal PATH, and the
 // requested environment spec applied on top. Everything else, including all
 // MEGAPORT_* config, is dropped so tests are hermetic by default.
 func sandboxEnv(t *testing.T, envSpec []string) []string {
 	t.Helper()
-	// A fixed minimal PATH keeps the sandbox hermetic. The standard system dirs
-	// cover the few tools the CLI may shell out to on its darwin and linux build
-	// targets; git (used for the version string) is best-effort and degrades
-	// gracefully when unresolved.
-	env := []string{
-		"HOME=" + t.TempDir(),
-		"PATH=/usr/bin:/bin",
+	env := append(baseSandboxEnv(t.TempDir()),
 		// Suppress the GitHub update-check HTTP call so hermetic tests remain
 		// network-free even when MEGAPORT_CLI_E2E_BIN points at a versioned binary.
 		"NO_UPDATE_CHECK=1",
-	}
+	)
 	for _, entry := range envSpec {
 		// An explicit NAME=value entry is set verbatim; a bare NAME is forwarded
 		// from the host only when it is actually set.
@@ -105,4 +101,36 @@ func sandboxEnv(t *testing.T, envSpec []string) []string {
 		}
 	}
 	return env
+}
+
+// baseSandboxEnv returns the OS-appropriate isolated home and minimal PATH. The
+// CLI resolves its config dir via os.UserHomeDir, which reads HOME on Unix and
+// USERPROFILE on Windows, so each OS needs its own variable pointed at the temp
+// dir. The minimal PATH covers the few tools the CLI may shell out to; git (used
+// for the version string) is best-effort and degrades gracefully when unresolved.
+func baseSandboxEnv(home string) []string {
+	if runtime.GOOS == "windows" {
+		systemRoot := os.Getenv("SystemRoot")
+		if systemRoot == "" {
+			systemRoot = `C:\Windows`
+		}
+		drive := filepath.VolumeName(home)
+		// USERPROFILE is the var os.UserHomeDir reads; HOMEDRIVE/HOMEPATH and
+		// TEMP/TMP point any child tooling and its temp files at the same isolated
+		// home so the sandbox stays hermetic.
+		return []string{
+			"USERPROFILE=" + home,
+			"HOMEDRIVE=" + drive,
+			"HOMEPATH=" + strings.TrimPrefix(home, drive),
+			"TEMP=" + home,
+			"TMP=" + home,
+			// Many Windows programs misbehave without SystemRoot in the environment.
+			"SystemRoot=" + systemRoot,
+			"PATH=" + systemRoot + `\System32;` + systemRoot,
+		}
+	}
+	return []string{
+		"HOME=" + home,
+		"PATH=/usr/bin:/bin",
+	}
 }

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -57,6 +58,9 @@ func setupAndRun(m *testing.M) (int, error) {
 	defer os.RemoveAll(tmp)
 
 	bin := filepath.Join(tmp, "megaport-cli")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
 	build := exec.Command("go", "build", "-o", bin, ".")
 	build.Dir = root
 	// Build from the module's own definition, ignoring any ambient go.work, so the


### PR DESCRIPTION
Two related bits of e2e plumbing, bundled. Resolves ESD-1496 and ESD-1511.

**Wire the e2e suites into CI (ESD-1496, YAML only):**
- `e2e-hermetic` in `test.yml`: runs the hermetic suite on push to `main` and on every PR, so it gates PRs. No credentials. It runs as a matrix over `ubuntu-latest` and `windows-latest` so the cross-platform sandbox is exercised on both. The step calls `go test` directly under `bash` rather than `make e2e`, since `make` is absent on the Windows runner (this matches the other CI jobs, which already inline `go test`).
- `e2e-staging` in `integration-test.yml`: runs `make e2e-staging` on the nightly schedule and manual dispatch, with the `MEGAPORT_*` staging secrets. The tests self-skip when secrets are absent, so it stays green without them.
- Both jobs reuse the action SHAs already pinned in these files. Existing unit, lint, and integration jobs are unchanged. Validated with `actionlint`.

**Make the e2e sandbox cross-platform (ESD-1511):**
- Build the CLI binary with a `.exe` suffix on Windows.
- Seed the sandbox with OS-appropriate home vars (`USERPROFILE` plus `HOMEDRIVE`/`HOMEPATH` and `TEMP`/`TMP`) and a minimal Windows `PATH` (`System32` plus `SystemRoot`) instead of the Unix `HOME` and `/usr/bin:/bin`.
- Unix behavior is unchanged: the hermetic suite still passes locally, and the package vets for both `darwin` and `windows`. Windows runtime behavior is unverified here (no Windows runner).
