### PR TITLE
fix: classify ValidationError as usage exit code (ESD-1523)

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/validation"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 )
@@ -306,6 +307,13 @@ func classifyError(err error) int {
 	var cliErr *exitcodes.CLIError
 	if errors.As(err, &cliErr) {
 		return cliErr.Code
+	}
+
+	// A validation failure is caller error, so map it to the usage code. Type
+	// matching avoids depending on the "Invalid %s" message wording.
+	var validationErr *validation.ValidationError
+	if errors.As(err, &validationErr) {
+		return exitcodes.Usage
 	}
 
 	// Type-safe SDK error inspection first

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/megaport/megaport-cli/internal/base/exitcodes"
+	"github.com/megaport/megaport-cli/internal/validation"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -560,6 +561,18 @@ func TestClassifyError_SDKErrors(t *testing.T) {
 			assert.Equal(t, tt.wantCode, code)
 		})
 	}
+}
+
+func TestClassifyError_ValidationError(t *testing.T) {
+	// A raw ValidationError must map to the usage exit code. Its message is
+	// "Invalid <field>: ..." (capital I), which the lowercase "invalid" heuristic
+	// misses, so the type check carries it.
+	verr := validation.NewValidationError("name", "", "must not be empty")
+	assert.Equal(t, exitcodes.Usage, classifyError(verr))
+
+	// errors.As traverses wrapping, so a wrapped ValidationError classifies the same.
+	wrapped := fmt.Errorf("validation failed for port: %w", verr)
+	assert.Equal(t, exitcodes.Usage, classifyError(wrapped))
 }
 
 func TestWrapRunE_CancelledError(t *testing.T) {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -630,6 +630,21 @@ func TestWrapRunE_APIError(t *testing.T) {
 	assert.Equal(t, exitcodes.API, cliErr.Code)
 }
 
+func TestWrapRunE_ValidationError(t *testing.T) {
+	// A command that fails with a ValidationError must exit with the usage code,
+	// end to end through the wrapper, not just at classifyError.
+	wrapped := WrapRunE(func(cmd *cobra.Command, args []string) error {
+		return validation.NewValidationError("name", "", "must not be empty")
+	})
+	cmd := &cobra.Command{Use: "test"}
+	err := wrapped(cmd, []string{})
+	require.Error(t, err)
+
+	var cliErr *exitcodes.CLIError
+	require.True(t, errors.As(err, &cliErr))
+	assert.Equal(t, exitcodes.Usage, cliErr.Code)
+}
+
 // parseErrorJSON unmarshals a JSON error envelope from s.
 func parseErrorJSON(t *testing.T, s string) (code int, errType, message string) {
 	t.Helper()


### PR DESCRIPTION
`classifyError` picked the exit code by matching the lowercase substring `"invalid"` and also requiring `"ID"`. A raw `ValidationError` formats its message as `"Invalid %s: ..."` (capital I), so it never matched and the process exited with code 1 (General) instead of 2 (Usage). Scripts couldn't tell a usage/validation failure from a generic one.

The fix maps the error by type instead of by message text:

- Add an `errors.As(err, &validationErr)` check in `classifyError` that returns `exitcodes.Usage` for any `ValidationError`, placed right after the existing `CLIError` passthrough (which still wins).
- Substring heuristics and the `ValidationError` message format are left untouched.
- Add `TestClassifyError_ValidationError` covering the bare and `%w`-wrapped cases.

`go build ./...`, `go test ./...`, and `golangci-lint run` are clean.

Jira: ESD-1523
