### PR TITLE
fix(json): tighten JSON input value handling to match flags (ESD-1521)

### DIFF
--- a/internal/commands/mcr/mcr_inputs.go
+++ b/internal/commands/mcr/mcr_inputs.go
@@ -26,6 +26,10 @@ func processJSONMCRInput(jsonStr, jsonFile string) (*megaport.BuyMCRRequest, err
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
+	if err := utils.RejectEmptyTagKeys(req.ResourceTags); err != nil {
+		return nil, err
+	}
+
 	// BuyMCRRequest.AddOns is []MCRAddOn (interface) and cannot be directly
 	// unmarshaled by the standard library. Read tunnelCount separately using a
 	// pointer so we can distinguish "key absent" from an explicit value.

--- a/internal/commands/mcr/mcr_inputs_test.go
+++ b/internal/commands/mcr/mcr_inputs_test.go
@@ -38,6 +38,16 @@ func TestProcessJSONMCRInput(t *testing.T) {
 			name:      "valid JSON file",
 			writeFile: `{"name":"file-mcr","term":12,"portSpeed":5000,"locationId":1,"marketplaceVisibility":true}`,
 		},
+		{
+			name:          "empty tag key rejected",
+			jsonStr:       `{"name":"test","term":12,"portSpeed":5000,"locationId":1,"marketplaceVisibility":true,"resourceTags":{"":"x"}}`,
+			expectedError: "tag key must not be empty",
+		},
+		{
+			name:          "empty tag key rejected via file",
+			writeFile:     `{"name":"test","term":12,"portSpeed":5000,"locationId":1,"marketplaceVisibility":true,"resourceTags":{"":"x"}}`,
+			expectedError: "tag key must not be empty",
+		},
 	}
 
 	for _, tt := range tests {
@@ -55,7 +65,7 @@ func TestProcessJSONMCRInput(t *testing.T) {
 
 			req, err := processJSONMCRInput(tt.jsonStr, jsonFile)
 			if tt.expectedError != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
 			} else {
 				assert.NoError(t, err)
@@ -63,6 +73,13 @@ func TestProcessJSONMCRInput(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProcessJSONMCRInput_ValidResourceTags(t *testing.T) {
+	req, err := processJSONMCRInput(`{"name":"test","term":12,"portSpeed":5000,"locationId":1,"marketplaceVisibility":true,"resourceTags":{"env":"prod"}}`, "")
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	assert.Equal(t, "prod", req.ResourceTags["env"])
 }
 
 func TestProcessJSONUpdateMCRInput(t *testing.T) {

--- a/internal/commands/mve/mve_inputs.go
+++ b/internal/commands/mve/mve_inputs.go
@@ -24,31 +24,45 @@ func processJSONBuyMVEInput(jsonStr, jsonFilePath string) (*megaport.BuyMVEReque
 
 	req := &megaport.BuyMVERequest{}
 
-	if name, ok := jsonData["name"].(string); ok && name != "" {
+	if name, present, err := utils.JSONString(jsonData, "name"); err != nil {
+		return nil, err
+	} else if present && name != "" {
 		req.Name = name
 	}
 
-	if term, ok := jsonData["term"].(float64); ok && term > 0 {
+	if term, present, err := utils.JSONNumber(jsonData, "term"); err != nil {
+		return nil, err
+	} else if present && term > 0 {
 		req.Term = int(term)
 	}
 
-	if locationID, ok := jsonData["locationId"].(float64); ok && locationID > 0 {
+	if locationID, present, err := utils.JSONNumber(jsonData, "locationId"); err != nil {
+		return nil, err
+	} else if present && locationID > 0 {
 		req.LocationID = int(locationID)
 	}
 
-	if diversityZone, ok := jsonData["diversityZone"].(string); ok {
+	if diversityZone, present, err := utils.JSONString(jsonData, "diversityZone"); err != nil {
+		return nil, err
+	} else if present {
 		req.DiversityZone = diversityZone
 	}
 
-	if promoCode, ok := jsonData["promoCode"].(string); ok {
+	if promoCode, present, err := utils.JSONString(jsonData, "promoCode"); err != nil {
+		return nil, err
+	} else if present {
 		req.PromoCode = promoCode
 	}
 
-	if costCentre, ok := jsonData["costCentre"].(string); ok {
+	if costCentre, present, err := utils.JSONString(jsonData, "costCentre"); err != nil {
+		return nil, err
+	} else if present {
 		req.CostCentre = costCentre
 	}
 
-	if vendorConfigMap, ok := jsonData["vendorConfig"].(map[string]interface{}); ok {
+	if vendorConfigMap, present, err := utils.JSONObject(jsonData, "vendorConfig"); err != nil {
+		return nil, err
+	} else if present {
 		vendorConfig, err := ParseVendorConfig(vendorConfigMap)
 		if err != nil {
 			return nil, err
@@ -56,22 +70,30 @@ func processJSONBuyMVEInput(jsonStr, jsonFilePath string) (*megaport.BuyMVEReque
 		req.VendorConfig = vendorConfig
 	}
 
-	if vnicsData, ok := jsonData["vnics"].([]interface{}); ok {
+	if vnicsData, present, err := utils.JSONArray(jsonData, "vnics"); err != nil {
+		return nil, err
+	} else if present {
 		vnics := make([]megaport.MVENetworkInterface, 0, len(vnicsData))
-		for _, vnicData := range vnicsData {
-			if vnicMap, ok := vnicData.(map[string]interface{}); ok {
-				vnic := megaport.MVENetworkInterface{}
-
-				if description, ok := vnicMap["description"].(string); ok {
-					vnic.Description = description
-				}
-
-				if vlan, ok := vnicMap["vlan"].(float64); ok {
-					vnic.VLAN = int(vlan)
-				}
-
-				vnics = append(vnics, vnic)
+		for i, vnicData := range vnicsData {
+			vnicMap, ok := vnicData.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("vnics[%d] must be an object", i)
 			}
+			vnic := megaport.MVENetworkInterface{}
+
+			if description, present, err := utils.JSONString(vnicMap, "description"); err != nil {
+				return nil, fmt.Errorf("vnics[%d] %w", i, err)
+			} else if present {
+				vnic.Description = description
+			}
+
+			if vlan, present, err := utils.JSONNumber(vnicMap, "vlan"); err != nil {
+				return nil, fmt.Errorf("vnics[%d] %w", i, err)
+			} else if present {
+				vnic.VLAN = int(vlan)
+			}
+
+			vnics = append(vnics, vnic)
 		}
 		req.Vnics = vnics
 	}
@@ -629,15 +651,21 @@ func processJSONUpdateMVEInput(jsonStr, jsonFilePath, mveUID string) (*megaport.
 		MVEID: mveUID,
 	}
 
-	if name, ok := jsonData["name"].(string); ok && name != "" {
+	if name, present, err := utils.JSONString(jsonData, "name"); err != nil {
+		return nil, err
+	} else if present && name != "" {
 		req.Name = name
 	}
 
-	if costCentre, ok := jsonData["costCentre"].(string); ok && costCentre != "" {
+	if costCentre, present, err := utils.JSONString(jsonData, "costCentre"); err != nil {
+		return nil, err
+	} else if present && costCentre != "" {
 		req.CostCentre = costCentre
 	}
 
-	if contractTermMonths, ok := jsonData["contractTermMonths"].(float64); ok {
+	if contractTermMonths, present, err := utils.JSONNumber(jsonData, "contractTermMonths"); err != nil {
+		return nil, err
+	} else if present {
 		termMonths := int(contractTermMonths)
 		req.ContractTermMonths = &termMonths
 	}

--- a/internal/commands/mve/mve_inputs_test.go
+++ b/internal/commands/mve/mve_inputs_test.go
@@ -294,6 +294,21 @@ func TestProcessJSONUpdateMVEInput(t *testing.T) {
 			jsonStr: `{"contractTermMonths":24}`,
 		},
 		{
+			name:          "name wrong type",
+			jsonStr:       `{"name":123}`,
+			expectedError: "name must be a string",
+		},
+		{
+			name:          "cost centre wrong type",
+			jsonStr:       `{"costCentre":true}`,
+			expectedError: "costCentre must be a string",
+		},
+		{
+			name:          "contract term wrong type",
+			jsonStr:       `{"contractTermMonths":"two years"}`,
+			expectedError: "contractTermMonths must be a number",
+		},
+		{
 			name:          "invalid JSON",
 			jsonStr:       `{invalid}`,
 			expectedError: "failed to parse JSON",
@@ -333,6 +348,108 @@ func TestProcessJSONUpdateMVEInput(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProcessJSONBuyMVEInput(t *testing.T) {
+	validVendorConfig := `"vendorConfig":{"vendor":"6wind","imageId":1,"productSize":"MEDIUM","sshPublicKey":"ssh-rsa AAAA"}`
+
+	tests := []struct {
+		name          string
+		jsonStr       string
+		expectedError string
+	}{
+		{
+			name:    "valid buy request",
+			jsonStr: `{"name":"test-mve","term":12,"locationId":5,` + validVendorConfig + `}`,
+		},
+		{
+			name:    "valid buy request with vnics",
+			jsonStr: `{"name":"test-mve","term":12,"locationId":5,` + validVendorConfig + `,"vnics":[{"description":"data","vlan":100}]}`,
+		},
+		{
+			name:    "valid buy request with empty vnics array",
+			jsonStr: `{"name":"test-mve","term":12,"locationId":5,` + validVendorConfig + `,"vnics":[]}`,
+		},
+		{
+			name:          "name wrong type",
+			jsonStr:       `{"name":123}`,
+			expectedError: "name must be a string",
+		},
+		{
+			name:          "term wrong type",
+			jsonStr:       `{"term":"yearly"}`,
+			expectedError: "term must be a number",
+		},
+		{
+			name:          "locationId wrong type",
+			jsonStr:       `{"locationId":"five"}`,
+			expectedError: "locationId must be a number",
+		},
+		{
+			name:          "diversityZone wrong type",
+			jsonStr:       `{"diversityZone":5}`,
+			expectedError: "diversityZone must be a string",
+		},
+		{
+			name:          "promoCode wrong type",
+			jsonStr:       `{"promoCode":5}`,
+			expectedError: "promoCode must be a string",
+		},
+		{
+			name:          "costCentre wrong type",
+			jsonStr:       `{"costCentre":true}`,
+			expectedError: "costCentre must be a string",
+		},
+		{
+			name:          "vendorConfig wrong type",
+			jsonStr:       `{"vendorConfig":"6wind"}`,
+			expectedError: "vendorConfig must be an object",
+		},
+		{
+			name:          "vnics wrong type",
+			jsonStr:       `{"vnics":"data"}`,
+			expectedError: "vnics must be an array",
+		},
+		{
+			name:          "vnics entry wrong type",
+			jsonStr:       `{"vnics":["data"]}`,
+			expectedError: "vnics[0] must be an object",
+		},
+		{
+			name:          "vnics description wrong type",
+			jsonStr:       `{"vnics":[{"description":123}]}`,
+			expectedError: "description must be a string",
+		},
+		{
+			name:          "vnics vlan wrong type",
+			jsonStr:       `{"vnics":[{"vlan":"hundred"}]}`,
+			expectedError: "vlan must be a number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := processJSONBuyMVEInput(tt.jsonStr, "")
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, req)
+			}
+		})
+	}
+}
+
+func TestProcessJSONBuyMVEInput_OptionalStringsRoundTrip(t *testing.T) {
+	jsonStr := `{"name":"test-mve","term":12,"locationId":5,"diversityZone":"red","promoCode":"PROMO","costCentre":"CC-1","vendorConfig":{"vendor":"6wind","imageId":1,"productSize":"MEDIUM","sshPublicKey":"ssh-rsa AAAA"}}`
+
+	req, err := processJSONBuyMVEInput(jsonStr, "")
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	assert.Equal(t, "red", req.DiversityZone)
+	assert.Equal(t, "PROMO", req.PromoCode)
+	assert.Equal(t, "CC-1", req.CostCentre)
 }
 
 func TestProcessFlagUpdateMVEInput(t *testing.T) {

--- a/internal/commands/nat_gateway/nat_gateway_inputs.go
+++ b/internal/commands/nat_gateway/nat_gateway_inputs.go
@@ -36,6 +36,10 @@ func processJSONCreateNATGatewayInput(jsonStr, jsonFile string) (*megaport.Creat
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
+	if err := utils.RejectEmptyTagKeys(raw.ResourceTags); err != nil {
+		return nil, err
+	}
+
 	req := &megaport.CreateNATGatewayRequest{
 		ProductName:           raw.Name,
 		LocationID:            raw.LocationID,
@@ -165,6 +169,10 @@ func processJSONUpdateNATGatewayInput(jsonStr, jsonFile, uid string) (*megaport.
 	}
 	if err := json.Unmarshal(jsonData, &raw); err != nil {
 		return nil, updateExplicitFields{}, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	if err := utils.RejectEmptyTagKeys(raw.ResourceTags); err != nil {
+		return nil, updateExplicitFields{}, err
 	}
 
 	explicit := updateExplicitFields{

--- a/internal/commands/nat_gateway/nat_gateway_inputs_test.go
+++ b/internal/commands/nat_gateway/nat_gateway_inputs_test.go
@@ -87,6 +87,36 @@ func TestProcessJSONCreateNATGatewayInput_WithBooleanFields(t *testing.T) {
 	assert.True(t, req.AutoRenewTerm)
 }
 
+func TestProcessJSONCreateNATGatewayInput_RejectsEmptyTagKey(t *testing.T) {
+	_, err := processJSONCreateNATGatewayInput(
+		`{"name":"GW","term":12,"speed":1000,"locationId":1,"resourceTags":{"":"x"}}`, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tag key must not be empty")
+}
+
+func TestProcessJSONCreateNATGatewayInput_RejectsEmptyTagKeyFromFile(t *testing.T) {
+	content := `{"name":"GW","term":12,"speed":1000,"locationId":1,"resourceTags":{"":"x"}}`
+	tmp, err := os.CreateTemp("", "ng-create-emptytag-*.json")
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	_, err = tmp.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+
+	_, err = processJSONCreateNATGatewayInput("", tmp.Name())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tag key must not be empty")
+}
+
+func TestProcessJSONCreateNATGatewayInput_ValidResourceTags(t *testing.T) {
+	req, err := processJSONCreateNATGatewayInput(
+		`{"name":"GW","term":12,"speed":1000,"locationId":1,"resourceTags":{"env":"prod"}}`, "")
+	require.NoError(t, err)
+	require.Len(t, req.ResourceTags, 1)
+	assert.Equal(t, "env", req.ResourceTags[0].Key)
+	assert.Equal(t, "prod", req.ResourceTags[0].Value)
+}
+
 // ---- processFlagCreateNATGatewayInput ----
 
 func TestProcessFlagCreateNATGatewayInput_Valid(t *testing.T) {
@@ -160,6 +190,22 @@ func TestProcessFlagCreateNATGatewayInput_ValidResourceTags(t *testing.T) {
 }
 
 // ---- processJSONUpdateNATGatewayInput ----
+
+func TestProcessJSONUpdateNATGatewayInput_RejectsEmptyTagKey(t *testing.T) {
+	_, _, err := processJSONUpdateNATGatewayInput(
+		`{"name":"GW","resourceTags":{"":"x"}}`, "", "uid-empty-tag")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tag key must not be empty")
+}
+
+func TestProcessJSONUpdateNATGatewayInput_ValidResourceTags(t *testing.T) {
+	req, _, err := processJSONUpdateNATGatewayInput(
+		`{"name":"GW","resourceTags":{"env":"prod"}}`, "", "uid-valid-tag")
+	require.NoError(t, err)
+	require.Len(t, req.ResourceTags, 1)
+	assert.Equal(t, "env", req.ResourceTags[0].Key)
+	assert.Equal(t, "prod", req.ResourceTags[0].Value)
+}
 
 func TestProcessJSONUpdateNATGatewayInput_Valid(t *testing.T) {
 	req, explicit, err := processJSONUpdateNATGatewayInput(

--- a/internal/commands/ports/ports_inputs.go
+++ b/internal/commands/ports/ports_inputs.go
@@ -167,6 +167,10 @@ func processJSONPortInput(jsonStr, jsonFile string) (*megaport.BuyPortRequest, e
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
+	if err := utils.RejectEmptyTagKeys(req.ResourceTags); err != nil {
+		return nil, err
+	}
+
 	if err := validation.ValidatePortRequest(req); err != nil {
 		return nil, err
 	}

--- a/internal/commands/ports/ports_inputs_test.go
+++ b/internal/commands/ports/ports_inputs_test.go
@@ -167,6 +167,16 @@ func TestProcessJSONPortInput(t *testing.T) {
 			name:      "valid JSON file",
 			writeFile: `{"name":"file-test","term":12,"portSpeed":10000,"locationId":1,"marketPlaceVisibility":true}`,
 		},
+		{
+			name:          "empty tag key rejected",
+			jsonStr:       `{"name":"test","term":12,"portSpeed":10000,"locationId":1,"marketPlaceVisibility":true,"resourceTags":{"":"x"}}`,
+			expectedError: "tag key must not be empty",
+		},
+		{
+			name:          "empty tag key rejected via file",
+			writeFile:     `{"name":"test","term":12,"portSpeed":10000,"locationId":1,"marketPlaceVisibility":true,"resourceTags":{"":"x"}}`,
+			expectedError: "tag key must not be empty",
+		},
 	}
 
 	for _, tt := range tests {
@@ -184,7 +194,7 @@ func TestProcessJSONPortInput(t *testing.T) {
 
 			req, err := processJSONPortInput(tt.jsonStr, jsonFile)
 			if tt.expectedError != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
 			} else {
 				assert.NoError(t, err)
@@ -192,6 +202,13 @@ func TestProcessJSONPortInput(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProcessJSONPortInput_ValidResourceTags(t *testing.T) {
+	req, err := processJSONPortInput(`{"name":"test","term":12,"portSpeed":10000,"locationId":1,"marketPlaceVisibility":true,"resourceTags":{"env":"prod"}}`, "")
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	assert.Equal(t, "prod", req.ResourceTags["env"])
 }
 
 func TestProcessJSONUpdatePortInput(t *testing.T) {

--- a/internal/commands/vxc/vxc_inputs.go
+++ b/internal/commands/vxc/vxc_inputs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 
 	"github.com/megaport/megaport-cli/internal/utils"
 	"github.com/megaport/megaport-cli/internal/validation"
@@ -143,20 +144,28 @@ var buildVXCRequestFromFlags = func(cmd *cobra.Command, ctx context.Context, svc
 func parseVXCEndpointConfig(endConfigRaw map[string]interface{}, endLabel string) (megaport.VXCOrderEndpointConfiguration, error) {
 	config := megaport.VXCOrderEndpointConfiguration{}
 
-	if productUID, ok := endConfigRaw["productUID"].(string); ok {
+	if productUID, present, err := utils.JSONString(endConfigRaw, "productUID"); err != nil {
+		return config, fmt.Errorf("%s: %w", endLabel, err)
+	} else if present {
 		config.ProductUID = productUID
 	}
 
-	if vlan, ok := endConfigRaw["vlan"].(float64); ok {
+	if vlan, present, err := utils.JSONNumber(endConfigRaw, "vlan"); err != nil {
+		return config, fmt.Errorf("%s: %w", endLabel, err)
+	} else if present {
 		config.VLAN = int(vlan)
 	}
 
-	if diversityZone, ok := endConfigRaw["diversityZone"].(string); ok {
+	if diversityZone, present, err := utils.JSONString(endConfigRaw, "diversityZone"); err != nil {
+		return config, fmt.Errorf("%s: %w", endLabel, err)
+	} else if present {
 		config.DiversityZone = diversityZone
 	}
 
 	// Handle partner config - directly use map data
-	if partnerConfigRaw, ok := endConfigRaw["partnerConfig"].(map[string]interface{}); ok {
+	if partnerConfigRaw, present, err := utils.JSONObject(endConfigRaw, "partnerConfig"); err != nil {
+		return config, fmt.Errorf("%s: %w", endLabel, err)
+	} else if present {
 		partnerConfig, err := parsePartnerConfigFromMap(partnerConfigRaw)
 		if err != nil {
 			return config, fmt.Errorf("failed to parse %s partner config: %w", endLabel, err)
@@ -166,8 +175,14 @@ func parseVXCEndpointConfig(endConfigRaw map[string]interface{}, endLabel string
 	}
 
 	// Handle MVE config
-	innerVLAN, hasInnerVLAN := endConfigRaw["innerVlan"].(float64)
-	vNicIndex, hasVNicIndex := endConfigRaw["vNicIndex"].(float64)
+	innerVLAN, hasInnerVLAN, err := utils.JSONNumber(endConfigRaw, "innerVlan")
+	if err != nil {
+		return config, fmt.Errorf("%s: %w", endLabel, err)
+	}
+	vNicIndex, hasVNicIndex, err := utils.JSONNumber(endConfigRaw, "vNicIndex")
+	if err != nil {
+		return config, fmt.Errorf("%s: %w", endLabel, err)
+	}
 
 	if hasInnerVLAN || hasVNicIndex {
 		mveConfig := &megaport.VXCOrderMVEConfig{}
@@ -202,8 +217,11 @@ func buildVXCRequestFromJSON(jsonStr string, jsonFilePath string) (*megaport.Buy
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
-	portUID, ok := rawData["portUid"].(string)
-	if !ok {
+	portUID, present, err := utils.JSONString(rawData, "portUid")
+	if err != nil {
+		return nil, err
+	}
+	if !present {
 		return nil, validation.NewValidationError("portUid", "", "Port UID is required")
 	}
 
@@ -213,46 +231,72 @@ func buildVXCRequestFromJSON(jsonStr string, jsonFilePath string) (*megaport.Buy
 	}
 
 	// Set simple fields
-	if vxcName, ok := rawData["vxcName"].(string); ok {
+	if vxcName, present, err := utils.JSONString(rawData, "vxcName"); err != nil {
+		return nil, err
+	} else if present {
 		req.VXCName = vxcName
 	}
 
-	if rateLimit, ok := rawData["rateLimit"].(float64); ok {
+	if rateLimit, present, err := utils.JSONNumber(rawData, "rateLimit"); err != nil {
+		return nil, err
+	} else if present {
+		if rateLimit != math.Trunc(rateLimit) {
+			return nil, fmt.Errorf("rateLimit must be a whole number, got %v", rateLimit)
+		}
 		req.RateLimit = int(rateLimit)
 	}
 
-	if term, ok := rawData["term"].(float64); ok {
+	if term, present, err := utils.JSONNumber(rawData, "term"); err != nil {
+		return nil, err
+	} else if present {
+		if term != math.Trunc(term) {
+			return nil, fmt.Errorf("term must be a whole number, got %v", term)
+		}
 		req.Term = int(term)
 	}
 
-	if shutdown, ok := rawData["shutdown"].(bool); ok {
+	if shutdown, present, err := utils.JSONBool(rawData, "shutdown"); err != nil {
+		return nil, err
+	} else if present {
 		req.Shutdown = shutdown
 	}
 
-	if promoCode, ok := rawData["promoCode"].(string); ok {
+	if promoCode, present, err := utils.JSONString(rawData, "promoCode"); err != nil {
+		return nil, err
+	} else if present {
 		req.PromoCode = promoCode
 	}
 
-	if serviceKey, ok := rawData["serviceKey"].(string); ok {
+	if serviceKey, present, err := utils.JSONString(rawData, "serviceKey"); err != nil {
+		return nil, err
+	} else if present {
 		req.ServiceKey = serviceKey
 	}
 
-	if costCentre, ok := rawData["costCentre"].(string); ok {
+	if costCentre, present, err := utils.JSONString(rawData, "costCentre"); err != nil {
+		return nil, err
+	} else if present {
 		req.CostCentre = costCentre
 	}
 
 	// Handle resource tags if they exist
-	if resourceTags, ok := rawData["resourceTags"].(map[string]interface{}); ok {
+	if resourceTags, present, err := utils.JSONObject(rawData, "resourceTags"); err != nil {
+		return nil, err
+	} else if present {
 		req.ResourceTags = make(map[string]string)
 		for k, v := range resourceTags {
-			if strValue, ok := v.(string); ok {
-				req.ResourceTags[k] = strValue
+			strValue, ok := v.(string)
+			if !ok {
+				return nil, fmt.Errorf("resourceTags value for key %q must be a string", k)
 			}
+			req.ResourceTags[k] = strValue
 		}
 	}
 
 	// Handle A-End configuration
-	if aEndConfigRaw, ok := rawData["aEndConfiguration"].(map[string]interface{}); ok {
+	if aEndConfigRaw, present, err := utils.JSONObject(rawData, "aEndConfiguration"); err != nil {
+		return nil, err
+	} else if present {
 		aEndConfig, err := parseVXCEndpointConfig(aEndConfigRaw, "A-End")
 		if err != nil {
 			return nil, err
@@ -261,7 +305,9 @@ func buildVXCRequestFromJSON(jsonStr string, jsonFilePath string) (*megaport.Buy
 	}
 
 	// Handle B-End configuration
-	if bEndConfigRaw, ok := rawData["bEndConfiguration"].(map[string]interface{}); ok {
+	if bEndConfigRaw, present, err := utils.JSONObject(rawData, "bEndConfiguration"); err != nil {
+		return nil, err
+	} else if present {
 		bEndConfig, err := parseVXCEndpointConfig(bEndConfigRaw, "B-End")
 		if err != nil {
 			return nil, err

--- a/internal/commands/vxc/vxc_inputs.go
+++ b/internal/commands/vxc/vxc_inputs.go
@@ -291,6 +291,9 @@ func buildVXCRequestFromJSON(jsonStr string, jsonFilePath string) (*megaport.Buy
 			}
 			req.ResourceTags[k] = strValue
 		}
+		if err := utils.RejectEmptyTagKeys(req.ResourceTags); err != nil {
+			return nil, err
+		}
 	}
 
 	// Handle A-End configuration

--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -3,6 +3,7 @@ package vxc
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	megaport "github.com/megaport/megaportgo"
@@ -790,6 +791,29 @@ func TestBuildVXCRequestFromJSON(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildVXCRequestFromJSON_RejectsEmptyTagKey(t *testing.T) {
+	const payload = `{"portUid":"port-1","vxcName":"Test VXC","rateLimit":1000,"term":12,"resourceTags":{"":"x"},"bEndConfiguration":{"productUID":"port-2"}}`
+
+	t.Run("via json", func(t *testing.T) {
+		_, err := buildVXCRequestFromJSON(payload, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tag key must not be empty")
+	})
+
+	t.Run("via json-file", func(t *testing.T) {
+		tmp, err := os.CreateTemp("", "vxc-emptytag-*.json")
+		require.NoError(t, err)
+		defer os.Remove(tmp.Name())
+		_, err = tmp.WriteString(payload)
+		require.NoError(t, err)
+		require.NoError(t, tmp.Close())
+
+		_, err = buildVXCRequestFromJSON("", tmp.Name())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tag key must not be empty")
+	})
 }
 
 func TestBuildUpdateVXCRequestFromJSON_PartnerConfigs(t *testing.T) {

--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -639,6 +639,26 @@ func TestParseVXCEndpointConfig(t *testing.T) {
 			},
 			expectedError: "partner config",
 		},
+		{
+			name:          "vlan wrong type rejected",
+			config:        map[string]interface{}{"vlan": "one hundred"},
+			expectedError: "vlan must be a number",
+		},
+		{
+			name:          "productUID wrong type rejected",
+			config:        map[string]interface{}{"productUID": 123.0},
+			expectedError: "productUID must be a string",
+		},
+		{
+			name:          "partnerConfig wrong type rejected",
+			config:        map[string]interface{}{"partnerConfig": "not-an-object"},
+			expectedError: "partnerConfig must be an object",
+		},
+		{
+			name:          "innerVlan wrong type rejected",
+			config:        map[string]interface{}{"innerVlan": "x"},
+			expectedError: "innerVlan must be a number",
+		},
 	}
 
 	for _, tt := range tests {
@@ -704,6 +724,56 @@ func TestBuildVXCRequestFromJSON(t *testing.T) {
 			jsonFilePath:  "",
 			expectedError: "either json or json-file must be provided",
 		},
+		{
+			name:          "fractional rateLimit rejected",
+			jsonStr:       `{"portUid":"port-1","rateLimit":10.9,"term":12}`,
+			expectedError: "rateLimit must be a whole number",
+		},
+		{
+			name:          "fractional term rejected",
+			jsonStr:       `{"portUid":"port-1","rateLimit":1000,"term":10.9}`,
+			expectedError: "term must be a whole number",
+		},
+		{
+			name:          "rateLimit wrong type rejected",
+			jsonStr:       `{"portUid":"port-1","rateLimit":"fast","term":12}`,
+			expectedError: "rateLimit must be a number",
+		},
+		{
+			name:          "term wrong type rejected",
+			jsonStr:       `{"portUid":"port-1","rateLimit":1000,"term":"yearly"}`,
+			expectedError: "term must be a number",
+		},
+		{
+			name:          "vxcName wrong type rejected",
+			jsonStr:       `{"portUid":"port-1","vxcName":123,"rateLimit":1000,"term":12}`,
+			expectedError: "vxcName must be a string",
+		},
+		{
+			name:          "costCentre wrong type rejected",
+			jsonStr:       `{"portUid":"port-1","rateLimit":1000,"term":12,"costCentre":true}`,
+			expectedError: "costCentre must be a string",
+		},
+		{
+			name:          "shutdown wrong type rejected",
+			jsonStr:       `{"portUid":"port-1","rateLimit":1000,"term":12,"shutdown":"yes"}`,
+			expectedError: "shutdown must be a boolean",
+		},
+		{
+			name:          "portUid wrong type rejected",
+			jsonStr:       `{"portUid":123,"rateLimit":1000,"term":12}`,
+			expectedError: "portUid must be a string",
+		},
+		{
+			name:          "resourceTags value wrong type rejected",
+			jsonStr:       `{"portUid":"port-1","rateLimit":1000,"term":12,"resourceTags":{"env":123}}`,
+			expectedError: "resourceTags value for key \"env\" must be a string",
+		},
+		{
+			name:          "aEndConfiguration wrong type rejected",
+			jsonStr:       `{"portUid":"port-1","rateLimit":1000,"term":12,"aEndConfiguration":"not-an-object"}`,
+			expectedError: "aEndConfiguration must be an object",
+		},
 	}
 
 	for _, tt := range tests {
@@ -765,6 +835,19 @@ func TestBuildUpdateVXCRequestFromJSON_PartnerConfigs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildUpdateVXCRequestFromJSON_FractionalRateLimit(t *testing.T) {
+	_, err := buildUpdateVXCRequestFromJSON(`{"rateLimit":10.9}`, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rateLimit must be a whole number")
+}
+
+func TestBuildUpdateVXCRequestFromJSON_WholeRateLimit(t *testing.T) {
+	req, err := buildUpdateVXCRequestFromJSON(`{"rateLimit":2000}`, "")
+	require.NoError(t, err)
+	require.NotNil(t, req.RateLimit)
+	assert.Equal(t, 2000, *req.RateLimit)
 }
 
 func TestResolvePartnerPortUID(t *testing.T) {

--- a/internal/commands/vxc/vxc_inputs_update.go
+++ b/internal/commands/vxc/vxc_inputs_update.go
@@ -169,6 +169,9 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 	req := &megaport.UpdateVXCRequest{}
 
 	if rateLimit, ok := rawData["rateLimit"].(float64); ok {
+		if rateLimit != math.Trunc(rateLimit) {
+			return nil, fmt.Errorf("rateLimit must be a whole number, got %v", rateLimit)
+		}
 		rateLimitInt := int(rateLimit)
 		if rateLimitInt < 0 {
 			return nil, fmt.Errorf("rateLimit must be greater than or equal to 0")

--- a/internal/utils/json_map.go
+++ b/internal/utils/json_map.go
@@ -1,0 +1,75 @@
+package utils
+
+import "fmt"
+
+// These helpers read typed values out of a JSON object decoded into
+// map[string]interface{}. An absent key is reported via present=false and is
+// never an error, so callers keep optional fields optional. A key that is
+// present but holds the wrong JSON type returns an error instead of being
+// silently dropped, matching how the struct-based decoders surface a
+// json.UnmarshalTypeError.
+
+// JSONString returns the string at m[key].
+func JSONString(m map[string]interface{}, key string) (value string, present bool, err error) {
+	raw, ok := m[key]
+	if !ok {
+		return "", false, nil
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return "", true, fmt.Errorf("%s must be a string", key)
+	}
+	return s, true, nil
+}
+
+// JSONNumber returns the number at m[key]. JSON numbers decode to float64.
+func JSONNumber(m map[string]interface{}, key string) (value float64, present bool, err error) {
+	raw, ok := m[key]
+	if !ok {
+		return 0, false, nil
+	}
+	f, ok := raw.(float64)
+	if !ok {
+		return 0, true, fmt.Errorf("%s must be a number", key)
+	}
+	return f, true, nil
+}
+
+// JSONBool returns the boolean at m[key].
+func JSONBool(m map[string]interface{}, key string) (value bool, present bool, err error) {
+	raw, ok := m[key]
+	if !ok {
+		return false, false, nil
+	}
+	b, ok := raw.(bool)
+	if !ok {
+		return false, true, fmt.Errorf("%s must be a boolean", key)
+	}
+	return b, true, nil
+}
+
+// JSONObject returns the nested object at m[key].
+func JSONObject(m map[string]interface{}, key string) (value map[string]interface{}, present bool, err error) {
+	raw, ok := m[key]
+	if !ok {
+		return nil, false, nil
+	}
+	obj, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, true, fmt.Errorf("%s must be an object", key)
+	}
+	return obj, true, nil
+}
+
+// JSONArray returns the array at m[key].
+func JSONArray(m map[string]interface{}, key string) (value []interface{}, present bool, err error) {
+	raw, ok := m[key]
+	if !ok {
+		return nil, false, nil
+	}
+	arr, ok := raw.([]interface{})
+	if !ok {
+		return nil, true, fmt.Errorf("%s must be an array", key)
+	}
+	return arr, true, nil
+}

--- a/internal/utils/json_map_test.go
+++ b/internal/utils/json_map_test.go
@@ -1,0 +1,129 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONString(t *testing.T) {
+	m := map[string]interface{}{"name": "abc", "num": 1.0}
+
+	t.Run("present and correct type", func(t *testing.T) {
+		v, present, err := JSONString(m, "name")
+		require.NoError(t, err)
+		assert.True(t, present)
+		assert.Equal(t, "abc", v)
+	})
+
+	t.Run("absent key is optional", func(t *testing.T) {
+		v, present, err := JSONString(m, "missing")
+		require.NoError(t, err)
+		assert.False(t, present)
+		assert.Equal(t, "", v)
+	})
+
+	t.Run("present but wrong type errors", func(t *testing.T) {
+		_, present, err := JSONString(m, "num")
+		require.Error(t, err)
+		assert.True(t, present)
+		assert.Contains(t, err.Error(), "num must be a string")
+	})
+}
+
+func TestJSONNumber(t *testing.T) {
+	m := map[string]interface{}{"n": 10.0, "s": "x"}
+
+	t.Run("present and correct type", func(t *testing.T) {
+		v, present, err := JSONNumber(m, "n")
+		require.NoError(t, err)
+		assert.True(t, present)
+		assert.Equal(t, 10.0, v)
+	})
+
+	t.Run("absent key is optional", func(t *testing.T) {
+		_, present, err := JSONNumber(m, "missing")
+		require.NoError(t, err)
+		assert.False(t, present)
+	})
+
+	t.Run("present but wrong type errors", func(t *testing.T) {
+		_, present, err := JSONNumber(m, "s")
+		require.Error(t, err)
+		assert.True(t, present)
+		assert.Contains(t, err.Error(), "s must be a number")
+	})
+}
+
+func TestJSONBool(t *testing.T) {
+	m := map[string]interface{}{"b": true, "s": "x"}
+
+	t.Run("present and correct type", func(t *testing.T) {
+		v, present, err := JSONBool(m, "b")
+		require.NoError(t, err)
+		assert.True(t, present)
+		assert.True(t, v)
+	})
+
+	t.Run("absent key is optional", func(t *testing.T) {
+		_, present, err := JSONBool(m, "missing")
+		require.NoError(t, err)
+		assert.False(t, present)
+	})
+
+	t.Run("present but wrong type errors", func(t *testing.T) {
+		_, present, err := JSONBool(m, "s")
+		require.Error(t, err)
+		assert.True(t, present)
+		assert.Contains(t, err.Error(), "s must be a boolean")
+	})
+}
+
+func TestJSONObject(t *testing.T) {
+	m := map[string]interface{}{"o": map[string]interface{}{"k": "v"}, "s": "x"}
+
+	t.Run("present and correct type", func(t *testing.T) {
+		v, present, err := JSONObject(m, "o")
+		require.NoError(t, err)
+		assert.True(t, present)
+		assert.Equal(t, "v", v["k"])
+	})
+
+	t.Run("absent key is optional", func(t *testing.T) {
+		_, present, err := JSONObject(m, "missing")
+		require.NoError(t, err)
+		assert.False(t, present)
+	})
+
+	t.Run("present but wrong type errors", func(t *testing.T) {
+		_, present, err := JSONObject(m, "s")
+		require.Error(t, err)
+		assert.True(t, present)
+		assert.Contains(t, err.Error(), "s must be an object")
+	})
+}
+
+func TestJSONArray(t *testing.T) {
+	m := map[string]interface{}{"a": []interface{}{1.0, 2.0}, "s": "x"}
+
+	t.Run("present and correct type", func(t *testing.T) {
+		v, present, err := JSONArray(m, "a")
+		require.NoError(t, err)
+		assert.True(t, present)
+		assert.Len(t, v, 2)
+	})
+
+	t.Run("absent key is optional", func(t *testing.T) {
+		_, present, err := JSONArray(m, "missing")
+		require.NoError(t, err)
+		assert.False(t, present)
+	})
+
+	t.Run("present but wrong type errors", func(t *testing.T) {
+		_, present, err := JSONArray(m, "s")
+		require.Error(t, err)
+		assert.True(t, present)
+		assert.Contains(t, err.Error(), "s must be an array")
+	})
+}

--- a/internal/utils/resource_tags.go
+++ b/internal/utils/resource_tags.go
@@ -180,6 +180,15 @@ func UpdateResourceTags(opts UpdateTagsOptions) error {
 	return nil
 }
 
+// rejectEmptyTagKeys rejects a tag map with an empty key, matching the
+// interactive tag entry which treats an empty key as "stop" rather than a tag.
+func rejectEmptyTagKeys(tags map[string]string) error {
+	if _, ok := tags[""]; ok {
+		return fmt.Errorf("tag key must not be empty")
+	}
+	return nil
+}
+
 // ParseResourceTagsInput reads resource tags from --json or --json-file flags.
 func ParseResourceTagsInput(cmd *cobra.Command) (map[string]string, error) {
 	jsonStr, _ := cmd.Flags().GetString("json")
@@ -201,6 +210,10 @@ func ParseResourceTagsInput(cmd *cobra.Command) (map[string]string, error) {
 		}
 	} else {
 		return nil, fmt.Errorf("no input provided, use --interactive, --json, or --json-file to specify resource tags")
+	}
+
+	if err := rejectEmptyTagKeys(resourceTags); err != nil {
+		return nil, err
 	}
 
 	return resourceTags, nil
@@ -248,6 +261,10 @@ func parseResourceTagsInputExtended(cmd *cobra.Command) (map[string]string, erro
 		}
 	default:
 		return nil, fmt.Errorf("no input provided, use --interactive, --json, --json-file, --tags, --resource-tags, or --tags-file to specify resource tags")
+	}
+
+	if err := rejectEmptyTagKeys(resourceTags); err != nil {
+		return nil, err
 	}
 
 	return resourceTags, nil

--- a/internal/utils/resource_tags.go
+++ b/internal/utils/resource_tags.go
@@ -180,9 +180,9 @@ func UpdateResourceTags(opts UpdateTagsOptions) error {
 	return nil
 }
 
-// rejectEmptyTagKeys rejects a tag map with an empty key, matching the
+// RejectEmptyTagKeys rejects a tag map with an empty key, matching the
 // interactive tag entry which treats an empty key as "stop" rather than a tag.
-func rejectEmptyTagKeys(tags map[string]string) error {
+func RejectEmptyTagKeys(tags map[string]string) error {
 	if _, ok := tags[""]; ok {
 		return fmt.Errorf("tag key must not be empty")
 	}
@@ -212,7 +212,7 @@ func ParseResourceTagsInput(cmd *cobra.Command) (map[string]string, error) {
 		return nil, fmt.Errorf("no input provided, use --interactive, --json, or --json-file to specify resource tags")
 	}
 
-	if err := rejectEmptyTagKeys(resourceTags); err != nil {
+	if err := RejectEmptyTagKeys(resourceTags); err != nil {
 		return nil, err
 	}
 
@@ -263,7 +263,7 @@ func parseResourceTagsInputExtended(cmd *cobra.Command) (map[string]string, erro
 		return nil, fmt.Errorf("no input provided, use --interactive, --json, --json-file, --tags, --resource-tags, or --tags-file to specify resource tags")
 	}
 
-	if err := rejectEmptyTagKeys(resourceTags); err != nil {
+	if err := RejectEmptyTagKeys(resourceTags); err != nil {
 		return nil, err
 	}
 

--- a/internal/utils/resource_tags_test.go
+++ b/internal/utils/resource_tags_test.go
@@ -59,6 +59,11 @@ func TestParseResourceTagsInput(t *testing.T) {
 			flags:       map[string]string{},
 			expectError: "no input provided",
 		},
+		{
+			name:        "empty tag key rejected",
+			flags:       map[string]string{"json": `{"":"x"}`},
+			expectError: "tag key must not be empty",
+		},
 	}
 
 	for _, tt := range tests {
@@ -192,6 +197,11 @@ func TestParseResourceTagsInputExtended(t *testing.T) {
 			name:     "json takes precedence over tags",
 			flags:    map[string]string{"json": `{"from":"json"}`, "tags": `{"from":"tags"}`},
 			expected: map[string]string{"from": "json"},
+		},
+		{
+			name:        "empty tag key rejected via tags flag",
+			flags:       map[string]string{"tags": `{"":"x"}`},
+			expectError: "tag key must not be empty",
 		},
 	}
 


### PR DESCRIPTION
Tightens the `--json` / `--json-file` input path so it validates values as strictly as the flag and update paths.

- VXC buy now rejects fractional `term`/`rateLimit` (e.g. `10.9`) instead of silently flooring to `10`; the same `rateLimit` whole-number check is added to VXC update.
- VXC buy, MVE buy, and MVE update now return a clear `X must be a <type>` error when a JSON field is present but the wrong type, instead of silently dropping it. Absent optional keys stay optional.
- The tag JSON parser now rejects an empty key (`{"":"x"}`), matching interactive entry which treats an empty key as "stop".

Mechanism is a shared `internal/utils/json_map.go` helper set (`JSONString/JSONNumber/JSONBool/JSONObject/JSONArray`) returning `(value, present, err)`.

Two deliberate boundaries, both for compatibility:
- VXC update keeps only the fractional-number check, not the wrong-type errors, because of its dual-key fallbacks (`name`/`vxcName`, `aEndConfiguration`/`aEndVlan`).
- The embedded `resourceTags` map in buy commands is left as-is. Empty-key rejection there would need to land uniformly across all buy commands (which decode tags differently), so it is tracked as a follow-up.
