### PR TITLE
fix: guard nil SDK responses and honor vNIC index 0 on VXC (ESD-1524, ESD-1525)

### DIFF
--- a/internal/commands/apply/apply_actions.go
+++ b/internal/commands/apply/apply_actions.go
@@ -194,6 +194,9 @@ func ApplyConfig(cmd *cobra.Command, _ []string, noColor bool, outputFormat stri
 			if e != nil {
 				return "", e
 			}
+			if port == nil {
+				return "", fmt.Errorf("empty response from API")
+			}
 			return port.ProvisioningStatus, nil
 		}); err != nil {
 			createSpinner.Stop()
@@ -268,6 +271,9 @@ func ApplyConfig(cmd *cobra.Command, _ []string, noColor bool, outputFormat stri
 			mcr, e := client.MCRService.GetMCR(ctx, uid)
 			if e != nil {
 				return "", e
+			}
+			if mcr == nil {
+				return "", fmt.Errorf("empty response from API")
 			}
 			return mcr.ProvisioningStatus, nil
 		}); err != nil {
@@ -354,6 +360,9 @@ func ApplyConfig(cmd *cobra.Command, _ []string, noColor bool, outputFormat stri
 			m, e := client.MVEService.GetMVE(ctx, uid)
 			if e != nil {
 				return "", e
+			}
+			if m == nil {
+				return "", fmt.Errorf("empty response from API")
 			}
 			return m.ProvisioningStatus, nil
 		}); err != nil {
@@ -447,6 +456,9 @@ func ApplyConfig(cmd *cobra.Command, _ []string, noColor bool, outputFormat stri
 			vxc, e := client.VXCService.GetVXC(ctx, uid)
 			if e != nil {
 				return "", e
+			}
+			if vxc == nil {
+				return "", fmt.Errorf("empty response from API")
 			}
 			return vxc.ProvisioningStatus, nil
 		}); err != nil {

--- a/internal/commands/apply/apply_mock.go
+++ b/internal/commands/apply/apply_mock.go
@@ -19,6 +19,7 @@ type MockPortService struct {
 	DeletePortCalledWith []string
 	GetPortStatus        string // provisioning status returned by GetPort (default ready)
 	GetPortErr           error  // error returned by GetPort (simulates a provision-wait failure)
+	GetPortReturnNil     bool   // GetPort returns (nil, nil) (simulates an empty API response)
 }
 
 func (m *MockPortService) BuyPort(ctx context.Context, req *megaport.BuyPortRequest) (*megaport.BuyPortResponse, error) {
@@ -45,6 +46,9 @@ func (m *MockPortService) ListPorts(ctx context.Context) ([]*megaport.Port, erro
 func (m *MockPortService) GetPort(ctx context.Context, portId string) (*megaport.Port, error) {
 	if m.GetPortErr != nil {
 		return nil, m.GetPortErr
+	}
+	if m.GetPortReturnNil {
+		return nil, nil
 	}
 	status := m.GetPortStatus
 	if status == "" {
@@ -97,6 +101,7 @@ type MockMCRService struct {
 	DeleteMCRCalledWith  []string
 	GetMCRStatus         string // provisioning status returned by GetMCR (default ready)
 	GetMCRErr            error  // error returned by GetMCR (simulates a provision-wait failure)
+	GetMCRReturnNil      bool   // GetMCR returns (nil, nil) (simulates an empty API response)
 }
 
 func (m *MockMCRService) BuyMCR(ctx context.Context, req *megaport.BuyMCRRequest) (*megaport.BuyMCRResponse, error) {
@@ -123,6 +128,9 @@ func (m *MockMCRService) ListMCRs(ctx context.Context, req *megaport.ListMCRsReq
 func (m *MockMCRService) GetMCR(ctx context.Context, mcrId string) (*megaport.MCR, error) {
 	if m.GetMCRErr != nil {
 		return nil, m.GetMCRErr
+	}
+	if m.GetMCRReturnNil {
+		return nil, nil
 	}
 	status := m.GetMCRStatus
 	if status == "" {
@@ -196,6 +204,7 @@ type MockMVEService struct {
 	DeleteMVECalledWith []string
 	GetMVEStatus        string // provisioning status returned by GetMVE (default ready)
 	GetMVEErr           error  // error returned by GetMVE (simulates a provision-wait failure)
+	GetMVEReturnNil     bool   // GetMVE returns (nil, nil) (simulates an empty API response)
 }
 
 func (m *MockMVEService) BuyMVE(ctx context.Context, req *megaport.BuyMVERequest) (*megaport.BuyMVEResponse, error) {
@@ -221,6 +230,9 @@ func (m *MockMVEService) ListMVEs(ctx context.Context, req *megaport.ListMVEsReq
 func (m *MockMVEService) GetMVE(ctx context.Context, mveId string) (*megaport.MVE, error) {
 	if m.GetMVEErr != nil {
 		return nil, m.GetMVEErr
+	}
+	if m.GetMVEReturnNil {
+		return nil, nil
 	}
 	status := m.GetMVEStatus
 	if status == "" {
@@ -264,6 +276,7 @@ type MockVXCService struct {
 	DeleteVXCCalledWith []string
 	GetVXCStatus        string // provisioning status returned by GetVXC (default ready)
 	GetVXCErr           error  // error returned by GetVXC (simulates a provision-wait failure)
+	GetVXCReturnNil     bool   // GetVXC returns (nil, nil) (simulates an empty API response)
 }
 
 func (m *MockVXCService) BuyVXC(ctx context.Context, req *megaport.BuyVXCRequest) (*megaport.BuyVXCResponse, error) {
@@ -291,6 +304,9 @@ func (m *MockVXCService) ListVXCs(ctx context.Context, req *megaport.ListVXCsReq
 func (m *MockVXCService) GetVXC(ctx context.Context, id string) (*megaport.VXC, error) {
 	if m.GetVXCErr != nil {
 		return nil, m.GetVXCErr
+	}
+	if m.GetVXCReturnNil {
+		return nil, nil
 	}
 	status := m.GetVXCStatus
 	if status == "" {

--- a/internal/commands/apply/apply_test.go
+++ b/internal/commands/apply/apply_test.go
@@ -1153,6 +1153,121 @@ vxcs:
 	assert.Contains(t, err.Error(), "empty response")
 }
 
+// --- nil provisioning-poll response tests ---
+// These cover the GetPort/GetMCR/GetMVE/GetVXC paths inside waitForProvision,
+// where the SDK can return (nil, nil) and the status was read off the nil pointer.
+
+func TestApplyConfig_PortProvisionNilResponse(t *testing.T) {
+	mockPort := &MockPortService{GetPortReturnNil: true}
+	defer setupMockClient(mockPort, &MockMCRService{}, &MockMVEService{}, &MockVXCService{})()
+
+	yaml := `
+ports:
+  - name: Nil-Provision-Port
+    location_id: 1
+    speed: 1000
+    term: 12
+    marketplace_visibility: false
+`
+	f := writeTempFile(t, "config.yaml", yaml)
+	cmd := applyCmd(f, false, true)
+
+	var err error
+	require.NotPanics(t, func() {
+		output.CaptureOutput(func() {
+			err = ApplyConfig(cmd, nil, true, "table")
+		})
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response")
+}
+
+func TestApplyConfig_MCRProvisionNilResponse(t *testing.T) {
+	mockMCR := &MockMCRService{GetMCRReturnNil: true}
+	defer setupMockClient(&MockPortService{}, mockMCR, &MockMVEService{}, &MockVXCService{})()
+
+	yaml := `
+mcrs:
+  - name: Nil-Provision-MCR
+    location_id: 1
+    speed: 1000
+    term: 12
+`
+	f := writeTempFile(t, "config.yaml", yaml)
+	cmd := applyCmd(f, false, true)
+
+	var err error
+	require.NotPanics(t, func() {
+		output.CaptureOutput(func() {
+			err = ApplyConfig(cmd, nil, true, "table")
+		})
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response")
+}
+
+func TestApplyConfig_MVEProvisionNilResponse(t *testing.T) {
+	mockMVE := &MockMVEService{GetMVEReturnNil: true}
+	defer setupMockClient(&MockPortService{}, &MockMCRService{}, mockMVE, &MockVXCService{})()
+
+	yaml := `
+mves:
+  - name: Nil-Provision-MVE
+    location_id: 1
+    term: 1
+    vendor_config:
+      vendor: 6wind
+      imageId: 42
+      productSize: SMALL
+      sshPublicKey: "ssh-rsa AAAA"
+`
+	f := writeTempFile(t, "config.yaml", yaml)
+	cmd := applyCmd(f, false, true)
+
+	var err error
+	require.NotPanics(t, func() {
+		output.CaptureOutput(func() {
+			err = ApplyConfig(cmd, nil, true, "table")
+		})
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response")
+}
+
+func TestApplyConfig_VXCProvisionNilResponse(t *testing.T) {
+	mockVXC := &MockVXCService{GetVXCReturnNil: true}
+	defer setupMockClient(&MockPortService{}, &MockMCRService{}, &MockMVEService{}, mockVXC)()
+
+	yaml := `
+ports:
+  - name: VXCProvision-Port
+    location_id: 1
+    speed: 1000
+    term: 12
+    marketplace_visibility: false
+
+vxcs:
+  - name: Nil-Provision-VXC
+    rate_limit: 100
+    term: 12
+    a_end:
+      product_uid: "{{.port.VXCProvision-Port}}"
+    b_end:
+      product_uid: some-uid
+`
+	f := writeTempFile(t, "config.yaml", yaml)
+	cmd := applyCmd(f, false, true)
+
+	var err error
+	require.NotPanics(t, func() {
+		output.CaptureOutput(func() {
+			err = ApplyConfig(cmd, nil, true, "table")
+		})
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response")
+}
+
 // --- helpers (also used by other test functions) ---
 
 func TestResolveTemplates_NoTemplate(t *testing.T) {

--- a/internal/commands/ix/ix_actions.go
+++ b/internal/commands/ix/ix_actions.go
@@ -254,6 +254,11 @@ func BuyIX(cmd *cobra.Command, args []string, noColor bool) error {
 		return err
 	}
 
+	if resp == nil {
+		output.PrintError("IX buy returned an empty API response", noColor)
+		return fmt.Errorf("empty response from API")
+	}
+
 	output.PrintResourceCreated("IX", resp.TechnicalServiceUID, noColor)
 	return nil
 }

--- a/internal/commands/ix/ix_actions_test.go
+++ b/internal/commands/ix/ix_actions_test.go
@@ -16,6 +16,7 @@ import (
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListIXs(t *testing.T) {
@@ -664,8 +665,10 @@ func TestBuyIX_NilResponse(t *testing.T) {
 	})
 
 	var err error
-	output.CaptureOutput(func() {
-		err = cmd.RunE(cmd, nil)
+	require.NotPanics(t, func() {
+		output.CaptureOutput(func() {
+			err = cmd.RunE(cmd, nil)
+		})
 	})
 
 	assert.Error(t, err)

--- a/internal/commands/ix/ix_actions_test.go
+++ b/internal/commands/ix/ix_actions_test.go
@@ -614,6 +614,64 @@ func TestBuyIX(t *testing.T) {
 	}
 }
 
+func TestBuyIX_NilResponse(t *testing.T) {
+	originalBuyIXFunc := buyIXFunc
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
+	defer func() {
+		cleanup()
+		buyIXFunc = originalBuyIXFunc
+	}()
+	originalBuyConfirmPrompt := utils.GetBuyConfirmPrompt()
+	defer func() { utils.SetBuyConfirmPrompt(originalBuyConfirmPrompt) }()
+	utils.SetBuyConfirmPrompt(func(_ string, _ []utils.BuyConfirmDetail, _ bool) bool { return true })
+
+	config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+		client := &megaport.Client{}
+		client.IXService = &MockIXService{}
+		return client, nil
+	})
+
+	buyIXFunc = func(ctx context.Context, client *megaport.Client, req *megaport.BuyIXRequest) (*megaport.BuyIXResponse, error) {
+		return nil, nil
+	}
+
+	cmd := &cobra.Command{
+		Use:  "buy",
+		RunE: testutil.NoColorAdapter(BuyIX),
+	}
+	cmd.Flags().BoolP("interactive", "i", false, "")
+	cmd.Flags().Bool("no-wait", false, "")
+	cmd.Flags().String("product-uid", "", "")
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("network-service-type", "", "")
+	cmd.Flags().Int("asn", 0, "")
+	cmd.Flags().String("mac-address", "", "")
+	cmd.Flags().Int("rate-limit", 0, "")
+	cmd.Flags().Int("vlan", 0, "")
+	cmd.Flags().Bool("shutdown", false, "")
+	cmd.Flags().String("promo-code", "", "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+
+	testutil.SetFlags(t, cmd, map[string]string{
+		"product-uid":          "port-uid-123",
+		"name":                 "Test IX",
+		"network-service-type": "Los Angeles IX",
+		"asn":                  "65000",
+		"mac-address":          "00:11:22:33:44:55",
+		"rate-limit":           "1000",
+		"vlan":                 "100",
+	})
+
+	var err error
+	output.CaptureOutput(func() {
+		err = cmd.RunE(cmd, nil)
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response from API")
+}
+
 func TestBuyIX_NoWaitFlag(t *testing.T) {
 	originalBuyIXFunc := buyIXFunc
 	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})

--- a/internal/commands/managed_account/managed_account_actions.go
+++ b/internal/commands/managed_account/managed_account_actions.go
@@ -124,6 +124,11 @@ func CreateManagedAccount(cmd *cobra.Command, args []string, noColor bool) error
 		return err
 	}
 
+	if account == nil {
+		output.PrintError("Managed account create returned an empty API response", noColor)
+		return fmt.Errorf("empty response from API")
+	}
+
 	output.PrintResourceCreated("Managed Account", account.CompanyUID, noColor)
 	return nil
 }

--- a/internal/commands/managed_account/managed_account_actions_test.go
+++ b/internal/commands/managed_account/managed_account_actions_test.go
@@ -12,6 +12,7 @@ import (
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListManagedAccounts(t *testing.T) {
@@ -566,6 +567,44 @@ func TestCreateManagedAccount(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCreateManagedAccount_NilResponse(t *testing.T) {
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
+	defer cleanup()
+	originalCreateFunc := createManagedAccountFunc
+	defer func() { createManagedAccountFunc = originalCreateFunc }()
+
+	// createResult left nil so the mock returns (nil, nil).
+	mockService := &MockManagedAccountService{}
+	config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+		client := &megaport.Client{}
+		client.ManagedAccountService = mockService
+		return client, nil
+	})
+	createManagedAccountFunc = func(ctx context.Context, client *megaport.Client, req *megaport.ManagedAccountRequest) (*megaport.ManagedAccount, error) {
+		return mockService.CreateManagedAccount(ctx, req)
+	}
+
+	cmd := testutil.NewCommand("create", testutil.NoColorAdapter(CreateManagedAccount))
+	cmd.Flags().String("account-name", "", "")
+	cmd.Flags().String("account-ref", "", "")
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	testutil.SetFlags(t, cmd, map[string]string{
+		"account-name": "Test Account",
+		"account-ref":  "REF-001",
+	})
+
+	var err error
+	require.NotPanics(t, func() {
+		output.CaptureOutput(func() {
+			err = cmd.RunE(cmd, []string{})
+		})
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response")
 }
 
 func TestCreateManagedAccount_InvalidJSON(t *testing.T) {

--- a/internal/commands/servicekeys/servicekeys_actions.go
+++ b/internal/commands/servicekeys/servicekeys_actions.go
@@ -147,6 +147,11 @@ func UpdateServiceKey(cmd *cobra.Command, args []string, noColor bool) error {
 		return fmt.Errorf("failed to update service key: %w", err)
 	}
 
+	if resp == nil {
+		output.PrintError("Service key update returned an empty API response", noColor)
+		return fmt.Errorf("empty response from API")
+	}
+
 	if !resp.IsUpdated {
 		output.PrintError("Service key update was not applied", noColor)
 		return fmt.Errorf("service key update was not applied")
@@ -180,6 +185,11 @@ func ListServiceKeys(cmd *cobra.Command, args []string, noColor bool, outputForm
 	if err != nil {
 		output.PrintError("Failed to list service keys: %v", noColor, err)
 		return fmt.Errorf("failed to list service keys: %w", err)
+	}
+
+	if resp == nil {
+		output.PrintError("Service key list returned an empty API response", noColor)
+		return fmt.Errorf("empty response from API")
 	}
 
 	serviceKeys := resp.ServiceKeys

--- a/internal/commands/servicekeys/servicekeys_actions.go
+++ b/internal/commands/servicekeys/servicekeys_actions.go
@@ -77,6 +77,11 @@ func CreateServiceKey(cmd *cobra.Command, args []string, noColor bool) error {
 		return fmt.Errorf("failed to create service key: %w", err)
 	}
 
+	if resp == nil {
+		output.PrintError("Service key create returned an empty API response", noColor)
+		return fmt.Errorf("empty response from API")
+	}
+
 	output.PrintResourceCreated("Service Key", resp.ServiceKeyUID, noColor)
 	return nil
 }
@@ -102,6 +107,11 @@ func UpdateServiceKey(cmd *cobra.Command, args []string, noColor bool) error {
 	if err != nil {
 		output.PrintError("Failed to fetch current service key: %v", noColor, err)
 		return fmt.Errorf("failed to fetch current service key: %w", err)
+	}
+
+	if current == nil {
+		output.PrintError("Service key get returned an empty API response", noColor)
+		return fmt.Errorf("empty response from API")
 	}
 
 	req := &megaport.UpdateServiceKeyRequest{
@@ -221,6 +231,11 @@ func GetServiceKey(cmd *cobra.Command, args []string, noColor bool, outputFormat
 	if err != nil {
 		output.PrintError("Failed to get service key: %v", noColor, err)
 		return fmt.Errorf("failed to get service key: %w", err)
+	}
+
+	if resp == nil {
+		output.PrintError("Service key get returned an empty API response", noColor)
+		return fmt.Errorf("empty response from API")
 	}
 
 	op, err := toServiceKeyOutput(resp)

--- a/internal/commands/servicekeys/servicekeys_actions_test.go
+++ b/internal/commands/servicekeys/servicekeys_actions_test.go
@@ -340,6 +340,25 @@ func TestUpdateServiceKey_NilResponse(t *testing.T) {
 	assert.Nil(t, mockService.CapturedUpdateServiceKeyRequest)
 }
 
+func TestUpdateServiceKey_NilUpdateResponse(t *testing.T) {
+	mockService := &MockServiceKeyService{UpdateServiceKeyReturnNil: true}
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {
+		c.ServiceKeyService = mockService
+	})
+	defer cleanup()
+
+	cmd := newUpdateServiceKeyCmd()
+	testutil.SetFlags(t, cmd, map[string]string{"active": "true"})
+
+	var err error
+	output.CaptureOutput(func() {
+		err = cmd.RunE(cmd, []string{"test-key-123"})
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response from API")
+}
+
 func TestUpdateServiceKey_BothProductFlagsRejected(t *testing.T) {
 	mockService := &MockServiceKeyService{}
 	cleanup := testutil.SetupLogin(func(c *megaport.Client) {
@@ -644,4 +663,25 @@ func TestListServiceKeys_NegativeLimit(t *testing.T) {
 	err := cmd.RunE(cmd, []string{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "--limit must be a non-negative integer")
+}
+
+func TestListServiceKeys_NilResponse(t *testing.T) {
+	mockService := &MockServiceKeyService{ListServiceKeysReturnNil: true}
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {
+		c.ServiceKeyService = mockService
+	})
+	defer cleanup()
+
+	cmd := testutil.NewCommand("list", testutil.OutputAdapter(ListServiceKeys))
+	cmd.Flags().String("product-uid", "", "")
+	cmd.Flags().Int("limit", 0, "")
+	defer output.SetOutputFormat("table")
+
+	var err error
+	output.CaptureOutput(func() {
+		err = cmd.RunE(cmd, []string{})
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response from API")
 }

--- a/internal/commands/servicekeys/servicekeys_actions_test.go
+++ b/internal/commands/servicekeys/servicekeys_actions_test.go
@@ -63,6 +63,58 @@ func TestCreateServiceKey_FlagsPropagated(t *testing.T) {
 	assert.Equal(t, 100, req.VLAN)
 }
 
+func TestCreateServiceKey_NilResponse(t *testing.T) {
+	mockService := &MockServiceKeyService{CreateServiceKeyReturnNil: true}
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {
+		c.ServiceKeyService = mockService
+	})
+	defer cleanup()
+
+	cmd := testutil.NewCommand("create", testutil.NoColorAdapter(CreateServiceKey))
+	cmd.Flags().String("product-uid", "", "")
+	cmd.Flags().Int("product-id", 0, "")
+	cmd.Flags().Bool("single-use", false, "")
+	cmd.Flags().Int("max-speed", 0, "")
+	cmd.Flags().String("description", "", "")
+	cmd.Flags().String("start-date", "", "")
+	cmd.Flags().String("end-date", "", "")
+	cmd.Flags().Bool("active", false, "")
+	cmd.Flags().Bool("pre-approved", false, "")
+	cmd.Flags().Int("vlan", 0, "")
+
+	testutil.SetFlags(t, cmd, map[string]string{
+		"product-uid": "prod-uid-123",
+		"description": "test key",
+	})
+
+	var err error
+	output.CaptureOutput(func() {
+		err = cmd.RunE(cmd, []string{})
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response from API")
+}
+
+func TestGetServiceKey_NilResponse(t *testing.T) {
+	mockService := &MockServiceKeyService{GetServiceKeyReturnNil: true}
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {
+		c.ServiceKeyService = mockService
+	})
+	defer cleanup()
+
+	cmd := testutil.NewCommand("get", testutil.OutputAdapter(GetServiceKey))
+	defer output.SetOutputFormat("table")
+
+	var err error
+	output.CaptureOutput(func() {
+		err = cmd.RunE(cmd, []string{"test-key-id"})
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response from API")
+}
+
 func TestCreateServiceKey_InvalidDateParsing(t *testing.T) {
 	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
 	defer cleanup()
@@ -267,6 +319,25 @@ func TestUpdateServiceKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUpdateServiceKey_NilResponse(t *testing.T) {
+	mockService := &MockServiceKeyService{GetServiceKeyReturnNil: true}
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {
+		c.ServiceKeyService = mockService
+	})
+	defer cleanup()
+
+	cmd := newUpdateServiceKeyCmd()
+
+	var err error
+	output.CaptureOutput(func() {
+		err = cmd.RunE(cmd, []string{"test-key-123"})
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response from API")
+	assert.Nil(t, mockService.CapturedUpdateServiceKeyRequest)
 }
 
 func TestUpdateServiceKey_BothProductFlagsRejected(t *testing.T) {

--- a/internal/commands/servicekeys/servicekeys_mock.go
+++ b/internal/commands/servicekeys/servicekeys_mock.go
@@ -14,10 +14,12 @@ type MockServiceKeyService struct {
 
 	ListServiceKeysError           error
 	ListServiceKeysResult          *megaport.ListServiceKeysResponse
+	ListServiceKeysReturnNil       bool
 	CapturedListServiceKeysRequest *megaport.ListServiceKeysRequest
 
 	UpdateServiceKeyError           error
 	UpdateServiceKeyResult          *megaport.UpdateServiceKeyResponse
+	UpdateServiceKeyReturnNil       bool
 	CapturedUpdateServiceKeyRequest *megaport.UpdateServiceKeyRequest
 
 	GetServiceKeyError         error
@@ -46,6 +48,9 @@ func (m *MockServiceKeyService) ListServiceKeys(ctx context.Context, req *megapo
 	m.CapturedListServiceKeysRequest = req
 	if m.ListServiceKeysError != nil {
 		return nil, m.ListServiceKeysError
+	}
+	if m.ListServiceKeysReturnNil {
+		return nil, nil
 	}
 	if m.ListServiceKeysResult != nil {
 		return m.ListServiceKeysResult, nil
@@ -76,6 +81,9 @@ func (m *MockServiceKeyService) UpdateServiceKey(ctx context.Context, req *megap
 	m.CapturedUpdateServiceKeyRequest = req
 	if m.UpdateServiceKeyError != nil {
 		return nil, m.UpdateServiceKeyError
+	}
+	if m.UpdateServiceKeyReturnNil {
+		return nil, nil
 	}
 	if m.UpdateServiceKeyResult != nil {
 		return m.UpdateServiceKeyResult, nil

--- a/internal/commands/servicekeys/servicekeys_mock.go
+++ b/internal/commands/servicekeys/servicekeys_mock.go
@@ -9,6 +9,7 @@ import (
 type MockServiceKeyService struct {
 	CreateServiceKeyError           error
 	CreateServiceKeyResult          *megaport.CreateServiceKeyResponse
+	CreateServiceKeyReturnNil       bool
 	CapturedCreateServiceKeyRequest *megaport.CreateServiceKeyRequest
 
 	ListServiceKeysError           error
@@ -21,6 +22,7 @@ type MockServiceKeyService struct {
 
 	GetServiceKeyError         error
 	GetServiceKeyResult        *megaport.ServiceKey
+	GetServiceKeyReturnNil     bool
 	CapturedGetServiceKeyKeyID string
 }
 
@@ -28,6 +30,9 @@ func (m *MockServiceKeyService) CreateServiceKey(ctx context.Context, req *megap
 	m.CapturedCreateServiceKeyRequest = req
 	if m.CreateServiceKeyError != nil {
 		return nil, m.CreateServiceKeyError
+	}
+	if m.CreateServiceKeyReturnNil {
+		return nil, nil
 	}
 	if m.CreateServiceKeyResult != nil {
 		return m.CreateServiceKeyResult, nil
@@ -84,6 +89,9 @@ func (m *MockServiceKeyService) GetServiceKey(ctx context.Context, keyId string)
 	m.CapturedGetServiceKeyKeyID = keyId
 	if m.GetServiceKeyError != nil {
 		return nil, m.GetServiceKeyError
+	}
+	if m.GetServiceKeyReturnNil {
+		return nil, nil
 	}
 	if m.GetServiceKeyResult != nil {
 		return m.GetServiceKeyResult, nil

--- a/internal/commands/users/users_actions.go
+++ b/internal/commands/users/users_actions.go
@@ -179,6 +179,11 @@ func CreateUser(cmd *cobra.Command, args []string, noColor bool) error {
 		return err
 	}
 
+	if resp == nil {
+		output.PrintError("User create returned an empty API response", noColor)
+		return fmt.Errorf("empty response from API")
+	}
+
 	output.PrintResourceCreated("User", strconv.Itoa(resp.EmployeeID), noColor)
 	return nil
 }

--- a/internal/commands/users/users_actions_test.go
+++ b/internal/commands/users/users_actions_test.go
@@ -280,6 +280,41 @@ func TestCreateUser(t *testing.T) {
 	}
 }
 
+func TestCreateUser_NilResponse(t *testing.T) {
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
+	defer cleanup()
+
+	mockService := &MockUserManagementService{ForceNilCreateUser: true}
+	config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+		client := &megaport.Client{}
+		client.UserManagementService = mockService
+		return client, nil
+	})
+
+	cmd := &cobra.Command{Use: "create"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().String("first-name", "", "")
+	cmd.Flags().String("last-name", "", "")
+	cmd.Flags().String("email", "", "")
+	cmd.Flags().String("position", "", "")
+	cmd.Flags().String("phone", "", "")
+	require.NoError(t, cmd.Flags().Set("first-name", "John"))
+	require.NoError(t, cmd.Flags().Set("last-name", "Doe"))
+	require.NoError(t, cmd.Flags().Set("email", "john@example.com"))
+	require.NoError(t, cmd.Flags().Set("position", "Technical Admin"))
+
+	var err error
+	require.NotPanics(t, func() {
+		output.CaptureOutput(func() {
+			err = CreateUser(cmd, nil, true)
+		})
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response")
+}
+
 func TestUpdateUser(t *testing.T) {
 	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
 	defer cleanup()

--- a/internal/commands/users/users_mock.go
+++ b/internal/commands/users/users_mock.go
@@ -24,12 +24,16 @@ type MockUserManagementService struct {
 	CapturedEmployeeID  int
 	CapturedActivityReq *megaport.GetUserActivityRequest
 	ForceNilGetUser     bool
+	ForceNilCreateUser  bool
 }
 
 func (m *MockUserManagementService) CreateUser(ctx context.Context, req *megaport.CreateUserRequest) (*megaport.CreateUserResponse, error) {
 	m.CapturedCreateReq = req
 	if m.CreateUserErr != nil {
 		return nil, m.CreateUserErr
+	}
+	if m.ForceNilCreateUser {
+		return nil, nil
 	}
 	if m.CreateUserResult != nil {
 		return m.CreateUserResult, nil

--- a/internal/commands/vxc/vxc_actions.go
+++ b/internal/commands/vxc/vxc_actions.go
@@ -314,6 +314,11 @@ func BuyVXC(cmd *cobra.Command, args []string, noColor bool) error {
 		return err
 	}
 
+	if resp == nil {
+		output.PrintError("VXC buy returned an empty API response", noColor)
+		return fmt.Errorf("empty response from API")
+	}
+
 	output.PrintResourceCreated("VXC", resp.TechnicalServiceUID, noColor)
 	return nil
 }

--- a/internal/commands/vxc/vxc_actions_test.go
+++ b/internal/commands/vxc/vxc_actions_test.go
@@ -16,6 +16,42 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestBuyVXC_NilResponse(t *testing.T) {
+	originalBuyVXCFunc := buyVXCFunc
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
+	defer func() {
+		cleanup()
+		buyVXCFunc = originalBuyVXCFunc
+	}()
+
+	config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+		return &megaport.Client{VXCService: &MockVXCService{}}, nil
+	})
+
+	buyVXCFunc = func(ctx context.Context, client *megaport.Client, req *megaport.BuyVXCRequest) (*megaport.BuyVXCResponse, error) {
+		return nil, nil
+	}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().Bool("no-wait", false, "")
+	cmd.Flags().Bool("yes", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+
+	testutil.SetFlags(t, cmd, map[string]string{
+		"json": `{"portUid":"port-aaa-111","vxcName":"JSON VXC","rateLimit":500,"term":12,"bEndConfiguration":{"productUID":"port-bbb-222"}}`,
+	})
+
+	var err error
+	output.CaptureOutput(func() {
+		err = BuyVXC(cmd, nil, true)
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response from API")
+}
+
 func TestBuyVXC(t *testing.T) {
 	originalResourcePrompt := utils.GetResourcePrompt()
 	originalBuyVXCFunc := buyVXCFunc

--- a/internal/commands/vxc/vxc_actions_test.go
+++ b/internal/commands/vxc/vxc_actions_test.go
@@ -14,6 +14,7 @@ import (
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuyVXC_NilResponse(t *testing.T) {
@@ -44,8 +45,10 @@ func TestBuyVXC_NilResponse(t *testing.T) {
 	})
 
 	var err error
-	output.CaptureOutput(func() {
-		err = BuyVXC(cmd, nil, true)
+	require.NotPanics(t, func() {
+		output.CaptureOutput(func() {
+			err = BuyVXC(cmd, nil, true)
+		})
 	})
 
 	assert.Error(t, err)

--- a/internal/commands/vxc/vxc_inputs.go
+++ b/internal/commands/vxc/vxc_inputs.go
@@ -56,8 +56,9 @@ var buildVXCRequestFromFlags = func(cmd *cobra.Command, ctx context.Context, svc
 		VLAN: aEndVLAN,
 	}
 
-	// Set MVE config if needed
-	if aEndInnerVLAN != 0 || aEndVNICIndex > 0 {
+	// Set MVE config if needed. vNIC index 0 is valid, so gate on whether the
+	// flag was set rather than on a non-zero value.
+	if aEndInnerVLAN != 0 || cmd.Flags().Changed("a-end-vnic-index") {
 		aEndConfig.VXCOrderMVEConfig = &megaport.VXCOrderMVEConfig{
 			InnerVLAN:             aEndInnerVLAN,
 			NetworkInterfaceIndex: aEndVNICIndex,
@@ -120,8 +121,9 @@ var buildVXCRequestFromFlags = func(cmd *cobra.Command, ctx context.Context, svc
 	bEndConfig.ProductUID = bEndUID
 	bEndConfig.VLAN = bEndVLAN
 
-	// Set MVE config if needed
-	if bEndInnerVLAN != 0 || bEndVNICIndex > 0 {
+	// Set MVE config if needed. vNIC index 0 is valid, so gate on whether the
+	// flag was set rather than on a non-zero value.
+	if bEndInnerVLAN != 0 || cmd.Flags().Changed("b-end-vnic-index") {
 		bEndConfig.VXCOrderMVEConfig = &megaport.VXCOrderMVEConfig{
 			InnerVLAN:             bEndInnerVLAN,
 			NetworkInterfaceIndex: bEndVNICIndex,

--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -852,6 +852,69 @@ func TestResolvePartnerPortUID(t *testing.T) {
 	}
 }
 
+func TestBuildVXCRequestFromFlags_VNICIndexZero(t *testing.T) {
+	newBuyCmd := func() *cobra.Command {
+		cmd := &cobra.Command{Use: "buy"}
+		cmd.Flags().String("a-end-uid", "", "")
+		cmd.Flags().String("b-end-uid", "", "")
+		cmd.Flags().String("name", "", "")
+		cmd.Flags().Int("rate-limit", 0, "")
+		cmd.Flags().Int("term", 0, "")
+		cmd.Flags().Int("a-end-vlan", 0, "")
+		cmd.Flags().Int("b-end-vlan", 0, "")
+		cmd.Flags().Int("a-end-inner-vlan", 0, "")
+		cmd.Flags().Int("b-end-inner-vlan", 0, "")
+		cmd.Flags().Int("a-end-vnic-index", 0, "")
+		cmd.Flags().Int("b-end-vnic-index", 0, "")
+		cmd.Flags().String("promo-code", "", "")
+		cmd.Flags().String("service-key", "", "")
+		cmd.Flags().String("cost-centre", "", "")
+		cmd.Flags().String("a-end-partner-config", "", "")
+		cmd.Flags().String("b-end-partner-config", "", "")
+		return cmd
+	}
+
+	setRequired := func(t *testing.T, cmd *cobra.Command) {
+		require.NoError(t, cmd.Flags().Set("name", "Test VXC"))
+		require.NoError(t, cmd.Flags().Set("a-end-uid", "a-end-uid-123"))
+		require.NoError(t, cmd.Flags().Set("b-end-uid", "b-end-uid-123"))
+		require.NoError(t, cmd.Flags().Set("rate-limit", "100"))
+		require.NoError(t, cmd.Flags().Set("term", "1"))
+	}
+
+	t.Run("A-End vNIC index 0 set via flag builds MVE config", func(t *testing.T) {
+		cmd := newBuyCmd()
+		setRequired(t, cmd)
+		require.NoError(t, cmd.Flags().Set("a-end-vnic-index", "0"))
+
+		req, err := buildVXCRequestFromFlags(cmd, context.Background(), &MockVXCService{})
+		require.NoError(t, err)
+		require.NotNil(t, req.AEndConfiguration.VXCOrderMVEConfig)
+		assert.Equal(t, 0, req.AEndConfiguration.NetworkInterfaceIndex)
+	})
+
+	t.Run("B-End vNIC index 0 set via flag builds MVE config", func(t *testing.T) {
+		cmd := newBuyCmd()
+		setRequired(t, cmd)
+		require.NoError(t, cmd.Flags().Set("b-end-vnic-index", "0"))
+
+		req, err := buildVXCRequestFromFlags(cmd, context.Background(), &MockVXCService{})
+		require.NoError(t, err)
+		require.NotNil(t, req.BEndConfiguration.VXCOrderMVEConfig)
+		assert.Equal(t, 0, req.BEndConfiguration.NetworkInterfaceIndex)
+	})
+
+	t.Run("vNIC index not set leaves MVE config nil", func(t *testing.T) {
+		cmd := newBuyCmd()
+		setRequired(t, cmd)
+
+		req, err := buildVXCRequestFromFlags(cmd, context.Background(), &MockVXCService{})
+		require.NoError(t, err)
+		assert.Nil(t, req.AEndConfiguration.VXCOrderMVEConfig)
+		assert.Nil(t, req.BEndConfiguration.VXCOrderMVEConfig)
+	})
+}
+
 func TestBuildVXCRequestFromFlags_PartnerConfig(t *testing.T) {
 	origResolve := resolvePartnerPortUID
 	defer func() { resolvePartnerPortUID = origResolve }()

--- a/internal/commands/vxc/vxc_prompts.go
+++ b/internal/commands/vxc/vxc_prompts.go
@@ -95,7 +95,7 @@ var buildVXCRequestFromPrompt = func(ctx context.Context, svc megaport.VXCServic
 		VLAN: aEndVLAN,
 	}
 
-	if aEndInnerVLAN != 0 || aEndVNICIndex > 0 {
+	if aEndInnerVLAN != 0 || aEndVNICIndexStr != "" {
 		aEndConfig.VXCOrderMVEConfig = &megaport.VXCOrderMVEConfig{
 			InnerVLAN:             aEndInnerVLAN,
 			NetworkInterfaceIndex: aEndVNICIndex,
@@ -176,7 +176,7 @@ var buildVXCRequestFromPrompt = func(ctx context.Context, svc megaport.VXCServic
 		}
 	}
 
-	if bEndInnerVLAN != 0 || bEndVNICIndex > 0 {
+	if bEndInnerVLAN != 0 || bEndVNICIndexStr != "" {
 		bEndConfig.VXCOrderMVEConfig = &megaport.VXCOrderMVEConfig{
 			InnerVLAN:             bEndInnerVLAN,
 			NetworkInterfaceIndex: bEndVNICIndex,

--- a/internal/commands/vxc/vxc_prompts_test.go
+++ b/internal/commands/vxc/vxc_prompts_test.go
@@ -749,6 +749,37 @@ func TestBuildVXCRequestFromPrompt(t *testing.T) {
 				assert.Equal(t, "port-b-456", req.BEndConfiguration.ProductUID)
 			},
 		},
+		{
+			// vNIC index 0 is a valid MVE interface. Entering "0" must build the
+			// MVE config, not silently drop it (the old gate keyed on index > 0).
+			name: "vNIC index 0 builds MVE config on both ends",
+			responses: []string{
+				"Test VXC",   // name
+				"100",        // rate limit
+				"12",         // term
+				"100",        // A-End VLAN
+				"",           // A-End inner VLAN
+				"0",          // A-End vNIC index
+				"no",         // A-End partner config
+				"port-a-123", // A-End product UID
+				"200",        // B-End VLAN
+				"",           // B-End inner VLAN
+				"0",          // B-End vNIC index
+				"no",         // B-End partner config
+				"port-b-456", // B-End product UID
+				"",           // promo code
+				"",           // service key
+				"",           // cost centre
+			},
+			verify: func(t *testing.T, req *megaport.BuyVXCRequest) {
+				if assert.NotNil(t, req.AEndConfiguration.VXCOrderMVEConfig) {
+					assert.Equal(t, 0, req.AEndConfiguration.NetworkInterfaceIndex)
+				}
+				if assert.NotNil(t, req.BEndConfiguration.VXCOrderMVEConfig) {
+					assert.Equal(t, 0, req.BEndConfiguration.NetworkInterfaceIndex)
+				}
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Two small robustness fixes, swept across every path that had the same shape.

**Nil response guards.** A number of paths dereferenced the SDK response without checking it was non-nil, so a `(nil, nil)` return would panic. They now return a clear "empty response from API" error instead, matching the existing ports/MCR/MVE guards. Covered:

- VXC buy, IX buy
- All four service-key paths (create, get, update, list)
- User create and managed-account create
- The `apply` provisioning polls (port, MCR, MVE, VXC), which read status off the polled resource

**vNIC index 0.** Building a VXC with an MVE endpoint at vNIC index 0 silently dropped that endpoint, because the code gated on a non-zero index. Fixed on both input modes that had it: the flag path (gates on whether the flag was set) and the interactive prompt (gates on whether an index was entered). The JSON path already keyed off presence and is unchanged.

Notes:
- Out of scope by design: `ValidateVNICIndex` and the JSON parse path are untouched.
- Sibling update/get paths that feed nil into helpers already guarding nil were left as-is, so they don't panic.

Every guarded path and the vNIC fix have tests; each was confirmed to fail (panic, or drop the endpoint) before the fix. `go build`, `go test ./...`, and `golangci-lint` are clean.
