### PR TITLE
fix: reject explicit non-positive --timeout and clarify help (ESD-1526)

### DIFF
--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -81,7 +81,7 @@ func InitializeCommon() {
 	rootCmd.PersistentFlags().StringVar(&utils.Env, "env", "", "Environment to use (prod, dev, or staging)")
 	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Suppress informational output, only show errors and data")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Show additional debug information")
-	rootCmd.PersistentFlags().Duration("timeout", 0, "Timeout for the operation (e.g., 30s, 2m, 5m); 0 uses each command's built-in default (see the command's own help)")
+	rootCmd.PersistentFlags().Duration("timeout", 0, "Timeout for the operation (e.g., 30s, 2m, 5m); must be positive. Omit to use each command's built-in default (see the command's own help)")
 	rootCmd.PersistentFlags().String("fields", "", "Comma-separated list of fields to include in output (e.g., uid,name,status); use an unknown name to list available fields")
 	rootCmd.PersistentFlags().String("query", "", "JMESPath query to filter JSON output (requires --output json)")
 	rootCmd.PersistentFlags().BoolVar(&utils.NoRetry, "no-retry", false, "Disable automatic retry on transient API failures")
@@ -120,6 +120,9 @@ func InitializeCommon() {
 		output.ApplyOutputConfig(cfg)
 		if utils.MaxRetries < 0 {
 			return fmt.Errorf("--max-retries must be >= 0, got %d", utils.MaxRetries)
+		}
+		if err := utils.ValidateTimeoutFlag(cmd); err != nil {
+			return err
 		}
 		if existingPreRunE != nil {
 			return existingPreRunE(cmd, args)

--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -81,7 +81,7 @@ func InitializeCommon() {
 	rootCmd.PersistentFlags().StringVar(&utils.Env, "env", "", "Environment to use (prod, dev, or staging)")
 	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Suppress informational output, only show errors and data")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Show additional debug information")
-	rootCmd.PersistentFlags().Duration("timeout", 0, "Request timeout duration (e.g., 30s, 2m, 5m); 0 uses the internal default of 90s")
+	rootCmd.PersistentFlags().Duration("timeout", 0, "Timeout for the operation (e.g., 30s, 2m, 5m); 0 uses each command's built-in default (see the command's own help)")
 	rootCmd.PersistentFlags().String("fields", "", "Comma-separated list of fields to include in output (e.g., uid,name,status); use an unknown name to list available fields")
 	rootCmd.PersistentFlags().String("query", "", "JMESPath query to filter JSON output (requires --output json)")
 	rootCmd.PersistentFlags().BoolVar(&utils.NoRetry, "no-retry", false, "Disable automatic retry on transient API failures")

--- a/cmd/megaport/megaport.go
+++ b/cmd/megaport/megaport.go
@@ -70,6 +70,11 @@ func init() {
 			return exitcodes.NewUsageError(fmt.Errorf("--max-retries must be >= 0, got %d", utils.MaxRetries))
 		}
 
+		// Reject an explicit non-positive --timeout; omitting it uses the default.
+		if err := utils.ValidateTimeoutFlag(cmd); err != nil {
+			return exitcodes.NewUsageError(err)
+		}
+
 		return nil
 	}
 

--- a/cmd/megaport/megaport_common.go
+++ b/cmd/megaport/megaport_common.go
@@ -93,7 +93,7 @@ func InitializeCommon() {
 	rootCmd.PersistentFlags().StringVar(&utils.ProfileOverride, "profile", "", "Use a specific config profile for this command")
 	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Suppress informational output, only show errors and data")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Show additional debug information")
-	rootCmd.PersistentFlags().Duration("timeout", 0, "Request timeout duration (e.g., 30s, 2m, 5m); 0 uses the internal default of 90s")
+	rootCmd.PersistentFlags().Duration("timeout", 0, "Timeout for the operation (e.g., 30s, 2m, 5m); 0 uses each command's built-in default (see the command's own help)")
 	rootCmd.PersistentFlags().String("fields", "", "Comma-separated list of fields to include in output (e.g., uid,name,status); use an unknown name to list available fields")
 	rootCmd.PersistentFlags().String("query", "", "JMESPath query to filter JSON output (requires --output json)")
 	rootCmd.PersistentFlags().BoolVar(&utils.NoRetry, "no-retry", false, "Disable automatic retry on transient API failures")

--- a/cmd/megaport/megaport_common.go
+++ b/cmd/megaport/megaport_common.go
@@ -93,7 +93,7 @@ func InitializeCommon() {
 	rootCmd.PersistentFlags().StringVar(&utils.ProfileOverride, "profile", "", "Use a specific config profile for this command")
 	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Suppress informational output, only show errors and data")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Show additional debug information")
-	rootCmd.PersistentFlags().Duration("timeout", 0, "Timeout for the operation (e.g., 30s, 2m, 5m); 0 uses each command's built-in default (see the command's own help)")
+	rootCmd.PersistentFlags().Duration("timeout", 0, "Timeout for the operation (e.g., 30s, 2m, 5m); must be positive. Omit to use each command's built-in default (see the command's own help)")
 	rootCmd.PersistentFlags().String("fields", "", "Comma-separated list of fields to include in output (e.g., uid,name,status); use an unknown name to list available fields")
 	rootCmd.PersistentFlags().String("query", "", "JMESPath query to filter JSON output (requires --output json)")
 	rootCmd.PersistentFlags().BoolVar(&utils.NoRetry, "no-retry", false, "Disable automatic retry on transient API failures")

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -83,6 +83,29 @@ func TestNoPagerDefaultApplied(t *testing.T) {
 	assert.True(t, output.GetNoPager(), "output.GetNoPager() should be true after PersistentPreRunE wires NoPager via ApplyOutputConfig")
 }
 
+// TestTimeoutFlagRejectsNonPositive verifies that an explicit non-positive
+// --timeout is rejected as a usage error through PersistentPreRunE, rather than
+// silently falling back to a default.
+func TestTimeoutFlagRejectsNonPositive(t *testing.T) {
+	// Reset the shared persistent flag so the explicit value (and Changed state)
+	// doesn't leak into sibling tests that run through rootCmd.
+	defer func() {
+		f := rootCmd.PersistentFlags().Lookup("timeout")
+		_ = f.Value.Set("0s")
+		f.Changed = false
+	}()
+
+	rootCmd.SetArgs([]string{"version", "--timeout", "0"})
+	var execErr error
+	_ = output.CaptureOutput(func() {
+		execErr = rootCmd.Execute()
+	})
+
+	require.Error(t, execErr)
+	assert.Equal(t, exitcodes.Usage, exitCodeFromError(execErr))
+	assert.Contains(t, execErr.Error(), "--timeout must be greater than 0")
+}
+
 // TestApplyDefaultSettings_WarnsOnConfigLoadFailure verifies that when
 // NewConfigManager fails (e.g. the configured config dir cannot be created),
 // applyDefaultSettings returns a warning message instead of silently skipping.

--- a/internal/utils/context.go
+++ b/internal/utils/context.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -34,6 +35,20 @@ func ContextFromCmd(cmd *cobra.Command) (context.Context, context.CancelFunc) {
 // where the operation-appropriate default differs from the global 90-second default.
 func ContextFromCmdWithDefault(cmd *cobra.Command, defaultTimeout time.Duration) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), TimeoutFromCmd(cmd, defaultTimeout))
+}
+
+// ValidateTimeoutFlag rejects an explicitly supplied --timeout that is not
+// positive. An unset flag is valid: each command falls back to its own default.
+// Only an explicit zero or negative value (e.g. --timeout 0) is an error, since
+// silently substituting a default for it would hide the user's mistake.
+func ValidateTimeoutFlag(cmd *cobra.Command) error {
+	if cmd == nil || !cmd.Flags().Changed("timeout") {
+		return nil
+	}
+	if val, err := cmd.Flags().GetDuration("timeout"); err == nil && val <= 0 {
+		return fmt.Errorf("--timeout must be greater than 0, got %s", val)
+	}
+	return nil
 }
 
 // TimeoutFromCmd returns the effective timeout duration from the command's

--- a/internal/utils/context_test.go
+++ b/internal/utils/context_test.go
@@ -109,3 +109,52 @@ func TestContextFromCmd(t *testing.T) {
 		assertDeadlineWithin(t, deadline, start, 90*time.Second)
 	})
 }
+
+func TestValidateTimeoutFlag(t *testing.T) {
+	t.Run("nil command is valid", func(t *testing.T) {
+		assert.NoError(t, ValidateTimeoutFlag(nil))
+	})
+
+	t.Run("missing timeout flag is valid", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		assert.NoError(t, ValidateTimeoutFlag(cmd))
+	})
+
+	t.Run("unset timeout flag is valid", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		cmd.Flags().Duration("timeout", 0, "")
+		assert.NoError(t, ValidateTimeoutFlag(cmd))
+	})
+
+	t.Run("positive timeout is valid", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		cmd.Flags().Duration("timeout", 0, "")
+		require.NoError(t, cmd.Flags().Set("timeout", "2m"))
+		assert.NoError(t, ValidateTimeoutFlag(cmd))
+	})
+
+	t.Run("explicit zero timeout is rejected", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		cmd.Flags().Duration("timeout", 0, "")
+		require.NoError(t, cmd.Flags().Set("timeout", "0s"))
+		err := ValidateTimeoutFlag(cmd)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--timeout must be greater than 0")
+	})
+
+	t.Run("explicit negative timeout is rejected", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		cmd.Flags().Duration("timeout", 0, "")
+		require.NoError(t, cmd.Flags().Set("timeout", "-5s"))
+		assert.Error(t, ValidateTimeoutFlag(cmd))
+	})
+
+	t.Run("explicit zero on inherited persistent flag is rejected", func(t *testing.T) {
+		root := &cobra.Command{Use: "root"}
+		child := &cobra.Command{Use: "child"}
+		root.PersistentFlags().Duration("timeout", 0, "")
+		root.AddCommand(child)
+		require.NoError(t, child.ParseFlags([]string{"--timeout", "0"}))
+		assert.Error(t, ValidateTimeoutFlag(child))
+	})
+}


### PR DESCRIPTION
Fixes ESD-1526.

The global `--timeout` help claimed `0 uses the internal default of 90s`, but 90s is only the default for read-only commands. Mutation commands default to 15m, `topology` to 120s, one `vxc` path to 5m, and `apply` to 10m (and treats `--timeout` as a per-resource budget since ESD-1522). The single "90s" claim was wrong for most commands, and the "request timeout" framing was wrong for `apply`.

On review, `--timeout 0` was also treated as a silent "use the default" sentinel, which hides user mistakes. It is now a usage error: omit the flag to get a command's default, or pass a positive duration.

- Reword the help: `Timeout for the operation (...); must be positive. Omit to use each command's built-in default (see the command's own help)`.
- Drop the misleading "request timeout" / fixed-90s wording.
- Reject an explicit non-positive `--timeout` via a shared `utils.ValidateTimeoutFlag` helper (uses `FlagSet.Changed`), wired into `PersistentPreRunE` for native and WASM, alongside the existing `--max-retries` check.
- Add unit tests for the helper and an end-to-end test that `version --timeout 0` exits with a usage error.