### PR TITLE
fix(tags): reject empty tag keys in buy/create JSON input (ESD-1527)

### DIFF
--- a/internal/commands/mcr/mcr_inputs.go
+++ b/internal/commands/mcr/mcr_inputs.go
@@ -26,6 +26,10 @@ func processJSONMCRInput(jsonStr, jsonFile string) (*megaport.BuyMCRRequest, err
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
+	if err := utils.RejectEmptyTagKeys(req.ResourceTags); err != nil {
+		return nil, err
+	}
+
 	// BuyMCRRequest.AddOns is []MCRAddOn (interface) and cannot be directly
 	// unmarshaled by the standard library. Read tunnelCount separately using a
 	// pointer so we can distinguish "key absent" from an explicit value.

--- a/internal/commands/mcr/mcr_inputs_test.go
+++ b/internal/commands/mcr/mcr_inputs_test.go
@@ -38,6 +38,16 @@ func TestProcessJSONMCRInput(t *testing.T) {
 			name:      "valid JSON file",
 			writeFile: `{"name":"file-mcr","term":12,"portSpeed":5000,"locationId":1,"marketplaceVisibility":true}`,
 		},
+		{
+			name:          "empty tag key rejected",
+			jsonStr:       `{"name":"test","term":12,"portSpeed":5000,"locationId":1,"marketplaceVisibility":true,"resourceTags":{"":"x"}}`,
+			expectedError: "tag key must not be empty",
+		},
+		{
+			name:          "empty tag key rejected via file",
+			writeFile:     `{"name":"test","term":12,"portSpeed":5000,"locationId":1,"marketplaceVisibility":true,"resourceTags":{"":"x"}}`,
+			expectedError: "tag key must not be empty",
+		},
 	}
 
 	for _, tt := range tests {
@@ -55,7 +65,7 @@ func TestProcessJSONMCRInput(t *testing.T) {
 
 			req, err := processJSONMCRInput(tt.jsonStr, jsonFile)
 			if tt.expectedError != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
 			} else {
 				assert.NoError(t, err)
@@ -63,6 +73,13 @@ func TestProcessJSONMCRInput(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProcessJSONMCRInput_ValidResourceTags(t *testing.T) {
+	req, err := processJSONMCRInput(`{"name":"test","term":12,"portSpeed":5000,"locationId":1,"marketplaceVisibility":true,"resourceTags":{"env":"prod"}}`, "")
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	assert.Equal(t, "prod", req.ResourceTags["env"])
 }
 
 func TestProcessJSONUpdateMCRInput(t *testing.T) {

--- a/internal/commands/nat_gateway/nat_gateway_inputs.go
+++ b/internal/commands/nat_gateway/nat_gateway_inputs.go
@@ -36,6 +36,10 @@ func processJSONCreateNATGatewayInput(jsonStr, jsonFile string) (*megaport.Creat
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
+	if err := utils.RejectEmptyTagKeys(raw.ResourceTags); err != nil {
+		return nil, err
+	}
+
 	req := &megaport.CreateNATGatewayRequest{
 		ProductName:           raw.Name,
 		LocationID:            raw.LocationID,
@@ -165,6 +169,10 @@ func processJSONUpdateNATGatewayInput(jsonStr, jsonFile, uid string) (*megaport.
 	}
 	if err := json.Unmarshal(jsonData, &raw); err != nil {
 		return nil, updateExplicitFields{}, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	if err := utils.RejectEmptyTagKeys(raw.ResourceTags); err != nil {
+		return nil, updateExplicitFields{}, err
 	}
 
 	explicit := updateExplicitFields{

--- a/internal/commands/nat_gateway/nat_gateway_inputs_test.go
+++ b/internal/commands/nat_gateway/nat_gateway_inputs_test.go
@@ -87,6 +87,36 @@ func TestProcessJSONCreateNATGatewayInput_WithBooleanFields(t *testing.T) {
 	assert.True(t, req.AutoRenewTerm)
 }
 
+func TestProcessJSONCreateNATGatewayInput_RejectsEmptyTagKey(t *testing.T) {
+	_, err := processJSONCreateNATGatewayInput(
+		`{"name":"GW","term":12,"speed":1000,"locationId":1,"resourceTags":{"":"x"}}`, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tag key must not be empty")
+}
+
+func TestProcessJSONCreateNATGatewayInput_RejectsEmptyTagKeyFromFile(t *testing.T) {
+	content := `{"name":"GW","term":12,"speed":1000,"locationId":1,"resourceTags":{"":"x"}}`
+	tmp, err := os.CreateTemp("", "ng-create-emptytag-*.json")
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	_, err = tmp.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+
+	_, err = processJSONCreateNATGatewayInput("", tmp.Name())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tag key must not be empty")
+}
+
+func TestProcessJSONCreateNATGatewayInput_ValidResourceTags(t *testing.T) {
+	req, err := processJSONCreateNATGatewayInput(
+		`{"name":"GW","term":12,"speed":1000,"locationId":1,"resourceTags":{"env":"prod"}}`, "")
+	require.NoError(t, err)
+	require.Len(t, req.ResourceTags, 1)
+	assert.Equal(t, "env", req.ResourceTags[0].Key)
+	assert.Equal(t, "prod", req.ResourceTags[0].Value)
+}
+
 // ---- processFlagCreateNATGatewayInput ----
 
 func TestProcessFlagCreateNATGatewayInput_Valid(t *testing.T) {
@@ -160,6 +190,22 @@ func TestProcessFlagCreateNATGatewayInput_ValidResourceTags(t *testing.T) {
 }
 
 // ---- processJSONUpdateNATGatewayInput ----
+
+func TestProcessJSONUpdateNATGatewayInput_RejectsEmptyTagKey(t *testing.T) {
+	_, _, err := processJSONUpdateNATGatewayInput(
+		`{"name":"GW","resourceTags":{"":"x"}}`, "", "uid-empty-tag")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tag key must not be empty")
+}
+
+func TestProcessJSONUpdateNATGatewayInput_ValidResourceTags(t *testing.T) {
+	req, _, err := processJSONUpdateNATGatewayInput(
+		`{"name":"GW","resourceTags":{"env":"prod"}}`, "", "uid-valid-tag")
+	require.NoError(t, err)
+	require.Len(t, req.ResourceTags, 1)
+	assert.Equal(t, "env", req.ResourceTags[0].Key)
+	assert.Equal(t, "prod", req.ResourceTags[0].Value)
+}
 
 func TestProcessJSONUpdateNATGatewayInput_Valid(t *testing.T) {
 	req, explicit, err := processJSONUpdateNATGatewayInput(

--- a/internal/commands/ports/ports_inputs.go
+++ b/internal/commands/ports/ports_inputs.go
@@ -167,6 +167,10 @@ func processJSONPortInput(jsonStr, jsonFile string) (*megaport.BuyPortRequest, e
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
+	if err := utils.RejectEmptyTagKeys(req.ResourceTags); err != nil {
+		return nil, err
+	}
+
 	if err := validation.ValidatePortRequest(req); err != nil {
 		return nil, err
 	}

--- a/internal/commands/ports/ports_inputs_test.go
+++ b/internal/commands/ports/ports_inputs_test.go
@@ -167,6 +167,16 @@ func TestProcessJSONPortInput(t *testing.T) {
 			name:      "valid JSON file",
 			writeFile: `{"name":"file-test","term":12,"portSpeed":10000,"locationId":1,"marketPlaceVisibility":true}`,
 		},
+		{
+			name:          "empty tag key rejected",
+			jsonStr:       `{"name":"test","term":12,"portSpeed":10000,"locationId":1,"marketPlaceVisibility":true,"resourceTags":{"":"x"}}`,
+			expectedError: "tag key must not be empty",
+		},
+		{
+			name:          "empty tag key rejected via file",
+			writeFile:     `{"name":"test","term":12,"portSpeed":10000,"locationId":1,"marketPlaceVisibility":true,"resourceTags":{"":"x"}}`,
+			expectedError: "tag key must not be empty",
+		},
 	}
 
 	for _, tt := range tests {
@@ -184,7 +194,7 @@ func TestProcessJSONPortInput(t *testing.T) {
 
 			req, err := processJSONPortInput(tt.jsonStr, jsonFile)
 			if tt.expectedError != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
 			} else {
 				assert.NoError(t, err)
@@ -192,6 +202,13 @@ func TestProcessJSONPortInput(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProcessJSONPortInput_ValidResourceTags(t *testing.T) {
+	req, err := processJSONPortInput(`{"name":"test","term":12,"portSpeed":10000,"locationId":1,"marketPlaceVisibility":true,"resourceTags":{"env":"prod"}}`, "")
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	assert.Equal(t, "prod", req.ResourceTags["env"])
 }
 
 func TestProcessJSONUpdatePortInput(t *testing.T) {

--- a/internal/commands/vxc/vxc_inputs.go
+++ b/internal/commands/vxc/vxc_inputs.go
@@ -291,6 +291,9 @@ func buildVXCRequestFromJSON(jsonStr string, jsonFilePath string) (*megaport.Buy
 			}
 			req.ResourceTags[k] = strValue
 		}
+		if err := utils.RejectEmptyTagKeys(req.ResourceTags); err != nil {
+			return nil, err
+		}
 	}
 
 	// Handle A-End configuration

--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -3,6 +3,7 @@ package vxc
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	megaport "github.com/megaport/megaportgo"
@@ -790,6 +791,29 @@ func TestBuildVXCRequestFromJSON(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildVXCRequestFromJSON_RejectsEmptyTagKey(t *testing.T) {
+	const payload = `{"portUid":"port-1","vxcName":"Test VXC","rateLimit":1000,"term":12,"resourceTags":{"":"x"},"bEndConfiguration":{"productUID":"port-2"}}`
+
+	t.Run("via json", func(t *testing.T) {
+		_, err := buildVXCRequestFromJSON(payload, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tag key must not be empty")
+	})
+
+	t.Run("via json-file", func(t *testing.T) {
+		tmp, err := os.CreateTemp("", "vxc-emptytag-*.json")
+		require.NoError(t, err)
+		defer os.Remove(tmp.Name())
+		_, err = tmp.WriteString(payload)
+		require.NoError(t, err)
+		require.NoError(t, tmp.Close())
+
+		_, err = buildVXCRequestFromJSON("", tmp.Name())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tag key must not be empty")
+	})
 }
 
 func TestBuildUpdateVXCRequestFromJSON_PartnerConfigs(t *testing.T) {

--- a/internal/utils/resource_tags.go
+++ b/internal/utils/resource_tags.go
@@ -180,9 +180,9 @@ func UpdateResourceTags(opts UpdateTagsOptions) error {
 	return nil
 }
 
-// rejectEmptyTagKeys rejects a tag map with an empty key, matching the
+// RejectEmptyTagKeys rejects a tag map with an empty key, matching the
 // interactive tag entry which treats an empty key as "stop" rather than a tag.
-func rejectEmptyTagKeys(tags map[string]string) error {
+func RejectEmptyTagKeys(tags map[string]string) error {
 	if _, ok := tags[""]; ok {
 		return fmt.Errorf("tag key must not be empty")
 	}
@@ -212,7 +212,7 @@ func ParseResourceTagsInput(cmd *cobra.Command) (map[string]string, error) {
 		return nil, fmt.Errorf("no input provided, use --interactive, --json, or --json-file to specify resource tags")
 	}
 
-	if err := rejectEmptyTagKeys(resourceTags); err != nil {
+	if err := RejectEmptyTagKeys(resourceTags); err != nil {
 		return nil, err
 	}
 
@@ -263,7 +263,7 @@ func parseResourceTagsInputExtended(cmd *cobra.Command) (map[string]string, erro
 		return nil, fmt.Errorf("no input provided, use --interactive, --json, --json-file, --tags, --resource-tags, or --tags-file to specify resource tags")
 	}
 
-	if err := rejectEmptyTagKeys(resourceTags); err != nil {
+	if err := RejectEmptyTagKeys(resourceTags); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Empty tag keys (`{"": "x"}`) were already rejected by `update-tags` (ESD-1521) but the buy/create commands' embedded `resourceTags` still accepted them. This makes the rejection uniform.

- Export the existing `rejectEmptyTagKeys` helper as `utils.RejectEmptyTagKeys` (same `tag key must not be empty` message, no duplicated logic).
- Call it on the populated tag map (before the `[]ResourceTag` conversion) in: `buy vxc`, `buy mcr`, `buy port`, and both `create` and `update` nat-gateway JSON paths.
- Unit test per path, including `--json-file` coverage and a valid-tags-survive case.

Stacked on #446 (ESD-1521); base is `worktree-ESD-1521-json-input-hardening`, not `main`.
