### PR TITLE
test: add LAG port update lifecycle integration test (ESD-1528)

### DIFF
--- a/docs/INTEGRATION_TESTING.md
+++ b/docs/INTEGRATION_TESTING.md
@@ -61,7 +61,7 @@ A lifecycle test that lives in a package the nightly read-only job also runs car
 package servicekeys
 ```
 
-The nightly read-only job builds only `-tags integration`, so this tag keeps the mutating test out of it. It is needed only for packages that the read-only job runs — currently `servicekeys` and `users`, which have read-only `list`/`get` tests nightly but whose lifecycle tests provision resources (the service key test buys a port to use as its product). Lifecycle tests in packages the read-only job does not run (ports, VXC, MCR, MVE, IX) are excluded from nightly by package selection alone, so they stay `//go:build integration` only.
+The nightly read-only job builds only `-tags integration`, so this tag keeps the mutating test out of it. It is needed for packages whose read-only tests run nightly: `servicekeys` and `users` (read-only `list`/`get` tests, whose lifecycle tests provision resources, e.g. the service key test buys a port to use as its product), and `ports`, whose lifecycle tests live in `ports_integration_test.go` under `//go:build integration && provisioning`. The read-only job does select the `ports`, VXC, MCR, MVE, and IX packages, but scopes them to the `-run 'TestIntegration_.*ReadOnly$'` name filter. For `ports` the `provisioning` tag is a second guard on top of that filter, so the lifecycle tests cannot compile into the nightly binary even if the name filter were ever loosened. VXC, MCR, MVE, and IX lifecycle tests currently rely on the name filter alone (`//go:build integration`); aligning them with the `ports` approach is a known follow-up. IX is the weakest case: its lifecycle and read-only tests share one file (`ix_integration_test.go`), so only the `-run` regex keeps the IX lifecycle test out of nightly.
 
 ## CI
 
@@ -77,7 +77,7 @@ Integration tests run in CI via `.github/workflows/integration-test.yml`:
 3. Authenticate using one of the helpers below (see "Authentication helpers")
 4. Call action functions directly. For parallel tests, read state via `testutil.SharedIntegrationClient(t)` rather than `output.CaptureOutput` (see "Output capture and parallelism")
 5. Use `t.Cleanup()` for resource deletion (e.g. deleting staging ports/VXCs) so cleanup runs even on test failure; `defer` is fine for non-resource cleanup like restoring login state
-6. If the test mutates real resources *and* lives in a package the nightly read-only job runs (e.g. `servicekeys`, `users`), add `&& provisioning` to the build tag and put it in its own file so the read-only job skips it. A mutating test in a package the read-only job does not run needs only `//go:build integration` — package selection keeps it out of nightly
+6. If the test mutates real resources *and* lives in a package the nightly read-only job runs (`servicekeys`, `users`, `ports`, VXC, MCR, MVE, IX), keep it in the package's provisioning-lifecycle file rather than the read-only file. For `servicekeys`, `users`, and `ports` that file carries `//go:build integration && provisioning` so the tag itself excludes it from nightly; for VXC, MCR, MVE, and IX the lifecycle file is still `//go:build integration` and relies on the read-only job's `-run 'TestIntegration_.*ReadOnly$'` name filter alone
 7. Add the package to the provisioning job in `.github/workflows/integration-test.yml`
 
 See `internal/commands/locations/locations_integration_test.go` for a serial read-only example and `internal/commands/ports/ports_integration_test.go` for a parallel provisioning-lifecycle example.

--- a/internal/commands/ports/ports_integration_test.go
+++ b/internal/commands/ports/ports_integration_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && provisioning
 
 package ports
 
@@ -506,4 +506,71 @@ func TestIntegration_PortJSONFileLifecycle(t *testing.T) {
 
 	updated := portFromSDK(t, uid)
 	assert.Equal(t, newName, updated.Name)
+}
+
+// TestIntegration_LAGPortUpdateLifecycle exercises the LAG port update path
+// that TestIntegration_LAGPortLifecycle (name-only) does not.
+//
+// Immutable via the update action: the LAG member count (--lag-count) and the
+// port speed (--port-speed). Neither is a field on megaport.ModifyPortRequest,
+// and neither has an update flag (see WithPortUpdateFlags and
+// processFlagUpdatePortInput), so `ports update` cannot change them post-buy;
+// changing either means a buy/replace, not an update. Mutable via the update
+// action: name, marketplace visibility, cost centre, and contract term. Name
+// is already covered by TestIntegration_LAGPortLifecycle, and a term change can
+// apply at renewal rather than immediately, so this test asserts the two
+// attributes that flip and read back deterministically on a LAG primary:
+// marketplace visibility and cost centre.
+func TestIntegration_LAGPortUpdateLifecycle(t *testing.T) {
+	t.Parallel()
+	testutil.RequireStagingForProvisioning(t)
+	testutil.RequireSharedIntegrationClient(t)
+
+	portName := fmt.Sprintf("CLI-Test-LAG-Update-%s", generateUniqueID(t))
+
+	buyCmd := newBuyLAGPortCmd()
+	require.NoError(t, buyCmd.Flags().Set("name", portName))
+	require.NoError(t, buyCmd.Flags().Set("term", "1"))
+	require.NoError(t, buyCmd.Flags().Set("port-speed", "10000"))
+	require.NoError(t, buyCmd.Flags().Set("location-id", fmt.Sprintf("%d", integrationLocationID)))
+	require.NoError(t, buyCmd.Flags().Set("lag-count", "1"))
+	require.NoError(t, buyCmd.Flags().Set("marketplace-visibility", "false"))
+	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
+
+	uid := runBuyLAGPort(t, buyCmd, portName)
+	t.Logf("Created LAG port with UID: %s", uid)
+
+	// Baseline read. We assert the buy landed the values the updates move away
+	// from, so each assertion below proves a real change rather than passing
+	// trivially. LAGPrimary/speed are captured to confirm the attribute updates
+	// leave the LAG topology untouched.
+	port := portFromSDK(t, uid)
+	assert.Equal(t, uid, port.UID)
+	assert.Equal(t, portName, port.Name)
+	require.False(t, port.MarketplaceVisibility, "buy set marketplace visibility to false")
+	require.Equal(t, 10000, port.PortSpeed, "buy requested a 10G LAG port")
+	initialLAGPrimary := port.LAGPrimary
+	t.Logf("LAG port baseline: lagPrimary=%t lagId=%d", port.LAGPrimary, port.LAGID)
+
+	// Update 1: marketplace visibility false -> true.
+	runUpdatePortWithFlag(t, uid, "marketplace-visibility", "true")
+	afterMV := portFromSDK(t, uid)
+	assert.True(t, afterMV.MarketplaceVisibility, "marketplace visibility should be true after update")
+
+	// Update 2: set a cost centre and read it back.
+	costCentre := "CLI-ESD-1528-" + generateUniqueID(t)
+	runUpdatePortWithFlag(t, uid, "cost-centre", costCentre)
+	afterCC := portFromSDK(t, uid)
+	assert.Equal(t, costCentre, afterCC.CostCentre, "cost centre should round-trip after update")
+	// The cost-centre-only update must not clobber the earlier visibility flip.
+	assert.True(t, afterCC.MarketplaceVisibility, "marketplace visibility should persist across the cost-centre update")
+
+	// LAG count and speed are immutable via the update action; confirm the
+	// attribute updates left the LAG topology and speed untouched.
+	assert.Equal(t, initialLAGPrimary, afterCC.LAGPrimary, "LAG primary status should be unchanged by attribute updates")
+	assert.Equal(t, 10000, afterCC.PortSpeed, "port speed should be unchanged by attribute updates")
+
+	// Delete and decommissioning are asserted by the cleanup registered in
+	// runBuyLAGPort: registerPortCleanup deletes the port and polls the SDK
+	// until it reaches DECOMMISSIONING/DECOMMISSIONED.
 }


### PR DESCRIPTION
Adds `TestIntegration_LAGPortUpdateLifecycle`. It buys a LAG port and exercises the update path the existing name-only LAG test skips: flip marketplace visibility, set a cost centre, each verified through an SDK `GetPort` read. Delete and decommissioning ride on the existing `t.Cleanup` poll helper.

LAG member count and port speed turn out to be immutable via the update action (no field on `ModifyPortRequest`, no update flag), so the test scopes to the mutable set and records the immutable attributes in a comment.

- New `integration && provisioning` test in `ports_integration_test.go`
- Retag the file from `integration` to `integration && provisioning` so the provisioning lifecycle tests are kept out of the nightly read-only build by the tag itself, not just the `-run '...ReadOnly$'` filter (matches the servicekeys/users convention)
- Doc update: describe the ports tag and flag VXC/MCR/MVE/IX (IX especially) as a follow-up to align the same way

Validation: `go build` and `go test` (no tag) pass; vet/lint clean under `integration provisioning`; tag-discovery confirms the new test runs only in the provisioning build and is excluded from nightly read-only. The test provisions a real staging LAG port, so it runs in the manual provisioning job (not nightly).