### PR TITLE
ci: pin GPG import action to allowlisted v6

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd  # v7.0.0
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec  # v6.3.0
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}


### PR DESCRIPTION
The v0.13.0 release run failed with a `startup_failure` (zero jobs): the org actions allowlist rejected the GPG-import action.

`release.yaml` pinned `crazy-max/ghaction-import-gpg` to v7.0.0, but the org allowlist (`github-iac` `terraform-actions/allowed_actions.tf`) only permits that unverified action at v6. The bump to v7 landed in `ce8e39c4` during the Node 20 cutover, and since `release.yaml` only runs on tag push, it never showed up in PR checks. It first broke when the v0.13.0 tag was pushed.

This restores the v6.3.0 SHA that every other Megaport release workflow already uses. The action's inputs and `fingerprint` output are identical between v6 and v7, so it's a safe drop-in.

After this merges, the `v0.13.0` tag needs re-pointing to the fixed commit (no release was published under it).
