### PR TITLE
ci: generate CHANGELOG.md from release notes, backfill to v0.13.0 (ESD-1533)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,3 +71,54 @@ jobs:
           subject-path: |
             dist/megaport-cli_*.zip
             dist/megaport-cli_*_SHA256SUMS
+
+  # Fold the notes GoReleaser generated for the draft release into CHANGELOG.md
+  # and open a PR against the default branch (which is protected by org rulesets,
+  # so a direct push is not possible). Runs after goreleaser so a failure here
+  # never blocks the build/sign/publish steps above.
+  update-changelog:
+    name: Update CHANGELOG.md
+    runs-on: ubuntu-latest
+    needs: goreleaser
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+
+      - name: Fold generated release notes into CHANGELOG.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          notes="$(mktemp)"
+          gh release view "$TAG" --json body --jq '.body // ""' > "$notes"
+          bash scripts/update-changelog.sh "$TAG" "$notes"
+
+      - name: Open a PR with the CHANGELOG.md update
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "CHANGELOG.md already up to date for $TAG; nothing to do."
+            exit 0
+          fi
+          branch="chore/changelog-$TAG"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add CHANGELOG.md
+          git commit -m "docs: update CHANGELOG.md for $TAG"
+          git push --force origin "$branch"
+          body="Automated changelog update for ${TAG}, generated from the release notes. Merge to record ${TAG} in CHANGELOG.md."
+          if [ -n "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
+            echo "PR already open for $branch; branch updated."
+          elif ! gh pr create --base "$DEFAULT_BRANCH" --head "$branch" \
+                 --title "docs: update CHANGELOG.md for $TAG" --body "$body"; then
+            echo "::warning::Could not open the PR automatically. Branch $branch is pushed; open one manually: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/$DEFAULT_BRANCH...$branch"
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,6 +96,12 @@ jobs:
         run: |
           notes="$(mktemp)"
           gh release view "$TAG" --json body --jq '.body // ""' > "$notes"
+          # Authoritative previous version: the version tag before this one. Beats
+          # reading the changelog link, which can be stale if an earlier release's
+          # changelog PR hasn't merged. Empty on the first release; the script then
+          # falls back to the changelog link.
+          PREV_VERSION="$(git describe --tags --abbrev=0 --match 'v*' "${TAG}^" 2>/dev/null || true)"
+          export PREV_VERSION
           bash scripts/update-changelog.sh "$TAG" "$notes"
 
       - name: Open a PR with the CHANGELOG.md update

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -129,4 +129,31 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   draft: true
 changelog:
-  disable: true
+  use: git
+  sort: asc
+  abbrev: -1
+  filters:
+    exclude:
+      - '^docs'
+      - '^test'
+      - '^chore'
+      - '^ci'
+      - '^build'
+      - '^style'
+      - '^refactor'
+      - '^Merge '
+      - '^Revert '
+  groups:
+    - title: Added
+      regexp: '^.*?feat(\(.+\))??!?:.*$'
+      order: 0
+    - title: Changed
+      regexp: '^.*?perf(\(.+\))??!?:.*$'
+      order: 1
+    - title: Fixed
+      regexp: '^.*?fix(\(.+\))??!?:.*$'
+      order: 2
+    # Catch-all (no regexp) so non-conventional subjects, e.g. ESD-XXXX, are kept
+    # in a titled section instead of being dropped or left heading-less.
+    - title: Other Changes
+      order: 999

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,187 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<!-- Released sections below are generated from the release notes by the release
+workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries under
+[Unreleased]; anything placed there is overwritten on the next release. -->
+
 ## [Unreleased]
+
+## [v0.13.0] - 2026-06-23
+
+### Added
+- MCR ASN updates via `mcr update --mcr-asn`, with ASN range validation on buy and update paths
+- One-command static web build for CDN hosting, with a content-hashed WASM filename for immutable caching
+- WASM build now includes the `nat-gateway` module and the read-only `status`, `topology`, and `product` modules
 
 ### Changed
 - `servicekeys update` now exits non-zero when the API reports the update was not applied (previously it warned and exited 0)
+- Local web server hardened: binds to loopback by default, adds a documented `--bind` flag, and sets HTTP server timeouts
+- Updated the Go toolchain to 1.26.4 and `golang.org/x/net` to v0.56.0
+- Updated megaportgo to v1.13.1
 
 ### Fixed
 - `servicekeys update` no longer resets `active` and `single-use` to false when those flags are omitted
 - `servicekeys update`: passing both `--product-uid` and `--product-id` now errors instead of being sent to the SDK
-- Removed the non-functional `--description` flag from `servicekeys update`
+- Client-side validation added for IX ASN, MAC address, VLAN, and rate limit
+- Failed resource mutations now return a non-zero error instead of reporting success
+- Usage errors (wrong argument count, `--json` parse failures, invalid integer arguments) now exit with code 2
+- Buy and order calls are no longer retried on ambiguous errors, avoiding duplicate orders
+- Password input masked in the WASM terminal prompt
+- `apply` rollback now respects `--timeout` and uses a fresh context
+- `list-market-codes` no longer emits blank market codes
+- Credential keys redacted in `--log-http` output
+
+### Removed
+- Non-functional `--description` flag from `servicekeys update` (the update API does not support it)
+
+## [v0.12.0] - 2026-06-11
+
+### Added
+- In-place vNIC description updates for MVE via `mve update --vnics`, with validation of vNIC entries
+
+### Fixed
+- `mve update` now honors the registered `--term` flag
+- WASM: slice-valued flags (such as `--tag`) now reset correctly between invocations
+
+## [v0.11.0] - 2026-06-05
+
+### Added
+- MCR Looking Glass commands for IP route, BGP route, and BGP session diagnostics
+- `--base-url` flag to override the API base URL, with `--token-url` for authenticated login against it
+- `--rollback-on-failure` flag on `apply`, with reporting of orphaned resources
+- MVE `adminPassword` support for Cisco and Palo Alto vendor configs
+- WASM `setAuthToken` now accepts an explicit environment override, with validation
+
+### Changed
+- Config profile commands now prompt securely for credentials (masked input, validated before prompting)
+- Corrupt config files are preserved as `.corrupt-<timestamp>` instead of being overwritten, and backups are restricted to `0600`
+- Updated megaportgo to v1.13.0
+
+### Fixed
+- `mcr update` now registers the `--term` flag
+- MVE size labels such as "MVE 2/8" are normalized before validation
+- `apply` rollback now covers provision-timeout failures
+- Ports no longer experience delayed cancellation
+- WASM secret prompts are routed through the JS callback in browser builds
+
+## [v0.10.0] - 2026-05-04
+
+### Added
+- `nat-gateway buy` and `nat-gateway validate` subcommands
+- `--yes` accepted as an alias for `--force` on `nat-gateway delete`
+
+### Changed
+- Output formatting unified through the output package for consistent spacing, with icon-free `PrintPlain` used for CSV section headers
+
+### Fixed
+- Closed a TOCTOU window in the tags-file size check and hardened file reads
+- DNS temporary-error detection now uses a type assertion
+
+## [v0.9.4] - 2026-04-30
+
+### Fixed
+- Homebrew tap update sets the head branch and PR base so the formula bump opens a pull request
+
+## [v0.9.3] - 2026-04-29
+
+### Changed
+- Homebrew tap formula updates now open a pull request, authenticated with a minted app token
+
+## [v0.9.2] - 2026-04-28
+
+### Changed
+- Updated megaportgo to v1.10.1
+
+## [v0.9.1] - 2026-04-27
+
+### Added
+- SLSA build provenance attestation in the release workflow
+
+## [v0.9.0] - 2026-04-24
+
+### Added
+- `--generate-skeleton` flag on buy and update commands to emit a JSON template
+- `--output go-template` support for scriptable output
+- `--tag` filter on `ports`, `vxc`, `mcr`, and `mve` list commands
+- `--no-header` flag to suppress table and CSV column headers
+- Structured JSON errors when `--output json` is active
+- Pager integration and consistent "did you mean" command suggestions
+
+### Changed
+- Tag fetches parallelized with bounded concurrency
+
+### Fixed
+- VLAN help text and validation aligned across commands, with corrected inner-VLAN prompt text
+- `--output` value normalized to lowercase and resolved from the executed command to handle local flag shadowing
+- Output without a trailing newline preserved, and real TTY width preserved during pager buffering
+- Context cancellation respected during tag fetches
+- Redundant client-side name filter removed from VXC list in favor of SDK filtering
+
+## [v0.8.0] - 2026-04-13
+
+### Added
+- `nat-gateway` command group with full CRUD, telemetry, and session listing
+- `locations rtt` command for round-trip time queries
+- `--log-http` global flag for API request/response debugging
+
+### Fixed
+- Spinner suppressed for CSV and XML output to prevent stream corruption
+- `--log-http` redacts sensitive fields
+- `x-app: cli` header sent on all API requests
+- `locations rtt` defaults to the previous month, since data publishes after month end
+- Auto-renew prompts accept `y`/`yes`/`n`/`no`
+
+## [v0.7.1] - 2026-04-10
+
+### Added
+- `auth status` and `auth whoami` commands
+- MCR IPSec add-on support
+
+### Fixed
+- IPSec tunnel count: consistent 0/omit semantics across `buy` and `add-ipsec-addon`, applied in interactive mode, with clearer help text
+
+## [v0.7.0] - 2026-04-09
+
+### Changed
+- CSV and XML output now share deduplicated reflection logic
+
+### Fixed
+- `--watch`: `--interval` validated to prevent a ticker panic, with timeout handling added and duplicate error output on timeout removed
+- CSV header fallback no longer includes JSON struct-tag options
+- Login error messages no longer double-wrapped, and VXC input validation restored
+- WASM proxy server applies security headers on all routes and sanitizes auth error messages
+
+## [v0.6.0] - 2026-04-05
+
+### Added
+- `apply` command for bulk provisioning from a config file
+- `topology` command showing a resource relationship tree
+- `product` command group (`list`, `get-type`)
+- `--query` flag with JMESPath support for filtering JSON output
+- `--fields` flag for selecting output columns
+- `--limit` flag on all list commands
+- `--watch` flag for continuous status monitoring
+- `--export` flag on get commands to emit recreatable JSON config
+- Global `--timeout` flag for configurable request timeouts
+- Shorthand command aliases (`ls`, `rm`, `show`, `st`)
+- Version-update check when running `megaport version`
+- Man page generation in the `generate-docs` command
+- Automatic retry with exponential backoff for transient API failures
+- Color-coded resource status values in table output
+- Helpful messages when list commands return no results
+- New `Cancelled` exit code returned when the user aborts an operation
+- Elapsed time shown on the provisioning spinner
+- Homebrew tap auto-update on release
+
+### Changed
+- Locations API commands no longer require authentication
+
+### Fixed
+- Race conditions, deadlocks, and panics resolved in the output package
+- WASM proxy server hardened with a hostname allowlist, restricted CORS origins, and response bodies no longer logged
+- `--limit` now rejects negative values
+- Provisioning operations now use a 15-minute default timeout
 
 ## [v0.5.5] — 2026-04-02
 
@@ -242,7 +414,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Credential support via environment variables (`MEGAPORT_ACCESS_KEY`, `MEGAPORT_SECRET_KEY`, `MEGAPORT_ENVIRONMENT`)
 - Automated CI with golangci-lint and Go test suite
 
-[Unreleased]: https://github.com/megaport/megaport-cli/compare/v0.5.5...HEAD
+[Unreleased]: https://github.com/megaport/megaport-cli/compare/v0.13.0...HEAD
+[v0.13.0]: https://github.com/megaport/megaport-cli/compare/v0.12.0...v0.13.0
+[v0.12.0]: https://github.com/megaport/megaport-cli/compare/v0.11.0...v0.12.0
+[v0.11.0]: https://github.com/megaport/megaport-cli/compare/v0.10.0...v0.11.0
+[v0.10.0]: https://github.com/megaport/megaport-cli/compare/v0.9.4...v0.10.0
+[v0.9.4]: https://github.com/megaport/megaport-cli/compare/v0.9.3...v0.9.4
+[v0.9.3]: https://github.com/megaport/megaport-cli/compare/v0.9.2...v0.9.3
+[v0.9.2]: https://github.com/megaport/megaport-cli/compare/v0.9.1...v0.9.2
+[v0.9.1]: https://github.com/megaport/megaport-cli/compare/v0.9.0...v0.9.1
+[v0.9.0]: https://github.com/megaport/megaport-cli/compare/v0.8.0...v0.9.0
+[v0.8.0]: https://github.com/megaport/megaport-cli/compare/v0.7.1...v0.8.0
+[v0.7.1]: https://github.com/megaport/megaport-cli/compare/v0.7.0...v0.7.1
+[v0.7.0]: https://github.com/megaport/megaport-cli/compare/v0.6.0...v0.7.0
+[v0.6.0]: https://github.com/megaport/megaport-cli/compare/v0.5.5...v0.6.0
 [v0.5.5]: https://github.com/megaport/megaport-cli/compare/v0.5.4...v0.5.5
 [v0.5.4]: https://github.com/megaport/megaport-cli/compare/v0.5.3...v0.5.4
 [v0.5.3]: https://github.com/megaport/megaport-cli/compare/v0.5.2...v0.5.3

--- a/scripts/update-changelog.sh
+++ b/scripts/update-changelog.sh
@@ -33,7 +33,8 @@ grep -q '^\[Unreleased\]: ' "$changelog" || { echo "error: no '[Unreleased]:' re
 
 date="${CHANGELOG_DATE:-$(date -u +%F)}"
 
-# Previous version is whatever the [Unreleased] compare link currently points at.
+# Previous version = the base of the current [Unreleased] compare link. Assumes
+# the prior release's changelog PR has merged; out-of-order PRs can skip a version.
 prev="$(sed -n 's#^\[Unreleased\]:.*/compare/\(v[0-9A-Za-z.\-]*\)\.\.\.HEAD.*#\1#p' "$changelog" | head -n1)"
 
 # Transform the generated notes into the version's section body:

--- a/scripts/update-changelog.sh
+++ b/scripts/update-changelog.sh
@@ -33,9 +33,13 @@ grep -q '^\[Unreleased\]: ' "$changelog" || { echo "error: no '[Unreleased]:' re
 
 date="${CHANGELOG_DATE:-$(date -u +%F)}"
 
-# Previous version = the base of the current [Unreleased] compare link. Assumes
-# the prior release's changelog PR has merged; out-of-order PRs can skip a version.
-prev="$(sed -n 's#^\[Unreleased\]:.*/compare/\(v[0-9A-Za-z.\-]*\)\.\.\.HEAD.*#\1#p' "$changelog" | head -n1)"
+# Previous version: prefer PREV_VERSION (the release workflow passes the previous
+# git tag, which is authoritative even if an earlier changelog PR hasn't merged
+# yet). Fall back to the base of the current [Unreleased] compare link.
+prev="${PREV_VERSION:-}"
+if [ -z "$prev" ]; then
+  prev="$(sed -n 's#^\[Unreleased\]:.*/compare/\(v[0-9A-Za-z.\-]*\)\.\.\.HEAD.*#\1#p' "$changelog" | head -n1)"
+fi
 
 # Transform the generated notes into the version's section body:
 #   - drop GoReleaser's "## Changelog" header

--- a/scripts/update-changelog.sh
+++ b/scripts/update-changelog.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Fold GoReleaser-generated release notes into CHANGELOG.md in Keep a Changelog
+# format. Called by the release workflow after a tag is published; the notes are
+# the body of the draft GitHub release that GoReleaser created.
+#
+# Usage: update-changelog.sh <version> <notes-file> [changelog-file]
+#   version        the release tag, e.g. v0.13.0
+#   notes-file     file holding the generated notes (GoReleaser's "## Changelog"
+#                  block with "### Added/### Fixed/..." groups)
+#   changelog-file defaults to CHANGELOG.md at the repo root
+#
+# Idempotent: if the version heading already exists, it is a no-op.
+# The release date is today (UTC); override with CHANGELOG_DATE for tests.
+set -euo pipefail
+
+version="${1:?usage: update-changelog.sh <version> <notes-file> [changelog-file]}"
+notes_file="${2:?missing notes file}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+changelog="${3:-$repo_root/CHANGELOG.md}"
+repo_url="https://github.com/megaport/megaport-cli"
+
+[ -f "$notes_file" ] || { echo "error: notes file not found: $notes_file" >&2; exit 1; }
+[ -f "$changelog" ] || { echo "error: changelog not found: $changelog" >&2; exit 1; }
+
+if grep -qF "## [$version]" "$changelog"; then
+  echo "CHANGELOG.md already documents $version; nothing to do."
+  exit 0
+fi
+
+# The insertion below anchors on these two lines; fail clearly if either is gone.
+grep -q '^## \[Unreleased\]' "$changelog" || { echo "error: no '## [Unreleased]' heading in $changelog" >&2; exit 1; }
+grep -q '^\[Unreleased\]: ' "$changelog" || { echo "error: no '[Unreleased]:' reference link in $changelog" >&2; exit 1; }
+
+date="${CHANGELOG_DATE:-$(date -u +%F)}"
+
+# Previous version is whatever the [Unreleased] compare link currently points at.
+prev="$(sed -n 's#^\[Unreleased\]:.*/compare/\(v[0-9A-Za-z.\-]*\)\.\.\.HEAD.*#\1#p' "$changelog" | head -n1)"
+
+# Transform the generated notes into the version's section body:
+#   - drop GoReleaser's "## Changelog" header
+#   - turn "*  <msg>" bullets into "- <msg>"
+#   - blank line before each group heading after the first
+#   - strip the conventional-commit type prefix (the heading already says the
+#     category) while keeping the rest of the message intact
+section_body="$(
+  awk '
+    { sub(/\r$/, "") }
+    /^## Changelog[[:space:]]*$/ { next }
+    /^###[[:space:]]/ {
+      if (seen) print ""
+      seen = 1
+      print
+      next
+    }
+    /^\*[[:space:]]/ {
+      sub(/^\*[[:space:]]+/, "- ")
+      print
+      next
+    }
+    # Keep only group headings and bullets; drop prose, footers, and stray lines.
+    { next }
+  ' "$notes_file" \
+    | sed -E 's/^- (feat|fix|perf|refactor|build|ci|docs|test|style|chore|revert)(\([^)]*\))?!?: /- /' \
+    | sed -E 's/^- [A-Z]+-[0-9]+: /- /'
+)"
+
+# An empty section means no qualifying commits (e.g. a docs/tooling-only release),
+# not an error: leave the changelog untouched rather than failing the release job.
+if [ -z "$section_body" ]; then
+  echo "No user-facing changes to record for $version; leaving CHANGELOG.md unchanged."
+  exit 0
+fi
+
+NEW_BLOCK="$(printf '## [%s] - %s\n\n%s' "$version" "$date" "$section_body")"
+export NEW_BLOCK
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+# Insert the new version block right below [Unreleased] (whose body is reset to
+# empty, since releases now come from generated notes, not hand-edited items),
+# then repoint the [Unreleased] compare link and add the new version's link.
+awk -v ver="$version" -v prev="$prev" -v url="$repo_url" '
+  /^## \[Unreleased\]/ {
+    print
+    print ""
+    print ENVIRON["NEW_BLOCK"]
+    print ""
+    inunreleased = 1
+    next
+  }
+  inunreleased && (/^## \[/ || /^\[[^]]+\]:[[:space:]]/) { inunreleased = 0 }
+  inunreleased { next }
+  /^\[Unreleased\]: / {
+    sub(/compare\/[^ ]+\.\.\.HEAD/, "compare/" ver "...HEAD")
+    print
+    if (prev != "")
+      print "[" ver "]: " url "/compare/" prev "..." ver
+    else
+      print "[" ver "]: " url "/releases/tag/" ver
+    next
+  }
+  { print }
+' "$changelog" > "$tmp"
+
+mv "$tmp" "$changelog"
+trap - EXIT
+echo "CHANGELOG.md updated for $version (previous: ${prev:-none}, date: $date)."


### PR DESCRIPTION
Makes CHANGELOG.md generate from release notes instead of being hand-maintained, and catches it up through v0.13.0.

- Re-enable GoReleaser changelog generation: Added (feat), Changed (perf), Fixed (fix), plus an "Other Changes" catch-all so non-conventional `ESD-XXXX:` subjects aren't dropped. Docs/test/chore/ci/build/style/refactor, merges, and reverts are filtered out.
- New release-workflow job folds the generated notes into CHANGELOG.md via `scripts/update-changelog.sh` and opens a PR. It opens a PR rather than pushing to `main` because `main` is protected by org rulesets that require PRs.
- Backfill v0.6.0 through v0.13.0; every date and compare link verified against git. Pre-v0.6.0 entries are untouched.

One prerequisite for the automation: the org setting "Allow GitHub Actions to create and approve pull requests" must be enabled. If it is off, the job still pushes the `chore/changelog-<tag>` branch and logs a link to open the PR by hand, so a release is never blocked.

v0.5.6 through v0.5.9 are folded into the v0.6.0 entry (its compare link spans them); the ticket scoped the catch-up to v0.6.0 onward.
