### PR TITLE
test: use CaptureStdout in locations integration tests that parse JSON

### DIFF
--- a/internal/commands/locations/locations_integration_test.go
+++ b/internal/commands/locations/locations_integration_test.go
@@ -31,7 +31,7 @@ func TestIntegration_ListLocations(t *testing.T) {
 	cmd := integrationListLocationsCmd()
 
 	var err error
-	captured := output.CaptureOutput(func() {
+	captured := output.CaptureStdout(func() {
 		err = ListLocations(cmd, nil, true, "json")
 	})
 
@@ -56,7 +56,7 @@ func TestIntegration_ListLocations_FilterByCountry(t *testing.T) {
 	require.NoError(t, cmd.Flags().Set("country", "Australia"))
 
 	var err error
-	captured := output.CaptureOutput(func() {
+	captured := output.CaptureStdout(func() {
 		err = ListLocations(cmd, nil, true, "json")
 	})
 
@@ -72,7 +72,7 @@ func TestIntegration_SearchLocations(t *testing.T) {
 	defer testutil.LoginWithClient(t, client)()
 
 	var err error
-	captured := output.CaptureOutput(func() {
+	captured := output.CaptureStdout(func() {
 		err = SearchLocations(&cobra.Command{Use: "search"}, []string{"Sydney"}, true, "json")
 	})
 
@@ -91,7 +91,7 @@ func TestIntegration_GetLocation(t *testing.T) {
 	cmd := integrationListLocationsCmd()
 
 	var listErr error
-	listOut := output.CaptureOutput(func() {
+	listOut := output.CaptureStdout(func() {
 		listErr = ListLocations(cmd, nil, true, "json")
 	})
 	require.NoError(t, listErr)
@@ -106,7 +106,7 @@ func TestIntegration_GetLocation(t *testing.T) {
 	locationID := int(firstID)
 
 	var getErr error
-	getOut := output.CaptureOutput(func() {
+	getOut := output.CaptureStdout(func() {
 		getErr = GetLocation(&cobra.Command{Use: "get"}, []string{formatLocationID(locationID)}, true, "json")
 	})
 


### PR DESCRIPTION
PR #427 changed `CaptureOutput` to capture stdout and stderr combined, and changed `PrintInfo` (and friends) to always route to stderr. The locations integration tests were using `CaptureOutput` and then calling `json.Unmarshal` on the captured output. The `ℹ Filtering by country: ...` and `ℹ Found N locations...` messages now land in the combined capture and break the JSON parse with `invalid character 'â' looking for beginning of value`.

Switch all five `CaptureOutput` calls in `locations_integration_test.go` to `CaptureStdout`, which captures only the data stream (stdout). This is what tests that parse machine-readable output should use.

Fixes `TestIntegration_ListLocations_FilterByCountry` and `TestIntegration_SearchLocations` from the [2026-06-25 nightly run](https://github.com/megaport/megaport-cli/actions/runs/28144488017/job/83348609221).