### PR TITLE
test: widen per-resource timeout budget for flake resistance (ESD-1522)

### DIFF
--- a/internal/commands/apply/apply_test.go
+++ b/internal/commands/apply/apply_test.go
@@ -731,7 +731,7 @@ func TestApplyConfig_PerResourceTimeout(t *testing.T) {
 		}
 	}
 
-	const perResourceConsume = 180 * time.Millisecond
+	const perResourceConsume = 600 * time.Millisecond
 	mockPort := &MockPortService{
 		BuyPortResult:     &megaport.BuyPortResponse{TechnicalServiceUIDs: []string{"slow-port-uid"}},
 		GetPortStatusFunc: readyAfter(perResourceConsume),
@@ -758,10 +758,12 @@ mcrs:
 `
 	f := writeTempFile(t, "config.yaml", cfg)
 	cmd := applyCmd(f, false, true)
-	// Per-resource budget of 300ms. Each resource takes ~180ms, so the two together
-	// (~360ms) exceed a single shared 300ms budget but each stays within its own.
+	// Per-resource budget of 1s. Each resource takes ~600ms, so the two together
+	// (~1.2s) exceed a single shared 1s budget but each stays within its own. The
+	// 400ms per-resource margin gives slack against CPU-contention stalls on a
+	// loaded runner.
 	cmd.Flags().Duration("timeout", 0, "")
-	require.NoError(t, cmd.Flags().Set("timeout", "300ms"))
+	require.NoError(t, cmd.Flags().Set("timeout", "1s"))
 
 	var err error
 	output.CaptureOutput(func() {


### PR DESCRIPTION
Follow-up to #445 addressing two review comments.

- Widen the budget in `TestApplyConfig_PerResourceTimeout` so the assertion has more wall-clock slack: per-resource budget 300ms to 1s, per-resource consume 180ms to 600ms. The two resources together (~1.2s) still exceed a single shared 1s budget, so the regression proof is unchanged, while the per-resource margin grows from ~120ms to 400ms (more room against a CPU-contention stall on a loaded runner).
- Kept consume at 600ms rather than the suggested 300ms: with two resources, a 300ms consume sums to 600ms which no longer exceeds a 1s shared budget, so a shared-context run would also pass and the test would stop proving the fix. 600ms preserves "combined ~1.2s > 1s shared".
- The `hasDeadline` fallback in `internal/utils/provision.go` was never actually removed, and shouldn't be: it still caps any deadline-free caller at `DefaultProvisionTimeout`. PR #445's description claimed it was removed, so I corrected that description.

Jira: ESD-1522
