### PR TITLE
fix(cli): route PreRunE validation errors through the JSON error envelope (ESD-1553)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 - vRouter interface validation now accepts an untagged VLAN (-1), matching the Azure peer and shared VLAN checks. Previously a `-1` VLAN was rejected client-side even though the API accepts it, which also blocked the interactive "press Enter for no VLAN" path
 - The interactive BGP connection password is now read without echo, matching the IPsec pre-shared key. Previously it was typed in cleartext on screen
 - Interactive `vxc update` now applies the A-End vRouter partner config to the A-End. Previously it was written to the B-End field, so the A-End config was lost and the B-End was overwritten
+- Flag-validation failures (conditional-requirement checks, `--max-retries`, `--timeout`, invalid `--output`) now emit the same JSON error envelope as other errors under `--output json`, and no longer print the cobra usage block
 
 ## [v0.13.0] - 2026-06-23
 

--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/base/registry"
 	"github.com/megaport/megaport-cli/internal/utils"
@@ -109,8 +110,11 @@ func InitializeCommon() {
 			}
 		}
 		if !validFmt {
-			return fmt.Errorf("invalid output format: %s. Must be one of: %s",
-				outputFormat, strings.Join(utils.ValidFormatsWASM, ", "))
+			// Type the error as a usage CLIError so ExecuteWithArgs emits the JSON
+			// envelope under --output json, matching the native root and the shared
+			// conditional-requirement validators.
+			return exitcodes.NewUsageError(fmt.Errorf("invalid output format: %s. Must be one of: %s",
+				outputFormat, strings.Join(utils.ValidFormatsWASM, ", ")))
 		}
 		cfg := output.GetOutputConfig()
 		cfg.NoHeader = noHeader
@@ -119,10 +123,10 @@ func InitializeCommon() {
 		cfg.Format = format
 		output.ApplyOutputConfig(cfg)
 		if utils.MaxRetries < 0 {
-			return fmt.Errorf("--max-retries must be >= 0, got %d", utils.MaxRetries)
+			return exitcodes.NewUsageError(fmt.Errorf("--max-retries must be >= 0, got %d", utils.MaxRetries))
 		}
 		if err := utils.ValidateTimeoutFlag(cmd); err != nil {
-			return err
+			return exitcodes.NewUsageError(err)
 		}
 		if existingPreRunE != nil {
 			return existingPreRunE(cmd, args)

--- a/cmd/megaport/megaport.go
+++ b/cmd/megaport/megaport.go
@@ -40,8 +40,8 @@ func init() {
 			}
 		}
 		if !validFmt {
-			return fmt.Errorf("invalid output format: %s. Must be one of: %s",
-				outputFormat, strings.Join(utils.ValidFormats, ", "))
+			return utils.FinishPreRunError(cmd, args, exitcodes.NewUsageError(fmt.Errorf("invalid output format: %s. Must be one of: %s",
+				outputFormat, strings.Join(utils.ValidFormats, ", "))))
 		}
 		output.SetOutputFormat(format)
 
@@ -67,12 +67,12 @@ func init() {
 
 		// Validate retry flags
 		if utils.MaxRetries < 0 {
-			return exitcodes.NewUsageError(fmt.Errorf("--max-retries must be >= 0, got %d", utils.MaxRetries))
+			return utils.FinishPreRunError(cmd, args, exitcodes.NewUsageError(fmt.Errorf("--max-retries must be >= 0, got %d", utils.MaxRetries)))
 		}
 
 		// Reject an explicit non-positive --timeout; omitting it uses the default.
 		if err := utils.ValidateTimeoutFlag(cmd); err != nil {
-			return exitcodes.NewUsageError(err)
+			return utils.FinishPreRunError(cmd, args, exitcodes.NewUsageError(err))
 		}
 
 		return nil

--- a/cmd/megaport/megaport_test.go
+++ b/cmd/megaport/megaport_test.go
@@ -106,6 +106,52 @@ func TestTimeoutFlagRejectsNonPositive(t *testing.T) {
 	assert.Contains(t, execErr.Error(), "--timeout must be greater than 0")
 }
 
+// TestInvalidOutputFormatRejected verifies that an unknown --output value is
+// rejected as a usage error through PersistentPreRunE and routed through
+// FinishPreRunError (so it carries a usage exit code), not silently accepted.
+func TestInvalidOutputFormatRejected(t *testing.T) {
+	t.Setenv("MEGAPORT_CONFIG_DIR", t.TempDir())
+	defer func() {
+		output.ResetState()
+		f := rootCmd.PersistentFlags().Lookup("output")
+		_ = f.Value.Set("table")
+		f.Changed = false
+	}()
+
+	rootCmd.SetArgs([]string{"version", "--output", "bogus"})
+	var execErr error
+	_ = output.CaptureOutput(func() {
+		execErr = rootCmd.Execute()
+	})
+
+	require.Error(t, execErr)
+	assert.Equal(t, exitcodes.Usage, exitCodeFromError(execErr))
+	assert.Contains(t, execErr.Error(), "invalid output format")
+}
+
+// TestNegativeMaxRetriesRejected verifies that a negative --max-retries is
+// rejected as a usage error through PersistentPreRunE and routed through
+// FinishPreRunError.
+func TestNegativeMaxRetriesRejected(t *testing.T) {
+	t.Setenv("MEGAPORT_CONFIG_DIR", t.TempDir())
+	defer func() {
+		output.ResetState()
+		f := rootCmd.PersistentFlags().Lookup("max-retries")
+		_ = f.Value.Set("3") // restore the default; IntVar binding resets utils.MaxRetries too
+		f.Changed = false
+	}()
+
+	rootCmd.SetArgs([]string{"version", "--max-retries=-1"})
+	var execErr error
+	_ = output.CaptureOutput(func() {
+		execErr = rootCmd.Execute()
+	})
+
+	require.Error(t, execErr)
+	assert.Equal(t, exitcodes.Usage, exitCodeFromError(execErr))
+	assert.Contains(t, execErr.Error(), "--max-retries must be >= 0")
+}
+
 // TestApplyDefaultSettings_WarnsOnConfigLoadFailure verifies that when
 // NewConfigManager fails (e.g. the configured config dir cannot be created),
 // applyDefaultSettings returns a warning message instead of silently skipping.

--- a/e2e/contract_test.go
+++ b/e2e/contract_test.go
@@ -90,13 +90,30 @@ func TestE2E_Contract(t *testing.T) {
 			// Match the full composite message to avoid false positives from two
 			// independent substrings accidentally both appearing in unrelated output.
 			stderrContains: []string{"not set when not using interactive or JSON input"},
-			stderrAbsent:   []string{"Logging in"},
+			// A PreRunE validation failure routes through finishWithError, which
+			// sets SilenceUsage, so cobra must not append its usage block.
+			stderrAbsent: []string{"Logging in", "Usage:"},
 		},
 		{
 			name:           "invalid output format is a usage error",
 			args:           []string{"version", "--output", "bogus"},
 			wantExit:       exitcodes.Usage,
 			stderrContains: []string{"invalid output format"},
+			stderrAbsent:   []string{"Usage:"},
+		},
+		{
+			name:           "negative max-retries is a usage error without usage block",
+			args:           []string{"version", "--max-retries=-1"},
+			wantExit:       exitcodes.Usage,
+			stderrContains: []string{"--max-retries must be >= 0"},
+			stderrAbsent:   []string{"Usage:"},
+		},
+		{
+			name:           "non-positive timeout is a usage error without usage block",
+			args:           []string{"version", "--timeout", "0"},
+			wantExit:       exitcodes.Usage,
+			stderrContains: []string{"--timeout must be greater than 0"},
+			stderrAbsent:   []string{"Usage:"},
 		},
 	}
 
@@ -154,4 +171,62 @@ func TestE2E_JSONErrorEnvelope(t *testing.T) {
 	assert.Equal(t, exitcodes.Usage, envelope.Error.Code, "envelope code should be 2 (usage error)")
 	assert.Equal(t, "usage_error", envelope.Error.Type, "envelope type should be usage_error")
 	assert.NotEmpty(t, envelope.Error.Message, "envelope should carry an error message")
+}
+
+// TestE2E_PreRunJSONErrorEnvelope verifies that PreRunE / PersistentPreRunE
+// validation failures (conditional-requirement checks, --max-retries, --timeout)
+// emit the same structured JSON envelope under --output json as the RunE error
+// paths do. These checks run before any login, so each case is hermetic. It also
+// asserts stdout stays empty and the cobra usage block is not appended.
+func TestE2E_PreRunJSONErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "conditional-requirement failure",
+			args: []string{"ports", "buy", "--output", "json"},
+		},
+		{
+			name: "negative max-retries",
+			args: []string{"version", "--max-retries=-1", "--output", "json"},
+		},
+		{
+			name: "non-positive timeout",
+			args: []string{"version", "--timeout", "0", "--output", "json"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res := Run(t, tc.args...)
+
+			require.Equalf(t, exitcodes.Usage, res.Exit,
+				"PreRunE validation failure should be a usage error (exit 2)\nstderr: %s", res.Stderr)
+			assert.Emptyf(t, res.Stdout, "stdout should stay empty on a validation failure\nstdout: %s", res.Stdout)
+			assert.NotContains(t, res.Stderr, "Usage:", "SilenceUsage should suppress the cobra usage block")
+
+			// Anchor on the first '{' so the test is robust whether or not a
+			// preceding line (e.g. a config-default warning) is written first.
+			idx := strings.IndexByte(res.Stderr, '{')
+			require.NotEqualf(t, -1, idx, "no JSON envelope found on stderr: %s", res.Stderr)
+
+			var envelope struct {
+				Error struct {
+					Code    int    `json:"code"`
+					Type    string `json:"type"`
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			dec := json.NewDecoder(strings.NewReader(res.Stderr[idx:]))
+			require.NoErrorf(t, dec.Decode(&envelope), "envelope should be valid JSON: %s", res.Stderr[idx:])
+
+			assert.Equal(t, exitcodes.Usage, envelope.Error.Code, "envelope code should be 2 (usage error)")
+			assert.Equal(t, "usage_error", envelope.Error.Type, "envelope type should be usage_error")
+			assert.NotEmpty(t, envelope.Error.Message, "envelope should carry an error message")
+		})
+	}
 }

--- a/internal/base/cmdbuilder/builder.go
+++ b/internal/base/cmdbuilder/builder.go
@@ -206,7 +206,7 @@ func (b *CommandBuilder) WithConditionalRequirements(conditionallyRequiredFlags 
 				}
 
 				if !atLeastOneSet {
-					return exitcodes.NewUsageError(fmt.Errorf("at least one of these flags must be set: %s", strings.Join(flagList, ", ")))
+					return utils.FinishPreRunError(cmd, args, exitcodes.NewUsageError(fmt.Errorf("at least one of these flags must be set: %s", strings.Join(flagList, ", "))))
 				}
 			} else {
 				// Handle normal required flag
@@ -217,7 +217,7 @@ func (b *CommandBuilder) WithConditionalRequirements(conditionallyRequiredFlags 
 
 				// Check if flag has been explicitly set
 				if !cmd.Flags().Changed(flagSpec) {
-					return exitcodes.NewUsageError(fmt.Errorf("required flag \"%s\" not set when not using interactive or JSON input", flagSpec))
+					return utils.FinishPreRunError(cmd, args, exitcodes.NewUsageError(fmt.Errorf("required flag \"%s\" not set when not using interactive or JSON input", flagSpec)))
 				}
 			}
 		}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -181,6 +181,24 @@ func finishWithError(cmd *cobra.Command, args []string, err error, format string
 	return exitcodes.New(code, wrapped)
 }
 
+// FinishPreRunError routes a PreRunE / PersistentPreRunE validation failure
+// through the same single-envelope path RunE errors use. Without it these
+// errors bypass finishWithError, so under --output json cobra prints plain text
+// plus a usage block instead of the structured envelope every other error path
+// emits. Call sites must return the error this returns: finishWithError sets
+// SilenceUsage/SilenceErrors on the command so cobra neither re-prints the error
+// nor dumps usage, and Execute maps the embedded exit code.
+func FinishPreRunError(cmd *cobra.Command, args []string, err error) error {
+	// A prior command in the long-lived WASM process may have left the latch
+	// set; reset so the non-json path always surfaces this error on stderr.
+	output.ResetErrorEmitted()
+	rawFormat, _ := cmd.Root().PersistentFlags().GetString("output")
+	format := strings.ToLower(rawFormat)
+	syncOutputFormat(format)
+	noColor := resolveNoColor(cmd)
+	return finishWithError(cmd, args, err, format, noColor)
+}
+
 // syncOutputFormat aligns the output package's format with the format the
 // wrapper resolved from the flags. This matters in the long-lived WASM process,
 // where a stale "json" left by a previous command would otherwise make

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -187,7 +187,8 @@ func finishWithError(cmd *cobra.Command, args []string, err error, format string
 // plus a usage block instead of the structured envelope every other error path
 // emits. Call sites must return the error this returns: finishWithError sets
 // SilenceUsage/SilenceErrors on the command so cobra neither re-prints the error
-// nor dumps usage, and Execute maps the embedded exit code.
+// nor dumps usage, and the embedded *CLIError carries the exit code (mapped by
+// the native Execute; surfaced by the WASM ExecuteWithArgs envelope branch).
 func FinishPreRunError(cmd *cobra.Command, args []string, err error) error {
 	// A prior command in the long-lived WASM process may have left the latch
 	// set; reset so the non-json path always surfaces this error on stderr.

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -795,3 +795,73 @@ func TestWrapOutputFormatRunE_JSONErrorOutput(t *testing.T) {
 	assert.Equal(t, "api_error", errType)
 	assert.Equal(t, "failed to get port: not found", msg)
 }
+
+// buildPreRunChild builds a minimal root+child tree carrying the persistent
+// flags FinishPreRunError reads (--output, --no-color), with --output pre-set.
+func buildPreRunChild(format string) *cobra.Command {
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("output", format, "")
+	root.PersistentFlags().Bool("no-color", false, "")
+	child := &cobra.Command{Use: "buy"}
+	root.AddCommand(child)
+	return child
+}
+
+func TestFinishPreRunError(t *testing.T) {
+	t.Run("json mode emits the structured envelope and silences usage", func(t *testing.T) {
+		child := buildPreRunChild("json")
+		var err error
+		stderr := captureStderr(t, func() {
+			err = FinishPreRunError(child, []string{}, exitcodes.NewUsageError(errors.New("bad flag")))
+		})
+
+		require.Error(t, err)
+		assert.True(t, child.SilenceUsage, "usage must be silenced so cobra does not dump the usage block")
+		assert.True(t, child.SilenceErrors)
+
+		var cliErr *exitcodes.CLIError
+		require.True(t, errors.As(err, &cliErr))
+		assert.Equal(t, exitcodes.Usage, cliErr.Code)
+
+		code, errType, msg := parseErrorJSON(t, stderr)
+		assert.Equal(t, exitcodes.Usage, code)
+		assert.Equal(t, "usage_error", errType)
+		assert.Equal(t, "bad flag", msg)
+	})
+
+	t.Run("non-json mode prints to stderr and returns a wrapped usage error", func(t *testing.T) {
+		child := buildPreRunChild("table")
+		var err error
+		stderr := captureStderr(t, func() {
+			err = FinishPreRunError(child, []string{"arg1"}, exitcodes.NewUsageError(errors.New("bad flag")))
+		})
+
+		require.Error(t, err)
+		assert.True(t, child.SilenceUsage)
+		assert.Contains(t, stderr, "bad flag", "the error should surface on stderr in non-json mode")
+		assert.NotContains(t, stderr, "\"error\"", "non-json mode must not emit the JSON envelope")
+
+		var cliErr *exitcodes.CLIError
+		require.True(t, errors.As(err, &cliErr))
+		assert.Equal(t, exitcodes.Usage, cliErr.Code)
+		assert.Contains(t, err.Error(), "error running buy command")
+	})
+
+	t.Run("missing --output flag defaults to table without panicking", func(t *testing.T) {
+		root := &cobra.Command{Use: "root"}
+		child := &cobra.Command{Use: "buy"}
+		root.AddCommand(child)
+
+		var err error
+		stderr := captureStderr(t, func() {
+			err = FinishPreRunError(child, []string{}, exitcodes.NewUsageError(errors.New("bad flag")))
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, stderr, "bad flag")
+
+		var cliErr *exitcodes.CLIError
+		require.True(t, errors.As(err, &cliErr))
+		assert.Equal(t, exitcodes.Usage, cliErr.Code)
+	})
+}


### PR DESCRIPTION
Flag-validation failures that happen in cobra's `PreRunE`/`PersistentPreRunE` (the conditional-requirement checks, plus `--max-retries`, `--timeout`, and invalid `--output`) used to bypass `finishWithError`. So under `--output json` they printed plain text and a cobra usage block instead of the structured JSON error envelope every other error path emits. The exit code (2), stderr routing, and empty stdout were already correct, so this is a consistency gap: a script parsing the envelope got nothing parseable for this one class of failure.

This routes those errors through the same path RunE errors use, and sets `SilenceUsage` so a validation failure no longer dumps usage.

- New `utils.FinishPreRunError` helper resolves the output format and hands off to the existing `finishWithError`
- Conditional-requirement validators (shared command builder) and the native root `PersistentPreRunE` call it
- WASM root checks now return typed usage errors so the WASM envelope branch fires too, keeping both targets consistent
- e2e: JSON-envelope coverage across all three PreRunE failure types, plus contract assertions that the usage block is gone and stdout stays empty

Exit codes and stream routing are unchanged.
