### PR TITLE
fix(vxc): accept valid single-field flag updates (ESD-1550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 - vRouter interface validation now accepts an untagged VLAN (-1), matching the Azure peer and shared VLAN checks. Previously a `-1` VLAN was rejected client-side even though the API accepts it, which also blocked the interactive "press Enter for no VLAN" path
 - The interactive BGP connection password is now read without echo, matching the IPsec pre-shared key. Previously it was typed in cleartext on screen
 - Interactive `vxc update` now applies the A-End vRouter partner config to the A-End. Previously it was written to the B-End field, so the A-End config was lost and the B-End was overwritten
+- `vxc update` no longer rejects a single valid flag (such as `--shutdown`, `--cost-centre`, `--term`, `--is-approved`, or the vNIC index flags) with "at least one field must be updated". The non-interactive gate now matches the flags the update command actually registers
 
 ## [v0.13.0] - 2026-06-23
 

--- a/internal/base/cmdbuilder/flagsets_test.go
+++ b/internal/base/cmdbuilder/flagsets_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -334,6 +335,20 @@ func TestWithVXCUpdateFlags(t *testing.T) {
 	for _, flag := range expectedFlags {
 		assert.NotNil(t, cmd.Flags().Lookup(flag), "VXC update flag %q should exist", flag)
 	}
+}
+
+// TestVXCUpdateFlagNamesMatchRegistered guards against the update gate's flag
+// list drifting from the flags WithVXCUpdateFlags actually registers.
+func TestVXCUpdateFlagNamesMatchRegistered(t *testing.T) {
+	cmd := NewCommand("test", "test").WithVXCUpdateFlags().Build()
+
+	var registered []string
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		registered = append(registered, f.Name)
+	})
+
+	assert.ElementsMatch(t, VXCUpdateFlagNames, registered,
+		"VXCUpdateFlagNames must match exactly the flags WithVXCUpdateFlags registers")
 }
 
 func TestWithVXCFilterFlags(t *testing.T) {

--- a/internal/base/cmdbuilder/vxc_flagsets.go
+++ b/internal/base/cmdbuilder/vxc_flagsets.go
@@ -46,6 +46,17 @@ func (b *CommandBuilder) WithVXCCreateFlags() *CommandBuilder {
 	return b
 }
 
+// VXCUpdateFlagNames lists the flags WithVXCUpdateFlags registers; the update
+// gate treats any of these being set as a field to update.
+// TestVXCUpdateFlagNamesMatchRegistered guards the two against drift.
+var VXCUpdateFlagNames = []string{
+	"name", "rate-limit", "term", "cost-centre",
+	"a-end-uid", "b-end-uid", "a-end-vlan", "b-end-vlan",
+	"a-end-inner-vlan", "b-end-inner-vlan",
+	"a-end-partner-config", "b-end-partner-config",
+	"shutdown", "is-approved", "a-vnic-index", "b-vnic-index",
+}
+
 // WithVXCUpdateFlags adds all flags needed for VXC updates
 func (b *CommandBuilder) WithVXCUpdateFlags() *CommandBuilder {
 	b.WithVXCCommonFlags()

--- a/internal/commands/vxc/vxc_actions.go
+++ b/internal/commands/vxc/vxc_actions.go
@@ -218,11 +218,26 @@ func watchGetVXC(cmd *cobra.Command, args []string, noColor bool, outputFormat s
 		})
 }
 
+// emptyMeansUnsetUpdateFlags are flags whose update builder skips an empty
+// value, so an explicit empty string carries no change and must not pass the
+// gate (buildUpdateVXCRequestFromFlags). Other string flags treat "" as a
+// meaningful value (e.g. clearing the cost centre).
+var emptyMeansUnsetUpdateFlags = map[string]bool{
+	"a-end-partner-config": true,
+	"b-end-partner-config": true,
+}
+
 var hasUpdateVXCNonInteractiveFlags = func(cmd *cobra.Command) bool {
 	for _, name := range cmdbuilder.VXCUpdateFlagNames {
-		if cmd.Flags().Changed(name) {
-			return true
+		if !cmd.Flags().Changed(name) {
+			continue
 		}
+		if emptyMeansUnsetUpdateFlags[name] {
+			if v, _ := cmd.Flags().GetString(name); v == "" {
+				continue
+			}
+		}
+		return true
 	}
 	return false
 }

--- a/internal/commands/vxc/vxc_actions.go
+++ b/internal/commands/vxc/vxc_actions.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/megaport/megaport-cli/internal/base/cmdbuilder"
 	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/commands/config"
@@ -218,8 +219,7 @@ func watchGetVXC(cmd *cobra.Command, args []string, noColor bool, outputFormat s
 }
 
 var hasUpdateVXCNonInteractiveFlags = func(cmd *cobra.Command) bool {
-	flagNames := []string{"name", "rate-limit", "a-end-vlan", "b-end-vlan", "a-end-location", "b-end-location", "locked"}
-	for _, name := range flagNames {
+	for _, name := range cmdbuilder.VXCUpdateFlagNames {
 		if cmd.Flags().Changed(name) {
 			return true
 		}

--- a/internal/commands/vxc/vxc_actions_test.go
+++ b/internal/commands/vxc/vxc_actions_test.go
@@ -1569,6 +1569,21 @@ func TestHasUpdateVXCNonInteractiveFlags(t *testing.T) {
 		require.NoError(t, cmd.Flags().Set("interactive", "true"))
 		assert.False(t, hasUpdateVXCNonInteractiveFlags(cmd))
 	})
+
+	for _, name := range []string{"a-end-partner-config", "b-end-partner-config"} {
+		t.Run("empty "+name+" alone does not pass the gate", func(t *testing.T) {
+			cmd := cmdbuilder.NewCommand("update", "test").WithVXCUpdateFlags().Build()
+			require.NoError(t, cmd.Flags().Set(name, ""))
+			assert.False(t, hasUpdateVXCNonInteractiveFlags(cmd))
+		})
+	}
+
+	t.Run("empty partner-config alongside a real flag still passes the gate", func(t *testing.T) {
+		cmd := cmdbuilder.NewCommand("update", "test").WithVXCUpdateFlags().Build()
+		require.NoError(t, cmd.Flags().Set("a-end-partner-config", ""))
+		require.NoError(t, cmd.Flags().Set("cost-centre", "eng"))
+		assert.True(t, hasUpdateVXCNonInteractiveFlags(cmd))
+	})
 }
 
 func TestBuildUpdateVXCRequestFromFlags_NewFields_InvalidVNICIndex(t *testing.T) {

--- a/internal/commands/vxc/vxc_actions_test.go
+++ b/internal/commands/vxc/vxc_actions_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/megaport/megaport-cli/internal/base/cmdbuilder"
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/commands/config"
 	"github.com/megaport/megaport-cli/internal/testutil"
@@ -1546,6 +1547,28 @@ func TestBuildUpdateVXCRequestFromFlags_NewFields(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHasUpdateVXCNonInteractiveFlags(t *testing.T) {
+	t.Run("no flags set fails the gate", func(t *testing.T) {
+		cmd := cmdbuilder.NewCommand("update", "test").WithVXCUpdateFlags().Build()
+		assert.False(t, hasUpdateVXCNonInteractiveFlags(cmd))
+	})
+
+	for _, name := range cmdbuilder.VXCUpdateFlagNames {
+		t.Run(name+" alone passes the gate", func(t *testing.T) {
+			cmd := cmdbuilder.NewCommand("update", "test").WithVXCUpdateFlags().Build()
+			require.NoError(t, cmd.Flags().Set(name, "1"))
+			assert.True(t, hasUpdateVXCNonInteractiveFlags(cmd))
+		})
+	}
+
+	t.Run("a non-update flag does not pass the gate", func(t *testing.T) {
+		cmd := cmdbuilder.NewCommand("update", "test").WithVXCUpdateFlags().Build()
+		cmd.Flags().Bool("interactive", false, "")
+		require.NoError(t, cmd.Flags().Set("interactive", "true"))
+		assert.False(t, hasUpdateVXCNonInteractiveFlags(cmd))
+	})
 }
 
 func TestBuildUpdateVXCRequestFromFlags_NewFields_InvalidVNICIndex(t *testing.T) {


### PR DESCRIPTION
`megaport vxc update <uid>` rejected valid single-flag updates (for example `--shutdown`, `--cost-centre`, `--term`, `--is-approved`, or the vNIC index flags) with "at least one field must be updated". The non-interactive gate checked a stale flag list: it omitted most of the flags `WithVXCUpdateFlags` registers and included three that are not update flags at all (`a-end-location`, `b-end-location`, `locked`).

The fix replaces the hardcoded list with a single source of truth, `cmdbuilder.VXCUpdateFlagNames`, that the gate iterates, so it can no longer disagree with the flags the command registers.

Changes:
- New `cmdbuilder.VXCUpdateFlagNames` lists exactly the flags `WithVXCUpdateFlags` registers; the gate iterates it.
- Drop the three dead entries from the gate.
- Table test: each update flag set on its own passes the gate, no flags fails, and a non-update flag does not pass.
- Drift-guard test asserts `VXCUpdateFlagNames` matches what `WithVXCUpdateFlags` actually registers, so the two cannot drift again.

Fixes ESD-1550.
