### PR TITLE
ESD-1549: fix vxc buy dropping --resource-tags on the flags path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 - Bumped the megaportgo SDK to v1.14.1, which models `ipSecTunnelOptions` as a single object per `ipSecTunnel` interface (one tunnel each) instead of an array
 
 ### Fixed
+- `vxc buy --resource-tags` now applies tags when buying via flags, matching the `--json` path. Previously the flag was registered but silently ignored. Both paths now share one parse and validation, so malformed JSON, non-string values, and empty keys return a usage error before the order is placed
 - vRouter `bgpConnections` are now parsed from JSON input (`--json` / `--a-end-partner-config` / `--b-end-partner-config`) when buying or updating a VXC. Previously they were silently dropped on the JSON path and only honored via the interactive prompts
 - `vxc update` now validates vRouter partner configs (interfaces, BGP, and IPsec tunnels) client-side before the API call, matching the create path
 - vRouter interface validation now accepts an untagged VLAN (-1), matching the Azure peer and shared VLAN checks. Previously a `-1` VLAN was rejected client-side even though the API accepts it, which also blocked the interactive "press Enter for no VLAN" path

--- a/internal/commands/vxc/vxc_inputs.go
+++ b/internal/commands/vxc/vxc_inputs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/utils"
 	"github.com/megaport/megaport-cli/internal/validation"
 	megaport "github.com/megaport/megaportgo"
@@ -42,14 +43,21 @@ var buildVXCRequestFromFlags = func(cmd *cobra.Command, ctx context.Context, svc
 	serviceKey, _ := cmd.Flags().GetString("service-key")
 	costCentre, _ := cmd.Flags().GetString("cost-centre")
 
+	resourceTagsStr, _ := cmd.Flags().GetString("resource-tags")
+	resourceTags, err := utils.ParseResourceTagsFlag(resourceTagsStr)
+	if err != nil {
+		return nil, exitcodes.NewUsageError(err)
+	}
+
 	// Create the base request
 	req := &megaport.BuyVXCRequest{
-		VXCName:    name,
-		RateLimit:  rateLimit,
-		Term:       term,
-		PromoCode:  promoCode,
-		ServiceKey: serviceKey,
-		CostCentre: costCentre,
+		VXCName:      name,
+		RateLimit:    rateLimit,
+		Term:         term,
+		PromoCode:    promoCode,
+		ServiceKey:   serviceKey,
+		CostCentre:   costCentre,
+		ResourceTags: resourceTags,
 	}
 
 	// A-End configuration
@@ -285,17 +293,11 @@ func buildVXCRequestFromJSON(jsonStr string, jsonFilePath string) (*megaport.Buy
 	if resourceTags, present, err := utils.JSONObject(rawData, "resourceTags"); err != nil {
 		return nil, err
 	} else if present {
-		req.ResourceTags = make(map[string]string)
-		for k, v := range resourceTags {
-			strValue, ok := v.(string)
-			if !ok {
-				return nil, fmt.Errorf("resourceTags value for key %q must be a string", k)
-			}
-			req.ResourceTags[k] = strValue
-		}
-		if err := utils.RejectEmptyTagKeys(req.ResourceTags); err != nil {
+		tags, err := utils.TagMapFromObject(resourceTags)
+		if err != nil {
 			return nil, err
 		}
+		req.ResourceTags = tags
 	}
 
 	// Handle A-End configuration

--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -2,10 +2,12 @@ package vxc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
 
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -1573,6 +1575,91 @@ func TestBuildVXCRequestFromFlags_VNICIndexZero(t *testing.T) {
 		require.NoError(t, err)
 		assert.Nil(t, req.AEndConfiguration.VXCOrderMVEConfig)
 		assert.Nil(t, req.BEndConfiguration.VXCOrderMVEConfig)
+	})
+}
+
+func TestBuildVXCRequestFromFlags_ResourceTags(t *testing.T) {
+	newBuyCmd := func() *cobra.Command {
+		cmd := &cobra.Command{Use: "buy"}
+		cmd.Flags().String("a-end-uid", "", "")
+		cmd.Flags().String("b-end-uid", "", "")
+		cmd.Flags().String("name", "", "")
+		cmd.Flags().Int("rate-limit", 0, "")
+		cmd.Flags().Int("term", 0, "")
+		cmd.Flags().Int("a-end-vlan", 0, "")
+		cmd.Flags().Int("b-end-vlan", 0, "")
+		cmd.Flags().Int("a-end-inner-vlan", 0, "")
+		cmd.Flags().Int("b-end-inner-vlan", 0, "")
+		cmd.Flags().Int("a-end-vnic-index", 0, "")
+		cmd.Flags().Int("b-end-vnic-index", 0, "")
+		cmd.Flags().String("promo-code", "", "")
+		cmd.Flags().String("service-key", "", "")
+		cmd.Flags().String("cost-centre", "", "")
+		cmd.Flags().String("a-end-partner-config", "", "")
+		cmd.Flags().String("b-end-partner-config", "", "")
+		cmd.Flags().String("resource-tags", "", "")
+		require.NoError(t, cmd.Flags().Set("name", "Test VXC"))
+		require.NoError(t, cmd.Flags().Set("a-end-uid", "a-end-uid-123"))
+		require.NoError(t, cmd.Flags().Set("b-end-uid", "b-end-uid-123"))
+		require.NoError(t, cmd.Flags().Set("rate-limit", "100"))
+		require.NoError(t, cmd.Flags().Set("term", "1"))
+		return cmd
+	}
+
+	t.Run("tags round-trip through the flags path", func(t *testing.T) {
+		cmd := newBuyCmd()
+		require.NoError(t, cmd.Flags().Set("resource-tags", `{"env":"prod","team":"networking"}`))
+
+		req, err := buildVXCRequestFromFlags(cmd, context.Background(), &MockVXCService{})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"env": "prod", "team": "networking"}, req.ResourceTags)
+	})
+
+	t.Run("no flag leaves tags nil", func(t *testing.T) {
+		cmd := newBuyCmd()
+
+		req, err := buildVXCRequestFromFlags(cmd, context.Background(), &MockVXCService{})
+		require.NoError(t, err)
+		assert.Nil(t, req.ResourceTags)
+	})
+
+	t.Run("malformed JSON is a usage error", func(t *testing.T) {
+		cmd := newBuyCmd()
+		require.NoError(t, cmd.Flags().Set("resource-tags", `{bad}`))
+
+		_, err := buildVXCRequestFromFlags(cmd, context.Background(), &MockVXCService{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse resource tags JSON")
+
+		var cliErr *exitcodes.CLIError
+		require.True(t, errors.As(err, &cliErr))
+		assert.Equal(t, exitcodes.Usage, cliErr.Code)
+	})
+
+	t.Run("empty tag key rejected", func(t *testing.T) {
+		cmd := newBuyCmd()
+		require.NoError(t, cmd.Flags().Set("resource-tags", `{"":"x"}`))
+
+		_, err := buildVXCRequestFromFlags(cmd, context.Background(), &MockVXCService{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tag key must not be empty")
+
+		var cliErr *exitcodes.CLIError
+		require.True(t, errors.As(err, &cliErr))
+		assert.Equal(t, exitcodes.Usage, cliErr.Code)
+	})
+
+	t.Run("null tag value rejected, matching the JSON path", func(t *testing.T) {
+		cmd := newBuyCmd()
+		require.NoError(t, cmd.Flags().Set("resource-tags", `{"env":null}`))
+
+		_, err := buildVXCRequestFromFlags(cmd, context.Background(), &MockVXCService{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `resourceTags value for key "env" must be a string`)
+
+		var cliErr *exitcodes.CLIError
+		require.True(t, errors.As(err, &cliErr))
+		assert.Equal(t, exitcodes.Usage, cliErr.Code)
 	})
 }
 

--- a/internal/utils/resource_tags.go
+++ b/internal/utils/resource_tags.go
@@ -189,6 +189,42 @@ func RejectEmptyTagKeys(tags map[string]string) error {
 	return nil
 }
 
+// TagMapFromObject converts a decoded JSON object into a string tag map,
+// rejecting non-string values (including null) and empty keys. It is the shared
+// validation behind both the --resource-tags flag and the JSON-body
+// resourceTags field so the two paths accept and reject identically.
+func TagMapFromObject(raw map[string]interface{}) (map[string]string, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	tags := make(map[string]string, len(raw))
+	for k, v := range raw {
+		strValue, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("resourceTags value for key %q must be a string", k)
+		}
+		tags[k] = strValue
+	}
+	if err := RejectEmptyTagKeys(tags); err != nil {
+		return nil, err
+	}
+	return tags, nil
+}
+
+// ParseResourceTagsFlag parses the --resource-tags JSON string into a tag map,
+// applying the same value and empty-key validation as the JSON path. An empty
+// string (flag unset) yields a nil map and no error.
+func ParseResourceTagsFlag(resourceTagsStr string) (map[string]string, error) {
+	if resourceTagsStr == "" {
+		return nil, nil
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal([]byte(resourceTagsStr), &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse resource tags JSON: %w", err)
+	}
+	return TagMapFromObject(raw)
+}
+
 // ParseResourceTagsInput reads resource tags from --json or --json-file flags.
 func ParseResourceTagsInput(cmd *cobra.Command) (map[string]string, error) {
 	jsonStr, _ := cmd.Flags().GetString("json")

--- a/internal/utils/resource_tags_test.go
+++ b/internal/utils/resource_tags_test.go
@@ -443,3 +443,41 @@ func TestUpdateResourceTags(t *testing.T) {
 		assert.Contains(t, err.Error(), "no input provided")
 	})
 }
+
+func TestParseResourceTagsFlag(t *testing.T) {
+	t.Run("valid tags parse and round-trip", func(t *testing.T) {
+		tags, err := ParseResourceTagsFlag(`{"env":"prod","team":"net"}`)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"env": "prod", "team": "net"}, tags)
+	})
+
+	t.Run("empty string yields nil map", func(t *testing.T) {
+		tags, err := ParseResourceTagsFlag("")
+		require.NoError(t, err)
+		assert.Nil(t, tags)
+	})
+
+	t.Run("malformed JSON returns parse error", func(t *testing.T) {
+		_, err := ParseResourceTagsFlag(`{bad}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse resource tags JSON")
+	})
+
+	t.Run("non-string value rejected, matching the JSON path", func(t *testing.T) {
+		_, err := ParseResourceTagsFlag(`{"env":123}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `resourceTags value for key "env" must be a string`)
+	})
+
+	t.Run("null value rejected, matching the JSON path", func(t *testing.T) {
+		_, err := ParseResourceTagsFlag(`{"env":null}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `resourceTags value for key "env" must be a string`)
+	})
+
+	t.Run("empty key rejected", func(t *testing.T) {
+		_, err := ParseResourceTagsFlag(`{"":"x"}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tag key must not be empty")
+	})
+}


### PR DESCRIPTION
`vxc buy --resource-tags '{"env":"prod"}'` built the order from flags and silently dropped the tags: the flags builder never read the flag, while the `--json` path applied it. This wires the flag in so both paths set tags identically.

- `buildVXCRequestFromFlags` now reads `--resource-tags` and assigns it to the buy request, matching the JSON path.
- Parsing goes through a new shared `utils.ParseResourceTagsFlag` helper (json parse + empty-key rejection), so the two paths converge on one parse and one validation.
- Malformed `--resource-tags` JSON now returns a usage error (exit 2) before any order call, instead of being misclassified.
- Tests: flags-path round-trip, nil-when-unset, malformed-JSON usage error, and empty-key rejection, plus direct helper coverage.

Follow-up (out of scope, pre-existing): `--resource-tags-file` is registered on `vxc buy` (and ports/mcr) but unwired on every input path. Worth a separate ticket.