### PR TITLE
ESD-1556: wire resource-tag flags into the buy flags builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 
 ### Fixed
 - `vxc buy --resource-tags` now applies tags when buying via flags, matching the `--json` path. Previously the flag was registered but silently ignored. Both paths now share one parse and validation, so malformed JSON, non-string values, and empty keys return a usage error before the order is placed
+- `mve buy --resource-tags` / `--resource-tags-file` and the `--resource-tags-file` flag on `vxc`, `ports`, and `mcr` buy now apply tags on the flags path, matching `nat-gateway`. Previously these registered flags were silently ignored; malformed JSON, non-string values, and empty keys now return a usage error before the order is placed
 - vRouter `bgpConnections` are now parsed from JSON input (`--json` / `--a-end-partner-config` / `--b-end-partner-config`) when buying or updating a VXC. Previously they were silently dropped on the JSON path and only honored via the interactive prompts
 - `vxc update` now validates vRouter partner configs (interfaces, BGP, and IPsec tunnels) client-side before the API call, matching the create path
 - vRouter interface validation now accepts an untagged VLAN (-1), matching the Azure peer and shared VLAN checks. Previously a `-1` VLAN was rejected client-side even though the API accepts it, which also blocked the interactive "press Enter for no VLAN" path

--- a/internal/commands/mcr/mcr_inputs.go
+++ b/internal/commands/mcr/mcr_inputs.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/commands/config"
 	"github.com/megaport/megaport-cli/internal/utils"
 	"github.com/megaport/megaport-cli/internal/validation"
@@ -76,11 +77,10 @@ func processFlagMCRInput(cmd *cobra.Command) (*megaport.BuyMCRRequest, error) {
 	diversityZone, _ := cmd.Flags().GetString("diversity-zone")
 
 	resourceTagsStr, _ := cmd.Flags().GetString("resource-tags")
-	var resourceTags map[string]string
-	if resourceTagsStr != "" {
-		if err := json.Unmarshal([]byte(resourceTagsStr), &resourceTags); err != nil {
-			return nil, fmt.Errorf("failed to parse resource tags JSON: %w", err)
-		}
+	resourceTagsFile, _ := cmd.Flags().GetString("resource-tags-file")
+	resourceTags, err := utils.ParseResourceTagsFlagOrFile(resourceTagsStr, resourceTagsFile)
+	if err != nil {
+		return nil, exitcodes.NewUsageError(err)
 	}
 
 	req := &megaport.BuyMCRRequest{

--- a/internal/commands/mcr/mcr_inputs_tags_file_test.go
+++ b/internal/commands/mcr/mcr_inputs_tags_file_test.go
@@ -1,0 +1,56 @@
+package mcr
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessFlagMCRInput_ResourceTagsFile(t *testing.T) {
+	newBuyCmd := func() *cobra.Command {
+		cmd := &cobra.Command{Use: "test"}
+		cmd.Flags().String("name", "test-mcr", "")
+		cmd.Flags().Int("term", 12, "")
+		cmd.Flags().Int("port-speed", 5000, "")
+		cmd.Flags().Int("location-id", 1, "")
+		cmd.Flags().Int("mcr-asn", 0, "")
+		cmd.Flags().String("cost-centre", "", "")
+		cmd.Flags().String("promo-code", "", "")
+		cmd.Flags().String("diversity-zone", "", "")
+		cmd.Flags().String("resource-tags", "", "")
+		cmd.Flags().String("resource-tags-file", "", "")
+		cmd.Flags().Int("ipsec-tunnel-count", 0, "")
+		return cmd
+	}
+
+	t.Run("tags from file round-trip", func(t *testing.T) {
+		cmd := newBuyCmd()
+		path := filepath.Join(t.TempDir(), "tags.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"env":"prod","owner":"net"}`), 0o600))
+		require.NoError(t, cmd.Flags().Set("resource-tags-file", path))
+
+		req, err := processFlagMCRInput(cmd)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"env": "prod", "owner": "net"}, req.ResourceTags)
+	})
+
+	t.Run("malformed file JSON is a usage error", func(t *testing.T) {
+		cmd := newBuyCmd()
+		path := filepath.Join(t.TempDir(), "tags.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{bad}`), 0o600))
+		require.NoError(t, cmd.Flags().Set("resource-tags-file", path))
+
+		_, err := processFlagMCRInput(cmd)
+		require.Error(t, err)
+
+		var cliErr *exitcodes.CLIError
+		require.True(t, errors.As(err, &cliErr))
+		assert.Equal(t, exitcodes.Usage, cliErr.Code)
+	})
+}

--- a/internal/commands/mve/mve_inputs.go
+++ b/internal/commands/mve/mve_inputs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/utils"
 	"github.com/megaport/megaport-cli/internal/validation"
 	megaport "github.com/megaport/megaportgo"
@@ -115,6 +116,8 @@ func processFlagBuyMVEInput(cmd *cobra.Command) (*megaport.BuyMVERequest, error)
 	costCentre, _ := cmd.Flags().GetString("cost-centre")
 	vendorConfigStr, _ := cmd.Flags().GetString("vendor-config")
 	vnicsStr, _ := cmd.Flags().GetString("vnics")
+	resourceTagsStr, _ := cmd.Flags().GetString("resource-tags")
+	resourceTagsFile, _ := cmd.Flags().GetString("resource-tags-file")
 
 	var vendorConfig megaport.VendorConfig
 	if vendorConfigStr != "" {
@@ -155,6 +158,11 @@ func processFlagBuyMVEInput(cmd *cobra.Command) (*megaport.BuyMVERequest, error)
 		}
 	}
 
+	resourceTags, err := utils.ParseResourceTagsFlagOrFile(resourceTagsStr, resourceTagsFile)
+	if err != nil {
+		return nil, exitcodes.NewUsageError(err)
+	}
+
 	req := &megaport.BuyMVERequest{
 		Name:          name,
 		Term:          term,
@@ -164,6 +172,7 @@ func processFlagBuyMVEInput(cmd *cobra.Command) (*megaport.BuyMVERequest, error)
 		CostCentre:    costCentre,
 		VendorConfig:  vendorConfig,
 		Vnics:         vnics,
+		ResourceTags:  resourceTags,
 	}
 
 	if err := validation.ValidateBuyMVERequest(req); err != nil {

--- a/internal/commands/mve/mve_inputs_tags_test.go
+++ b/internal/commands/mve/mve_inputs_tags_test.go
@@ -1,0 +1,76 @@
+package mve
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessFlagBuyMVEInput_ResourceTags(t *testing.T) {
+	const validVendorConfig = `{"vendor":"aruba","productSize":"MEDIUM","imageId":1,"accountName":"test","accountKey":"test","systemTag":"test"}`
+
+	newBuyCmd := func(t *testing.T) *cobra.Command {
+		cmd := &cobra.Command{Use: "buy"}
+		cmd.Flags().String("name", "", "")
+		cmd.Flags().Int("term", 0, "")
+		cmd.Flags().Int("location-id", 0, "")
+		cmd.Flags().String("diversity-zone", "", "")
+		cmd.Flags().String("promo-code", "", "")
+		cmd.Flags().String("cost-centre", "", "")
+		cmd.Flags().String("vendor-config", "", "")
+		cmd.Flags().String("vnics", "", "")
+		cmd.Flags().String("resource-tags", "", "")
+		cmd.Flags().String("resource-tags-file", "", "")
+		require.NoError(t, cmd.Flags().Set("name", "Test MVE"))
+		require.NoError(t, cmd.Flags().Set("term", "12"))
+		require.NoError(t, cmd.Flags().Set("location-id", "123"))
+		require.NoError(t, cmd.Flags().Set("vendor-config", validVendorConfig))
+		return cmd
+	}
+
+	t.Run("tags round-trip through the flags path", func(t *testing.T) {
+		cmd := newBuyCmd(t)
+		require.NoError(t, cmd.Flags().Set("resource-tags", `{"env":"prod","owner":"netops"}`))
+
+		req, err := processFlagBuyMVEInput(cmd)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"env": "prod", "owner": "netops"}, req.ResourceTags)
+	})
+
+	t.Run("tags from file round-trip", func(t *testing.T) {
+		cmd := newBuyCmd(t)
+		path := filepath.Join(t.TempDir(), "tags.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"env":"staging"}`), 0o600))
+		require.NoError(t, cmd.Flags().Set("resource-tags-file", path))
+
+		req, err := processFlagBuyMVEInput(cmd)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"env": "staging"}, req.ResourceTags)
+	})
+
+	t.Run("no tag flags leaves tags nil", func(t *testing.T) {
+		cmd := newBuyCmd(t)
+
+		req, err := processFlagBuyMVEInput(cmd)
+		require.NoError(t, err)
+		assert.Nil(t, req.ResourceTags)
+	})
+
+	t.Run("malformed JSON is a usage error", func(t *testing.T) {
+		cmd := newBuyCmd(t)
+		require.NoError(t, cmd.Flags().Set("resource-tags", `{bad}`))
+
+		_, err := processFlagBuyMVEInput(cmd)
+		require.Error(t, err)
+
+		var cliErr *exitcodes.CLIError
+		require.True(t, errors.As(err, &cliErr))
+		assert.Equal(t, exitcodes.Usage, cliErr.Code)
+	})
+}

--- a/internal/commands/ports/ports_inputs.go
+++ b/internal/commands/ports/ports_inputs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/utils"
 	"github.com/megaport/megaport-cli/internal/validation"
 	megaport "github.com/megaport/megaportgo"
@@ -22,11 +23,10 @@ func processFlagLAGPortInput(cmd *cobra.Command) (*megaport.BuyPortRequest, erro
 	costCentre, _ := cmd.Flags().GetString("cost-centre")
 	promoCode, _ := cmd.Flags().GetString("promo-code")
 	resourceTagsStr, _ := cmd.Flags().GetString("resource-tags")
-	var resourceTags map[string]string
-	if resourceTagsStr != "" {
-		if err := json.Unmarshal([]byte(resourceTagsStr), &resourceTags); err != nil {
-			return nil, fmt.Errorf("failed to parse resource tags JSON: %w", err)
-		}
+	resourceTagsFile, _ := cmd.Flags().GetString("resource-tags-file")
+	resourceTags, err := utils.ParseResourceTagsFlagOrFile(resourceTagsStr, resourceTagsFile)
+	if err != nil {
+		return nil, exitcodes.NewUsageError(err)
 	}
 
 	req := &megaport.BuyPortRequest{
@@ -130,11 +130,10 @@ func processFlagPortInput(cmd *cobra.Command) (*megaport.BuyPortRequest, error) 
 	costCentre, _ := cmd.Flags().GetString("cost-centre")
 	promoCode, _ := cmd.Flags().GetString("promo-code")
 	resourceTagsStr, _ := cmd.Flags().GetString("resource-tags")
-	var resourceTags map[string]string
-	if resourceTagsStr != "" {
-		if err := json.Unmarshal([]byte(resourceTagsStr), &resourceTags); err != nil {
-			return nil, fmt.Errorf("failed to parse resource tags JSON: %w", err)
-		}
+	resourceTagsFile, _ := cmd.Flags().GetString("resource-tags-file")
+	resourceTags, err := utils.ParseResourceTagsFlagOrFile(resourceTagsStr, resourceTagsFile)
+	if err != nil {
+		return nil, exitcodes.NewUsageError(err)
 	}
 
 	req := &megaport.BuyPortRequest{

--- a/internal/commands/ports/ports_inputs_tags_file_test.go
+++ b/internal/commands/ports/ports_inputs_tags_file_test.go
@@ -1,0 +1,71 @@
+package ports
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newBuyPortTagCmd(t *testing.T) *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().Int("term", 0, "")
+	cmd.Flags().Int("port-speed", 0, "")
+	cmd.Flags().Int("location-id", 0, "")
+	cmd.Flags().Int("lag-count", 0, "")
+	cmd.Flags().Bool("marketplace-visibility", false, "")
+	cmd.Flags().String("diversity-zone", "", "")
+	cmd.Flags().String("cost-centre", "", "")
+	cmd.Flags().String("promo-code", "", "")
+	cmd.Flags().String("resource-tags", "", "")
+	cmd.Flags().String("resource-tags-file", "", "")
+	require.NoError(t, cmd.Flags().Set("name", "test-port"))
+	require.NoError(t, cmd.Flags().Set("term", "12"))
+	require.NoError(t, cmd.Flags().Set("port-speed", "10000"))
+	require.NoError(t, cmd.Flags().Set("location-id", "1"))
+	require.NoError(t, cmd.Flags().Set("marketplace-visibility", "true"))
+	return cmd
+}
+
+func TestProcessFlagPortInput_ResourceTagsFile(t *testing.T) {
+	cmd := newBuyPortTagCmd(t)
+	path := filepath.Join(t.TempDir(), "tags.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"env":"prod"}`), 0o600))
+	require.NoError(t, cmd.Flags().Set("resource-tags-file", path))
+
+	req, err := processFlagPortInput(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"env": "prod"}, req.ResourceTags)
+}
+
+func TestProcessFlagLAGPortInput_ResourceTagsFile(t *testing.T) {
+	cmd := newBuyPortTagCmd(t)
+	require.NoError(t, cmd.Flags().Set("lag-count", "2"))
+	path := filepath.Join(t.TempDir(), "tags.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"env":"prod"}`), 0o600))
+	require.NoError(t, cmd.Flags().Set("resource-tags-file", path))
+
+	req, err := processFlagLAGPortInput(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"env": "prod"}, req.ResourceTags)
+}
+
+func TestProcessFlagPortInput_ResourceTagsFileMalformed(t *testing.T) {
+	cmd := newBuyPortTagCmd(t)
+	path := filepath.Join(t.TempDir(), "tags.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{bad}`), 0o600))
+	require.NoError(t, cmd.Flags().Set("resource-tags-file", path))
+
+	_, err := processFlagPortInput(cmd)
+	require.Error(t, err)
+
+	var cliErr *exitcodes.CLIError
+	require.True(t, errors.As(err, &cliErr))
+	assert.Equal(t, exitcodes.Usage, cliErr.Code)
+}

--- a/internal/commands/vxc/vxc_inputs.go
+++ b/internal/commands/vxc/vxc_inputs.go
@@ -44,7 +44,8 @@ var buildVXCRequestFromFlags = func(cmd *cobra.Command, ctx context.Context, svc
 	costCentre, _ := cmd.Flags().GetString("cost-centre")
 
 	resourceTagsStr, _ := cmd.Flags().GetString("resource-tags")
-	resourceTags, err := utils.ParseResourceTagsFlag(resourceTagsStr)
+	resourceTagsFile, _ := cmd.Flags().GetString("resource-tags-file")
+	resourceTags, err := utils.ParseResourceTagsFlagOrFile(resourceTagsStr, resourceTagsFile)
 	if err != nil {
 		return nil, exitcodes.NewUsageError(err)
 	}

--- a/internal/commands/vxc/vxc_inputs_tags_file_test.go
+++ b/internal/commands/vxc/vxc_inputs_tags_file_test.go
@@ -1,0 +1,65 @@
+package vxc
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildVXCRequestFromFlags_ResourceTagsFile(t *testing.T) {
+	newBuyCmd := func(t *testing.T) *cobra.Command {
+		cmd := &cobra.Command{Use: "buy"}
+		cmd.Flags().String("a-end-uid", "", "")
+		cmd.Flags().String("b-end-uid", "", "")
+		cmd.Flags().String("name", "", "")
+		cmd.Flags().Int("rate-limit", 0, "")
+		cmd.Flags().Int("term", 0, "")
+		cmd.Flags().Int("a-end-vlan", 0, "")
+		cmd.Flags().Int("b-end-vlan", 0, "")
+		cmd.Flags().Int("a-end-inner-vlan", 0, "")
+		cmd.Flags().Int("b-end-inner-vlan", 0, "")
+		cmd.Flags().Int("a-end-vnic-index", 0, "")
+		cmd.Flags().Int("b-end-vnic-index", 0, "")
+		cmd.Flags().String("promo-code", "", "")
+		cmd.Flags().String("service-key", "", "")
+		cmd.Flags().String("cost-centre", "", "")
+		cmd.Flags().String("a-end-partner-config", "", "")
+		cmd.Flags().String("b-end-partner-config", "", "")
+		cmd.Flags().String("resource-tags", "", "")
+		cmd.Flags().String("resource-tags-file", "", "")
+		require.NoError(t, cmd.Flags().Set("name", "Test VXC"))
+		require.NoError(t, cmd.Flags().Set("a-end-uid", "a-end-uid-123"))
+		require.NoError(t, cmd.Flags().Set("b-end-uid", "b-end-uid-123"))
+		require.NoError(t, cmd.Flags().Set("rate-limit", "100"))
+		require.NoError(t, cmd.Flags().Set("term", "1"))
+		return cmd
+	}
+
+	t.Run("tags from file round-trip", func(t *testing.T) {
+		cmd := newBuyCmd(t)
+		path := filepath.Join(t.TempDir(), "tags.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"env":"prod","team":"networking"}`), 0o600))
+		require.NoError(t, cmd.Flags().Set("resource-tags-file", path))
+
+		req, err := buildVXCRequestFromFlags(cmd, context.Background(), &MockVXCService{})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"env": "prod", "team": "networking"}, req.ResourceTags)
+	})
+
+	t.Run("flag string takes precedence over file", func(t *testing.T) {
+		cmd := newBuyCmd(t)
+		path := filepath.Join(t.TempDir(), "tags.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"from":"file"}`), 0o600))
+		require.NoError(t, cmd.Flags().Set("resource-tags", `{"from":"string"}`))
+		require.NoError(t, cmd.Flags().Set("resource-tags-file", path))
+
+		req, err := buildVXCRequestFromFlags(cmd, context.Background(), &MockVXCService{})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"from": "string"}, req.ResourceTags)
+	})
+}

--- a/internal/utils/resource_tags.go
+++ b/internal/utils/resource_tags.go
@@ -215,11 +215,30 @@ func TagMapFromObject(raw map[string]interface{}) (map[string]string, error) {
 // applying the same value and empty-key validation as the JSON path. An empty
 // string (flag unset) yields a nil map and no error.
 func ParseResourceTagsFlag(resourceTagsStr string) (map[string]string, error) {
-	if resourceTagsStr == "" {
+	return ParseResourceTagsFlagOrFile(resourceTagsStr, "")
+}
+
+// ParseResourceTagsFlagOrFile parses resource tags from the --resource-tags JSON
+// string or, when that is empty, the --resource-tags-file path. The string takes
+// precedence over the file (matching utils.ReadJSONInput). It applies the same
+// value and empty-key validation as the JSON path via TagMapFromObject. When
+// neither is set it returns a nil map and no error.
+func ParseResourceTagsFlagOrFile(resourceTagsStr, resourceTagsFile string) (map[string]string, error) {
+	var data []byte
+	switch {
+	case resourceTagsStr != "":
+		data = []byte(resourceTagsStr)
+	case resourceTagsFile != "":
+		fileData, err := readTagsFile(resourceTagsFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read resource tags file: %w", err)
+		}
+		data = fileData
+	default:
 		return nil, nil
 	}
 	var raw map[string]interface{}
-	if err := json.Unmarshal([]byte(resourceTagsStr), &raw); err != nil {
+	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil, fmt.Errorf("failed to parse resource tags JSON: %w", err)
 	}
 	return TagMapFromObject(raw)

--- a/internal/utils/resource_tags_flagorfile_test.go
+++ b/internal/utils/resource_tags_flagorfile_test.go
@@ -1,0 +1,75 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseResourceTagsFlagOrFile(t *testing.T) {
+	t.Run("string round-trips", func(t *testing.T) {
+		tags, err := ParseResourceTagsFlagOrFile(`{"env":"prod"}`, "")
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"env": "prod"}, tags)
+	})
+
+	t.Run("file round-trips", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "tags.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"env":"staging","team":"net"}`), 0o600))
+
+		tags, err := ParseResourceTagsFlagOrFile("", path)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"env": "staging", "team": "net"}, tags)
+	})
+
+	t.Run("string takes precedence over file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "tags.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"from":"file"}`), 0o600))
+
+		tags, err := ParseResourceTagsFlagOrFile(`{"from":"string"}`, path)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"from": "string"}, tags)
+	})
+
+	t.Run("neither set yields nil", func(t *testing.T) {
+		tags, err := ParseResourceTagsFlagOrFile("", "")
+		require.NoError(t, err)
+		assert.Nil(t, tags)
+	})
+
+	t.Run("malformed file JSON returns parse error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "tags.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{bad}`), 0o600))
+
+		_, err := ParseResourceTagsFlagOrFile("", path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse resource tags JSON")
+	})
+
+	t.Run("missing file returns read error", func(t *testing.T) {
+		_, err := ParseResourceTagsFlagOrFile("", filepath.Join(t.TempDir(), "absent.json"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read resource tags file")
+	})
+
+	t.Run("empty key from file rejected", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "tags.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"":"x"}`), 0o600))
+
+		_, err := ParseResourceTagsFlagOrFile("", path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tag key must not be empty")
+	})
+
+	t.Run("non-string value from file rejected, matching the JSON path", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "tags.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"env":123}`), 0o600))
+
+		_, err := ParseResourceTagsFlagOrFile("", path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `resourceTags value for key "env" must be a string`)
+	})
+}


### PR DESCRIPTION
Stacked on #464 (ESD-1549). Review/merge that first; this PR targets its branch so the diff shows only the ESD-1556 changes.

`WithResourceTagFlags` registers `--resource-tags` and `--resource-tags-file` on every buy command, but the flags builders only honored some of them: `mve buy` dropped both, and `vxc`/`ports`/`mcr` ignored `--resource-tags-file`. The flags were registered and documented, so the user got no signal they did nothing.

This wires all four buy flags builders through one shared helper.

- New `utils.ParseResourceTagsFlagOrFile`: reads the `--resource-tags` JSON string or, when empty, the `--resource-tags-file` path (string wins, mirroring `utils.ReadJSONInput`), validating through `TagMapFromObject` so the flags and JSON paths accept and reject identically.
- `vxc`, `ports` (both port and LAG builders), `mcr`, and `mve` buy now use it. MVE was net-new (it read neither flag).
- Malformed JSON, non-string values, and empty keys return a usage error (exit 2) before any order is placed.
- Unit tests: file-path round-trip per resource type, MVE flags-path round-trip, string-over-file precedence, and malformed-input usage errors.

Out of scope: JSON/interactive paths, `nat-gateway` (the reference), and update commands are untouched.