### PR TITLE
test(integration): add location and MVE capacity fallback (ESD-1559)

### DIFF
--- a/internal/commands/apply/apply_integration_test.go
+++ b/internal/commands/apply/apply_integration_test.go
@@ -22,9 +22,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// integrationLocationID is the staging data center used for all apply lifecycle
-// tests. Location 67 matches the canonical example used across the CLI test
-// suite and supports the 1G port speed these tests exercise.
+// integrationLocationID is the staging data center apply lifecycle tests prefer.
+// FindPortTestLocation falls back to another orderable location advertising the
+// 1G port speed these tests exercise when it is out of capacity.
 const integrationLocationID = 67
 
 // 90s allows for apply's sequential teardown: VXCs are deleted and polled to
@@ -225,10 +225,11 @@ func registerSweepCleanup(t *testing.T, prefix string) {
 	})
 }
 
-// twoPortVXCConfig returns a YAML apply config with two ports and one
-// port-to-port VXC whose endpoints reference the ports via {{.port.<name>}}
-// templates. Names are derived from prefix so a single sweep cleans them up.
-func twoPortVXCConfig(prefix string) (yamlContent, portAName, portBName, vxcName string) {
+// twoPortVXCConfig returns a YAML apply config with two ports (both at
+// locationID) and one port-to-port VXC whose endpoints reference the ports via
+// {{.port.<name>}} templates. Names are derived from prefix so a single sweep
+// cleans them up.
+func twoPortVXCConfig(prefix string, locationID int) (yamlContent, portAName, portBName, vxcName string) {
 	portAName = prefix + "-PortA"
 	portBName = prefix + "-PortB"
 	vxcName = prefix + "-VXC"
@@ -251,7 +252,7 @@ vxcs:
       product_uid: "{{.port.%s}}"
     b_end:
       product_uid: "{{.port.%s}}"
-`, portAName, integrationLocationID, portBName, integrationLocationID, vxcName, portAName, portBName)
+`, portAName, locationID, portBName, locationID, vxcName, portAName, portBName)
 	return yamlContent, portAName, portBName, vxcName
 }
 
@@ -261,7 +262,8 @@ func TestIntegration_ApplyDryRun(t *testing.T) {
 	prefix := fmt.Sprintf("CLI-Apply-Test-%s", generateUniqueID(t))
 	registerSweepCleanup(t, prefix) // safety net; dry-run should create nothing
 
-	yamlContent, portAName, portBName, _ := twoPortVXCConfig(prefix)
+	locationID := testutil.FindPortTestLocation(t, testutil.SharedIntegrationClient(t), 1000, integrationLocationID)
+	yamlContent, portAName, portBName, _ := twoPortVXCConfig(prefix, locationID)
 	cfgPath := writeApplyConfig(t, yamlContent)
 	cmd := applyIntegrationCmd(t, cfgPath, true /*dryRun*/, true /*yes*/, false /*rollback*/)
 
@@ -310,7 +312,8 @@ func TestIntegration_ApplyLifecycle(t *testing.T) {
 	prefix := fmt.Sprintf("CLI-Apply-Test-%s", generateUniqueID(t))
 	registerSweepCleanup(t, prefix)
 
-	yamlContent, portAName, portBName, vxcName := twoPortVXCConfig(prefix)
+	locationID := testutil.FindPortTestLocation(t, testutil.SharedIntegrationClient(t), 1000, integrationLocationID)
+	yamlContent, portAName, portBName, vxcName := twoPortVXCConfig(prefix, locationID)
 	cfgPath := writeApplyConfig(t, yamlContent)
 	cmd := applyIntegrationCmd(t, cfgPath, false /*dryRun*/, true /*yes*/, false /*rollback*/)
 
@@ -347,6 +350,7 @@ func TestIntegration_ApplyRollbackOnFailure(t *testing.T) {
 
 	portName := prefix + "-Port"
 	vxcName := prefix + "-VXC"
+	locationID := testutil.FindPortTestLocation(t, testutil.SharedIntegrationClient(t), 1000, integrationLocationID)
 	// One valid port, then a VXC whose b_end references a non-existent resource.
 	// The port provisions for real; the VXC stage fails at template resolution
 	// before any VXC order is placed, so only the port is ever created. Rollback
@@ -365,7 +369,7 @@ vxcs:
       product_uid: "{{.port.%s}}"
     b_end:
       product_uid: "{{.port.DoesNotExist}}"
-`, portName, integrationLocationID, vxcName, portName)
+`, portName, locationID, vxcName, portName)
 
 	cfgPath := writeApplyConfig(t, yamlContent)
 	cmd := applyIntegrationCmd(t, cfgPath, false /*dryRun*/, true /*yes*/, true /*rollback*/)

--- a/internal/commands/mcr/mcr_integration_test.go
+++ b/internal/commands/mcr/mcr_integration_test.go
@@ -117,10 +117,10 @@ func integrationMCRPrefixFilterCmd() *cobra.Command {
 	return cmd
 }
 
-// parseCreatedUID pulls the resource UID out of a "<resource> created <uid>"
-// success message.
-func parseCreatedUID(out, resource string) string {
-	marker := resource + " created "
+// parseCreatedUID pulls the MCR UID out of a "MCR created <uid>" success
+// message.
+func parseCreatedUID(out string) string {
+	const marker = "MCR created "
 	for _, line := range strings.Split(out, "\n") {
 		if i := strings.Index(line, marker); i >= 0 {
 			return strings.TrimSpace(line[i+len(marker):])
@@ -188,7 +188,7 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 	buyOut := captureTableOutput(func() { buyErr = BuyMCR(buyCmd, nil, true) })
 	require.NoError(t, buyErr, "buy MCR output: %s", buyOut)
 
-	mcrUID := parseCreatedUID(buyOut, "MCR")
+	mcrUID := parseCreatedUID(buyOut)
 	// Register cleanup before asserting on mcrUID, so any created MCR is
 	// deleted even if the UID parse fails.
 	t.Cleanup(func() {
@@ -381,7 +381,7 @@ func TestIntegration_MCRJSONInputLifecycle(t *testing.T) {
 	buyOut := captureTableOutput(func() { buyErr = BuyMCR(buyCmd, nil, true) })
 	require.NoError(t, buyErr, "buy MCR (JSON) output: %s", buyOut)
 
-	mcrUID := parseCreatedUID(buyOut, "MCR")
+	mcrUID := parseCreatedUID(buyOut)
 	// Register cleanup before asserting on mcrUID, so any created MCR is
 	// deleted even if the UID parse fails.
 	t.Cleanup(func() {
@@ -513,7 +513,7 @@ func TestIntegration_MCRIPv6PrefixFilterLifecycle(t *testing.T) {
 	buyOut := captureTableOutput(func() { buyErr = BuyMCR(buyCmd, nil, true) })
 	require.NoError(t, buyErr, "buy MCR output: %s", buyOut)
 
-	mcrUID := parseCreatedUID(buyOut, "MCR")
+	mcrUID := parseCreatedUID(buyOut)
 	// Register cleanup before asserting on mcrUID, so any created MCR is
 	// deleted even if the UID parse fails.
 	t.Cleanup(func() {

--- a/internal/commands/mcr/mcr_integration_test.go
+++ b/internal/commands/mcr/mcr_integration_test.go
@@ -22,8 +22,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// stagingMCRLocationID is a known MCR-capable staging location. Discovering one
-// via ListLocations would be overengineering for this lifecycle test.
+// stagingMCRLocationID is the staging location MCR lifecycle tests prefer. It
+// has historically been MCR-capable, but it is only a preference: each test
+// resolves its location through testutil.FindMCRTestLocation, which falls back
+// to another active MCR-capable location (or skips) if this one ever stops
+// advertising the speed under test.
 const stagingMCRLocationID = 67
 
 func generateUniqueID() string {
@@ -169,6 +172,7 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 	t.Cleanup(func() { output.SetOutputFormat(origFmt) })
 
 	name := fmt.Sprintf("CLI-Test-MCR-%s", generateUniqueID())
+	locationID := testutil.FindMCRTestLocation(t, client, 1000, stagingMCRLocationID)
 
 	// Buy a new MCR using flags. BuyMCR waits for provisioning (no --no-wait),
 	// so the MCR is ready for prefix-filter-list operations once it returns.
@@ -176,7 +180,7 @@ func TestIntegration_MCRLifecycle(t *testing.T) {
 	require.NoError(t, buyCmd.Flags().Set("name", name))
 	require.NoError(t, buyCmd.Flags().Set("term", "1"))
 	require.NoError(t, buyCmd.Flags().Set("port-speed", "1000"))
-	require.NoError(t, buyCmd.Flags().Set("location-id", strconv.Itoa(stagingMCRLocationID)))
+	require.NoError(t, buyCmd.Flags().Set("location-id", strconv.Itoa(locationID)))
 	require.NoError(t, buyCmd.Flags().Set("marketplace-visibility", "false"))
 	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
 
@@ -360,6 +364,7 @@ func TestIntegration_MCRJSONInputLifecycle(t *testing.T) {
 	t.Cleanup(func() { output.SetOutputFormat(origFmt) })
 
 	name := fmt.Sprintf("CLI-JSON-MCR-%s", generateUniqueID())
+	locationID := testutil.FindMCRTestLocation(t, client, 1000, stagingMCRLocationID)
 
 	buyJSON := fmt.Sprintf(`{
 		"name": "%s",
@@ -367,7 +372,7 @@ func TestIntegration_MCRJSONInputLifecycle(t *testing.T) {
 		"portSpeed": 1000,
 		"locationId": %d,
 		"marketplaceVisibility": false
-	}`, name, stagingMCRLocationID)
+	}`, name, locationID)
 
 	buyCmd := integrationMCRBuyCmd()
 	require.NoError(t, buyCmd.Flags().Set("json", buyJSON))
@@ -492,6 +497,7 @@ func TestIntegration_MCRIPv6PrefixFilterLifecycle(t *testing.T) {
 	t.Cleanup(func() { output.SetOutputFormat(origFmt) })
 
 	name := fmt.Sprintf("CLI-Test-MCR-IPv6-%s", generateUniqueID())
+	locationID := testutil.FindMCRTestLocation(t, client, 1000, stagingMCRLocationID)
 
 	// Buy a new MCR using flags. BuyMCR waits for provisioning (no --no-wait),
 	// so the MCR is ready for prefix-filter-list operations once it returns.
@@ -499,7 +505,7 @@ func TestIntegration_MCRIPv6PrefixFilterLifecycle(t *testing.T) {
 	require.NoError(t, buyCmd.Flags().Set("name", name))
 	require.NoError(t, buyCmd.Flags().Set("term", "1"))
 	require.NoError(t, buyCmd.Flags().Set("port-speed", "1000"))
-	require.NoError(t, buyCmd.Flags().Set("location-id", strconv.Itoa(stagingMCRLocationID)))
+	require.NoError(t, buyCmd.Flags().Set("location-id", strconv.Itoa(locationID)))
 	require.NoError(t, buyCmd.Flags().Set("marketplace-visibility", "false"))
 	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
 

--- a/internal/commands/mcr/mcr_ipsec_addon_lifecycle_integration_test.go
+++ b/internal/commands/mcr/mcr_ipsec_addon_lifecycle_integration_test.go
@@ -139,7 +139,7 @@ func TestIntegration_MCRIPSecAddOnLifecycle(t *testing.T) {
 	buyOut := captureTableOutput(func() { buyErr = BuyMCR(buyCmd, nil, true) })
 	require.NoError(t, buyErr, "buy MCR output: %s", buyOut)
 
-	mcrUID := parseCreatedUID(buyOut, "MCR")
+	mcrUID := parseCreatedUID(buyOut)
 	// Register cleanup before asserting on mcrUID, so any created MCR is
 	// deleted even if the UID parse fails.
 	t.Cleanup(func() {

--- a/internal/commands/mcr/mcr_ipsec_addon_lifecycle_integration_test.go
+++ b/internal/commands/mcr/mcr_ipsec_addon_lifecycle_integration_test.go
@@ -110,6 +110,7 @@ func waitForMCRReadyBestEffort(t *testing.T, client *megaport.Client, mcrUID, st
 // add-on, updates its tunnel count, then disables it, tearing the MCR down in
 // t.Cleanup. It skips when staging does not support the add-on on the test MCR.
 func TestIntegration_MCRIPSecAddOnLifecycle(t *testing.T) {
+	testutil.RequireStagingForProvisioning(t)
 	client := testutil.SetupIntegrationClient(t)
 	// Restore login via t.Cleanup, not defer: defers run before t.Cleanup, so a
 	// deferred restore would swap back the default login (wrong environment)
@@ -122,6 +123,7 @@ func TestIntegration_MCRIPSecAddOnLifecycle(t *testing.T) {
 	t.Cleanup(func() { output.SetOutputFormat(origFmt) })
 
 	name := fmt.Sprintf("CLI-Test-MCR-IPSec-%s", generateUniqueID())
+	locationID := testutil.FindMCRTestLocation(t, client, 1000, stagingMCRLocationID)
 
 	// Buy a new MCR using flags. BuyMCR waits for provisioning (no --no-wait),
 	// so the MCR is ready for add-on operations once it returns.
@@ -129,7 +131,7 @@ func TestIntegration_MCRIPSecAddOnLifecycle(t *testing.T) {
 	require.NoError(t, buyCmd.Flags().Set("name", name))
 	require.NoError(t, buyCmd.Flags().Set("term", "1"))
 	require.NoError(t, buyCmd.Flags().Set("port-speed", "1000"))
-	require.NoError(t, buyCmd.Flags().Set("location-id", strconv.Itoa(stagingMCRLocationID)))
+	require.NoError(t, buyCmd.Flags().Set("location-id", strconv.Itoa(locationID)))
 	require.NoError(t, buyCmd.Flags().Set("marketplace-visibility", "false"))
 	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
 

--- a/internal/commands/mcr/mcr_lifecycle_integration_test.go
+++ b/internal/commands/mcr/mcr_lifecycle_integration_test.go
@@ -65,7 +65,7 @@ func TestIntegration_MCRLockLifecycle(t *testing.T) {
 	buyOut := captureTableOutput(func() { buyErr = BuyMCR(buyCmd, nil, true) })
 	require.NoError(t, buyErr, "buy MCR output: %s", buyOut)
 
-	mcrUID := parseCreatedUID(buyOut, "MCR")
+	mcrUID := parseCreatedUID(buyOut)
 	// Register cleanup before asserting on mcrUID, so any created MCR is cleaned
 	// up even if the UID parse fails. Unlock first: the API can refuse to delete
 	// a locked resource, so a test that fails after locking must unlock here.

--- a/internal/commands/mcr/mcr_lifecycle_integration_test.go
+++ b/internal/commands/mcr/mcr_lifecycle_integration_test.go
@@ -49,6 +49,7 @@ func TestIntegration_MCRLockLifecycle(t *testing.T) {
 	t.Cleanup(func() { output.SetOutputFormat(origFmt) })
 
 	name := fmt.Sprintf("CLI-Test-MCR-Lock-%s", generateUniqueID())
+	locationID := testutil.FindMCRTestLocation(t, client, 1000, stagingMCRLocationID)
 
 	// BuyMCR waits for provisioning (no --no-wait), so the MCR is lockable once
 	// it returns.
@@ -56,7 +57,7 @@ func TestIntegration_MCRLockLifecycle(t *testing.T) {
 	require.NoError(t, buyCmd.Flags().Set("name", name))
 	require.NoError(t, buyCmd.Flags().Set("term", "1"))
 	require.NoError(t, buyCmd.Flags().Set("port-speed", "1000"))
-	require.NoError(t, buyCmd.Flags().Set("location-id", strconv.Itoa(stagingMCRLocationID)))
+	require.NoError(t, buyCmd.Flags().Set("location-id", strconv.Itoa(locationID)))
 	require.NoError(t, buyCmd.Flags().Set("marketplace-visibility", "false"))
 	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
 

--- a/internal/commands/mve/mve_integration_test.go
+++ b/internal/commands/mve/mve_integration_test.go
@@ -16,13 +16,16 @@ import (
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/testutil"
 	"github.com/megaport/megaport-cli/internal/validation"
+	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// stagingMVELocationID is a known MVE-capable staging location. Discovering one
-// via ListLocations would be overengineering for this lifecycle test.
+// stagingMVELocationID is tried first when probing for MVE capacity. It is not
+// authoritative: when it is out of capacity, findMVECapacity sweeps every other
+// active MVE-capable location before giving up (mirroring the terraform
+// provider's acceptance tests).
 const stagingMVELocationID = 65
 
 func generateUniqueID() string {
@@ -144,20 +147,154 @@ func discoverArubaImage(t *testing.T) discoveredImage {
 	return discoveredImage{}
 }
 
-// productSize picks a size the image supports, preferring MEDIUM.
-// It normalizes label-format strings (e.g. "MVE 4/16") to their programmatic
-// equivalents (e.g. "MEDIUM") so the value is valid for the buy command.
-func (d discoveredImage) productSize() string {
+// productSizeCandidates returns the image's supported sizes ordered for a
+// capacity probe: MEDIUM first (the size we want to exercise), then SMALL and
+// the larger sizes, then any other size the image advertises. A given location
+// can be out of capacity for one size but have room for another, so the probe
+// tries each in turn. Label-format strings (e.g. "MVE 4/16") are normalized to
+// programmatic names ("MEDIUM").
+func (d discoveredImage) productSizeCandidates() []string {
+	supported := make(map[string]bool, len(d.AvailableSizes))
 	for _, s := range d.AvailableSizes {
-		normalized := validation.NormalizeMVEProductSize(strings.ToUpper(s))
-		if normalized == "MEDIUM" {
-			return "MEDIUM"
+		supported[validation.NormalizeMVEProductSize(strings.ToUpper(s))] = true
+	}
+	var ordered []string
+	emitted := make(map[string]bool, len(supported))
+	add := func(size string) {
+		if supported[size] && !emitted[size] {
+			ordered = append(ordered, size)
+			emitted[size] = true
 		}
 	}
-	if len(d.AvailableSizes) > 0 {
-		return validation.NormalizeMVEProductSize(strings.ToUpper(d.AvailableSizes[0]))
+	for _, size := range []string{"MEDIUM", "SMALL", "LARGE", "X_LARGE_12"} {
+		add(size)
 	}
-	return "MEDIUM"
+	// Probe any other advertised size after the preferred order, so an image
+	// whose sizes fall outside the list above is still tried, not skipped.
+	for _, s := range d.AvailableSizes {
+		add(validation.NormalizeMVEProductSize(strings.ToUpper(s)))
+	}
+	if len(ordered) == 0 {
+		ordered = append(ordered, "MEDIUM")
+	}
+	return ordered
+}
+
+// isMVECapacityError reports whether a buy/validate error is staging telling us
+// it has no host capacity for the request, rather than a genuine failure. Such a
+// shortage is environmental, so tests skip on it instead of failing.
+func isMVECapacityError(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "no available capacity")
+}
+
+// findMVECapacity probes staging for a location and product size with available
+// Aruba MVE capacity, mirroring the terraform provider's acceptance tests: it
+// validates the real order against the preferred location first, then sweeps
+// every active MVE-capable location, returning the first (location, size) the
+// API accepts. It skips the test only when no location in staging has capacity
+// for any supported size, so a shortage at one site no longer fails the build.
+func findMVECapacity(t *testing.T, client *megaport.Client, img discoveredImage) (locationID int, size string) {
+	t.Helper()
+	listCtx, listCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer listCancel()
+
+	locations, err := client.LocationService.ListLocationsV3(listCtx)
+	require.NoError(t, err, "list locations for MVE capacity probe")
+
+	// Each probe gets its own deadline rather than sharing one across the sweep:
+	// a shared budget could be drained by a few slow calls and skip later
+	// locations that actually have capacity.
+	probe := func(locID int, size string) bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		return client.MVEService.ValidateMVEOrder(ctx, &megaport.BuyMVERequest{
+			LocationID: locID,
+			Name:       "cli-capacity-probe",
+			Term:       1,
+			VendorConfig: &megaport.ArubaConfig{
+				Vendor:      "aruba",
+				ImageID:     img.ID,
+				ProductSize: size,
+				AccountName: "test",
+				AccountKey:  "test",
+				SystemTag:   "test",
+			},
+			Vnics: []megaport.MVENetworkInterface{
+				{Description: "MVE VNIC 1", VLAN: 55},
+				{Description: "MVE VNIC 2", VLAN: 56},
+			},
+		}) == nil
+	}
+
+	// Probe the preferred location first, then every other active MVE-capable
+	// location.
+	ordered := make([]*megaport.LocationV3, 0, len(locations))
+	for _, loc := range locations {
+		if loc == nil {
+			continue
+		}
+		if loc.ID == stagingMVELocationID && loc.IsStatusOrderable() && loc.HasMVESupport() {
+			ordered = append(ordered, loc)
+		}
+	}
+	for _, loc := range locations {
+		if loc == nil || loc.ID == stagingMVELocationID {
+			continue
+		}
+		if loc.IsStatusOrderable() && loc.HasMVESupport() {
+			ordered = append(ordered, loc)
+		}
+	}
+
+	sizes := img.productSizeCandidates()
+	for _, loc := range ordered {
+		for _, size := range sizes {
+			if probe(loc.ID, size) {
+				t.Logf("findMVECapacity: using location %d (%s) size %s", loc.ID, loc.Name, size)
+				return loc.ID, size
+			}
+		}
+	}
+	t.Skip("no staging location has available Aruba MVE capacity for any supported size")
+	return 0, ""
+}
+
+// buyMVEAtAvailableLocation discovers a location+size with capacity, runs BuyMVE
+// once with the command built by buildCmd, and returns the created MVE's UID with
+// a hard-delete cleanup registered. If capacity vanishes between the probe and
+// the buy (a race against other consumers of shared staging), it skips rather
+// than failing.
+func buyMVEAtAvailableLocation(t *testing.T, client *megaport.Client, img discoveredImage, buildCmd func(locationID int, size string) *cobra.Command) string {
+	t.Helper()
+	locationID, size := findMVECapacity(t, client, img)
+
+	cmd := buildCmd(locationID, size)
+	var buyErr error
+	buyOut := captureTableOutput(func() { buyErr = BuyMVE(cmd, nil, true) })
+	if isMVECapacityError(buyErr) {
+		t.Skipf("MVE capacity at location %d (size %s) disappeared between probe and buy", locationID, size)
+	}
+	require.NoError(t, buyErr, "buy MVE output: %s", buyOut)
+
+	mveUID := parseCreatedUID(buyOut, "MVE")
+	// Register cleanup before asserting on the UID, so any created MVE is torn
+	// down even if the parse below fails.
+	t.Cleanup(func() {
+		if mveUID == "" {
+			return
+		}
+		delCmd := integrationMVEDeleteCmd()
+		_ = delCmd.Flags().Set("force", "true")
+		var delErr error
+		out := captureTableOutput(func() { delErr = DeleteMVE(delCmd, []string{mveUID}, true) })
+		if delErr != nil {
+			t.Logf("cleanup: delete MVE %s failed: %v; output: %s", mveUID, delErr, out)
+			return
+		}
+		t.Logf("cleanup: delete MVE %s: %s", mveUID, out)
+	})
+	require.NotEmpty(t, mveUID, "could not parse MVE UID from: %s", buyOut)
+	return mveUID
 }
 
 // getMVEJSON retrieves an MVE as JSON and returns the decoded object.
@@ -190,49 +327,29 @@ func TestIntegration_MVELifecycle(t *testing.T) {
 
 	img := discoverArubaImage(t)
 	name := fmt.Sprintf("CLI-Test-MVE-%s", generateUniqueID())
-
-	vendorConfig := fmt.Sprintf(`{
-		"vendor": "aruba",
-		"productSize": "%s",
-		"imageId": %d,
-		"accountName": "test",
-		"accountKey": "test",
-		"systemTag": "test"
-	}`, img.productSize(), img.ID)
 	vnics := `[{"description": "MVE VNIC 1", "vlan": 55}, {"description": "MVE VNIC 2", "vlan": 56}]`
 
 	// BuyMVE waits for provisioning (no --no-wait), so the MVE is ready once it
-	// returns.
-	buyCmd := integrationMVEBuyCmd()
-	require.NoError(t, buyCmd.Flags().Set("name", name))
-	require.NoError(t, buyCmd.Flags().Set("term", "1"))
-	require.NoError(t, buyCmd.Flags().Set("location-id", strconv.Itoa(stagingMVELocationID)))
-	require.NoError(t, buyCmd.Flags().Set("vendor-config", vendorConfig))
-	require.NoError(t, buyCmd.Flags().Set("vnics", vnics))
-	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
-
-	var buyErr error
-	buyOut := captureTableOutput(func() { buyErr = BuyMVE(buyCmd, nil, true) })
-	require.NoError(t, buyErr, "buy MVE output: %s", buyOut)
-
-	mveUID := parseCreatedUID(buyOut, "MVE")
-	// Register cleanup before asserting on mveUID, so any created MVE is
-	// cleaned up even if the UID assertion below fails.
-	t.Cleanup(func() {
-		if mveUID == "" {
-			return
-		}
-		delCmd := integrationMVEDeleteCmd()
-		_ = delCmd.Flags().Set("force", "true")
-		var delErr error
-		out := captureTableOutput(func() { delErr = DeleteMVE(delCmd, []string{mveUID}, true) })
-		if delErr != nil {
-			t.Logf("cleanup: delete MVE %s failed: %v; output: %s", mveUID, delErr, out)
-			return
-		}
-		t.Logf("cleanup: delete MVE %s: %s", mveUID, out)
+	// returns. The buy retries across product sizes if staging is out of
+	// capacity, and skips the test if every size is exhausted.
+	mveUID := buyMVEAtAvailableLocation(t, client, img, func(locationID int, size string) *cobra.Command {
+		vendorConfig := fmt.Sprintf(`{
+			"vendor": "aruba",
+			"productSize": "%s",
+			"imageId": %d,
+			"accountName": "test",
+			"accountKey": "test",
+			"systemTag": "test"
+		}`, size, img.ID)
+		buyCmd := integrationMVEBuyCmd()
+		require.NoError(t, buyCmd.Flags().Set("name", name))
+		require.NoError(t, buyCmd.Flags().Set("term", "1"))
+		require.NoError(t, buyCmd.Flags().Set("location-id", strconv.Itoa(locationID)))
+		require.NoError(t, buyCmd.Flags().Set("vendor-config", vendorConfig))
+		require.NoError(t, buyCmd.Flags().Set("vnics", vnics))
+		require.NoError(t, buyCmd.Flags().Set("yes", "true"))
+		return buyCmd
 	})
-	require.NotEmpty(t, mveUID, "could not parse MVE UID from: %s", buyOut)
 
 	// Get and verify the core fields.
 	mve := getMVEJSON(t, mveUID)
@@ -332,46 +449,25 @@ func TestIntegration_MVEJSONInputLifecycle(t *testing.T) {
 	img := discoverArubaImage(t)
 	name := fmt.Sprintf("CLI-JSON-MVE-%s", generateUniqueID())
 
-	buyJSON := fmt.Sprintf(`{
-		"name": "%s",
-		"term": 1,
-		"locationId": %d,
-		"vendorConfig": {
-			"vendor": "aruba",
-			"productSize": "%s",
-			"imageId": %d,
-			"accountName": "test",
-			"accountKey": "test",
-			"systemTag": "test"
-		},
-		"vnics": [{"description": "MVE VNIC 1", "vlan": 55}, {"description": "MVE VNIC 2", "vlan": 56}]
-	}`, name, stagingMVELocationID, img.productSize(), img.ID)
-
-	buyCmd := integrationMVEBuyCmd()
-	require.NoError(t, buyCmd.Flags().Set("json", buyJSON))
-
-	var buyErr error
-	buyOut := captureTableOutput(func() { buyErr = BuyMVE(buyCmd, nil, true) })
-	require.NoError(t, buyErr, "buy MVE (JSON) output: %s", buyOut)
-
-	mveUID := parseCreatedUID(buyOut, "MVE")
-	// Register cleanup before asserting on mveUID, so any created MVE is
-	// cleaned up even if the UID assertion below fails.
-	t.Cleanup(func() {
-		if mveUID == "" {
-			return
-		}
-		delCmd := integrationMVEDeleteCmd()
-		_ = delCmd.Flags().Set("force", "true")
-		var delErr error
-		out := captureTableOutput(func() { delErr = DeleteMVE(delCmd, []string{mveUID}, true) })
-		if delErr != nil {
-			t.Logf("cleanup: delete MVE %s failed: %v; output: %s", mveUID, delErr, out)
-			return
-		}
-		t.Logf("cleanup: delete MVE %s: %s", mveUID, out)
+	mveUID := buyMVEAtAvailableLocation(t, client, img, func(locationID int, size string) *cobra.Command {
+		buyJSON := fmt.Sprintf(`{
+			"name": "%s",
+			"term": 1,
+			"locationId": %d,
+			"vendorConfig": {
+				"vendor": "aruba",
+				"productSize": "%s",
+				"imageId": %d,
+				"accountName": "test",
+				"accountKey": "test",
+				"systemTag": "test"
+			},
+			"vnics": [{"description": "MVE VNIC 1", "vlan": 55}, {"description": "MVE VNIC 2", "vlan": 56}]
+		}`, name, locationID, size, img.ID)
+		buyCmd := integrationMVEBuyCmd()
+		require.NoError(t, buyCmd.Flags().Set("json", buyJSON))
+		return buyCmd
 	})
-	require.NotEmpty(t, mveUID, "could not parse MVE UID from: %s", buyOut)
 
 	mve := getMVEJSON(t, mveUID)
 	assert.Equal(t, mveUID, mve["uid"])

--- a/internal/commands/mve/mve_integration_test.go
+++ b/internal/commands/mve/mve_integration_test.go
@@ -207,7 +207,7 @@ func findMVECapacity(t *testing.T, client *megaport.Client, img discoveredImage)
 	probe := func(locID int, size string) bool {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		return client.MVEService.ValidateMVEOrder(ctx, &megaport.BuyMVERequest{
+		err := client.MVEService.ValidateMVEOrder(ctx, &megaport.BuyMVERequest{
 			LocationID: locID,
 			Name:       "cli-capacity-probe",
 			Term:       1,
@@ -223,7 +223,12 @@ func findMVECapacity(t *testing.T, client *megaport.Client, img discoveredImage)
 				{Description: "MVE VNIC 1", VLAN: 55},
 				{Description: "MVE VNIC 2", VLAN: 56},
 			},
-		}) == nil
+		})
+		if err == nil {
+			return true
+		}
+		require.True(t, isMVECapacityError(err), "validate MVE order at location %d size %s", locID, size)
+		return false
 	}
 
 	// Probe the preferred location first, then every other active MVE-capable

--- a/internal/commands/mve/mve_lifecycle_integration_test.go
+++ b/internal/commands/mve/mve_lifecycle_integration_test.go
@@ -34,52 +34,30 @@ func mveLockedFromSDK(t *testing.T, client *megaport.Client, uid string) bool {
 // action (which waits for provisioning) and registers a best-effort hard delete
 // in t.Cleanup. It returns the new MVE's UID. The image is discovered
 // dynamically because staging image IDs change.
-func buyArubaMVEForLifecycle(t *testing.T, namePrefix string) string {
+func buyArubaMVEForLifecycle(t *testing.T, client *megaport.Client, namePrefix string) string {
 	t.Helper()
 	img := discoverArubaImage(t)
 	name := fmt.Sprintf("%s-%s", namePrefix, generateUniqueID())
-
-	vendorConfig := fmt.Sprintf(`{
-		"vendor": "aruba",
-		"productSize": "%s",
-		"imageId": %d,
-		"accountName": "test",
-		"accountKey": "test",
-		"systemTag": "test"
-	}`, img.productSize(), img.ID)
 	vnics := `[{"description": "MVE VNIC 1", "vlan": 55}, {"description": "MVE VNIC 2", "vlan": 56}]`
 
-	buyCmd := integrationMVEBuyCmd()
-	require.NoError(t, buyCmd.Flags().Set("name", name))
-	require.NoError(t, buyCmd.Flags().Set("term", "1"))
-	require.NoError(t, buyCmd.Flags().Set("location-id", strconv.Itoa(stagingMVELocationID)))
-	require.NoError(t, buyCmd.Flags().Set("vendor-config", vendorConfig))
-	require.NoError(t, buyCmd.Flags().Set("vnics", vnics))
-	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
-
-	var buyErr error
-	buyOut := captureTableOutput(func() { buyErr = BuyMVE(buyCmd, nil, true) })
-	require.NoError(t, buyErr, "buy MVE output: %s", buyOut)
-
-	mveUID := parseCreatedUID(buyOut, "MVE")
-	// Register the delete cleanup before asserting on the UID, so a created MVE
-	// is always torn down (CANCEL_NOW) even if the parse below fails.
-	t.Cleanup(func() {
-		if mveUID == "" {
-			return
-		}
-		delCmd := integrationMVEDeleteCmd()
-		_ = delCmd.Flags().Set("force", "true")
-		var delErr error
-		out := captureTableOutput(func() { delErr = DeleteMVE(delCmd, []string{mveUID}, true) })
-		if delErr != nil {
-			t.Logf("cleanup: delete MVE %s failed: %v; output: %s", mveUID, delErr, out)
-			return
-		}
-		t.Logf("cleanup: delete MVE %s: %s", mveUID, out)
+	return buyMVEAtAvailableLocation(t, client, img, func(locationID int, size string) *cobra.Command {
+		vendorConfig := fmt.Sprintf(`{
+			"vendor": "aruba",
+			"productSize": "%s",
+			"imageId": %d,
+			"accountName": "test",
+			"accountKey": "test",
+			"systemTag": "test"
+		}`, size, img.ID)
+		buyCmd := integrationMVEBuyCmd()
+		require.NoError(t, buyCmd.Flags().Set("name", name))
+		require.NoError(t, buyCmd.Flags().Set("term", "1"))
+		require.NoError(t, buyCmd.Flags().Set("location-id", strconv.Itoa(locationID)))
+		require.NoError(t, buyCmd.Flags().Set("vendor-config", vendorConfig))
+		require.NoError(t, buyCmd.Flags().Set("vnics", vnics))
+		require.NoError(t, buyCmd.Flags().Set("yes", "true"))
+		return buyCmd
 	})
-	require.NotEmpty(t, mveUID, "could not parse MVE UID from: %s", buyOut)
-	return mveUID
 }
 
 // TestIntegration_MVELockLifecycle buys an MVE, locks it, asserts the lock via an
@@ -100,7 +78,7 @@ func TestIntegration_MVELockLifecycle(t *testing.T) {
 	origFmt := output.GetOutputFormat()
 	t.Cleanup(func() { output.SetOutputFormat(origFmt) })
 
-	mveUID := buyArubaMVEForLifecycle(t, "CLI-Test-MVE-Lock")
+	mveUID := buyArubaMVEForLifecycle(t, client, "CLI-Test-MVE-Lock")
 
 	// Registered after the delete cleanup so it runs first (cleanups run LIFO):
 	// the API can refuse to delete a locked resource, so unlock before delete.

--- a/internal/commands/ports/ports_integration_test.go
+++ b/internal/commands/ports/ports_integration_test.go
@@ -22,11 +22,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// integrationLocationID is the staging data center used for port lifecycle
-// tests. ID 67 is the canonical example location across the CLI's README,
-// example flag strings, and the previous binary-invocation integration suite.
-// It is stable on staging and supports the 1G/10G port speeds these tests
-// exercise.
+// integrationLocationID is the staging data center port lifecycle tests prefer.
+// ID 67 is the canonical example location across the CLI's README, example flag
+// strings, and the previous binary-invocation integration suite, and it has
+// historically advertised the 1G/10G port speeds these tests exercise. It is
+// only a preference: each test resolves its location through
+// testutil.FindPortTestLocation, which falls back to another active location (or
+// skips) if 67 ever stops advertising the speed under test.
 const integrationLocationID = 67
 
 // These tests use t.Parallel(); see testutil.RequireSharedIntegrationClient
@@ -355,12 +357,13 @@ func TestIntegration_PortLifecycle(t *testing.T) {
 	testutil.RequireSharedIntegrationClient(t)
 
 	portName := fmt.Sprintf("CLI-Test-Port-%s", generateUniqueID(t))
+	locationID := testutil.FindPortTestLocation(t, testutil.SharedIntegrationClient(t), 1000, integrationLocationID)
 
 	buyCmd := newBuyPortCmd()
 	require.NoError(t, buyCmd.Flags().Set("name", portName))
 	require.NoError(t, buyCmd.Flags().Set("term", "1"))
 	require.NoError(t, buyCmd.Flags().Set("port-speed", "1000"))
-	require.NoError(t, buyCmd.Flags().Set("location-id", fmt.Sprintf("%d", integrationLocationID)))
+	require.NoError(t, buyCmd.Flags().Set("location-id", fmt.Sprintf("%d", locationID)))
 	require.NoError(t, buyCmd.Flags().Set("marketplace-visibility", "false"))
 	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
 
@@ -398,12 +401,13 @@ func TestIntegration_LAGPortLifecycle(t *testing.T) {
 	testutil.RequireSharedIntegrationClient(t)
 
 	portName := fmt.Sprintf("CLI-Test-LAG-%s", generateUniqueID(t))
+	locationID := testutil.FindPortTestLocation(t, testutil.SharedIntegrationClient(t), 10000, integrationLocationID)
 
 	buyCmd := newBuyLAGPortCmd()
 	require.NoError(t, buyCmd.Flags().Set("name", portName))
 	require.NoError(t, buyCmd.Flags().Set("term", "1"))
 	require.NoError(t, buyCmd.Flags().Set("port-speed", "10000"))
-	require.NoError(t, buyCmd.Flags().Set("location-id", fmt.Sprintf("%d", integrationLocationID)))
+	require.NoError(t, buyCmd.Flags().Set("location-id", fmt.Sprintf("%d", locationID)))
 	require.NoError(t, buyCmd.Flags().Set("lag-count", "1"))
 	require.NoError(t, buyCmd.Flags().Set("marketplace-visibility", "false"))
 	require.NoError(t, buyCmd.Flags().Set("yes", "true"))
@@ -429,12 +433,13 @@ func TestIntegration_PortJSONInputLifecycle(t *testing.T) {
 	testutil.RequireSharedIntegrationClient(t)
 
 	portName := fmt.Sprintf("CLI-Test-Port-JSON-%s", generateUniqueID(t))
+	locationID := testutil.FindPortTestLocation(t, testutil.SharedIntegrationClient(t), 1000, integrationLocationID)
 
 	buyPayload := map[string]any{
 		"name":                  portName,
 		"term":                  1,
 		"portSpeed":             1000,
-		"locationId":            integrationLocationID,
+		"locationId":            locationID,
 		"marketPlaceVisibility": false,
 	}
 	buyJSON, err := json.Marshal(buyPayload)
@@ -467,12 +472,13 @@ func TestIntegration_PortJSONFileLifecycle(t *testing.T) {
 	testutil.RequireSharedIntegrationClient(t)
 
 	portName := fmt.Sprintf("CLI-Test-Port-JSONFile-%s", generateUniqueID(t))
+	locationID := testutil.FindPortTestLocation(t, testutil.SharedIntegrationClient(t), 1000, integrationLocationID)
 
 	buyPayload := map[string]any{
 		"name":                  portName,
 		"term":                  1,
 		"portSpeed":             1000,
-		"locationId":            integrationLocationID,
+		"locationId":            locationID,
 		"marketPlaceVisibility": false,
 	}
 	buyJSON, err := json.MarshalIndent(buyPayload, "", "  ")
@@ -527,12 +533,13 @@ func TestIntegration_LAGPortUpdateLifecycle(t *testing.T) {
 	testutil.RequireSharedIntegrationClient(t)
 
 	portName := fmt.Sprintf("CLI-Test-LAG-Update-%s", generateUniqueID(t))
+	locationID := testutil.FindPortTestLocation(t, testutil.SharedIntegrationClient(t), 10000, integrationLocationID)
 
 	buyCmd := newBuyLAGPortCmd()
 	require.NoError(t, buyCmd.Flags().Set("name", portName))
 	require.NoError(t, buyCmd.Flags().Set("term", "1"))
 	require.NoError(t, buyCmd.Flags().Set("port-speed", "10000"))
-	require.NoError(t, buyCmd.Flags().Set("location-id", fmt.Sprintf("%d", integrationLocationID)))
+	require.NoError(t, buyCmd.Flags().Set("location-id", fmt.Sprintf("%d", locationID)))
 	require.NoError(t, buyCmd.Flags().Set("lag-count", "1"))
 	require.NoError(t, buyCmd.Flags().Set("marketplace-visibility", "false"))
 	require.NoError(t, buyCmd.Flags().Set("yes", "true"))

--- a/internal/commands/servicekeys/servicekeys_lifecycle_integration_test.go
+++ b/internal/commands/servicekeys/servicekeys_lifecycle_integration_test.go
@@ -20,9 +20,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// integrationLocationID is the staging data center used to provision the
-// throwaway port a service key needs as its product. ID 67 is the canonical
-// staging example location reused across the CLI's other integration tests.
+// integrationLocationID is the staging data center service key tests prefer for
+// the throwaway port a key needs as its product. FindPortTestLocation falls back
+// to another orderable location when it is out of capacity.
 const integrationLocationID = 67
 
 func uniqueSuffix(t *testing.T) string {
@@ -87,11 +87,12 @@ func provisionPortForServiceKey(t *testing.T, client *megaport.Client) string {
 	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
 	defer cancel()
 
+	locationID := testutil.FindPortTestLocation(t, client, 1000, integrationLocationID)
 	resp, err := client.PortService.BuyPort(ctx, &megaport.BuyPortRequest{
 		Name:                  portName,
 		Term:                  1,
 		PortSpeed:             1000,
-		LocationId:            integrationLocationID,
+		LocationId:            locationID,
 		MarketPlaceVisibility: false,
 		WaitForProvision:      true,
 		WaitForTime:           10 * time.Minute,

--- a/internal/commands/vxc/vxc_integration_test.go
+++ b/internal/commands/vxc/vxc_integration_test.go
@@ -22,9 +22,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// integrationLocationID is the staging data center used for all VXC lifecycle
-// tests. Location 67 matches the canonical example used across the CLI test
-// suite and supports the 1G port speed these tests exercise.
+// integrationLocationID is the staging data center VXC lifecycle tests prefer.
+// Location 67 matches the canonical example used across the CLI test suite and
+// has historically advertised the 1G port and 1G MCR capacity these tests
+// exercise. It is only a preference: each test resolves its location through the
+// testutil finder matching what it provisions (FindPortTestLocation for
+// port-to-port VXCs, FindMCRTestLocation or FindPortAndMCRTestLocation for the
+// MCR-attach tests), which falls back to another active location (or skips) if
+// 67 ever stops advertising the needed capacity.
 const integrationLocationID = 67
 
 const (
@@ -168,9 +173,9 @@ func newUpdateVXCCmd() *cobra.Command {
 // the ports package's integration buy hook. Cleanup is registered immediately
 // after the buy succeeds and before the UID is asserted, so a billable port is
 // never leaked if UID recovery fails.
-func buyPortAndGetUID(t *testing.T, portName string) string {
+func buyPortAndGetUID(t *testing.T, portName string, locationID int) string {
 	t.Helper()
-	cmd := buildPortCmd(t, portName, integrationLocationID)
+	cmd := buildPortCmd(t, portName, locationID)
 	require.NoErrorf(t, ports.BuyPort(cmd, nil, true), "BuyPort failed for %q", portName)
 
 	uid, ok := ports.IntegrationBuyPortUID(portName)
@@ -345,9 +350,9 @@ func newDeleteMCRCmd() *cobra.Command {
 // package's integration buy hook. Cleanup is registered immediately after the
 // buy succeeds and before the UID is asserted, so a billable MCR is never
 // leaked if UID recovery fails.
-func buyMCRAndGetUID(t *testing.T, mcrName string) string {
+func buyMCRAndGetUID(t *testing.T, mcrName string, locationID int) string {
 	t.Helper()
-	cmd := buildMCRCmd(t, mcrName, integrationLocationID)
+	cmd := buildMCRCmd(t, mcrName, locationID)
 	require.NoErrorf(t, mcr.BuyMCR(cmd, nil, true), "BuyMCR failed for %q", mcrName)
 
 	uid, ok := mcr.IntegrationBuyMCRUID(mcrName)
@@ -436,11 +441,12 @@ func TestIntegration_VXCPortToPortLifecycle(t *testing.T) {
 	portAName := fmt.Sprintf("CLI-Test-VXC-PortA-%s", id)
 	portBName := fmt.Sprintf("CLI-Test-VXC-PortB-%s", id)
 	vxcName := fmt.Sprintf("CLI-Test-VXC-%s", id)
+	locationID := testutil.FindPortTestLocation(t, testutil.SharedIntegrationClient(t), 1000, integrationLocationID)
 
-	portAUID := buyPortAndGetUID(t, portAName)
+	portAUID := buyPortAndGetUID(t, portAName, locationID)
 	t.Logf("Created port A: %s", portAUID)
 
-	portBUID := buyPortAndGetUID(t, portBName)
+	portBUID := buyPortAndGetUID(t, portBName, locationID)
 	t.Logf("Created port B: %s", portBUID)
 
 	vxcCmd := buildVXCCmd(t, vxcName, portAUID, portBUID, 100)
@@ -479,17 +485,19 @@ func TestIntegration_VXCPortToPortLifecycle(t *testing.T) {
 // live cloud-provider accounts on staging and are tracked separately.
 func TestIntegration_VXCMCRVrouterInnerVLANLifecycle(t *testing.T) {
 	t.Parallel()
+	testutil.RequireStagingForProvisioning(t)
 	testutil.RequireSharedIntegrationClient(t)
 
 	id := generateUniqueID(t)
 	mcrName := fmt.Sprintf("CLI-Test-VXC-MCR-%s", id)
 	portName := fmt.Sprintf("CLI-Test-VXC-MCRPort-%s", id)
 	vxcName := fmt.Sprintf("CLI-Test-VXC-MCRVrouter-%s", id)
+	locationID := testutil.FindPortAndMCRTestLocation(t, testutil.SharedIntegrationClient(t), 1000, 1000, integrationLocationID)
 
-	mcrUID := buyMCRAndGetUID(t, mcrName)
+	mcrUID := buyMCRAndGetUID(t, mcrName, locationID)
 	t.Logf("Created MCR (A-End): %s", mcrUID)
 
-	portUID := buyPortAndGetUID(t, portName)
+	portUID := buyPortAndGetUID(t, portName, locationID)
 	t.Logf("Created port (B-End): %s", portUID)
 
 	const (
@@ -545,10 +553,11 @@ func TestIntegration_VXCVLANModificationLifecycle(t *testing.T) {
 	portAName := fmt.Sprintf("CLI-Test-VLAN-PortA-%s", id)
 	portBName := fmt.Sprintf("CLI-Test-VLAN-PortB-%s", id)
 	vxcName := fmt.Sprintf("CLI-Test-VLAN-%s", id)
+	locationID := testutil.FindPortTestLocation(t, testutil.SharedIntegrationClient(t), 1000, integrationLocationID)
 
-	portAUID := buyPortAndGetUID(t, portAName)
+	portAUID := buyPortAndGetUID(t, portAName, locationID)
 
-	portBUID := buyPortAndGetUID(t, portBName)
+	portBUID := buyPortAndGetUID(t, portBName, locationID)
 
 	vxcCmd := buildVXCCmd(t, vxcName, portAUID, portBUID, 100)
 	require.NoError(t, vxcCmd.Flags().Set("a-end-vlan", "100"))
@@ -579,10 +588,11 @@ func TestIntegration_VXCJSONInputLifecycle(t *testing.T) {
 	portAName := fmt.Sprintf("CLI-Test-VXCJ-PortA-%s", id)
 	portBName := fmt.Sprintf("CLI-Test-VXCJ-PortB-%s", id)
 	vxcName := fmt.Sprintf("CLI-Test-VXCJ-%s", id)
+	locationID := testutil.FindPortTestLocation(t, testutil.SharedIntegrationClient(t), 1000, integrationLocationID)
 
-	portAUID := buyPortAndGetUID(t, portAName)
+	portAUID := buyPortAndGetUID(t, portAName, locationID)
 
-	portBUID := buyPortAndGetUID(t, portBName)
+	portBUID := buyPortAndGetUID(t, portBName, locationID)
 
 	buyPayload := map[string]any{
 		"portUid":   portAUID,

--- a/internal/commands/vxc/vxc_ipsec_integration_test.go
+++ b/internal/commands/vxc/vxc_ipsec_integration_test.go
@@ -58,9 +58,9 @@ func findTransitPartnerUID(t *testing.T, mcrLocationID int) string {
 // (via --ipsec-tunnel-count) and returns its UID. BuyMCR blocks until the MCR is
 // LIVE, so the add-on is provisioned before a tunnel VXC is attached. Cleanup is
 // registered before the UID is asserted so a billable MCR is never leaked.
-func buyMCRWithIPsecAndGetUID(t *testing.T, mcrName string, tunnelCount int) string {
+func buyMCRWithIPsecAndGetUID(t *testing.T, mcrName string, tunnelCount, locationID int) string {
 	t.Helper()
-	cmd := buildMCRCmd(t, mcrName, integrationLocationID)
+	cmd := buildMCRCmd(t, mcrName, locationID)
 	require.NoError(t, cmd.Flags().Set("ipsec-tunnel-count", fmt.Sprintf("%d", tunnelCount)))
 	require.NoErrorf(t, mcr.BuyMCR(cmd, nil, true), "BuyMCR with IPsec add-on failed for %q", mcrName)
 
@@ -93,10 +93,16 @@ func TestIntegration_VXCMCRIPsecTunnelLifecycle(t *testing.T) {
 	mcrName := fmt.Sprintf("CLI-Test-IPsec-MCR-%s", id)
 	vxcName := fmt.Sprintf("CLI-Test-IPsec-VXC-%s", id)
 
-	transitUID := findTransitPartnerUID(t, integrationLocationID)
+	// The MCR and the TRANSIT partner B-End must share a metro for a same-region
+	// Transit VXC, so both are pinned to one discovered location. This test buys
+	// no Megaport port (the B-End is a partner megaport), so it only needs MCR
+	// capacity. If the fallback location has no TRANSIT partner, findTransitPartnerUID skips.
+	locationID := testutil.FindMCRTestLocation(t, testutil.SharedIntegrationClient(t), 1000, integrationLocationID)
+
+	transitUID := findTransitPartnerUID(t, locationID)
 	t.Logf("Using TRANSIT partner (B-End): %s", transitUID)
 
-	mcrUID := buyMCRWithIPsecAndGetUID(t, mcrName, 10)
+	mcrUID := buyMCRWithIPsecAndGetUID(t, mcrName, 10, locationID)
 	t.Logf("Created MCR (A-End) with IPsec add-on: %s", mcrUID)
 
 	vrouterConfig := `{

--- a/internal/testutil/integration.go
+++ b/internal/testutil/integration.go
@@ -159,3 +159,91 @@ func SharedIntegrationClient(t *testing.T) *megaport.Client {
 	}
 	return sharedIntegrationClient
 }
+
+// locationHasPortSpeed reports whether loc advertises port (Megaport) capacity
+// at speedMbps in either diversity zone.
+func locationHasPortSpeed(loc *megaport.LocationV3, speedMbps int) bool {
+	for _, s := range loc.GetMegaportSpeeds() {
+		if s == speedMbps {
+			return true
+		}
+	}
+	return false
+}
+
+// locationHasMCRSpeed reports whether loc advertises MCR capacity at speedMbps
+// in either diversity zone.
+func locationHasMCRSpeed(loc *megaport.LocationV3, speedMbps int) bool {
+	for _, s := range loc.GetMCRSpeeds() {
+		if s == speedMbps {
+			return true
+		}
+	}
+	return false
+}
+
+// findOrderableLocation returns the ID of an active staging location satisfying
+// qualifies, preferring preferredID so a healthy canonical location keeps the
+// suite pinned where it has always run, and otherwise falling back to the first
+// other qualifying location. It skips the test when none qualifies: a location
+// losing a capability should route the suite elsewhere, not fail the build.
+// capability names the requirement for the log and skip messages.
+//
+// Unlike the MVE host-capacity probe, this only checks the speeds the location
+// advertises (the same signal the terraform provider's location helpers use);
+// it never places a validate order, so it is cheap and side-effect free.
+func findOrderableLocation(t *testing.T, client *megaport.Client, preferredID int, capability string, qualifies func(*megaport.LocationV3) bool) int {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	locations, err := client.LocationService.ListLocationsV3(ctx)
+	require.NoErrorf(t, err, "list locations to find %s", capability)
+
+	var fallback *megaport.LocationV3
+	for _, loc := range locations {
+		if loc == nil || !loc.IsStatusOrderable() || !qualifies(loc) {
+			continue
+		}
+		if loc.ID == preferredID {
+			return loc.ID
+		}
+		if fallback == nil {
+			fallback = loc
+		}
+	}
+	if fallback != nil {
+		t.Logf("preferred location %d unavailable for %s; using location %d (%s)", preferredID, capability, fallback.ID, fallback.Name)
+		return fallback.ID
+	}
+	t.Skipf("no active staging location advertises %s", capability)
+	return 0
+}
+
+// FindPortTestLocation returns a staging location that advertises port capacity
+// at speedMbps, preferring preferredID. See findOrderableLocation for the
+// fallback and skip behavior.
+func FindPortTestLocation(t *testing.T, client *megaport.Client, speedMbps, preferredID int) int {
+	t.Helper()
+	return findOrderableLocation(t, client, preferredID, fmt.Sprintf("%d Mbps port capacity", speedMbps), func(loc *megaport.LocationV3) bool {
+		return locationHasPortSpeed(loc, speedMbps)
+	})
+}
+
+// FindMCRTestLocation returns a staging location that advertises MCR capacity at
+// speedMbps, preferring preferredID.
+func FindMCRTestLocation(t *testing.T, client *megaport.Client, speedMbps, preferredID int) int {
+	t.Helper()
+	return findOrderableLocation(t, client, preferredID, fmt.Sprintf("%d Mbps MCR capacity", speedMbps), func(loc *megaport.LocationV3) bool {
+		return locationHasMCRSpeed(loc, speedMbps)
+	})
+}
+
+// FindPortAndMCRTestLocation returns a single staging location that advertises
+// both port capacity at portSpeedMbps and MCR capacity at mcrSpeedMbps, for VXC
+// tests that co-locate a port and an MCR. Prefers preferredID.
+func FindPortAndMCRTestLocation(t *testing.T, client *megaport.Client, portSpeedMbps, mcrSpeedMbps, preferredID int) int {
+	t.Helper()
+	return findOrderableLocation(t, client, preferredID, fmt.Sprintf("%d Mbps port + %d Mbps MCR capacity", portSpeedMbps, mcrSpeedMbps), func(loc *megaport.LocationV3) bool {
+		return locationHasPortSpeed(loc, portSpeedMbps) && locationHasMCRSpeed(loc, mcrSpeedMbps)
+	})
+}


### PR DESCRIPTION
Staging keeps running out of capacity at the location our integration tests pinned (67), so the MVE tests (and others) intermittently fail with `400 No available capacity`. This makes the provisioning tests pick a usable location at run time instead.

- Shared finders in `testutil` prefer the historical location, else the first active location advertising the needed speed, else skip.
- MVE host capacity isn't visible in advertised speeds, so it probes `ValidateMVEOrder` live and falls back across product sizes before skipping.
- The ports, MCR, VXC, MVE, service key, and apply provisioning tests now use the finders.
- Verified on staging: ports 6/6, VXC 6/6, MCR 6/6, MVE 3/3, service keys 3/3, apply 3/3 green. The MVE fallback fired live: the preferred location was out of capacity, so the test bought at the fallback location.

Runner passes fully in CI https://github.com/megaport/megaport-cli/actions/runs/28445324839
