### PR TITLE
test(mve): filter unmappable sizes from capacity probe

### DIFF
--- a/internal/commands/mve/mve_capacity_probe_integration_test.go
+++ b/internal/commands/mve/mve_capacity_probe_integration_test.go
@@ -1,0 +1,50 @@
+//go:build integration
+
+package mve
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIntegration_MVEProductSizeCandidates is a pure, in-memory guard on the
+// capacity-probe size filter: it makes no API calls. It lives under the
+// integration tag because productSizeCandidates does, and is named to match the
+// provisioning job's run filter so the regression is actually exercised in CI.
+func TestIntegration_MVEProductSizeCandidates(t *testing.T) {
+	tests := []struct {
+		name           string
+		availableSizes []string
+		want           []string
+	}{
+		{
+			name:           "drops unmappable label, keeps valid in preferred order",
+			availableSizes: []string{"MVE 4/16", "MVE 2/8", "MVE 16/64"},
+			want:           []string{"MEDIUM", "SMALL"},
+		},
+		{
+			name:           "only unmappable labels falls back to MEDIUM",
+			availableSizes: []string{"MVE 16/64", "MVE 32/128"},
+			want:           []string{"MEDIUM"},
+		},
+		{
+			name:           "empty falls back to MEDIUM",
+			availableSizes: nil,
+			want:           []string{"MEDIUM"},
+		},
+		{
+			name:           "programmatic names pass through in preferred order",
+			availableSizes: []string{"X_LARGE_12", "LARGE"},
+			want:           []string{"LARGE", "X_LARGE_12"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			img := discoveredImage{AvailableSizes: tt.availableSizes}
+			got := img.productSizeCandidates()
+			assert.Equal(t, tt.want, got)
+			assert.NotContains(t, got, "MVE 16/64", "raw label must never be probed")
+		})
+	}
+}

--- a/internal/commands/mve/mve_integration_test.go
+++ b/internal/commands/mve/mve_integration_test.go
@@ -156,7 +156,13 @@ func discoverArubaImage(t *testing.T) discoveredImage {
 func (d discoveredImage) productSizeCandidates() []string {
 	supported := make(map[string]bool, len(d.AvailableSizes))
 	for _, s := range d.AvailableSizes {
-		supported[validation.NormalizeMVEProductSize(strings.ToUpper(s))] = true
+		canonical := validation.NormalizeMVEProductSize(strings.ToUpper(s))
+		// Skip advertised sizes we can't map to a programmatic name the buy API
+		// accepts. Probing a raw label like "MVE 16/64" returns an invalid-size
+		// error, not a capacity error, which would fail the probe.
+		if validation.ValidateMVEProductSize(canonical) == nil {
+			supported[canonical] = true
+		}
 	}
 	var ordered []string
 	emitted := make(map[string]bool, len(supported))
@@ -169,7 +175,7 @@ func (d discoveredImage) productSizeCandidates() []string {
 	for _, size := range []string{"MEDIUM", "SMALL", "LARGE", "X_LARGE_12"} {
 		add(size)
 	}
-	// Probe any other advertised size after the preferred order, so an image
+	// Probe any other supported size after the preferred order, so an image
 	// whose sizes fall outside the list above is still tried, not skipped.
 	for _, s := range d.AvailableSizes {
 		add(validation.NormalizeMVEProductSize(strings.ToUpper(s)))


### PR DESCRIPTION
Staging's Aruba MVE image started advertising an `availableSizes` entry labeled `MVE 16/64`, which has no mapping in `MVELabelToProductSize`. The capacity probe passed that raw label straight to `ValidateMVEOrder`, the API rejected it as an invalid product size, and since that is not a "no available capacity" error the ESD-1559 assertion hard-failed the probe. That broke `TestIntegration_MVELifecycle`, `MVEJSONInputLifecycle`, and `MVELockLifecycle`.

- Probe only advertised sizes that normalize to a valid programmatic size, so unknown labels are dropped instead of sent to the API.
- Add an in-memory regression test for `productSizeCandidates` (fails before the fix, passes after).

If a 16/64 MVE size is a real product offering, adding it to `MVELabelToProductSize`, `ValidMVEProductSizes`, and the SDK enum is a separate change.