### PR TITLE
chore(ESD-1562): ignore superpowers planning artifacts in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ Thumbs.db
 # Claude Code
 .claude/
 /server
+
+# Agentic planning artifacts: the superpowers skill writes plans/specs into
+# docs/, which is a committed folder. Keep them out of the repo.
+docs/superpowers/


### PR DESCRIPTION
The Claude superpowers skill writes agentic plan/spec files into `docs/superpowers/`. Since `docs/` is a committed folder, those artifacts kept leaking into the repo (they were removed from main in the beta-prep cleanup, but nothing stops them coming back, and ~23 branches still carry them).

This adds a `.gitignore` rule so `docs/superpowers/` can never be committed again. Main is already clean, so this is purely preventive.

- Ignore `docs/superpowers/` (anchored at repo root; verified it matches the leaked `plans/` and `specs/` paths and none of the ~284 legitimate generated docs).