### PR TITLE
ESD-1571-fix(mve): make Cisco config parser match the validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 
 ## [Unreleased]
 
+### Fixed
+- require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
+
 ## [v1.0.0-beta.1] - 2026-07-01
 
 ### Added

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Megaport CLI Documentation
 
-> Generated on June 29, 2026 for version v0.13.0
+> Generated on July 5, 2026 for version v1.0.0-beta.1
 
 ## Available Commands
 

--- a/docs/megaport-cli_mve_buy.md
+++ b/docs/megaport-cli_mve_buy.md
@@ -34,8 +34,8 @@ This command allows you to purchase an MVE by providing the necessary details.
 
 ```sh
   megaport-cli mve buy --interactive
-  megaport-cli mve buy --name "My MVE" --term 12 --location-id 123 --vendor-config '{"vendor":"cisco","imageId":123,"productSize":"MEDIUM"}' --vnics '[{"description":"Data Plane","vlan":100}]' --resource-tags '{"env":"prod","owner":"netops"}'
-  megaport-cli mve buy --json '{"name":"My MVE","term":12,"locationId":123,"vendorConfig":{"vendor":"cisco","imageId":123,"productSize":"MEDIUM"},"vnics":[{"description":"Data Plane","vlan":100}],"resourceTags":{"env":"prod","owner":"netops"}}'
+  megaport-cli mve buy --name "My MVE" --term 12 --location-id 123 --vendor-config '{"vendor":"cisco","imageId":123,"productSize":"MEDIUM","manageLocally":true,"adminSshPublicKey":"ssh-rsa AAAA...","sshPublicKey":"ssh-rsa AAAA..."}' --vnics '[{"description":"Data Plane","vlan":100}]' --resource-tags '{"env":"prod","owner":"netops"}'
+  megaport-cli mve buy --json '{"name":"My MVE","term":12,"locationId":123,"vendorConfig":{"vendor":"cisco","imageId":123,"productSize":"MEDIUM","manageLocally":true,"adminSshPublicKey":"ssh-rsa AAAA...","sshPublicKey":"ssh-rsa AAAA..."},"vnics":[{"description":"Data Plane","vlan":100}],"resourceTags":{"env":"prod","owner":"netops"}}'
   megaport-cli mve buy --json-file ./mve-config.json
 ```
 ### JSON Format Example

--- a/docs/megaport-cli_mve_validate.md
+++ b/docs/megaport-cli_mve_validate.md
@@ -25,7 +25,7 @@ Use this for dry-run validation before purchasing, or in CI pipelines to check c
 ### Example Usage
 
 ```sh
-  megaport-cli mve validate --name "My MVE" --term 12 --location-id 123 --vendor-config '{"vendor":"cisco","imageId":123,"productSize":"MEDIUM"}' --vnics '[{"description":"Data Plane","vlan":100}]'
+  megaport-cli mve validate --name "My MVE" --term 12 --location-id 123 --vendor-config '{"vendor":"cisco","imageId":123,"productSize":"MEDIUM","manageLocally":true,"adminSshPublicKey":"ssh-rsa AAAA...","sshPublicKey":"ssh-rsa AAAA..."}' --vnics '[{"description":"Data Plane","vlan":100}]'
   megaport-cli mve validate --json-file ./mve-config.json
 ```
 

--- a/internal/commands/mve/mve.go
+++ b/internal/commands/mve/mve.go
@@ -36,8 +36,8 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithOptionalFlag("promo-code", "Promotional code for discounts").
 		WithOptionalFlag("cost-centre", "Cost centre for billing").
 		WithExample("megaport-cli mve buy --interactive").
-		WithExample("megaport-cli mve buy --name \"My MVE\" --term 12 --location-id 123 --vendor-config '{\"vendor\":\"cisco\",\"imageId\":123,\"productSize\":\"MEDIUM\"}' --vnics '[{\"description\":\"Data Plane\",\"vlan\":100}]' --resource-tags '{\"env\":\"prod\",\"owner\":\"netops\"}'").
-		WithExample("megaport-cli mve buy --json '{\"name\":\"My MVE\",\"term\":12,\"locationId\":123,\"vendorConfig\":{\"vendor\":\"cisco\",\"imageId\":123,\"productSize\":\"MEDIUM\"},\"vnics\":[{\"description\":\"Data Plane\",\"vlan\":100}],\"resourceTags\":{\"env\":\"prod\",\"owner\":\"netops\"}}'").
+		WithExample("megaport-cli mve buy --name \"My MVE\" --term 12 --location-id 123 --vendor-config '{\"vendor\":\"cisco\",\"imageId\":123,\"productSize\":\"MEDIUM\",\"manageLocally\":true,\"adminSshPublicKey\":\"ssh-rsa AAAA...\",\"sshPublicKey\":\"ssh-rsa AAAA...\"}' --vnics '[{\"description\":\"Data Plane\",\"vlan\":100}]' --resource-tags '{\"env\":\"prod\",\"owner\":\"netops\"}'").
+		WithExample("megaport-cli mve buy --json '{\"name\":\"My MVE\",\"term\":12,\"locationId\":123,\"vendorConfig\":{\"vendor\":\"cisco\",\"imageId\":123,\"productSize\":\"MEDIUM\",\"manageLocally\":true,\"adminSshPublicKey\":\"ssh-rsa AAAA...\",\"sshPublicKey\":\"ssh-rsa AAAA...\"},\"vnics\":[{\"description\":\"Data Plane\",\"vlan\":100}],\"resourceTags\":{\"env\":\"prod\",\"owner\":\"netops\"}}'").
 		WithExample("megaport-cli mve buy --json-file ./mve-config.json").
 		WithJSONExample(`{
   "name": "My MVE Display Name",
@@ -249,7 +249,7 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithDocumentedRequiredFlag("location-id", "The ID of the location where the MVE will be provisioned").
 		WithDocumentedRequiredFlag("vendor-config", "JSON string with vendor-specific configuration").
 		WithDocumentedRequiredFlag("vnics", "JSON array of network interfaces").
-		WithExample(`megaport-cli mve validate --name "My MVE" --term 12 --location-id 123 --vendor-config '{"vendor":"cisco","imageId":123,"productSize":"MEDIUM"}' --vnics '[{"description":"Data Plane","vlan":100}]'`).
+		WithExample(`megaport-cli mve validate --name "My MVE" --term 12 --location-id 123 --vendor-config '{"vendor":"cisco","imageId":123,"productSize":"MEDIUM","manageLocally":true,"adminSshPublicKey":"ssh-rsa AAAA...","sshPublicKey":"ssh-rsa AAAA..."}' --vnics '[{"description":"Data Plane","vlan":100}]'`).
 		WithExample("megaport-cli mve validate --json-file ./mve-config.json").
 		WithImportantNote("This command only validates the configuration — no resources are created and no charges are incurred").
 		WithRootCmd(rootCmd).

--- a/internal/commands/mve/mve_inputs.go
+++ b/internal/commands/mve/mve_inputs.go
@@ -332,8 +332,13 @@ func parseCiscoConfig(config map[string]interface{}) (*megaport.CiscoConfig, err
 	}
 
 	// FMC fields are only required for FMC-managed (non-local) deployments,
-	// mirroring ValidateCiscoConfig.
-	manageLocally, _ := getBoolFromMap(config, "manageLocally")
+	// mirroring ValidateCiscoConfig. manageLocally is optional and defaults to
+	// false, but a present-but-non-boolean value is a clear error rather than a
+	// silent false that would confusingly then demand the FMC fields.
+	manageLocally, ok := getBoolFromMap(config, "manageLocally")
+	if _, present := config["manageLocally"]; present && !ok {
+		return nil, fmt.Errorf("manageLocally must be a boolean for Cisco configuration")
+	}
 
 	fmcIPAddress, _ := getStringFromMap(config, "fmcIpAddress")
 	fmcRegistrationKey, _ := getStringFromMap(config, "fmcRegistrationKey")

--- a/internal/commands/mve/mve_inputs.go
+++ b/internal/commands/mve/mve_inputs.go
@@ -321,46 +321,37 @@ func parseCiscoConfig(config map[string]interface{}) (*megaport.CiscoConfig, err
 	}
 	productSize = validation.NormalizeMVEProductSize(strings.ToUpper(productSize))
 
-	mveLabel, ok := getStringFromMap(config, "mveLabel")
-	if !ok {
-		return nil, fmt.Errorf("mveLabel is required for Cisco configuration")
-	}
-
-	manageLocally, ok := getBoolFromMap(config, "manageLocally")
-	if !ok {
-		return nil, fmt.Errorf("manageLocally is required for Cisco configuration")
-	}
-
-	adminSSHPublicKey, ok := getStringFromMap(config, "adminSshPublicKey")
-	if !ok {
+	adminSSHPublicKey, _ := getStringFromMap(config, "adminSshPublicKey")
+	if adminSSHPublicKey == "" {
 		return nil, fmt.Errorf("adminSshPublicKey is required for Cisco configuration")
 	}
 
-	sshPublicKey, ok := getStringFromMap(config, "sshPublicKey")
-	if !ok {
+	sshPublicKey, _ := getStringFromMap(config, "sshPublicKey")
+	if sshPublicKey == "" {
 		return nil, fmt.Errorf("sshPublicKey is required for Cisco configuration")
 	}
 
-	cloudInit, ok := getStringFromMap(config, "cloudInit")
-	if !ok {
-		return nil, fmt.Errorf("cloudInit is required for Cisco configuration")
+	// FMC fields are only required for FMC-managed (non-local) deployments,
+	// mirroring ValidateCiscoConfig.
+	manageLocally, _ := getBoolFromMap(config, "manageLocally")
+
+	fmcIPAddress, _ := getStringFromMap(config, "fmcIpAddress")
+	fmcRegistrationKey, _ := getStringFromMap(config, "fmcRegistrationKey")
+	fmcNatID, _ := getStringFromMap(config, "fmcNatId")
+	if !manageLocally {
+		if fmcIPAddress == "" {
+			return nil, fmt.Errorf("fmcIpAddress is required for Cisco configuration when not managing locally")
+		}
+		if fmcRegistrationKey == "" {
+			return nil, fmt.Errorf("fmcRegistrationKey is required for Cisco configuration when not managing locally")
+		}
+		if fmcNatID == "" {
+			return nil, fmt.Errorf("fmcNatId is required for Cisco configuration when not managing locally")
+		}
 	}
 
-	fmcIPAddress, ok := getStringFromMap(config, "fmcIpAddress")
-	if !ok {
-		return nil, fmt.Errorf("fmcIpAddress is required for Cisco configuration")
-	}
-
-	fmcRegistrationKey, ok := getStringFromMap(config, "fmcRegistrationKey")
-	if !ok {
-		return nil, fmt.Errorf("fmcRegistrationKey is required for Cisco configuration")
-	}
-
-	fmcNatID, ok := getStringFromMap(config, "fmcNatId")
-	if !ok {
-		return nil, fmt.Errorf("fmcNatId is required for Cisco configuration")
-	}
-
+	mveLabel, _ := getStringFromMap(config, "mveLabel")
+	cloudInit, _ := getStringFromMap(config, "cloudInit")
 	adminPassword, _ := getStringFromMap(config, "adminPassword")
 
 	return &megaport.CiscoConfig{

--- a/internal/commands/mve/mve_inputs_test.go
+++ b/internal/commands/mve/mve_inputs_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/megaport/megaport-cli/internal/validation"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -647,4 +648,123 @@ func TestProcessFlagUpdateMVEInput_VnicsWhitespaceString(t *testing.T) {
 	_, err := processFlagUpdateMVEInput(cmd, "mve-123")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "vnics must be a non-empty JSON array")
+}
+
+// parseCiscoConfig must mirror ValidateCiscoConfig: FMC fields are only
+// required when not managing locally, and mveLabel/cloudInit are optional.
+func TestParseCiscoConfig_ManageLocallyParity(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        map[string]interface{}
+		expectedError string
+	}{
+		{
+			name: "locally managed accepted without FMC, mveLabel, or cloudInit",
+			config: map[string]interface{}{
+				"vendor": "cisco", "imageId": float64(1), "productSize": "MEDIUM",
+				"manageLocally":     true,
+				"adminSshPublicKey": "ssh-rsa AAAA", "sshPublicKey": "ssh-rsa AAAA",
+			},
+		},
+		{
+			name: "FMC managed accepted when manageLocally absent and FMC present",
+			config: map[string]interface{}{
+				"vendor": "cisco", "imageId": float64(1), "productSize": "MEDIUM",
+				"adminSshPublicKey": "ssh-rsa AAAA", "sshPublicKey": "ssh-rsa AAAA",
+				"fmcIpAddress": "10.0.0.1", "fmcRegistrationKey": "key", "fmcNatId": "nat",
+			},
+		},
+		{
+			name: "FMC managed rejected when FMC fields missing",
+			config: map[string]interface{}{
+				"vendor": "cisco", "imageId": float64(1), "productSize": "MEDIUM",
+				"manageLocally":     false,
+				"adminSshPublicKey": "ssh-rsa AAAA", "sshPublicKey": "ssh-rsa AAAA",
+			},
+			expectedError: "fmcIpAddress is required for Cisco configuration when not managing locally",
+		},
+		{
+			name: "locally managed still requires adminSshPublicKey",
+			config: map[string]interface{}{
+				"vendor": "cisco", "imageId": float64(1), "productSize": "MEDIUM",
+				"manageLocally": true, "sshPublicKey": "ssh-rsa AAAA",
+			},
+			expectedError: "adminSshPublicKey is required",
+		},
+		{
+			name: "locally managed still requires sshPublicKey",
+			config: map[string]interface{}{
+				"vendor": "cisco", "imageId": float64(1), "productSize": "MEDIUM",
+				"manageLocally": true, "adminSshPublicKey": "ssh-rsa AAAA",
+			},
+			expectedError: "sshPublicKey is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := ParseVendorConfig(tt.config)
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				return
+			}
+			require.NoError(t, err)
+			require.NoError(t, validation.ValidateMVEVendorConfig(cfg),
+				"a config accepted by the parser must also pass the validator")
+		})
+	}
+}
+
+// The documented `mve buy` Cisco examples must parse and validate on both the
+// flags path and the JSON path.
+func TestBuyMVE_CiscoConfigPaths(t *testing.T) {
+	cases := []struct {
+		name         string
+		vendorConfig string
+	}{
+		{
+			name:         "locally managed (documented example)",
+			vendorConfig: `{"vendor":"cisco","imageId":123,"productSize":"MEDIUM","manageLocally":true,"adminSshPublicKey":"ssh-rsa AAAA...","sshPublicKey":"ssh-rsa AAAA..."}`,
+		},
+		{
+			name:         "FMC managed",
+			vendorConfig: `{"vendor":"cisco","imageId":123,"productSize":"MEDIUM","adminSshPublicKey":"ssh-rsa AAAA...","sshPublicKey":"ssh-rsa AAAA...","fmcIpAddress":"10.0.0.1","fmcRegistrationKey":"key","fmcNatId":"nat"}`,
+		},
+	}
+
+	newCiscoBuyCmd := func(t *testing.T, vendorConfig string) *cobra.Command {
+		cmd := &cobra.Command{Use: "buy"}
+		cmd.Flags().String("name", "", "")
+		cmd.Flags().Int("term", 0, "")
+		cmd.Flags().Int("location-id", 0, "")
+		cmd.Flags().String("diversity-zone", "", "")
+		cmd.Flags().String("promo-code", "", "")
+		cmd.Flags().String("cost-centre", "", "")
+		cmd.Flags().String("vendor-config", "", "")
+		cmd.Flags().String("vnics", "", "")
+		cmd.Flags().String("resource-tags", "", "")
+		cmd.Flags().String("resource-tags-file", "", "")
+		require.NoError(t, cmd.Flags().Set("name", "My MVE"))
+		require.NoError(t, cmd.Flags().Set("term", "12"))
+		require.NoError(t, cmd.Flags().Set("location-id", "123"))
+		require.NoError(t, cmd.Flags().Set("vendor-config", vendorConfig))
+		require.NoError(t, cmd.Flags().Set("vnics", `[{"description":"Data Plane","vlan":100}]`))
+		return cmd
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+" via flags", func(t *testing.T) {
+			req, err := processFlagBuyMVEInput(newCiscoBuyCmd(t, tc.vendorConfig))
+			require.NoError(t, err)
+			require.NoError(t, validation.ValidateMVEVendorConfig(req.VendorConfig))
+		})
+
+		t.Run(tc.name+" via JSON", func(t *testing.T) {
+			jsonStr := `{"name":"My MVE","term":12,"locationId":123,"vendorConfig":` + tc.vendorConfig + `,"vnics":[{"description":"Data Plane","vlan":100}]}`
+			req, err := processJSONBuyMVEInput(jsonStr, "")
+			require.NoError(t, err)
+			require.NoError(t, validation.ValidateMVEVendorConfig(req.VendorConfig))
+		})
+	}
 }

--- a/internal/commands/mve/mve_inputs_test.go
+++ b/internal/commands/mve/mve_inputs_test.go
@@ -699,6 +699,15 @@ func TestParseCiscoConfig_ManageLocallyParity(t *testing.T) {
 			},
 			expectedError: "sshPublicKey is required",
 		},
+		{
+			name: "non-boolean manageLocally is a clear type error",
+			config: map[string]interface{}{
+				"vendor": "cisco", "imageId": float64(1), "productSize": "MEDIUM",
+				"manageLocally":     "true",
+				"adminSshPublicKey": "ssh-rsa AAAA", "sshPublicKey": "ssh-rsa AAAA",
+			},
+			expectedError: "manageLocally must be a boolean",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The Cisco vendor-config parser was stricter than the validator: it hard-required `mveLabel`, `manageLocally`, `cloudInit`, and all three FMC fields, even though the SDK marks them `omitempty` and the validator only requires the FMC fields when `manageLocally` is false. Both documented `mve buy` Cisco examples failed, and a locally-managed Cisco buyer couldn't purchase via flags or JSON at all.

- Made FMC field checks conditional on `manageLocally` in `parseCiscoConfig`, mirroring `ValidateCiscoConfig`
- Dropped the hard requirements on `mveLabel`, `manageLocally`, and `cloudInit`, which the validator never enforced
- Fixed the same missing-SSH-key bug in the `mve buy` and `mve validate` documented examples, and regenerated the CLI docs
- Added tests covering locally-managed and FMC-managed Cisco configs on both the flags and JSON paths

ESD-1571