### PR TITLE
ESD-1570-fix(mve): apply resourceTags on JSON and interactive buy paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 
 ### Fixed
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
+- `mve buy` and `mve validate` now apply `resourceTags` from JSON input, and interactive `mve buy` now prompts for tags, matching MCR. Previously the JSON path silently dropped the documented `resourceTags` field and interactive mode never asked. The JSON path shares the same value and empty-key validation as the flags path, so non-string values and empty keys return a usage error before the order is placed
 
 ## [v1.0.0-beta.1] - 2026-07-01
 

--- a/internal/commands/mve/mve_inputs.go
+++ b/internal/commands/mve/mve_inputs.go
@@ -99,6 +99,16 @@ func processJSONBuyMVEInput(jsonStr, jsonFilePath string) (*megaport.BuyMVEReque
 		req.Vnics = vnics
 	}
 
+	if resourceTags, present, err := utils.JSONObject(jsonData, "resourceTags"); err != nil {
+		return nil, exitcodes.NewUsageError(err)
+	} else if present {
+		tags, err := utils.TagMapFromObject(resourceTags)
+		if err != nil {
+			return nil, exitcodes.NewUsageError(err)
+		}
+		req.ResourceTags = tags
+	}
+
 	if err := validation.ValidateBuyMVERequest(req); err != nil {
 		return nil, err
 	}

--- a/internal/commands/mve/mve_inputs_tags_test.go
+++ b/internal/commands/mve/mve_inputs_tags_test.go
@@ -74,3 +74,61 @@ func TestProcessFlagBuyMVEInput_ResourceTags(t *testing.T) {
 		assert.Equal(t, exitcodes.Usage, cliErr.Code)
 	})
 }
+
+func TestProcessJSONBuyMVEInput_ResourceTags(t *testing.T) {
+	const baseBody = `{
+		"name": "Test MVE",
+		"term": 12,
+		"locationId": 123,
+		"vendorConfig": {"vendor":"aruba","productSize":"MEDIUM","imageId":1,"accountName":"test","accountKey":"test","systemTag":"test"}`
+
+	t.Run("tags from JSON reach the request", func(t *testing.T) {
+		body := baseBody + `,"resourceTags":{"env":"prod","owner":"netops"}}`
+
+		req, err := processJSONBuyMVEInput(body, "")
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"env": "prod", "owner": "netops"}, req.ResourceTags)
+	})
+
+	t.Run("no resourceTags leaves tags nil", func(t *testing.T) {
+		req, err := processJSONBuyMVEInput(baseBody+`}`, "")
+		require.NoError(t, err)
+		assert.Nil(t, req.ResourceTags)
+	})
+
+	t.Run("empty tag key is rejected as a usage error", func(t *testing.T) {
+		body := baseBody + `,"resourceTags":{"":"prod"}}`
+
+		_, err := processJSONBuyMVEInput(body, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tag key must not be empty")
+
+		var cliErr *exitcodes.CLIError
+		require.True(t, errors.As(err, &cliErr))
+		assert.Equal(t, exitcodes.Usage, cliErr.Code)
+	})
+
+	t.Run("non-string tag value is rejected as a usage error", func(t *testing.T) {
+		body := baseBody + `,"resourceTags":{"env":123}}`
+
+		_, err := processJSONBuyMVEInput(body, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a string")
+
+		var cliErr *exitcodes.CLIError
+		require.True(t, errors.As(err, &cliErr))
+		assert.Equal(t, exitcodes.Usage, cliErr.Code)
+	})
+
+	t.Run("non-object resourceTags is rejected as a usage error", func(t *testing.T) {
+		body := baseBody + `,"resourceTags":"not-an-object"}`
+
+		_, err := processJSONBuyMVEInput(body, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "resourceTags must be an object")
+
+		var cliErr *exitcodes.CLIError
+		require.True(t, errors.As(err, &cliErr))
+		assert.Equal(t, exitcodes.Usage, cliErr.Code)
+	})
+}

--- a/internal/commands/mve/mve_prompts.go
+++ b/internal/commands/mve/mve_prompts.go
@@ -27,6 +27,12 @@ func promptForBuyMVEDetails(noColor bool) (*megaport.BuyMVERequest, error) {
 	}
 	req.Vnics = vnics
 
+	resourceTags, err := utils.ResourceTagsPrompt(noColor)
+	if err != nil {
+		return nil, err
+	}
+	req.ResourceTags = resourceTags
+
 	if err := validation.ValidateBuyMVERequest(req); err != nil {
 		return nil, err
 	}

--- a/internal/commands/mve/mve_prompts_test.go
+++ b/internal/commands/mve/mve_prompts_test.go
@@ -47,6 +47,51 @@ func TestPromptMVEBaseDetails_Success(t *testing.T) {
 	assert.Equal(t, "my-label", mveLabel)
 }
 
+func TestPromptForBuyMVEDetails_CapturesResourceTags(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	originalTags := utils.GetResourceTagsPrompt()
+	defer func() {
+		utils.SetResourcePrompt(originalPrompt)
+		utils.SetResourceTagsPrompt(originalTags)
+	}()
+
+	// base details (10) + aruba vendor config (3) + one vnic then blank to finish (3)
+	utils.SetResourcePrompt(mockPromptSequence([]string{
+		"Test MVE", "12", "1", "", "", "", "aruba", "1", "MEDIUM", "",
+		"acct", "key", "systag",
+		"eth0", "100", "",
+	}))
+
+	wantTags := map[string]string{"env": "prod", "owner": "netops"}
+	utils.SetResourceTagsPrompt(func(bool) (map[string]string, error) { return wantTags, nil })
+
+	req, err := promptForBuyMVEDetails(true)
+	require.NoError(t, err)
+	assert.Equal(t, wantTags, req.ResourceTags)
+}
+
+func TestPromptForBuyMVEDetails_ResourceTagsPromptError(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	originalTags := utils.GetResourceTagsPrompt()
+	defer func() {
+		utils.SetResourcePrompt(originalPrompt)
+		utils.SetResourceTagsPrompt(originalTags)
+	}()
+
+	utils.SetResourcePrompt(mockPromptSequence([]string{
+		"Test MVE", "12", "1", "", "", "", "aruba", "1", "MEDIUM", "",
+		"acct", "key", "systag",
+		"eth0", "100", "",
+	}))
+	utils.SetResourceTagsPrompt(func(bool) (map[string]string, error) {
+		return nil, fmt.Errorf("tag prompt failed")
+	})
+
+	_, err := promptForBuyMVEDetails(true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tag prompt failed")
+}
+
 func TestPromptMVEBaseDetails_EmptyName(t *testing.T) {
 	original := utils.GetResourcePrompt()
 	defer func() { utils.SetResourcePrompt(original) }()


### PR DESCRIPTION
`mve buy` and `mve validate` silently dropped `resourceTags` from JSON input, even though the command's own JSON examples show the field. Interactive buy never prompted for tags either. Only the flags path handled them. This is the MVE half of the tag-drop class fixed for VXC under ESD-1549.

- Parse `resourceTags` from the JSON buy body via the shared `JSONObject` + `TagMapFromObject` helpers, matching the VXC fix.
- Add a tag prompt to interactive `mve buy`, mirroring MCR.
- `mve validate --json` shares the same builder, so it now reflects the tags too.
- JSON path uses the same value and empty-key validation as the flags path (non-string values and empty keys are rejected).

Tests cover JSON tags applied, absent-field stays nil, empty-key and non-string-value rejection, and the interactive prompt landing on the request.

Closes ESD-1570.