### PR TITLE
ESD-1573-fix(version): honor injected version and normalize update-check prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 
 ### Fixed
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
-- honor the ldflags-injected version instead of the surrounding git tag, and normalize the `v` prefix so a current binary no longer prompts to update (ESD-1573)
 
 ## [v1.0.0-beta.1] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 
 ### Fixed
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
+- honor the ldflags-injected version instead of the surrounding git tag, and normalize the `v` prefix so a current binary no longer prompts to update (ESD-1573)
 
 ## [v1.0.0-beta.1] - 2026-07-01
 

--- a/internal/commands/version/update_check.go
+++ b/internal/commands/version/update_check.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -36,7 +37,9 @@ func checkForUpdate(currentVersion string, client *http.Client, cacheDir string)
 		}
 		writeUpdateCache(cacheFile, latest)
 	}
-	if latest != currentVersion {
+	// goreleaser injects the bare version (e.g. "0.9.4") while GitHub's tag_name
+	// carries a "v" prefix; compare with both prefixes stripped.
+	if strings.TrimPrefix(latest, "v") != strings.TrimPrefix(currentVersion, "v") {
 		return latest, true
 	}
 	return "", false

--- a/internal/commands/version/update_check_test.go
+++ b/internal/commands/version/update_check_test.go
@@ -51,6 +51,37 @@ func TestCheckForUpdate_AlreadyCurrent(t *testing.T) {
 	assert.Empty(t, latest)
 }
 
+func TestCheckForUpdate_PrefixMismatchIsCurrent(t *testing.T) {
+	// goreleaser injects "0.9.4"; GitHub's tag_name is "v0.9.4". These are the
+	// same release and must not trigger an update prompt.
+	srv := httptest.NewServer(githubHandler("v0.9.4"))
+	defer srv.Close()
+
+	orig := githubLatestURL
+	githubLatestURL = srv.URL
+	defer func() { githubLatestURL = orig }()
+
+	dir := t.TempDir()
+	latest, hasUpdate := checkForUpdate("0.9.4", srv.Client(), dir)
+	assert.False(t, hasUpdate)
+	assert.Empty(t, latest)
+}
+
+func TestCheckForUpdate_PrefixDiffersRealUpdate(t *testing.T) {
+	// A genuine newer release still reports an update despite prefix normalization.
+	srv := httptest.NewServer(githubHandler("v1.0.0"))
+	defer srv.Close()
+
+	orig := githubLatestURL
+	githubLatestURL = srv.URL
+	defer func() { githubLatestURL = orig }()
+
+	dir := t.TempDir()
+	latest, hasUpdate := checkForUpdate("0.9.4", srv.Client(), dir)
+	assert.True(t, hasUpdate)
+	assert.Equal(t, "v1.0.0", latest)
+}
+
 func TestCheckForUpdate_DevVersion(t *testing.T) {
 	// Neither "dev" nor "" should trigger a network call.
 	callCount := 0

--- a/internal/commands/version/version.go
+++ b/internal/commands/version/version.go
@@ -34,14 +34,19 @@ func GetGitVersion() string {
 }
 
 func AddCommandsTo(rootCmd *cobra.Command) {
-	if v := GetGitVersion(); v != "" {
-		version = v
-	}
-
 	versionCmd := cmdbuilder.NewCommand("version", "Print the version number of Megaport CLI").
 		WithLongDesc("All software has versions. This is Megaport CLI's.").
 		WithColorAwareRunFunc(func(cmd *cobra.Command, args []string, noColor bool) error {
-			fmt.Fprintf(cmd.OutOrStdout(), "Megaport CLI Version: %s\n", version)
+			// Only shell out to git for source builds; a release binary keeps its
+			// ldflags-injected version even when run inside a tagged git repo.
+			reportedVersion := version
+			if reportedVersion == "dev" {
+				if v := GetGitVersion(); v != "" {
+					reportedVersion = v
+				}
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Megaport CLI Version: %s\n", reportedVersion)
 
 			cacheDir := os.Getenv("MEGAPORT_CONFIG_DIR")
 			if cacheDir == "" {
@@ -51,7 +56,7 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 			}
 			if cacheDir != "" {
 				client := &http.Client{Timeout: 5 * time.Second}
-				if latest, hasUpdate := checkForUpdate(version, client, cacheDir); hasUpdate {
+				if latest, hasUpdate := checkForUpdate(reportedVersion, client, cacheDir); hasUpdate {
 					output.PrintInfo(
 						"Update available: %s (https://github.com/megaport/megaport-cli/releases/latest)",
 						noColor, latest,

--- a/internal/commands/version/version_test.go
+++ b/internal/commands/version/version_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetGitVersion_WithMocks(t *testing.T) {
@@ -114,6 +115,7 @@ func TestVersionCommand_InjectedVersionIgnoresGitTag(t *testing.T) {
 
 	versionCmd, _, err := rootCmd.Find([]string{"version"})
 	assert.NoError(t, err)
+	require.NotNil(t, versionCmd.RunE)
 
 	buf := new(bytes.Buffer)
 	versionCmd.SetOut(buf)
@@ -146,6 +148,7 @@ func TestVersionCommand_DevFallsBackToGit(t *testing.T) {
 
 	versionCmd, _, err := rootCmd.Find([]string{"version"})
 	assert.NoError(t, err)
+	require.NotNil(t, versionCmd.RunE)
 
 	buf := new(bytes.Buffer)
 	versionCmd.SetOut(buf)

--- a/internal/commands/version/version_test.go
+++ b/internal/commands/version/version_test.go
@@ -89,6 +89,72 @@ func TestAddCommandsTo(t *testing.T) {
 	}
 }
 
+func TestVersionCommand_InjectedVersionIgnoresGitTag(t *testing.T) {
+	// A release binary (version injected via ldflags) run inside a tagged git
+	// repo must report the injected version, and must not shell out to git.
+	origVersion := version
+	origExec := execCommand
+	defer func() {
+		version = origVersion
+		execCommand = origExec
+	}()
+
+	gitCalls := 0
+	execCommand = func(command string, args ...string) *exec.Cmd {
+		gitCalls++
+		return exec.Command("echo", "v99.99.99")
+	}
+	version = "1.2.3"
+
+	t.Setenv("MEGAPORT_CONFIG_DIR", t.TempDir())
+	t.Setenv("NO_UPDATE_CHECK", "1")
+
+	rootCmd := &cobra.Command{Use: "test-cli"}
+	AddCommandsTo(rootCmd)
+
+	versionCmd, _, err := rootCmd.Find([]string{"version"})
+	assert.NoError(t, err)
+
+	buf := new(bytes.Buffer)
+	versionCmd.SetOut(buf)
+	versionCmd.SetErr(buf)
+	assert.NoError(t, versionCmd.RunE(versionCmd, []string{}))
+
+	assert.Contains(t, buf.String(), "Megaport CLI Version: 1.2.3")
+	assert.NotContains(t, buf.String(), "v99.99.99")
+	assert.Equal(t, 0, gitCalls, "git must not be invoked when version is injected")
+}
+
+func TestVersionCommand_DevFallsBackToGit(t *testing.T) {
+	origVersion := version
+	origExec := execCommand
+	defer func() {
+		version = origVersion
+		execCommand = origExec
+	}()
+
+	execCommand = func(command string, args ...string) *exec.Cmd {
+		return exec.Command("echo", "v4.5.6")
+	}
+	version = "dev"
+
+	t.Setenv("MEGAPORT_CONFIG_DIR", t.TempDir())
+	t.Setenv("NO_UPDATE_CHECK", "1")
+
+	rootCmd := &cobra.Command{Use: "test-cli"}
+	AddCommandsTo(rootCmd)
+
+	versionCmd, _, err := rootCmd.Find([]string{"version"})
+	assert.NoError(t, err)
+
+	buf := new(bytes.Buffer)
+	versionCmd.SetOut(buf)
+	versionCmd.SetErr(buf)
+	assert.NoError(t, versionCmd.RunE(versionCmd, []string{}))
+
+	assert.Contains(t, buf.String(), "Megaport CLI Version: v4.5.6")
+}
+
 func TestVersionModule(t *testing.T) {
 	module := NewModule()
 


### PR DESCRIPTION
Fixes two coupled defects in the `version` command (ESD-1573).

- Only fall back to `GetGitVersion()` when the compiled-in version is still `dev`, and do it inside the version RunFunc instead of at command registration. A release binary now reports its ldflags-injected version even inside a tagged git repo, and `git` is no longer spawned on every command invocation.
- Normalize the leading `v` on both sides of the update-check comparison, so a current binary (goreleaser injects `0.9.4`) no longer prompts to update against GitHub's `v0.9.4` tag.

Tests added: injected version survives inside a tagged repo (and git is never called), `dev` still falls back to git, and `0.9.4` vs `v0.9.4` reports up-to-date.
