### PR TITLE
ESD-1567-fix(cli): make --interactive take precedence over stray flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 
 ### Fixed
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
-- Combining `--interactive` with `--json`, `--json-file`, or value flags on any buy/update/create command now returns a usage error instead of silently ignoring the interactive request and skipping the prompts. The input modes are mutually exclusive; choose one. Previously `--interactive --name foo` printed "Using flag input", skipped every prompt, and could fail on missing required fields (ESD-1567)
 
 ## [v1.0.0-beta.1] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 
 ### Fixed
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
+- Combining `--interactive` with `--json`, `--json-file`, or value flags on any buy/update/create command now returns a usage error instead of silently ignoring the interactive request and skipping the prompts. The input modes are mutually exclusive; choose one. Previously `--interactive --name foo` printed "Using flag input", skipped every prompt, and could fail on missing required fields (ESD-1567)
 
 ## [v1.0.0-beta.1] - 2026-07-01
 

--- a/internal/base/cmdbuilder/builder.go
+++ b/internal/base/cmdbuilder/builder.go
@@ -176,9 +176,16 @@ func (b *CommandBuilder) WithConditionalRequirements(conditionallyRequiredFlags 
 		interactive, _ := cmd.Flags().GetBool("interactive")
 		jsonStr, _ := cmd.Flags().GetString("json")
 		jsonFile, _ := cmd.Flags().GetString("json-file")
+		skeleton, _ := cmd.Flags().GetBool("generate-skeleton")
+
+		// --interactive is mutually exclusive with JSON and value flags: agrees
+		// with ResolveInput (internal/utils/input.go) so a usage error surfaces
+		// up front instead of silently ignoring the gating this skips below.
+		if interactive && utils.HasConflictingInputFlags(cmd) {
+			return utils.FinishPreRunError(cmd, args, exitcodes.NewUsageError(utils.ErrInteractiveConflict))
+		}
 
 		// Skip validation if interactive mode, JSON input, or skeleton mode is used
-		skeleton, _ := cmd.Flags().GetBool("generate-skeleton")
 		if interactive || jsonStr != "" || jsonFile != "" || skeleton {
 			return nil
 		}

--- a/internal/base/cmdbuilder/builder_test.go
+++ b/internal/base/cmdbuilder/builder_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -366,6 +367,27 @@ func TestWithConditionalRequirements(t *testing.T) {
 		require.NoError(t, cmd.Flags().Set("json", `{"name":"test"}`))
 		err := cmd.PreRunE(cmd, []string{})
 		assert.NoError(t, err)
+	})
+
+	t.Run("fails when interactive is combined with a value flag", func(t *testing.T) {
+		cmd := buildTestCmd()
+		require.NoError(t, cmd.Flags().Set("interactive", "true"))
+		require.NoError(t, cmd.Flags().Set("name", "test-name"))
+		err := cmd.PreRunE(cmd, []string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be combined with")
+		var cliErr *exitcodes.CLIError
+		require.True(t, errors.As(err, &cliErr))
+		assert.Equal(t, exitcodes.Usage, cliErr.Code)
+	})
+
+	t.Run("fails when interactive is combined with json", func(t *testing.T) {
+		cmd := buildTestCmd()
+		require.NoError(t, cmd.Flags().Set("interactive", "true"))
+		require.NoError(t, cmd.Flags().Set("json", `{"name":"test"}`))
+		err := cmd.PreRunE(cmd, []string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be combined with")
 	})
 
 	t.Run("passes when json-file is set", func(t *testing.T) {

--- a/internal/commands/ix/ix_actions.go
+++ b/internal/commands/ix/ix_actions.go
@@ -344,6 +344,11 @@ func UpdateIX(cmd *cobra.Command, args []string, noColor bool) error {
 		cmd.Flags().Changed("reverse-dns") || cmd.Flags().Changed("a-end-product-uid") ||
 		cmd.Flags().Changed("shutdown")
 
+	if err := utils.CheckInteractiveConflict(interactive, utils.HasConflictingInputFlags(cmd)); err != nil {
+		output.PrintError("%v", noColor, err)
+		return err
+	}
+
 	var req *megaport.UpdateIXRequest
 	var err error
 

--- a/internal/commands/ix/ix_actions_test.go
+++ b/internal/commands/ix/ix_actions_test.go
@@ -527,7 +527,7 @@ func TestBuyIX(t *testing.T) {
 			expectedError: "no input provided",
 		},
 		{
-			name:        "JSON takes precedence over interactive flag",
+			name:        "interactive combined with JSON and flags is a usage error",
 			interactive: true,
 			flags: map[string]string{
 				"json":                 `{"productUid":"port-uid-123","productName":"JSON IX","networkServiceType":"Los Angeles IX","asn":65000,"macAddress":"00:11:22:33:44:55","rateLimit":1000,"vlan":100}`,
@@ -535,12 +535,8 @@ func TestBuyIX(t *testing.T) {
 				"name":                 "JSON IX",
 				"network-service-type": "Los Angeles IX",
 			},
-			setupMock: func(m *MockIXService) {
-				m.buyIXResponse = &megaport.BuyIXResponse{
-					TechnicalServiceUID: "ix-json-wins",
-				}
-			},
-			expectedOutput: "IX created",
+			setupMock:     func(m *MockIXService) {},
+			expectedError: "cannot be combined with",
 		},
 	}
 
@@ -1320,6 +1316,24 @@ func TestUpdateIX(t *testing.T) {
 			ixUID:         "ix-123",
 			setupMock:     func(m *MockIXService) {},
 			expectedError: "at least one field must be updated",
+		},
+		{
+			name:        "interactive combined with flags is rejected",
+			ixUID:       "ix-123",
+			interactive: true,
+			flags: map[string]string{
+				"name": "Updated IX",
+			},
+			setupMock:     func(m *MockIXService) {},
+			expectedError: "cannot be combined with",
+		},
+		{
+			name:          "interactive combined with JSON is rejected",
+			ixUID:         "ix-123",
+			interactive:   true,
+			jsonInput:     `{"name":"JSON Updated IX"}`,
+			setupMock:     func(m *MockIXService) {},
+			expectedError: "cannot be combined with",
 		},
 		{
 			name:  "API error during update",

--- a/internal/commands/managed_account/managed_account_actions.go
+++ b/internal/commands/managed_account/managed_account_actions.go
@@ -82,6 +82,11 @@ func CreateManagedAccount(cmd *cobra.Command, args []string, noColor bool) error
 
 	flagsProvided := cmd.Flags().Changed("account-name") || cmd.Flags().Changed("account-ref")
 
+	if err := utils.CheckInteractiveConflict(interactive, utils.HasConflictingInputFlags(cmd)); err != nil {
+		output.PrintError("%v", noColor, err)
+		return err
+	}
+
 	var req *megaport.ManagedAccountRequest
 	var err error
 
@@ -144,6 +149,11 @@ func UpdateManagedAccount(cmd *cobra.Command, args []string, noColor bool) error
 	jsonFile, _ := cmd.Flags().GetString("json-file")
 
 	flagsProvided := cmd.Flags().Changed("account-name") || cmd.Flags().Changed("account-ref")
+
+	if err := utils.CheckInteractiveConflict(interactive, utils.HasConflictingInputFlags(cmd)); err != nil {
+		output.PrintError("%v", noColor, err)
+		return err
+	}
 
 	var req *megaport.ManagedAccountRequest
 	var err error

--- a/internal/commands/managed_account/managed_account_actions_test.go
+++ b/internal/commands/managed_account/managed_account_actions_test.go
@@ -3,11 +3,13 @@ package managed_account
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"testing"
 
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/commands/config"
 	"github.com/megaport/megaport-cli/internal/testutil"
@@ -1145,6 +1147,111 @@ func TestGetManagedAccountFunc_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "managed account not found")
 	assert.Equal(t, "uid-123", mockService.capturedGetCompanyUID)
 	assert.Equal(t, "Nonexistent", mockService.capturedGetAccountName)
+}
+
+func TestCreateManagedAccount_InteractiveConflict(t *testing.T) {
+	tests := []struct {
+		name  string
+		flags map[string]string
+	}{
+		{
+			name: "interactive with value flag",
+			flags: map[string]string{
+				"interactive":  "true",
+				"account-name": "Test Account",
+			},
+		},
+		{
+			name: "interactive with json",
+			flags: map[string]string{
+				"interactive": "true",
+				"json":        `{"accountName":"JSON Account","accountRef":"JSON-REF"}`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Login must never be reached: the guard returns before it.
+			config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+				t.Fatal("login should not be called when input modes conflict")
+				return nil, nil
+			})
+
+			cmd := testutil.NewCommand("create", testutil.NoColorAdapter(CreateManagedAccount))
+			cmd.Flags().String("account-name", "", "")
+			cmd.Flags().String("account-ref", "", "")
+			cmd.Flags().Bool("interactive", false, "")
+			cmd.Flags().String("json", "", "")
+			cmd.Flags().String("json-file", "", "")
+
+			testutil.SetFlags(t, cmd, tt.flags)
+
+			var err error
+			output.CaptureOutput(func() {
+				err = cmd.RunE(cmd, []string{})
+			})
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "cannot be combined with")
+
+			var cliErr *exitcodes.CLIError
+			require.True(t, errors.As(err, &cliErr))
+			assert.Equal(t, exitcodes.Usage, cliErr.Code)
+		})
+	}
+}
+
+func TestUpdateManagedAccount_InteractiveConflict(t *testing.T) {
+	tests := []struct {
+		name  string
+		flags map[string]string
+	}{
+		{
+			name: "interactive with value flag",
+			flags: map[string]string{
+				"interactive":  "true",
+				"account-name": "Test Account",
+			},
+		},
+		{
+			name: "interactive with json",
+			flags: map[string]string{
+				"interactive": "true",
+				"json":        `{"accountName":"JSON Name","accountRef":"JSON-REF"}`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config.SetLoginFunc(func(ctx context.Context) (*megaport.Client, error) {
+				t.Fatal("login should not be called when input modes conflict")
+				return nil, nil
+			})
+
+			cmd := testutil.NewCommand("update", testutil.NoColorAdapter(UpdateManagedAccount))
+			cmd.Flags().String("account-name", "", "")
+			cmd.Flags().String("account-ref", "", "")
+			cmd.Flags().Bool("interactive", false, "")
+			cmd.Flags().String("json", "", "")
+			cmd.Flags().String("json-file", "", "")
+
+			testutil.SetFlags(t, cmd, tt.flags)
+
+			var err error
+			output.CaptureOutput(func() {
+				err = cmd.RunE(cmd, []string{"acct-uid"})
+			})
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "cannot be combined with")
+
+			var cliErr *exitcodes.CLIError
+			require.True(t, errors.As(err, &cliErr))
+			assert.Equal(t, exitcodes.Usage, cliErr.Code)
+		})
+	}
 }
 
 func captureStderr(t *testing.T, fn func()) (result string) {

--- a/internal/commands/mcr/mcr_actions.go
+++ b/internal/commands/mcr/mcr_actions.go
@@ -226,6 +226,11 @@ func UpdateMCR(cmd *cobra.Command, args []string, noColor bool) error {
 		cmd.Flags().Changed("marketplace-visibility") || cmd.Flags().Changed("term") ||
 		cmd.Flags().Changed("mcr-asn")
 
+	if err := utils.CheckInteractiveConflict(interactive, utils.HasConflictingInputFlags(cmd)); err != nil {
+		output.PrintError("%v", noColor, err)
+		return err
+	}
+
 	var req *megaport.ModifyMCRRequest
 	var err error
 

--- a/internal/commands/mcr/mcr_actions_ipsec_addon.go
+++ b/internal/commands/mcr/mcr_actions_ipsec_addon.go
@@ -25,6 +25,11 @@ func AddMCRIPSecAddOn(cmd *cobra.Command, args []string, noColor bool) error {
 	jsonFile, _ := cmd.Flags().GetString("json-file")
 	flagsProvided := cmd.Flags().Changed("tunnel-count")
 
+	if err := utils.CheckInteractiveConflict(interactive, utils.HasConflictingInputFlags(cmd)); err != nil {
+		output.PrintError("%v", noColor, err)
+		return err
+	}
+
 	var tunnelCount int
 	var err error
 
@@ -102,6 +107,11 @@ func UpdateMCRIPSecAddOn(cmd *cobra.Command, args []string, noColor bool) error 
 	jsonStr, _ := cmd.Flags().GetString("json")
 	jsonFile, _ := cmd.Flags().GetString("json-file")
 	flagsProvided := cmd.Flags().Changed("tunnel-count")
+
+	if err := utils.CheckInteractiveConflict(interactive, utils.HasConflictingInputFlags(cmd)); err != nil {
+		output.PrintError("%v", noColor, err)
+		return err
+	}
 
 	var tunnelCount int
 	var err error

--- a/internal/commands/mcr/mcr_actions_ipsec_addon_test.go
+++ b/internal/commands/mcr/mcr_actions_ipsec_addon_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/commands/config"
 	"github.com/megaport/megaport-cli/internal/testutil"
 	megaport "github.com/megaport/megaportgo"
@@ -343,6 +344,38 @@ func TestUpdateMCRIPSecAddOn_LoginError(t *testing.T) {
 	err := UpdateMCRIPSecAddOn(cmd, []string{"mcr-abc", "addon-abc"}, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "auth failed")
+}
+
+func TestAddMCRIPSecAddOn_InteractiveConflict(t *testing.T) {
+	cmd := &cobra.Command{Use: "add-ipsec-addon [mcrUID]"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().Int("tunnel-count", 0, "")
+	_ = cmd.Flags().Set("interactive", "true")
+	_ = cmd.Flags().Set("tunnel-count", "10")
+
+	err := AddMCRIPSecAddOn(cmd, []string{"mcr-abc"}, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be combined with")
+
+	var cliErr *exitcodes.CLIError
+	assert.ErrorAs(t, err, &cliErr)
+	assert.Equal(t, exitcodes.Usage, cliErr.Code)
+}
+
+func TestUpdateMCRIPSecAddOn_InteractiveConflict(t *testing.T) {
+	cmd := &cobra.Command{Use: "update-ipsec-addon [mcrUID] [addOnUID]"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().Int("tunnel-count", 0, "")
+	_ = cmd.Flags().Set("interactive", "true")
+	_ = cmd.Flags().Set("json", `{"tunnelCount":30}`)
+
+	err := UpdateMCRIPSecAddOn(cmd, []string{"mcr-abc", "addon-abc"}, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be combined with")
 }
 
 func TestParseIPSecTunnelCountFromJSON(t *testing.T) {

--- a/internal/commands/mcr/mcr_actions_prefix_filter.go
+++ b/internal/commands/mcr/mcr_actions_prefix_filter.go
@@ -26,6 +26,11 @@ func CreateMCRPrefixFilterList(cmd *cobra.Command, args []string, noColor bool) 
 	flagsProvided := cmd.Flags().Changed("description") || cmd.Flags().Changed("address-family") ||
 		cmd.Flags().Changed("entries")
 
+	if err := utils.CheckInteractiveConflict(interactive, utils.HasConflictingInputFlags(cmd)); err != nil {
+		output.PrintError("%v", noColor, err)
+		return err
+	}
+
 	var req *megaport.CreateMCRPrefixFilterListRequest
 	var err error
 
@@ -88,6 +93,11 @@ func UpdateMCRPrefixFilterList(cmd *cobra.Command, args []string, noColor bool) 
 
 	flagsProvided := cmd.Flags().Changed("description") || cmd.Flags().Changed("address-family") ||
 		cmd.Flags().Changed("entries")
+
+	if err := utils.CheckInteractiveConflict(interactive, utils.HasConflictingInputFlags(cmd)); err != nil {
+		output.PrintError("%v", noColor, err)
+		return err
+	}
 
 	// Validate input mode before logging in.
 	if jsonStr == "" && jsonFile == "" && !flagsProvided && !interactive {

--- a/internal/commands/mcr/mcr_actions_test.go
+++ b/internal/commands/mcr/mcr_actions_test.go
@@ -2210,6 +2210,24 @@ func TestUpdateMCR(t *testing.T) {
 			},
 			expectedError: "empty response from API",
 		},
+		{
+			name: "interactive combined with flags is a usage error",
+			args: []string{"mcr-123"},
+			flags: map[string]string{
+				"interactive": "true",
+				"name":        "Updated MCR",
+			},
+			expectedError: "cannot be combined with",
+		},
+		{
+			name: "interactive combined with JSON is a usage error",
+			args: []string{"mcr-123"},
+			flags: map[string]string{
+				"interactive": "true",
+				"json":        `{"name":"JSON Updated MCR"}`,
+			},
+			expectedError: "cannot be combined with",
+		},
 	}
 
 	for _, tt := range tests {
@@ -2359,6 +2377,24 @@ func TestCreateMCRPrefixFilterList(t *testing.T) {
 				}
 			},
 			expectedError: "API error: prefix filter list creation failed",
+		},
+		{
+			name: "interactive combined with flags is a usage error",
+			args: []string{"mcr-123"},
+			flags: map[string]string{
+				"interactive": "true",
+				"description": "Test Prefix List",
+			},
+			expectedError: "cannot be combined with",
+		},
+		{
+			name: "interactive combined with JSON is a usage error",
+			args: []string{"mcr-456"},
+			flags: map[string]string{
+				"interactive": "true",
+				"json":        `{"description":"JSON Prefix List","addressFamily":"IPv4","entries":[{"action":"deny","prefix":"192.168.0.0/16"}]}`,
+			},
+			expectedError: "cannot be combined with",
 		},
 	}
 
@@ -2560,6 +2596,15 @@ func TestUpdateMCRPrefixFilterList(t *testing.T) {
 				}
 			},
 			expectedError: "not successful for ID 456",
+		},
+		{
+			name: "interactive combined with flags is a usage error",
+			args: []string{"mcr-123", "456"},
+			flags: map[string]string{
+				"interactive": "true",
+				"description": "Updated Prefix List",
+			},
+			expectedError: "cannot be combined with",
 		},
 	}
 

--- a/internal/commands/mcr/mcr_actions_test.go
+++ b/internal/commands/mcr/mcr_actions_test.go
@@ -1036,17 +1036,22 @@ func TestBuyMCRCmd_WithMockClient(t *testing.T) {
 			expectedError: "no input provided",
 		},
 		{
-			name:        "JSON takes precedence over interactive flag",
+			name:        "interactive combined with JSON is a usage error",
 			interactive: true,
 			flags: map[string]string{
 				"json": `{"name":"JSON MCR","term":24,"portSpeed":10000,"locationId":123,"mcrAsn":65000,"diversityZone":"green","costCentre":"cost-789","promoCode":"JSONPROMO"}`,
 			},
-			setupMock: func(m *MockMCRService) {
-				m.BuyMCRResult = &megaport.BuyMCRResponse{
-					TechnicalServiceUID: "mcr-json-wins",
-				}
+			setupMock:     func(m *MockMCRService) {},
+			expectedError: "cannot be combined with",
+		},
+		{
+			name:        "interactive combined with flags is a usage error",
+			interactive: true,
+			flags: map[string]string{
+				"name": "Test MCR",
 			},
-			expectedOutput: "MCR created",
+			setupMock:     func(m *MockMCRService) {},
+			expectedError: "cannot be combined with",
 		},
 	}
 

--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -290,6 +290,18 @@ func UpdateMVE(cmd *cobra.Command, args []string, noColor bool) error {
 	mveUID := args[0]
 	formattedUID := output.FormatUID(mveUID, noColor)
 
+	interactive, _ := cmd.Flags().GetBool("interactive")
+	jsonStr, _ := cmd.Flags().GetString("json")
+	jsonFile, _ := cmd.Flags().GetString("json-file")
+
+	// Reject conflicting input modes before logging in, matching the other
+	// update commands: a usage error must surface up front, not after a
+	// login + GET round-trip.
+	if err := utils.CheckInteractiveConflict(interactive, utils.HasConflictingInputFlags(cmd)); err != nil {
+		output.PrintError("%v", noColor, err)
+		return err
+	}
+
 	client, err := config.Login(ctx)
 	if err != nil {
 		output.PrintError("Failed to log in: %v", noColor, err)
@@ -310,10 +322,6 @@ func UpdateMVE(cmd *cobra.Command, args []string, noColor bool) error {
 		output.PrintError("MVE %s not found", noColor, mveUID)
 		return fmt.Errorf("MVE %s not found", mveUID)
 	}
-
-	interactive, _ := cmd.Flags().GetBool("interactive")
-	jsonStr, _ := cmd.Flags().GetString("json")
-	jsonFile, _ := cmd.Flags().GetString("json-file")
 
 	flagsProvided := cmd.Flags().Changed("name") ||
 		cmd.Flags().Changed("cost-centre") ||

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -524,6 +524,20 @@ func TestUpdateMVE(t *testing.T) {
 				assert.Equal(t, "Mgmt", req.Vnics[1].Description)
 			},
 		},
+		{
+			name:          "interactive combined with flags is a usage error",
+			args:          []string{"mve-123"},
+			interactive:   true,
+			flags:         map[string]string{"name": "Updated MVE"},
+			expectedError: "cannot be combined with",
+		},
+		{
+			name:          "interactive combined with JSON is a usage error",
+			args:          []string{"mve-123"},
+			interactive:   true,
+			flags:         map[string]string{"json": `{"name":"JSON MVE"}`},
+			expectedError: "cannot be combined with",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -951,7 +951,7 @@ func TestBuyMVE(t *testing.T) {
 			expectedError: "failed to parse JSON",
 		},
 		{
-			name:        "JSON takes precedence over interactive flag",
+			name:        "interactive combined with JSON is a usage error",
 			interactive: true,
 			flags: map[string]string{
 				"json": `{
@@ -974,13 +974,15 @@ func TestBuyMVE(t *testing.T) {
 					"vnics": [{"description": "JSON VNIC", "vlan": 200}]
 				}`,
 			},
-			mockSetup: func(m *MockMVEService) {
-				m.ValidateMVEOrderErr = nil
-				m.BuyMVEResult = &megaport.BuyMVEResponse{
-					TechnicalServiceUID: "mve-json-wins",
-				}
-			},
-			expectedOutput: "MVE created mve-json-wins",
+			mockSetup:     func(m *MockMVEService) {},
+			expectedError: "cannot be combined with",
+		},
+		{
+			name:          "interactive combined with flags is a usage error",
+			interactive:   true,
+			flags:         map[string]string{"name": "Test MVE"},
+			mockSetup:     func(m *MockMVEService) {},
+			expectedError: "cannot be combined with",
 		},
 	}
 

--- a/internal/commands/nat_gateway/nat_gateway_actions.go
+++ b/internal/commands/nat_gateway/nat_gateway_actions.go
@@ -29,6 +29,11 @@ func CreateNATGateway(cmd *cobra.Command, args []string, noColor bool) error {
 		cmd.Flags().Changed("diversity-zone") || cmd.Flags().Changed("promo-code") ||
 		cmd.Flags().Changed("service-level-reference") || cmd.Flags().Changed("auto-renew")
 
+	if err := utils.CheckInteractiveConflict(interactive, utils.HasConflictingInputFlags(cmd)); err != nil {
+		output.PrintError("%v", noColor, err)
+		return err
+	}
+
 	var req *megaport.CreateNATGatewayRequest
 	var err error
 
@@ -217,6 +222,11 @@ func UpdateNATGateway(cmd *cobra.Command, args []string, noColor bool) error {
 		cmd.Flags().Changed("promo-code") || cmd.Flags().Changed("service-level-reference") ||
 		cmd.Flags().Changed("auto-renew") || cmd.Flags().Changed("resource-tags") ||
 		cmd.Flags().Changed("resource-tags-file")
+
+	if err := utils.CheckInteractiveConflict(interactive, utils.HasConflictingInputFlags(cmd)); err != nil {
+		output.PrintError("%v", noColor, err)
+		return err
+	}
 
 	if jsonStr == "" && jsonFile == "" && !flagsProvided && !interactive {
 		return fmt.Errorf("at least one field must be updated")

--- a/internal/commands/nat_gateway/nat_gateway_conflict_test.go
+++ b/internal/commands/nat_gateway/nat_gateway_conflict_test.go
@@ -1,0 +1,117 @@
+package nat_gateway
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The conflict guard runs before login, so these cases never reach the API.
+
+func TestCreateNATGateway_InteractiveConflict(t *testing.T) {
+	tests := []struct {
+		name    string
+		setFlag func(*cobra.Command)
+	}{
+		{
+			name: "interactive with value flag",
+			setFlag: func(cmd *cobra.Command) {
+				require.NoError(t, cmd.Flags().Set("name", "My NAT GW"))
+			},
+		},
+		{
+			name: "interactive with json",
+			setFlag: func(cmd *cobra.Command) {
+				require.NoError(t, cmd.Flags().Set("json", `{"name":"GW","term":12,"speed":1000,"locationId":1}`))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &MockNATGatewayService{}
+			defer setupMockNATGateway(mock)()
+
+			cmd := newTestCmd("create")
+			require.NoError(t, cmd.Flags().Set("interactive", "true"))
+			tt.setFlag(cmd)
+
+			err := CreateNATGateway(cmd, nil, true)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "cannot be combined with")
+			assert.Nil(t, mock.CapturedCreateReq)
+		})
+	}
+}
+
+func TestCreateNATGateway_InteractiveConflict_UsageCode(t *testing.T) {
+	mock := &MockNATGatewayService{}
+	defer setupMockNATGateway(mock)()
+
+	cmd := newTestCmd("create")
+	require.NoError(t, cmd.Flags().Set("interactive", "true"))
+	require.NoError(t, cmd.Flags().Set("name", "My NAT GW"))
+
+	err := CreateNATGateway(cmd, nil, true)
+	require.Error(t, err)
+
+	var cliErr *exitcodes.CLIError
+	require.True(t, errors.As(err, &cliErr))
+	assert.Equal(t, exitcodes.Usage, cliErr.Code)
+}
+
+func TestUpdateNATGateway_InteractiveConflict(t *testing.T) {
+	tests := []struct {
+		name    string
+		setFlag func(*cobra.Command)
+	}{
+		{
+			name: "interactive with value flag",
+			setFlag: func(cmd *cobra.Command) {
+				require.NoError(t, cmd.Flags().Set("name", "New Name"))
+			},
+		},
+		{
+			name: "interactive with json",
+			setFlag: func(cmd *cobra.Command) {
+				require.NoError(t, cmd.Flags().Set("json", `{"name":"Updated"}`))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &MockNATGatewayService{}
+			defer setupMockNATGateway(mock)()
+
+			cmd := newTestCmd("update")
+			require.NoError(t, cmd.Flags().Set("interactive", "true"))
+			tt.setFlag(cmd)
+
+			err := UpdateNATGateway(cmd, []string{"uid-conflict"}, true)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "cannot be combined with")
+			assert.Nil(t, mock.CapturedUpdateReq)
+		})
+	}
+}
+
+func TestUpdateNATGateway_InteractiveConflict_UsageCode(t *testing.T) {
+	mock := &MockNATGatewayService{}
+	defer setupMockNATGateway(mock)()
+
+	cmd := newTestCmd("update")
+	require.NoError(t, cmd.Flags().Set("interactive", "true"))
+	require.NoError(t, cmd.Flags().Set("name", "New Name"))
+
+	err := UpdateNATGateway(cmd, []string{"uid-conflict"}, true)
+	require.Error(t, err)
+
+	var cliErr *exitcodes.CLIError
+	require.True(t, errors.As(err, &cliErr))
+	assert.Equal(t, exitcodes.Usage, cliErr.Code)
+}

--- a/internal/commands/ports/ports_actions_manage.go
+++ b/internal/commands/ports/ports_actions_manage.go
@@ -14,18 +14,27 @@ import (
 )
 
 func UpdatePort(cmd *cobra.Command, args []string, noColor bool) error {
+	portUID := args[0]
+
+	interactive, _ := cmd.Flags().GetBool("interactive")
+	jsonStr, _ := cmd.Flags().GetString("json")
+	jsonFile, _ := cmd.Flags().GetString("json-file")
+	flagsProvided := cmd.Flags().Changed("name") || cmd.Flags().Changed("marketplace-visibility") ||
+		cmd.Flags().Changed("cost-centre") || cmd.Flags().Changed("term")
+
+	// Reject conflicting input modes before logging in, matching the other
+	// update commands: a usage error must surface up front, not after login.
+	if err := utils.CheckInteractiveConflict(interactive, utils.HasConflictingInputFlags(cmd)); err != nil {
+		output.PrintError("%v", noColor, err)
+		return err
+	}
+
 	ctx, cancel, client, err := utils.LoginClient(cmd, utils.DefaultMutationTimeout, config.Login)
 	if err != nil {
 		output.PrintError("Failed to log in: %v", noColor, err)
 		return err
 	}
 	defer cancel()
-
-	portUID := args[0]
-
-	interactive, _ := cmd.Flags().GetBool("interactive")
-	jsonStr, _ := cmd.Flags().GetString("json")
-	jsonFile, _ := cmd.Flags().GetString("json-file")
 
 	var req *megaport.ModifyPortRequest
 
@@ -49,8 +58,7 @@ func UpdatePort(cmd *cobra.Command, args []string, noColor bool) error {
 		if err == nil {
 			req.PortID = portUID
 		}
-	} else if cmd.Flags().Changed("name") || cmd.Flags().Changed("marketplace-visibility") ||
-		cmd.Flags().Changed("cost-centre") || cmd.Flags().Changed("term") {
+	} else if flagsProvided {
 		output.PrintInfo("Using flag input", noColor)
 		req, err = processFlagUpdatePortInput(cmd, portUID)
 		if err != nil {

--- a/internal/commands/ports/ports_actions_test.go
+++ b/internal/commands/ports/ports_actions_test.go
@@ -928,18 +928,22 @@ func TestBuyPort(t *testing.T) {
 			expectedError: "failed to parse JSON",
 		},
 		{
-			name:      "JSON takes precedence over interactive flag",
+			name:      "interactive combined with JSON is a usage error",
 			jsonInput: `{"name":"json-port","term":12,"portSpeed":1000,"locationId":1,"marketPlaceVisibility":false}`,
 			flags: map[string]string{
 				"interactive": "true",
 			},
-			setupMock: func(m *MockPortService) {},
-			buyPortOverride: func(ctx context.Context, client *megaport.Client, req *megaport.BuyPortRequest) (*megaport.BuyPortResponse, error) {
-				return &megaport.BuyPortResponse{
-					TechnicalServiceUIDs: []string{"json-over-interactive-uid"},
-				}, nil
+			setupMock:     func(m *MockPortService) {},
+			expectedError: "cannot be combined with",
+		},
+		{
+			name: "interactive combined with flags is a usage error",
+			flags: map[string]string{
+				"interactive": "true",
+				"name":        "test-port",
 			},
-			expectedContains: "json-over-interactive-uid",
+			setupMock:     func(m *MockPortService) {},
+			expectedError: "cannot be combined with",
 		},
 	}
 

--- a/internal/commands/ports/ports_actions_test.go
+++ b/internal/commands/ports/ports_actions_test.go
@@ -1559,6 +1559,19 @@ func TestUpdatePort(t *testing.T) {
 			},
 			expectedError: "at least one field must be updated",
 		},
+		{
+			name:          "interactive combined with flags is a usage error",
+			portUID:       "port-update-6",
+			flags:         map[string]string{"interactive": "true", "name": "Updated Port Name"},
+			expectedError: "cannot be combined with",
+		},
+		{
+			name:          "interactive combined with JSON is a usage error",
+			portUID:       "port-update-7",
+			flags:         map[string]string{"interactive": "true"},
+			jsonInput:     `{"name":"JSON Updated"}`,
+			expectedError: "cannot be combined with",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/commands/users/users_actions.go
+++ b/internal/commands/users/users_actions.go
@@ -23,6 +23,11 @@ func buildCreateUserRequest(cmd *cobra.Command, noColor bool) (*megaport.CreateU
 	flagsProvided := cmd.Flags().Changed("first-name") || cmd.Flags().Changed("last-name") ||
 		cmd.Flags().Changed("email") || cmd.Flags().Changed("position")
 
+	if err := utils.CheckInteractiveConflict(interactive, utils.HasConflictingInputFlags(cmd)); err != nil {
+		output.PrintError("%v", noColor, err)
+		return nil, err
+	}
+
 	if jsonStr != "" || jsonFile != "" {
 		output.PrintInfo("Using JSON input", noColor)
 		req, err := processJSONCreateUserInput(jsonStr, jsonFile)
@@ -61,6 +66,11 @@ func buildUpdateUserRequest(cmd *cobra.Command, noColor bool) (*megaport.UpdateU
 		cmd.Flags().Changed("email") || cmd.Flags().Changed("position") ||
 		cmd.Flags().Changed("phone") || cmd.Flags().Changed("active") ||
 		cmd.Flags().Changed("notification-enabled")
+
+	if err := utils.CheckInteractiveConflict(interactive, utils.HasConflictingInputFlags(cmd)); err != nil {
+		output.PrintError("%v", noColor, err)
+		return nil, err
+	}
 
 	if jsonStr != "" || jsonFile != "" {
 		output.PrintInfo("Using JSON input", noColor)

--- a/internal/commands/users/users_inputs_test.go
+++ b/internal/commands/users/users_inputs_test.go
@@ -1,13 +1,90 @@
 package users
 
 import (
+	"errors"
 	"os"
 	"testing"
 
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func newUserInputCommand() *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Bool("interactive", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().String("first-name", "", "")
+	cmd.Flags().String("last-name", "", "")
+	cmd.Flags().String("email", "", "")
+	cmd.Flags().String("position", "", "")
+	cmd.Flags().String("phone", "", "")
+	cmd.Flags().Bool("active", false, "")
+	cmd.Flags().Bool("notification-enabled", false, "")
+	return cmd
+}
+
+func TestBuildCreateUserRequestInteractiveConflict(t *testing.T) {
+	tests := []struct {
+		name  string
+		flags map[string]string
+	}{
+		{name: "interactive with first-name", flags: map[string]string{"first-name": "John"}},
+		{name: "interactive with json", flags: map[string]string{"json": `{"firstName":"John"}`}},
+		{name: "interactive with json-file", flags: map[string]string{"json-file": "/tmp/user.json"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newUserInputCommand()
+			require.NoError(t, cmd.Flags().Set("interactive", "true"))
+			for k, v := range tt.flags {
+				require.NoError(t, cmd.Flags().Set(k, v))
+			}
+
+			req, err := buildCreateUserRequest(cmd, true)
+			assert.Nil(t, req)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "cannot be combined with")
+
+			var cliErr *exitcodes.CLIError
+			require.True(t, errors.As(err, &cliErr))
+			assert.Equal(t, exitcodes.Usage, cliErr.Code)
+		})
+	}
+}
+
+func TestBuildUpdateUserRequestInteractiveConflict(t *testing.T) {
+	tests := []struct {
+		name  string
+		flags map[string]string
+	}{
+		{name: "interactive with first-name", flags: map[string]string{"first-name": "John"}},
+		{name: "interactive with json", flags: map[string]string{"json": `{"firstName":"John"}`}},
+		{name: "interactive with json-file", flags: map[string]string{"json-file": "/tmp/user.json"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newUserInputCommand()
+			require.NoError(t, cmd.Flags().Set("interactive", "true"))
+			for k, v := range tt.flags {
+				require.NoError(t, cmd.Flags().Set(k, v))
+			}
+
+			req, err := buildUpdateUserRequest(cmd, true)
+			assert.Nil(t, req)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "cannot be combined with")
+
+			var cliErr *exitcodes.CLIError
+			require.True(t, errors.As(err, &cliErr))
+			assert.Equal(t, exitcodes.Usage, cliErr.Code)
+		})
+	}
+}
 
 func TestProcessJSONCreateUserInput(t *testing.T) {
 	tests := []struct {

--- a/internal/commands/vxc/vxc_actions.go
+++ b/internal/commands/vxc/vxc_actions.go
@@ -405,6 +405,18 @@ func UpdateVXC(cmd *cobra.Command, args []string, noColor bool) error {
 	vxcUID := args[0]
 	formattedUID := output.FormatUID(vxcUID, noColor)
 
+	interactive, _ := cmd.Flags().GetBool("interactive")
+	jsonStr, _ := cmd.Flags().GetString("json")
+	jsonFilePath, _ := cmd.Flags().GetString("json-file")
+
+	// Reject conflicting input modes before logging in, matching the other
+	// update commands: a usage error must surface up front, not after a
+	// login + GET round-trip.
+	if err := utils.CheckInteractiveConflict(interactive, utils.HasConflictingInputFlags(cmd)); err != nil {
+		output.PrintError("%v", noColor, err)
+		return err
+	}
+
 	client, err := config.Login(ctx)
 	if err != nil {
 		output.PrintError("Failed to log in: %v", noColor, err)
@@ -424,10 +436,6 @@ func UpdateVXC(cmd *cobra.Command, args []string, noColor bool) error {
 
 	var req *megaport.UpdateVXCRequest
 	var buildErr error
-
-	interactive, _ := cmd.Flags().GetBool("interactive")
-	jsonStr, _ := cmd.Flags().GetString("json")
-	jsonFilePath, _ := cmd.Flags().GetString("json-file")
 
 	if jsonStr != "" || jsonFilePath != "" {
 		output.PrintInfo("Using JSON input for VXC %s", noColor, formattedUID)

--- a/internal/commands/vxc/vxc_actions_test.go
+++ b/internal/commands/vxc/vxc_actions_test.go
@@ -301,22 +301,26 @@ func TestBuyVXC(t *testing.T) {
 			},
 		},
 		{
-			name: "JSON takes precedence over interactive flag",
-			setupMock: func(t *testing.T, m *MockVXCService) {
-				buyVXCFunc = func(ctx context.Context, client *megaport.Client, req *megaport.BuyVXCRequest) (*megaport.BuyVXCResponse, error) {
-					return &megaport.BuyVXCResponse{
-						TechnicalServiceUID: "vxc-json-wins",
-					}, nil
-				}
-			},
+			name: "interactive combined with JSON is a usage error",
 			flags: map[string]string{
 				"json": `{"portUid":"port-aaa-111","vxcName":"JSON VXC","rateLimit":500,"term":12,"bEndConfiguration":{"productUID":"port-bbb-222"}}`,
 			},
 			flagsBool: map[string]bool{
 				"interactive": true,
 			},
-			skipRequest:    true,
-			expectedOutput: "VXC created vxc-json-wins",
+			skipRequest:   true,
+			expectedError: "cannot be combined with",
+		},
+		{
+			name: "interactive combined with flags is a usage error",
+			flags: map[string]string{
+				"name": "Test VXC",
+			},
+			flagsBool: map[string]bool{
+				"interactive": true,
+			},
+			skipRequest:   true,
+			expectedError: "cannot be combined with",
 		},
 	}
 

--- a/internal/commands/vxc/vxc_actions_test.go
+++ b/internal/commands/vxc/vxc_actions_test.go
@@ -2138,6 +2138,26 @@ func TestUpdateVXC(t *testing.T) {
 			},
 			expectedError: "invalid flag combination",
 		},
+		{
+			name:   "interactive combined with flags is a usage error",
+			vxcUID: "vxc-update-1",
+			flags: map[string]string{
+				"interactive": "true",
+				"name":        "Updated VXC",
+			},
+			setupMock:     func(m *MockVXCService) {},
+			expectedError: "cannot be combined with",
+		},
+		{
+			name:   "interactive combined with JSON is a usage error",
+			vxcUID: "vxc-update-1",
+			flags: map[string]string{
+				"interactive": "true",
+				"json":        `{"name":"JSON VXC"}`,
+			},
+			setupMock:     func(m *MockVXCService) {},
+			expectedError: "cannot be combined with",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/utils/input.go
+++ b/internal/utils/input.go
@@ -1,12 +1,76 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
+
+// ErrInteractiveConflict is returned when --interactive is combined with
+// --json, --json-file, or other value flags. The input modes are mutually
+// exclusive: silently picking one would ignore the other input the user
+// explicitly provided. Shared with the builder's required-flag gating
+// (cmdbuilder.WithConditionalRequirements) so both surfaces agree.
+var ErrInteractiveConflict = errors.New("--interactive cannot be combined with --json, --json-file, or other flags; choose a single input mode")
+
+// CheckInteractiveConflict rejects --interactive combined with --json,
+// --json-file, or other value flags. Update commands typically apply partial
+// changes via a hand-rolled JSON/flags/interactive chain rather than going
+// through ResolveInput; call this first in that chain so they enforce the
+// same mutual-exclusivity policy ResolveInput does. Pass HasConflictingInputFlags(cmd)
+// as hasOtherInput so every command detects the conflict the same way.
+func CheckInteractiveConflict(interactive, hasOtherInput bool) error {
+	if interactive && hasOtherInput {
+		return exitcodes.NewUsageError(ErrInteractiveConflict)
+	}
+	return nil
+}
+
+// nonInputFlags are command-local flags that don't supply resource input, so
+// setting one alongside --interactive is not a conflict: the input-mode
+// selectors themselves plus behavior toggles (confirmation skips, wait
+// control, output-only export). Global/persistent flags (--output, --env, ...)
+// are excluded structurally by HasConflictingInputFlags and need not be listed.
+var nonInputFlags = map[string]bool{
+	"interactive":       true,
+	"generate-skeleton": true,
+	"yes":               true,
+	"no-wait":           true,
+	"force":             true,
+	"export":            true,
+}
+
+// HasConflictingInputFlags reports whether the user explicitly set any
+// command-local flag that supplies resource input (--json, --json-file, or a
+// value flag) and therefore conflicts with --interactive. Inherited
+// global/persistent flags (--output, --no-color, --env, --timeout, ...) never
+// count, and behavior toggles are excluded via nonInputFlags. This keeps every
+// buy/update/create command's conflict detection identical and drift-free as
+// flags are added.
+//
+// We iterate cmd.Flags().Visit (the merged flagset's changed flags) rather than
+// LocalNonPersistentFlags().Visit: cobra rebuilds the latter with AddFlag, which
+// populates the set's formal map but not its actual map, so Visit sees nothing.
+// Lookup, by contrast, reads formal and works on the rebuilt inherited set.
+func HasConflictingInputFlags(cmd *cobra.Command) bool {
+	inherited := cmd.InheritedFlags()
+	conflict := false
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		if nonInputFlags[f.Name] {
+			return
+		}
+		if inherited.Lookup(f.Name) != nil {
+			return
+		}
+		conflict = true
+	})
+	return conflict
+}
 
 // ReadJSONInput reads JSON data from either a raw string or a file path.
 // If jsonStr is non-empty, it takes precedence; otherwise reads from jsonFile.
@@ -54,7 +118,10 @@ type InputConfig[T any] struct {
 // ResolveInput determines which input mode the user chose (JSON, flags, or
 // interactive) and delegates to the appropriate builder function.
 //
-// Precedence: JSON > flags > interactive > error.
+// Combining --interactive with --json/--json-file or other value flags is a
+// usage error (see ErrInteractiveConflict): the modes are mutually exclusive,
+// so ResolveInput never silently drops one in favor of another. Otherwise
+// precedence is JSON > flags > interactive > error.
 func ResolveInput[T any](cfg InputConfig[T]) (T, error) {
 	var zero T
 
@@ -75,8 +142,19 @@ func ResolveInput[T any](cfg InputConfig[T]) (T, error) {
 		return zero, fmt.Errorf("failed to read --interactive flag: %w", err)
 	}
 
+	hasJSON := jsonStr != "" || jsonFile != ""
+	hasFlags := cfg.FlagsProvided != nil && cfg.FlagsProvided()
+
+	// Detect the conflict from the full command-local flag set, not just the
+	// primary flags used for mode selection below, so optional value flags
+	// (--cost-centre, --promo-code, --resource-tags, ...) can't slip past.
+	if err := CheckInteractiveConflict(interactive, HasConflictingInputFlags(cfg.Cmd)); err != nil {
+		output.PrintError("%v", cfg.NoColor, err)
+		return zero, err
+	}
+
 	switch {
-	case jsonStr != "" || jsonFile != "":
+	case hasJSON:
 		if cfg.FromJSON == nil {
 			return zero, fmt.Errorf("JSON input provided but no JSON handler configured for %s", cfg.ResourceName)
 		}
@@ -88,7 +166,7 @@ func ResolveInput[T any](cfg InputConfig[T]) (T, error) {
 		}
 		return result, nil
 
-	case cfg.FlagsProvided != nil && cfg.FlagsProvided():
+	case hasFlags:
 		if cfg.FromFlags == nil {
 			return zero, fmt.Errorf("flag input provided but no flag handler configured for %s", cfg.ResourceName)
 		}

--- a/internal/utils/input_test.go
+++ b/internal/utils/input_test.go
@@ -1,10 +1,12 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"testing"
 
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -216,6 +218,157 @@ func TestResolveInput_NilCmd(t *testing.T) {
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no command configured")
+}
+
+func TestResolveInput_InteractiveWithFlagsIsConflict(t *testing.T) {
+	cmd := newTestCmd()
+	cmd.Flags().String("name", "", "")
+	require.NoError(t, cmd.Flags().Set("interactive", "true"))
+	require.NoError(t, cmd.Flags().Set("name", "test"))
+
+	_, err := ResolveInput(InputConfig[string]{
+		ResourceName:  "port",
+		Cmd:           cmd,
+		NoColor:       true,
+		FlagsProvided: func() bool { return cmd.Flags().Changed("name") },
+		FromJSON:      func(jsonStr, jsonFile string) (string, error) { return "", fmt.Errorf("should not be called") },
+		FromFlags:     func() (string, error) { return "", fmt.Errorf("should not be called") },
+		FromPrompt:    func() (string, error) { return "", fmt.Errorf("should not be called") },
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be combined with")
+}
+
+func TestResolveInput_InteractiveWithJSONIsConflict(t *testing.T) {
+	cmd := newTestCmd()
+	require.NoError(t, cmd.Flags().Set("interactive", "true"))
+	require.NoError(t, cmd.Flags().Set("json", `{}`))
+
+	_, err := ResolveInput(InputConfig[string]{
+		ResourceName: "port",
+		Cmd:          cmd,
+		NoColor:      true,
+		FromJSON:     func(jsonStr, jsonFile string) (string, error) { return "", fmt.Errorf("should not be called") },
+		FromPrompt:   func() (string, error) { return "", fmt.Errorf("should not be called") },
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be combined with")
+}
+
+func TestCheckInteractiveConflict(t *testing.T) {
+	assert.NoError(t, CheckInteractiveConflict(false, false))
+	assert.NoError(t, CheckInteractiveConflict(false, true))
+	assert.NoError(t, CheckInteractiveConflict(true, false))
+	err := CheckInteractiveConflict(true, true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be combined with")
+
+	// The ticket mandates usage exit code 2, so assert it at the source rather
+	// than only matching the message (which a plain fmt.Errorf would also pass).
+	var cliErr *exitcodes.CLIError
+	require.True(t, errors.As(err, &cliErr), "conflict error must be a CLIError")
+	assert.Equal(t, exitcodes.Usage, cliErr.Code)
+}
+
+// newConflictTestCmd builds a leaf command wired to a parent that owns the
+// global persistent flags, mirroring how real commands sit under the root. This
+// lets the test prove inherited globals never trip the conflict detector.
+func newConflictTestCmd() *cobra.Command {
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("output", "table", "")
+	root.PersistentFlags().Bool("no-color", false, "")
+	root.PersistentFlags().String("env", "production", "")
+
+	leaf := &cobra.Command{Use: "buy"}
+	leaf.Flags().Bool("interactive", false, "")
+	leaf.Flags().Bool("generate-skeleton", false, "")
+	leaf.Flags().Bool("yes", false, "")
+	leaf.Flags().Bool("no-wait", false, "")
+	leaf.Flags().Bool("force", false, "")
+	leaf.Flags().Bool("export", false, "")
+	leaf.Flags().String("json", "", "")
+	leaf.Flags().String("json-file", "", "")
+	leaf.Flags().String("name", "", "")
+	leaf.Flags().String("cost-centre", "", "")
+	root.AddCommand(leaf)
+	return leaf
+}
+
+func TestHasConflictingInputFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		set      map[string]string
+		expected bool
+	}{
+		{name: "nothing set", set: nil, expected: false},
+		{name: "only interactive", set: map[string]string{"interactive": "true"}, expected: false},
+		{name: "behavior flags only", set: map[string]string{"interactive": "true", "yes": "true", "no-wait": "true", "force": "true", "export": "true", "generate-skeleton": "true"}, expected: false},
+		{name: "value flag", set: map[string]string{"interactive": "true", "name": "foo"}, expected: true},
+		{name: "optional value flag", set: map[string]string{"interactive": "true", "cost-centre": "eng"}, expected: true},
+		{name: "json", set: map[string]string{"interactive": "true", "json": "{}"}, expected: true},
+		{name: "json-file", set: map[string]string{"interactive": "true", "json-file": "/tmp/x.json"}, expected: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newConflictTestCmd()
+			for k, v := range tt.set {
+				require.NoError(t, cmd.Flags().Set(k, v))
+			}
+			assert.Equal(t, tt.expected, HasConflictingInputFlags(cmd))
+		})
+	}
+}
+
+func TestHasConflictingInputFlags_InheritedGlobalsIgnored(t *testing.T) {
+	// Drive the real cobra parse path so inherited globals land in the merged
+	// flagset exactly as they do at runtime, then assert they don't count as a
+	// conflict. Isolated leaf.Flags().Set can't reach parent persistent flags.
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("output", "table", "")
+	root.PersistentFlags().Bool("no-color", false, "")
+
+	var got, ran bool
+	leaf := &cobra.Command{
+		Use: "buy",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ran = true
+			got = HasConflictingInputFlags(cmd)
+			return nil
+		},
+	}
+	leaf.Flags().Bool("interactive", false, "")
+	leaf.Flags().String("name", "", "")
+	root.AddCommand(leaf)
+
+	root.SetArgs([]string{"buy", "--interactive", "--output", "json", "--no-color"})
+	require.NoError(t, root.Execute())
+	require.True(t, ran, "leaf RunE did not run")
+	assert.False(t, got, "inherited globals must not count as a conflict")
+}
+
+func TestHasConflictingInputFlags_ValueFlagWithGlobals(t *testing.T) {
+	// Same real parse path, but now a value flag is set alongside the globals:
+	// this must be detected as a conflict.
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("output", "table", "")
+
+	var got, ran bool
+	leaf := &cobra.Command{
+		Use: "buy",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ran = true
+			got = HasConflictingInputFlags(cmd)
+			return nil
+		},
+	}
+	leaf.Flags().Bool("interactive", false, "")
+	leaf.Flags().String("name", "", "")
+	root.AddCommand(leaf)
+
+	root.SetArgs([]string{"buy", "--interactive", "--name", "foo", "--output", "json"})
+	require.NoError(t, root.Execute())
+	require.True(t, ran, "leaf RunE did not run")
+	assert.True(t, got, "value flag alongside globals must count as a conflict")
 }
 
 func TestReadJSONInput_FromString(t *testing.T) {

--- a/internal/utils/resource_tags.go
+++ b/internal/utils/resource_tags.go
@@ -102,6 +102,12 @@ type UpdateTagsOptions struct {
 // fetching existing tags, parsing input (interactive/JSON/JSON file), calling
 // the update function, and printing results.
 func UpdateResourceTags(opts UpdateTagsOptions) error {
+	interactive, _ := opts.Cmd.Flags().GetBool("interactive")
+	if err := CheckInteractiveConflict(interactive, HasConflictingInputFlags(opts.Cmd)); err != nil {
+		output.PrintError("%v", opts.NoColor, err)
+		return err
+	}
+
 	// Use a dedicated context for the initial list call so interactive prompts
 	// don't consume the timeout budget. Cancel immediately after the call to
 	// release timer resources before any potentially long interactive prompt.
@@ -112,8 +118,6 @@ func UpdateResourceTags(opts UpdateTagsOptions) error {
 		output.PrintError("Failed to log in or list existing resource tags: %v", opts.NoColor, err)
 		return fmt.Errorf("failed to log in or list existing resource tags: %w", err)
 	}
-
-	interactive, _ := opts.Cmd.Flags().GetBool("interactive")
 
 	var resourceTags map[string]string
 

--- a/internal/utils/resource_tags_test.go
+++ b/internal/utils/resource_tags_test.go
@@ -2,11 +2,13 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -441,6 +443,29 @@ func TestUpdateResourceTags(t *testing.T) {
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no input provided")
+	})
+
+	t.Run("interactive combined with tags is a usage error before login", func(t *testing.T) {
+		listCalled := false
+		trackingListFunc := func(ctx context.Context, uid string) (map[string]string, error) {
+			listCalled = true
+			return nil, nil
+		}
+		cmd := newUpdateCmd(t, map[string]string{"interactive": "true", "tags": "env=prod"})
+		err := UpdateResourceTags(UpdateTagsOptions{
+			ResourceType: "port",
+			UID:          "uid-7",
+			NoColor:      true,
+			Cmd:          cmd,
+			ListFunc:     trackingListFunc,
+			UpdateFunc:   successUpdateFunc,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be combined with")
+		assert.False(t, listCalled, "conflict must be rejected before the list/login call")
+		var cliErr *exitcodes.CLIError
+		require.True(t, errors.As(err, &cliErr))
+		assert.Equal(t, exitcodes.Usage, cliErr.Code)
 	})
 }
 


### PR DESCRIPTION
Combining `--interactive` with `--json`, `--json-file`, or value flags used to silently ignore the interactive request: the command printed "Using flag/JSON input", skipped every prompt, and could then fail on missing required fields. That was confusing and inconsistent.

Now the three input modes are mutually exclusive. Mixing `--interactive` with any other input returns a usage error (exit code 2) up front, before any login.

Changes:
- Add `CheckInteractiveConflict` and `HasConflictingInputFlags` in `internal/utils/input.go`.
- Reject the mix in `ResolveInput` (buy commands) and in the builder's required-flag gating.
- Apply the same check in every hand-rolled update/create path (vxc, mve, mcr, ports, ix, nat_gateway, managed_account, users, IPSec add-on, prefix filter) and in the shared `UpdateResourceTags` helper.
- The conflict check runs before login/GET so the error surfaces immediately.
- Tests cover the combination for buy and update commands plus the shared helpers.

ESD-1567
