### PR TITLE
ESD-1579-fix(wasm): fail file-input flags fast with a clear browser error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 ## [Unreleased]
 
 ### Fixed
-- in the WASM browser build, file-based input flags (`--json-file`, `--resource-tags-file`) now fail fast with a clear "file input is not supported in the browser" error pointing at the inline alternative (`--json` / `--resource-tags`) instead of a raw filesystem error, and `--help` annotates the flags as browser-unavailable (ESD-1579)
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
 - `mve buy` and `mve validate` now apply `resourceTags` from JSON input, and interactive `mve buy` now prompts for tags, matching MCR. Previously the JSON path silently dropped the documented `resourceTags` field and interactive mode never asked. The JSON path shares the same value and empty-key validation as the flags path, so non-string values and empty keys return a usage error before the order is placed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 ## [Unreleased]
 
 ### Fixed
-- `--json-file` and tags-file flags now fail fast with a clear "file input is not supported in the browser; pass the JSON inline with --json" message in the WASM build instead of a raw filesystem error, and those flags are annotated as browser-unavailable in `--help` (ESD-1579)
+- in the WASM browser build, file-based input flags (`--json-file`, `--resource-tags-file`) now fail fast with a clear "file input is not supported in the browser" error pointing at the inline alternative (`--json` / `--resource-tags`) instead of a raw filesystem error, and `--help` annotates the flags as browser-unavailable (ESD-1579)
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
 - `mve buy` and `mve validate` now apply `resourceTags` from JSON input, and interactive `mve buy` now prompts for tags, matching MCR. Previously the JSON path silently dropped the documented `resourceTags` field and interactive mode never asked. The JSON path shares the same value and empty-key validation as the flags path, so non-string values and empty keys return a usage error before the order is placed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 ## [Unreleased]
 
 ### Fixed
+- `--json-file` and tags-file flags now fail fast with a clear "file input is not supported in the browser; pass the JSON inline with --json" message in the WASM build instead of a raw filesystem error, and those flags are annotated as browser-unavailable in `--help` (ESD-1579)
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
 - `mve buy` and `mve validate` now apply `resourceTags` from JSON input, and interactive `mve buy` now prompts for tags, matching MCR. Previously the JSON path silently dropped the documented `resourceTags` field and interactive mode never asked. The JSON path shares the same value and empty-key validation as the flags path, so non-string values and empty keys return a usage error before the order is placed
 

--- a/internal/base/cmdbuilder/file_flag_usage_native.go
+++ b/internal/base/cmdbuilder/file_flag_usage_native.go
@@ -1,0 +1,8 @@
+//go:build !js || !wasm
+
+package cmdbuilder
+
+// fileInputUsage returns the usage string for a file-path input flag. On native
+// builds the flag works normally, so the base text is used unchanged (inlineFlag
+// only matters in the browser annotation).
+func fileInputUsage(base, _ string) string { return base }

--- a/internal/base/cmdbuilder/file_flag_usage_wasm.go
+++ b/internal/base/cmdbuilder/file_flag_usage_wasm.go
@@ -3,9 +3,10 @@
 package cmdbuilder
 
 // fileInputUsage annotates a file-path input flag's usage in the browser build,
-// where reading from an OS filesystem is unsupported (see readInputFile). The
-// flag stays registered so its input path still surfaces the clear runtime
-// error; inlineFlag names the inline alternative to point the user at.
+// where reading from an OS filesystem is unsupported (see the platform helpers
+// in internal/utils/input_file_wasm.go). The flag stays registered so its input
+// path still surfaces the clear runtime error; inlineFlag names the inline
+// alternative to point the user at.
 func fileInputUsage(base, inlineFlag string) string {
 	return base + " (not available in the browser; use " + inlineFlag + " instead)"
 }

--- a/internal/base/cmdbuilder/file_flag_usage_wasm.go
+++ b/internal/base/cmdbuilder/file_flag_usage_wasm.go
@@ -1,0 +1,11 @@
+//go:build js && wasm
+
+package cmdbuilder
+
+// fileInputUsage annotates a file-path input flag's usage in the browser build,
+// where reading from an OS filesystem is unsupported (see readInputFile). The
+// flag stays registered so its input path still surfaces the clear runtime
+// error; inlineFlag names the inline alternative to point the user at.
+func fileInputUsage(base, inlineFlag string) string {
+	return base + " (not available in the browser; use " + inlineFlag + " instead)"
+}

--- a/internal/base/cmdbuilder/flagsets.go
+++ b/internal/base/cmdbuilder/flagsets.go
@@ -13,7 +13,7 @@ func (b *CommandBuilder) WithWatchFlags() *CommandBuilder {
 func (b *CommandBuilder) WithStandardInputFlags() *CommandBuilder {
 	b.WithBoolFlagP("interactive", "i", false, "Use interactive mode with prompts")
 	b.WithFlag("json", "", "JSON string containing configuration")
-	b.WithFlag("json-file", "", "Path to JSON file containing configuration")
+	b.WithFlag("json-file", "", fileInputUsage("Path to JSON file containing configuration", "--json"))
 	return b
 }
 
@@ -27,16 +27,16 @@ func (b *CommandBuilder) WithDateRangeFlags() *CommandBuilder {
 // WithJSONConfigFlags adds flags for JSON configuration input
 func (b *CommandBuilder) WithJSONConfigFlags() *CommandBuilder {
 	b.WithFlag("json", "", "JSON string containing configuration")
-	b.WithFlag("json-file", "", "Path to JSON file containing configuration")
+	b.WithFlag("json-file", "", fileInputUsage("Path to JSON file containing configuration", "--json"))
 	return b
 }
 
 // WithResourceTagFlags adds flags for resource tagging
 func (b *CommandBuilder) WithResourceTagFlags() *CommandBuilder {
 	b.WithFlag("resource-tags", "", "Resource tags as a JSON string (e.g. {\"key1\":\"value1\",\"key2\":\"value2\"})")
-	b.WithFlag("resource-tags-file", "", "Path to JSON file containing resource tags")
+	b.WithFlag("resource-tags-file", "", fileInputUsage("Path to JSON file containing resource tags", "--resource-tags"))
 	b.WithOptionalFlag("resource-tags", "Resource tags as a JSON string (e.g. {\"key1\":\"value1\",\"key2\":\"value2\"})")
-	b.WithOptionalFlag("resource-tags-file", "Path to JSON file containing resource tags")
+	b.WithOptionalFlag("resource-tags-file", fileInputUsage("Path to JSON file containing resource tags", "--resource-tags"))
 	return b
 }
 

--- a/internal/utils/input.go
+++ b/internal/utils/input.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/base/output"
@@ -79,11 +78,7 @@ func ReadJSONInput(jsonStr, jsonFile string) ([]byte, error) {
 		return []byte(jsonStr), nil
 	}
 	if jsonFile != "" {
-		data, err := os.ReadFile(jsonFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read JSON file: %w", err)
-		}
-		return data, nil
+		return readInputFile(jsonFile)
 	}
 	return nil, nil
 }

--- a/internal/utils/input_file_native.go
+++ b/internal/utils/input_file_native.go
@@ -1,0 +1,54 @@
+//go:build !js || !wasm
+
+package utils
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// readInputFile reads a --json-file path from the OS filesystem.
+func readInputFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read JSON file: %w", err)
+	}
+	return data, nil
+}
+
+// readTagsFile reads a user-supplied JSON file path safely: it cleans the path,
+// rejects upward traversal, rejects non-regular files, and enforces a 1 MiB
+// size limit while reading (open + stat + LimitReader avoids a TOCTOU race).
+func readTagsFile(path string) ([]byte, error) {
+	clean := filepath.Clean(path)
+	// Reject paths that still navigate above the current directory after cleaning.
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return nil, fmt.Errorf("invalid file path %q: path traversal not allowed", path)
+	}
+	f, err := os.Open(clean)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("file %q is not a regular file", path)
+	}
+	if info.Size() > maxTagsFileSize {
+		return nil, fmt.Errorf("file %q exceeds maximum allowed size of 1 MiB (%d bytes)", path, info.Size())
+	}
+	data, err := io.ReadAll(io.LimitReader(f, maxTagsFileSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+	if len(data) > maxTagsFileSize {
+		return nil, fmt.Errorf("file %q exceeds maximum allowed size of 1 MiB (%d bytes)", path, len(data))
+	}
+	return data, nil
+}

--- a/internal/utils/input_file_native.go
+++ b/internal/utils/input_file_native.go
@@ -10,19 +10,23 @@ import (
 	"strings"
 )
 
-// readInputFile reads a --json-file path from the OS filesystem.
+// readInputFile reads a --json-file path from the OS filesystem, applying the
+// same path-traversal, regular-file, and size guards as readTagsFile.
 func readInputFile(path string) ([]byte, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read JSON file: %w", err)
-	}
-	return data, nil
+	return readFileGuarded(path, "failed to read JSON file")
 }
 
-// readTagsFile reads a user-supplied JSON file path safely: it cleans the path,
+// readTagsFile reads a --resource-tags-file / --tags-file path from the OS
+// filesystem under the same guards as readInputFile.
+func readTagsFile(path string) ([]byte, error) {
+	return readFileGuarded(path, "failed to read file")
+}
+
+// readFileGuarded reads a user-supplied file path safely: it cleans the path,
 // rejects upward traversal, rejects non-regular files, and enforces a 1 MiB
 // size limit while reading (open + stat + LimitReader avoids a TOCTOU race).
-func readTagsFile(path string) ([]byte, error) {
+// readErrPrefix labels I/O failures so callers keep their existing wording.
+func readFileGuarded(path, readErrPrefix string) ([]byte, error) {
 	clean := filepath.Clean(path)
 	// Reject paths that still navigate above the current directory after cleaning.
 	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
@@ -30,24 +34,24 @@ func readTagsFile(path string) ([]byte, error) {
 	}
 	f, err := os.Open(clean)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read file: %w", err)
+		return nil, fmt.Errorf("%s: %w", readErrPrefix, err)
 	}
 	defer f.Close()
 	info, err := f.Stat()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read file: %w", err)
+		return nil, fmt.Errorf("%s: %w", readErrPrefix, err)
 	}
 	if !info.Mode().IsRegular() {
 		return nil, fmt.Errorf("file %q is not a regular file", path)
 	}
-	if info.Size() > maxTagsFileSize {
+	if info.Size() > maxInputFileSize {
 		return nil, fmt.Errorf("file %q exceeds maximum allowed size of 1 MiB (%d bytes)", path, info.Size())
 	}
-	data, err := io.ReadAll(io.LimitReader(f, maxTagsFileSize+1))
+	data, err := io.ReadAll(io.LimitReader(f, maxInputFileSize+1))
 	if err != nil {
-		return nil, fmt.Errorf("failed to read file: %w", err)
+		return nil, fmt.Errorf("%s: %w", readErrPrefix, err)
 	}
-	if len(data) > maxTagsFileSize {
+	if len(data) > maxInputFileSize {
 		return nil, fmt.Errorf("file %q exceeds maximum allowed size of 1 MiB (%d bytes)", path, len(data))
 	}
 	return data, nil

--- a/internal/utils/input_file_native_test.go
+++ b/internal/utils/input_file_native_test.go
@@ -36,3 +36,35 @@ func TestReadJSONInput_Native_FromFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, `{"term":12}`, string(data))
 }
+
+func TestReadTagsFile_Native_ReadsContents(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tags.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"env":"prod"}`), 0o600))
+
+	data, err := readTagsFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, `{"env":"prod"}`, string(data))
+}
+
+func TestReadTagsFile_Native_RejectsTraversal(t *testing.T) {
+	_, err := readTagsFile("../secrets.json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "path traversal not allowed")
+}
+
+func TestReadTagsFile_Native_RejectsNonRegularFile(t *testing.T) {
+	_, err := readTagsFile(t.TempDir()) // a directory is not a regular file
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not a regular file")
+}
+
+func TestReadTagsFile_Native_RejectsOversizedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.json")
+	require.NoError(t, os.WriteFile(path, make([]byte, maxTagsFileSize+1), 0o600))
+
+	_, err := readTagsFile(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed size")
+}

--- a/internal/utils/input_file_native_test.go
+++ b/internal/utils/input_file_native_test.go
@@ -27,6 +27,28 @@ func TestReadInputFile_Native_MissingFile(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to read JSON file")
 }
 
+func TestReadInputFile_Native_RejectsTraversal(t *testing.T) {
+	_, err := readInputFile("../secrets.json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "path traversal not allowed")
+}
+
+func TestReadInputFile_Native_RejectsNonRegularFile(t *testing.T) {
+	_, err := readInputFile(t.TempDir()) // a directory is not a regular file
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not a regular file")
+}
+
+func TestReadInputFile_Native_RejectsOversizedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.json")
+	require.NoError(t, os.WriteFile(path, make([]byte, maxInputFileSize+1), 0o600))
+
+	_, err := readInputFile(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed size")
+}
+
 func TestReadJSONInput_Native_FromFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "order.json")
@@ -68,7 +90,7 @@ func TestReadTagsFile_Native_RejectsNonRegularFile(t *testing.T) {
 func TestReadTagsFile_Native_RejectsOversizedFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "big.json")
-	require.NoError(t, os.WriteFile(path, make([]byte, maxTagsFileSize+1), 0o600))
+	require.NoError(t, os.WriteFile(path, make([]byte, maxInputFileSize+1), 0o600))
 
 	_, err := readTagsFile(path)
 	require.Error(t, err)

--- a/internal/utils/input_file_native_test.go
+++ b/internal/utils/input_file_native_test.go
@@ -1,0 +1,38 @@
+//go:build !js || !wasm
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadInputFile_Native_ReadsContents(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"name":"port"}`), 0o600))
+
+	data, err := readInputFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, `{"name":"port"}`, string(data))
+}
+
+func TestReadInputFile_Native_MissingFile(t *testing.T) {
+	_, err := readInputFile(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read JSON file")
+}
+
+func TestReadJSONInput_Native_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "order.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"term":12}`), 0o600))
+
+	data, err := ReadJSONInput("", path)
+	require.NoError(t, err)
+	assert.Equal(t, `{"term":12}`, string(data))
+}

--- a/internal/utils/input_file_native_test.go
+++ b/internal/utils/input_file_native_test.go
@@ -38,7 +38,7 @@ func TestReadJSONInput_Native_FromFile(t *testing.T) {
 }
 
 func TestReadJSONInput_Native_FileNotFound(t *testing.T) {
-	_, err := ReadJSONInput("", "/nonexistent/path.json")
+	_, err := ReadJSONInput("", filepath.Join(t.TempDir(), "does-not-exist.json"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to read JSON file")
 }

--- a/internal/utils/input_file_native_test.go
+++ b/internal/utils/input_file_native_test.go
@@ -37,6 +37,12 @@ func TestReadJSONInput_Native_FromFile(t *testing.T) {
 	assert.Equal(t, `{"term":12}`, string(data))
 }
 
+func TestReadJSONInput_Native_FileNotFound(t *testing.T) {
+	_, err := ReadJSONInput("", "/nonexistent/path.json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read JSON file")
+}
+
 func TestReadTagsFile_Native_ReadsContents(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "tags.json")

--- a/internal/utils/input_file_wasm.go
+++ b/internal/utils/input_file_wasm.go
@@ -1,0 +1,19 @@
+//go:build js && wasm
+
+package utils
+
+import "errors"
+
+// errBrowserFileInput backs the --json-file path in the browser build, where
+// there is no OS filesystem to read from. The host should read the file with
+// the browser File API and pass its content inline via --json.
+var errBrowserFileInput = errors.New("file input is not supported in the browser; pass the JSON inline with --json")
+
+// errBrowserTagsFileInput backs the --resource-tags-file path. Its inline
+// counterpart is --resource-tags, not --json, so the hint stays generic rather
+// than naming the wrong flag.
+var errBrowserTagsFileInput = errors.New("file input is not supported in the browser; pass the tags inline instead")
+
+func readInputFile(_ string) ([]byte, error) { return nil, errBrowserFileInput }
+
+func readTagsFile(_ string) ([]byte, error) { return nil, errBrowserTagsFileInput }

--- a/internal/utils/input_file_wasm.go
+++ b/internal/utils/input_file_wasm.go
@@ -7,15 +7,15 @@ import "errors"
 // errBrowserFileInput backs the --json-file path in the browser build, where
 // there is no OS filesystem to read from. The host should read the file with
 // the browser File API and pass its content inline. ReadJSONInput also backs a
-// --resource-tags-file path (NAT gateway), so the hint names an example flag
-// rather than a single flag that would be wrong for one of the callers.
-var errBrowserFileInput = errors.New("file input is not supported in the browser; use the corresponding inline flag instead (e.g. --json)")
+// --resource-tags-file path (NAT gateway), whose inline counterpart is
+// --resource-tags rather than --json, so the message names no specific flag.
+var errBrowserFileInput = errors.New("file input is not supported in the browser; use the corresponding inline flag instead")
 
 // errBrowserTagsFileInput backs the tags-file reader (readTagsFile), which is
-// shared by --resource-tags-file, --tags-file, and the tags --json-file paths.
-// Their inline counterparts differ (--resource-tags / --tags / --json), so the
-// hint names an example rather than a single flag that would misdirect one path.
-var errBrowserTagsFileInput = errors.New("file input is not supported in the browser; use the corresponding inline flag instead (e.g. --resource-tags)")
+// shared by --resource-tags-file and a --json-file path used for resource-tags
+// commands. Their inline counterparts differ (--resource-tags vs --json), so
+// the message names no specific flag.
+var errBrowserTagsFileInput = errors.New("file input is not supported in the browser; use the corresponding inline flag instead")
 
 func readInputFile(_ string) ([]byte, error) { return nil, errBrowserFileInput }
 

--- a/internal/utils/input_file_wasm.go
+++ b/internal/utils/input_file_wasm.go
@@ -6,13 +6,16 @@ import "errors"
 
 // errBrowserFileInput backs the --json-file path in the browser build, where
 // there is no OS filesystem to read from. The host should read the file with
-// the browser File API and pass its content inline via --json.
-var errBrowserFileInput = errors.New("file input is not supported in the browser; pass the JSON inline with --json")
+// the browser File API and pass its content inline. ReadJSONInput also backs a
+// --resource-tags-file path (NAT gateway), so the hint names an example flag
+// rather than a single flag that would be wrong for one of the callers.
+var errBrowserFileInput = errors.New("file input is not supported in the browser; use the corresponding inline flag instead (e.g. --json)")
 
-// errBrowserTagsFileInput backs the --resource-tags-file path. Its inline
-// counterpart is --resource-tags, not --json, so the hint stays generic rather
-// than naming the wrong flag.
-var errBrowserTagsFileInput = errors.New("file input is not supported in the browser; pass the tags inline instead")
+// errBrowserTagsFileInput backs the tags-file reader (readTagsFile), which is
+// shared by --resource-tags-file, --tags-file, and the tags --json-file paths.
+// Their inline counterparts differ (--resource-tags / --tags / --json), so the
+// hint names an example rather than a single flag that would misdirect one path.
+var errBrowserTagsFileInput = errors.New("file input is not supported in the browser; use the corresponding inline flag instead (e.g. --resource-tags)")
 
 func readInputFile(_ string) ([]byte, error) { return nil, errBrowserFileInput }
 

--- a/internal/utils/input_file_wasm.go
+++ b/internal/utils/input_file_wasm.go
@@ -4,19 +4,14 @@ package utils
 
 import "errors"
 
-// errBrowserFileInput backs the --json-file path in the browser build, where
-// there is no OS filesystem to read from. The host should read the file with
-// the browser File API and pass its content inline. ReadJSONInput also backs a
-// --resource-tags-file path (NAT gateway), whose inline counterpart is
-// --resource-tags rather than --json, so the message names no specific flag.
+// errBrowserFileInput backs every file-path input in the browser build, where
+// there is no OS filesystem to read from: readInputFile's --json-file path
+// (also used by --resource-tags-file via ReadJSONInput in NAT gateway) and
+// readTagsFile's --resource-tags-file / --json-file paths. Their inline
+// counterparts differ (--json vs --resource-tags), so the message names no
+// specific flag.
 var errBrowserFileInput = errors.New("file input is not supported in the browser; use the corresponding inline flag instead")
-
-// errBrowserTagsFileInput backs the tags-file reader (readTagsFile), which is
-// shared by --resource-tags-file and a --json-file path used for resource-tags
-// commands. Their inline counterparts differ (--resource-tags vs --json), so
-// the message names no specific flag.
-var errBrowserTagsFileInput = errors.New("file input is not supported in the browser; use the corresponding inline flag instead")
 
 func readInputFile(_ string) ([]byte, error) { return nil, errBrowserFileInput }
 
-func readTagsFile(_ string) ([]byte, error) { return nil, errBrowserTagsFileInput }
+func readTagsFile(_ string) ([]byte, error) { return nil, errBrowserFileInput }

--- a/internal/utils/input_file_wasm_test.go
+++ b/internal/utils/input_file_wasm_test.go
@@ -1,0 +1,39 @@
+//go:build js && wasm
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	wasmJSONFileMsg = "file input is not supported in the browser; pass the JSON inline with --json"
+	wasmTagsFileMsg = "file input is not supported in the browser; pass the tags inline instead"
+)
+
+func TestReadInputFile_WASM_Unsupported(t *testing.T) {
+	_, err := readInputFile("/some/path.json")
+	require.Error(t, err)
+	assert.Equal(t, wasmJSONFileMsg, err.Error())
+}
+
+func TestReadTagsFile_WASM_Unsupported(t *testing.T) {
+	_, err := readTagsFile("/some/tags.json")
+	require.Error(t, err)
+	assert.Equal(t, wasmTagsFileMsg, err.Error())
+}
+
+func TestReadJSONInput_WASM_FileFails(t *testing.T) {
+	_, err := ReadJSONInput("", "/some/order.json")
+	require.Error(t, err)
+	assert.Equal(t, wasmJSONFileMsg, err.Error())
+}
+
+func TestReadJSONInput_WASM_InlineStillWorks(t *testing.T) {
+	data, err := ReadJSONInput(`{"term":12}`, "/ignored/path.json")
+	require.NoError(t, err)
+	assert.Equal(t, `{"term":12}`, string(data))
+}

--- a/internal/utils/input_file_wasm_test.go
+++ b/internal/utils/input_file_wasm_test.go
@@ -5,35 +5,29 @@ package utils
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-)
-
-const (
-	wasmJSONFileMsg = "file input is not supported in the browser; use the corresponding inline flag instead"
-	wasmTagsFileMsg = "file input is not supported in the browser; use the corresponding inline flag instead"
 )
 
 func TestReadInputFile_WASM_Unsupported(t *testing.T) {
 	_, err := readInputFile("/some/path.json")
 	require.Error(t, err)
-	assert.Equal(t, wasmJSONFileMsg, err.Error())
+	require.ErrorIs(t, err, errBrowserFileInput)
 }
 
 func TestReadTagsFile_WASM_Unsupported(t *testing.T) {
 	_, err := readTagsFile("/some/tags.json")
 	require.Error(t, err)
-	assert.Equal(t, wasmTagsFileMsg, err.Error())
+	require.ErrorIs(t, err, errBrowserFileInput)
 }
 
 func TestReadJSONInput_WASM_FileFails(t *testing.T) {
 	_, err := ReadJSONInput("", "/some/order.json")
 	require.Error(t, err)
-	assert.Equal(t, wasmJSONFileMsg, err.Error())
+	require.ErrorIs(t, err, errBrowserFileInput)
 }
 
 func TestReadJSONInput_WASM_InlineStillWorks(t *testing.T) {
 	data, err := ReadJSONInput(`{"term":12}`, "/ignored/path.json")
 	require.NoError(t, err)
-	assert.Equal(t, `{"term":12}`, string(data))
+	require.Equal(t, `{"term":12}`, string(data))
 }

--- a/internal/utils/input_file_wasm_test.go
+++ b/internal/utils/input_file_wasm_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	wasmJSONFileMsg = "file input is not supported in the browser; use the corresponding inline flag instead (e.g. --json)"
-	wasmTagsFileMsg = "file input is not supported in the browser; use the corresponding inline flag instead (e.g. --resource-tags)"
+	wasmJSONFileMsg = "file input is not supported in the browser; use the corresponding inline flag instead"
+	wasmTagsFileMsg = "file input is not supported in the browser; use the corresponding inline flag instead"
 )
 
 func TestReadInputFile_WASM_Unsupported(t *testing.T) {

--- a/internal/utils/input_file_wasm_test.go
+++ b/internal/utils/input_file_wasm_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	wasmJSONFileMsg = "file input is not supported in the browser; pass the JSON inline with --json"
-	wasmTagsFileMsg = "file input is not supported in the browser; pass the tags inline instead"
+	wasmJSONFileMsg = "file input is not supported in the browser; use the corresponding inline flag instead (e.g. --json)"
+	wasmTagsFileMsg = "file input is not supported in the browser; use the corresponding inline flag instead (e.g. --resource-tags)"
 )
 
 func TestReadInputFile_WASM_Unsupported(t *testing.T) {

--- a/internal/utils/input_test.go
+++ b/internal/utils/input_test.go
@@ -377,21 +377,6 @@ func TestReadJSONInput_FromString(t *testing.T) {
 	assert.Equal(t, `{"name":"test"}`, string(data))
 }
 
-func TestReadJSONInput_FromFile(t *testing.T) {
-	tmpFile := t.TempDir() + "/test.json"
-	require.NoError(t, os.WriteFile(tmpFile, []byte(`{"key":"value"}`), 0644))
-
-	data, err := ReadJSONInput("", tmpFile)
-	require.NoError(t, err)
-	assert.Equal(t, `{"key":"value"}`, string(data))
-}
-
-func TestReadJSONInput_FileNotFound(t *testing.T) {
-	_, err := ReadJSONInput("", "/nonexistent/path.json")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to read JSON file")
-}
-
 func TestReadJSONInput_StringOverridesFile(t *testing.T) {
 	tmpFile := t.TempDir() + "/test.json"
 	require.NoError(t, os.WriteFile(tmpFile, []byte(`{"from":"file"}`), 0644))

--- a/internal/utils/resource_tags.go
+++ b/internal/utils/resource_tags.go
@@ -12,10 +12,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// maxTagsFileSize bounds a tags file read (readTagsFile) to avoid loading an
-// unbounded file into memory. Declared here so it is available to both platform
-// builds; only the native readTagsFile enforces it.
-const maxTagsFileSize = 1 << 20 // 1 MiB
+// maxInputFileSize bounds a file-input read (readInputFile / readTagsFile) to
+// avoid loading an unbounded file into memory. Declared here so it is available
+// to both platform builds; only the native readers enforce it.
+const maxInputFileSize = 1 << 20 // 1 MiB
 
 const defaultTagsTimeout = 90 * time.Second
 

--- a/internal/utils/resource_tags.go
+++ b/internal/utils/resource_tags.go
@@ -4,11 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"os"
-	"path/filepath"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/megaport/megaport-cli/internal/base/exitcodes"
@@ -16,41 +12,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// maxTagsFileSize bounds a tags file read (readTagsFile) to avoid loading an
+// unbounded file into memory. Declared here so it is available to both platform
+// builds; only the native readTagsFile enforces it.
 const maxTagsFileSize = 1 << 20 // 1 MiB
-
-// readTagsFile reads a user-supplied JSON file path safely: it cleans the path,
-// rejects upward traversal, rejects non-regular files, and enforces a 1 MiB
-// size limit while reading (open + stat + LimitReader avoids a TOCTOU race).
-func readTagsFile(path string) ([]byte, error) {
-	clean := filepath.Clean(path)
-	// Reject paths that still navigate above the current directory after cleaning.
-	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
-		return nil, fmt.Errorf("invalid file path %q: path traversal not allowed", path)
-	}
-	f, err := os.Open(clean)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read file: %w", err)
-	}
-	defer f.Close()
-	info, err := f.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("failed to read file: %w", err)
-	}
-	if !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("file %q is not a regular file", path)
-	}
-	if info.Size() > maxTagsFileSize {
-		return nil, fmt.Errorf("file %q exceeds maximum allowed size of 1 MiB (%d bytes)", path, info.Size())
-	}
-	data, err := io.ReadAll(io.LimitReader(f, maxTagsFileSize+1))
-	if err != nil {
-		return nil, fmt.Errorf("failed to read file: %w", err)
-	}
-	if len(data) > maxTagsFileSize {
-		return nil, fmt.Errorf("file %q exceeds maximum allowed size of 1 MiB (%d bytes)", path, len(data))
-	}
-	return data, nil
-}
 
 const defaultTagsTimeout = 90 * time.Second
 

--- a/internal/utils/resource_tags_test.go
+++ b/internal/utils/resource_tags_test.go
@@ -111,7 +111,7 @@ func TestParseResourceTagsInput(t *testing.T) {
 	t.Run("file exceeding size limit rejected", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		path := filepath.Join(tmpDir, "big.json")
-		big := make([]byte, maxTagsFileSize+1)
+		big := make([]byte, maxInputFileSize+1)
 		big[0] = '{'
 		big[len(big)-1] = '}'
 		require.NoError(t, os.WriteFile(path, big, 0644))


### PR DESCRIPTION
In the browser build there's no OS filesystem, so `--json-file` and `--resource-tags-file` failed with a confusing raw `open ./x.json: no such file` error. This makes those flags fail fast with a clear message and flags the limitation in `--help`.

- Split the file read behind a platform helper: native reads the OS file exactly as before; wasm returns `file input is not supported in the browser; use the corresponding inline flag instead`. The message stays generic because the same helper backs flags with different inline alternatives (`--json` / `--resource-tags`).
- Route `ReadJSONInput` (`--json-file`) and the tags-file reader through it, so every buy/create/update/validate/update-tags command across the WASM modules gets the clear error.
- Annotate the file-input flags' `--help` usage in the browser build, pointing at the inline alternative (`--json` / `--resource-tags`).
- Native behavior is unchanged (same read, same errors, same path-traversal and 1 MiB guards on the tags file).
- Adds native tests and a WASM-tagged test for the browser error path.

Fixes ESD-1579.
