### PR TITLE
ESD-1578-ci(wasm): enforce full wasm build, vet, and test compilation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,3 +24,23 @@ jobs:
         with:
           version: 'v2.12.2'  # Pin the golangci-lint binary version to avoid CI drift
           args: --timeout=10m
+
+  golangci-wasm:
+    name: lint (js/wasm)
+    runs-on: ubuntu-latest
+    # Lint the wasm-tagged files with the same ruleset. golangci-lint only sees
+    # one GOOS/GOARCH per run, so the default job above never covers them.
+    env:
+      GOOS: js
+      GOARCH: wasm
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee  # v9.2.1
+        with:
+          version: 'v2.12.2'  # Pin the golangci-lint binary version to avoid CI drift
+          args: --build-tags js,wasm --timeout=10m

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,19 +26,6 @@ jobs:
           files: coverage.out
           fail_ci_if_error: false
 
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
-        with:
-          go-version-file: 'go.mod'
-      - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
-      - name: Run golangci-lint
-        run: golangci-lint run --timeout=5m
-
   e2e-hermetic:
     name: E2E Tests (Hermetic)
     # Run on Unix and Windows so OS-specific regressions in the cross-platform

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -20,10 +20,15 @@ jobs:
           go-version-file: 'go.mod'
       - name: Compile js/wasm target
         run: make wasm-build-guard
+      - name: Vet js/wasm target
+        # Compiles every wasm-tagged package, test files included, so any wasm
+        # test file that stops building is caught here.
+        run: make wasm-vet
       - name: Run WASM unit tests
-        # Only ./cmd/megaport runs under the bare go_js_wasm_exec (node) runtime.
-        # The other WASM test packages need a browser host (fetch, JS bridge
-        # globals, stdin pipes) and are verified manually in-browser.
+        # wasm-vet above already compiles all wasm test packages. Only
+        # ./cmd/megaport can also run under the bare go_js_wasm_exec (node)
+        # runtime; the rest need a browser host (fetch, JS bridge globals, stdin
+        # pipes) and are verified manually in-browser.
         run: |
           export PATH="$PATH:$(go env GOROOT)/lib/wasm"
           GOOS=js GOARCH=wasm go test -v -tags js,wasm ./cmd/megaport

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 ## [Unreleased]
 
 ### Fixed
+- repair the `js/wasm` build of `./...` (the WASM config manager was missing `GetProfile`, which `auth status` needs) and enforce the full wasm build, vet, test compilation, and wasm-tagged linting in CI so wasm code stops rotting silently (ESD-1578)
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
 - `mve buy` and `mve validate` now apply `resourceTags` from JSON input, and interactive `mve buy` now prompts for tags, matching MCR. Previously the JSON path silently dropped the documented `resourceTags` field and interactive mode never asked. The JSON path shares the same value and empty-key validation as the flags path, so non-string values and empty keys return a usage error before the order is placed
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-cover test-cover-html test-integration test-integration-readonly e2e e2e-staging lint fmt vet check clean wasm wasm-build-guard wasm-smoke wasm-compress web-static
+.PHONY: build test test-cover test-cover-html test-integration test-integration-readonly e2e e2e-staging lint fmt vet check clean wasm wasm-build-guard wasm-vet wasm-smoke wasm-compress web-static
 
 # Build the CLI binary
 build:
@@ -77,8 +77,14 @@ wasm:
 	GOOS=js GOARCH=wasm go build -trimpath -tags js,wasm -ldflags="-s -w" -o web/megaport.wasm .
 
 # Compile-only guard for the browser target. Fails fast if the WASM build breaks.
+# Covers the whole module so wasm-tagged code outside the root package can't rot silently.
 wasm-build-guard:
-	GOOS=js GOARCH=wasm go build -tags js,wasm -o /dev/null .
+	GOOS=js GOARCH=wasm go build -tags js,wasm ./...
+
+# Vet the whole js/wasm surface, including wasm-tagged test files. This compiles
+# every wasm test package, so test files that stop building are caught in CI.
+wasm-vet:
+	GOOS=js GOARCH=wasm go vet -tags js,wasm ./...
 
 # Smoke-test a read-only command end-to-end through the browser fetch transport.
 # Builds the WASM binary, then runs it under Node against a live API (default: staging).

--- a/internal/base/output/changes_test.go
+++ b/internal/base/output/changes_test.go
@@ -1,3 +1,5 @@
+//go:build !wasm
+
 package output
 
 import (

--- a/internal/base/output/common.go
+++ b/internal/base/output/common.go
@@ -349,69 +349,6 @@ func getStructTypeInfo[T OutputFields](data []T) (headers, jsonNames []string, f
 	return headers, jsonNames, fieldIndices, nil
 }
 
-// extractCSVFieldInfo extracts CSV-specific field metadata from the first element of data.
-// CSV uses the csv tag as the header name (falling back to json tag), and skips fields
-// that have neither a csv nor json tag. This differs from extractFieldInfo, which does
-// not require csv/json tags and instead falls back to header/csv/output tags or the field name.
-func extractCSVFieldInfo[T OutputFields](data []T) (headers, jsonNames []string, fieldIndices []int, err error) {
-	var sample T
-	if len(data) > 0 {
-		sample = data[0]
-	}
-	sampleVal := reflect.ValueOf(sample)
-	if !sampleVal.IsValid() {
-		return nil, nil, nil, nil
-	}
-	t := sampleVal.Type()
-	if t.Kind() == reflect.Pointer {
-		if sampleVal.IsNil() {
-			if t.Elem().Kind() != reflect.Struct {
-				return nil, nil, nil, nil
-			}
-			t = t.Elem()
-		} else {
-			t = sampleVal.Elem().Type()
-		}
-	}
-	if t.Kind() != reflect.Struct {
-		return nil, nil, nil, nil
-	}
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
-		if field.PkgPath != "" {
-			continue
-		}
-		if !isOutputCompatibleType(field.Type) {
-			continue
-		}
-		csvTag := field.Tag.Get("csv")
-		if csvTag == "-" {
-			continue
-		}
-		jsonTag := field.Tag.Get("json")
-		// Strip json tag options (e.g. "name,omitempty" -> "name") before
-		// using as a fallback header or for --fields matching.
-		jsonName := jsonTag
-		if idx := strings.Index(jsonName, ","); idx != -1 {
-			jsonName = jsonName[:idx]
-		}
-		if csvTag == "" {
-			if jsonName == "" || jsonName == "-" {
-				continue
-			}
-			csvTag = jsonName
-		}
-		jn := jsonName
-		if jn == "" || jn == "-" {
-			jn = strings.ToLower(field.Name)
-		}
-		headers = append(headers, csvTag)
-		jsonNames = append(jsonNames, jn)
-		fieldIndices = append(fieldIndices, i)
-	}
-	return headers, jsonNames, fieldIndices, nil
-}
-
 // extractFieldInfo extracts field information from a struct type.
 // Returns headers (display names), jsonNames (json tag names for --fields matching), and field indices.
 func extractFieldInfo(itemType reflect.Type) (headers, jsonNames []string, fieldIndices []int) {
@@ -544,12 +481,6 @@ func isOutputCompatibleType(t reflect.Type) bool {
 		// All primitive types are compatible
 		return true
 	}
-}
-
-// isNilOrInvalid returns true if item is a nil pointer or an invalid reflect value.
-func isNilOrInvalid(item interface{}) bool {
-	v := reflect.ValueOf(item)
-	return !v.IsValid() || (v.Kind() == reflect.Pointer && v.IsNil())
 }
 
 // extractRowData extracts field values from a struct for table/CSV output

--- a/internal/base/output/common_native.go
+++ b/internal/base/output/common_native.go
@@ -1,0 +1,77 @@
+//go:build !wasm
+
+package output
+
+import (
+	"reflect"
+	"strings"
+)
+
+// extractCSVFieldInfo extracts CSV-specific field metadata from the first element of data.
+// CSV uses the csv tag as the header name (falling back to json tag), and skips fields
+// that have neither a csv nor json tag. This differs from extractFieldInfo, which does
+// not require csv/json tags and instead falls back to header/csv/output tags or the field name.
+func extractCSVFieldInfo[T OutputFields](data []T) (headers, jsonNames []string, fieldIndices []int, err error) {
+	var sample T
+	if len(data) > 0 {
+		sample = data[0]
+	}
+	sampleVal := reflect.ValueOf(sample)
+	if !sampleVal.IsValid() {
+		return nil, nil, nil, nil
+	}
+	t := sampleVal.Type()
+	if t.Kind() == reflect.Pointer {
+		if sampleVal.IsNil() {
+			if t.Elem().Kind() != reflect.Struct {
+				return nil, nil, nil, nil
+			}
+			t = t.Elem()
+		} else {
+			t = sampleVal.Elem().Type()
+		}
+	}
+	if t.Kind() != reflect.Struct {
+		return nil, nil, nil, nil
+	}
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.PkgPath != "" {
+			continue
+		}
+		if !isOutputCompatibleType(field.Type) {
+			continue
+		}
+		csvTag := field.Tag.Get("csv")
+		if csvTag == "-" {
+			continue
+		}
+		jsonTag := field.Tag.Get("json")
+		// Strip json tag options (e.g. "name,omitempty" -> "name") before
+		// using as a fallback header or for --fields matching.
+		jsonName := jsonTag
+		if idx := strings.Index(jsonName, ","); idx != -1 {
+			jsonName = jsonName[:idx]
+		}
+		if csvTag == "" {
+			if jsonName == "" || jsonName == "-" {
+				continue
+			}
+			csvTag = jsonName
+		}
+		jn := jsonName
+		if jn == "" || jn == "-" {
+			jn = strings.ToLower(field.Name)
+		}
+		headers = append(headers, csvTag)
+		jsonNames = append(jsonNames, jn)
+		fieldIndices = append(fieldIndices, i)
+	}
+	return headers, jsonNames, fieldIndices, nil
+}
+
+// isNilOrInvalid returns true if item is a nil pointer or an invalid reflect value.
+func isNilOrInvalid(item interface{}) bool {
+	v := reflect.ValueOf(item)
+	return !v.IsValid() || (v.Kind() == reflect.Pointer && v.IsNil())
+}

--- a/internal/base/output/common_native_test.go
+++ b/internal/base/output/common_native_test.go
@@ -1,0 +1,75 @@
+//go:build !wasm
+
+package output
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type csvTagStruct struct {
+	A      string `csv:"col_a"`        // explicit csv header
+	B      string `json:"b_json"`      // csv falls back to json tag
+	C      string `csv:"-"`            // skipped: csv tag "-"
+	D      string `json:"-"`           // skipped: no csv, json "-"
+	E      string `json:"e,omitempty"` // json options stripped to "e"
+	F      string // skipped: no csv/json tag
+	G      func() `csv:"g"` // skipped: not output-compatible
+	hidden string //nolint:unused // exercises the unexported-field skip
+}
+
+func TestExtractCSVFieldInfo(t *testing.T) {
+	t.Run("value struct honors csv/json tags and skips the rest", func(t *testing.T) {
+		headers, jsonNames, indices, err := extractCSVFieldInfo([]csvTagStruct{{}})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"col_a", "b_json", "e"}, headers)
+		assert.Equal(t, []string{"a", "b_json", "e"}, jsonNames)
+		assert.Len(t, indices, 3)
+	})
+
+	t.Run("empty slice still derives fields from the element type", func(t *testing.T) {
+		headers, _, _, err := extractCSVFieldInfo([]csvTagStruct{})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"col_a", "b_json", "e"}, headers)
+	})
+
+	t.Run("non-nil pointer element", func(t *testing.T) {
+		headers, _, _, err := extractCSVFieldInfo([]*csvTagStruct{{}})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"col_a", "b_json", "e"}, headers)
+	})
+
+	t.Run("nil pointer to struct uses the element type", func(t *testing.T) {
+		headers, _, _, err := extractCSVFieldInfo([]*csvTagStruct{nil})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"col_a", "b_json", "e"}, headers)
+	})
+
+	t.Run("nil pointer to non-struct yields nothing", func(t *testing.T) {
+		headers, jsonNames, indices, err := extractCSVFieldInfo([]*int{nil})
+		assert.NoError(t, err)
+		assert.Nil(t, headers)
+		assert.Nil(t, jsonNames)
+		assert.Nil(t, indices)
+	})
+
+	t.Run("non-struct type yields nothing", func(t *testing.T) {
+		headers, _, _, err := extractCSVFieldInfo([]int{5})
+		assert.NoError(t, err)
+		assert.Nil(t, headers)
+	})
+
+	t.Run("invalid sample (nil interface) yields nothing", func(t *testing.T) {
+		headers, _, _, err := extractCSVFieldInfo([]any{})
+		assert.NoError(t, err)
+		assert.Nil(t, headers)
+	})
+}
+
+func TestIsNilOrInvalid(t *testing.T) {
+	assert.True(t, isNilOrInvalid(nil), "nil interface is invalid")
+	assert.True(t, isNilOrInvalid((*int)(nil)), "typed nil pointer")
+	assert.False(t, isNilOrInvalid(5), "non-nil value")
+	assert.False(t, isNilOrInvalid(&csvTagStruct{}), "non-nil pointer")
+}

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -1,3 +1,5 @@
+//go:build !wasm
+
 package output
 
 import (

--- a/internal/base/output/messages_wasm.go
+++ b/internal/base/output/messages_wasm.go
@@ -209,7 +209,7 @@ func PrintSuccess(format string, noColor bool, args ...interface{}) {
 	} else {
 		output = color.GreenString("✓ ") + msg + "\n"
 	}
-	wasm.WasmOutputBuffer.Write([]byte(output))
+	_, _ = wasm.WasmOutputBuffer.Write([]byte(output))
 }
 
 // PrintError overrides the base function for WASM to capture output. In json
@@ -227,7 +227,7 @@ func PrintError(format string, noColor bool, args ...interface{}) {
 	} else {
 		output = color.RedString("✗ ") + msg + "\n"
 	}
-	wasm.WasmOutputBuffer.Write([]byte(output))
+	_, _ = wasm.WasmOutputBuffer.Write([]byte(output))
 	markErrorEmitted()
 }
 
@@ -243,7 +243,7 @@ func PrintWarning(format string, noColor bool, args ...interface{}) {
 	} else {
 		output = color.YellowString("⚠ ") + msg + "\n"
 	}
-	wasm.WasmOutputBuffer.Write([]byte(output))
+	_, _ = wasm.WasmOutputBuffer.Write([]byte(output))
 }
 
 // PrintInfo overrides the base function for WASM to capture output
@@ -258,7 +258,7 @@ func PrintInfo(format string, noColor bool, args ...interface{}) {
 	} else {
 		output = color.BlueString("ℹ ") + msg + "\n"
 	}
-	wasm.WasmOutputBuffer.Write([]byte(output))
+	_, _ = wasm.WasmOutputBuffer.Write([]byte(output))
 }
 
 // PrintPlain overrides the base function for WASM to capture output.
@@ -267,7 +267,7 @@ func PrintPlain(format string, _ bool, args ...interface{}) {
 		return
 	}
 	msg := fmt.Sprintf(format, args...)
-	wasm.WasmOutputBuffer.Write([]byte(msg + "\n"))
+	_, _ = wasm.WasmOutputBuffer.Write([]byte(msg + "\n"))
 }
 
 // PrintNewline writes a blank line to the WASM output buffer, suppressed in quiet mode.
@@ -275,7 +275,7 @@ func PrintNewline() {
 	if IsQuiet() {
 		return
 	}
-	wasm.WasmOutputBuffer.Write([]byte("\n"))
+	_, _ = wasm.WasmOutputBuffer.Write([]byte("\n"))
 }
 
 // ClearScreen is a no-op in the WASM environment.

--- a/internal/base/output/output_wasm.go
+++ b/internal/base/output/output_wasm.go
@@ -193,12 +193,11 @@ func printXML[T OutputFields](data []T, opts printOptions) error {
 		data = []T{}
 	}
 
-	writeEmpty := func() error {
+	writeEmpty := func() {
 		WasmXMLWriter.WriteString(xml.Header + "<items></items>\n")
 		xmlOutput := WasmXMLWriter.String()
 		fmt.Print(xmlOutput)
 		js.Global().Set("wasmXMLOutput", xmlOutput)
-		return nil
 	}
 
 	var sample T
@@ -207,13 +206,15 @@ func printXML[T OutputFields](data []T, opts printOptions) error {
 	}
 	sampleVal := reflect.ValueOf(sample)
 	if !sampleVal.IsValid() {
-		return writeEmpty()
+		writeEmpty()
+		return nil
 	}
 	t := sampleVal.Type()
 	if t.Kind() == reflect.Pointer {
 		if sampleVal.IsNil() {
 			if t.Elem().Kind() != reflect.Struct {
-				return writeEmpty()
+				writeEmpty()
+				return nil
 			}
 			t = t.Elem()
 		} else {
@@ -222,7 +223,8 @@ func printXML[T OutputFields](data []T, opts printOptions) error {
 		}
 	}
 	if t.Kind() != reflect.Struct {
-		return writeEmpty()
+		writeEmpty()
+		return nil
 	}
 
 	type xmlField struct {

--- a/internal/commands/config/login_test.go
+++ b/internal/commands/config/login_test.go
@@ -1,3 +1,5 @@
+//go:build !js && !wasm
+
 package config
 
 import (

--- a/internal/commands/config/manager_wasm.go
+++ b/internal/commands/config/manager_wasm.go
@@ -118,8 +118,8 @@ func (m *ConfigManager) GetCurrentProfile() (*Profile, string, error) {
 }
 
 func (m *ConfigManager) GetProfile(name string) (*Profile, error) {
-	if m.config == nil || m.config.Profiles == nil {
-		return nil, ErrProfileNotFound
+	if m.config == nil {
+		return nil, fmt.Errorf("config not initialized")
 	}
 	profile, exists := m.config.Profiles[name]
 	if !exists {

--- a/internal/commands/config/manager_wasm.go
+++ b/internal/commands/config/manager_wasm.go
@@ -27,6 +27,7 @@ type ConfigManagerInterface interface {
 	Save() error
 	Export() (*ConfigFile, error)
 	GetCurrentProfile() (*Profile, string, error)
+	GetProfile(name string) (*Profile, error)
 }
 
 // Ensure ConfigManager implements the interface
@@ -114,6 +115,17 @@ func (m *ConfigManager) GetCurrentProfile() (*Profile, string, error) {
 		return nil, "", ErrProfileNotFound
 	}
 	return profile, profileName, nil
+}
+
+func (m *ConfigManager) GetProfile(name string) (*Profile, error) {
+	if m.config == nil || m.config.Profiles == nil {
+		return nil, ErrProfileNotFound
+	}
+	profile, exists := m.config.Profiles[name]
+	if !exists {
+		return nil, fmt.Errorf("profile %q not found", name)
+	}
+	return profile, nil
 }
 
 // ClearAllCredentials clears all stored credentials

--- a/internal/wasm/wasm.go
+++ b/internal/wasm/wasm.go
@@ -630,8 +630,12 @@ func isValidConfigFilename(filename string) bool {
 		return false
 	}
 	for _, c := range filename {
-		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
-			c == '.' || c == '_' || c == '-') {
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '.' || c == '_' || c == '-':
+		default:
 			return false
 		}
 	}

--- a/main_wasm_test.go
+++ b/main_wasm_test.go
@@ -194,7 +194,7 @@ func TestWasmOutputBufferIntegration(t *testing.T) {
 
 	// Write to the buffer
 	testData := "test integration data"
-	wasm.WasmOutputBuffer.Write([]byte(testData))
+	_, _ = wasm.WasmOutputBuffer.Write([]byte(testData))
 
 	// Verify it can be retrieved
 	output := wasm.WasmOutputBuffer.String()
@@ -326,7 +326,7 @@ func TestDumpBuffers(t *testing.T) {
 
 	// Add some content
 	wasm.ResetOutputBuffers()
-	wasm.WasmOutputBuffer.Write([]byte("test content"))
+	_, _ = wasm.WasmOutputBuffer.Write([]byte("test content"))
 
 	// Dump buffers
 	result := dumpBuffers.Invoke()


### PR DESCRIPTION
The wasm build guard only compiled the root package, so wasm-tagged code outside it rotted silently. The full `GOOS=js GOARCH=wasm go build -tags js,wasm ./...` was actually broken (auth's `GetProfile` was never implemented on the WASM config manager), and `go vet` under the wasm tags failed to compile three native-only test files. CI never noticed. This fixes the rot and makes CI enforce the whole wasm surface.

- add `GetProfile` to the WASM `ConfigManager` (and its interface), mirroring native, so `auth status` compiles and works in the browser build
- gate the native-only test files (`messages_test`, `changes_test`, `login_test`) with build tags, matching their sibling native tests
- fix the wasm-tagged lint findings (errcheck, unparam, staticcheck) and move two native-only output helpers into `common_native.go`, so wasm lints under the *same* golangci-lint ruleset with no linters disabled
- `wasm-build-guard` now builds `./...`; new `wasm-vet` target that vets the whole wasm surface (compiling every wasm test package)
- `wasm.yml` runs the wasm vet step in CI
- consolidate lint on one pinned golangci-lint version (drop the duplicate `v2.11.4` job in `test.yml`, keep `lint.yml` at `v2.12.2`) and add a `golangci-wasm` job that lints wasm-tagged files

Decision on wasm linting (AC5): done, not deferred. The two `unused`/`unparam` findings were native-only helpers sitting in a shared file that looked dead in the wasm compilation; relocating them removed the false positives structurally, so the wasm lint job runs the identical ruleset rather than disabling linters.

Node execution is unchanged: only `./cmd/megaport` runs cleanly under bare node; the rest need a browser host and are covered by `wasm-vet` for compilation.

ESD-1578
