### PR TITLE
ESD-1577-fix(wasm): show confirmation summaries in interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 ## [Unreleased]
 
 ### Fixed
+- show buy/design confirmation summaries and interactive tag-prompt context in the WASM browser build. These were printed to `os.Stdout`, which the browser routes to the console, so customers confirmed billable orders with the summary invisible. The text now travels on the live prompt channel, and the WASM `tags update` flow with no existing tags now matches the native path (ESD-1577)
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
 - `mve buy` and `mve validate` now apply `resourceTags` from JSON input, and interactive `mve buy` now prompts for tags, matching MCR. Previously the JSON path silently dropped the documented `resourceTags` field and interactive mode never asked. The JSON path shares the same value and empty-key validation as the flags path, so non-string values and empty keys return a usage error before the order is placed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 ## [Unreleased]
 
 ### Fixed
-- show buy/design confirmation summaries and interactive tag-prompt context in the WASM browser build. These were printed to `os.Stdout`, which the browser routes to the console, so customers confirmed billable orders with the summary invisible. The text now travels on the live prompt channel, and the WASM `tags update` flow with no existing tags now matches the native path (ESD-1577)
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
 - `mve buy` and `mve validate` now apply `resourceTags` from JSON input, and interactive `mve buy` now prompts for tags, matching MCR. Previously the JSON path silently dropped the documented `resourceTags` field and interactive mode never asked. The JSON path shares the same value and empty-key validation as the flags path, so non-string values and empty keys return a usage error before the order is placed
 

--- a/internal/utils/prompts_wasm.go
+++ b/internal/utils/prompts_wasm.go
@@ -18,16 +18,18 @@ import (
 // output (see flush) uses a plain \n because its renderer converts EOLs.
 const promptLineBreak = "\r\n"
 
-// sanitizeForTerminal strips C0 control characters and DEL from text that is
-// folded into a terminal-bound message. The host writes prompt messages to
+// sanitizeForTerminal strips C0 controls, DEL, and C1 controls from text that
+// is folded into a terminal-bound message. The host writes prompt messages to
 // xterm without escaping, so a crafted resource name or tag value could
 // otherwise inject cursor/erase sequences that rewrite the purchase summary
-// shown before the [y/N]. Only display copies are sanitized; the values stored
-// on the order come from the prompt responses, which are untouched. Structural
-// line breaks are inserted by callers after sanitizing, so they are preserved.
+// shown before the [y/N]. C1 (0x80-0x9f) is stripped because some terminals
+// treat it as escape controls (e.g. 0x9b as CSI). Only display copies are
+// sanitized; the values stored on the order come from the prompt responses,
+// which are untouched. Structural line breaks are inserted by callers after
+// sanitizing, so they are preserved.
 func sanitizeForTerminal(s string) string {
 	return strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f {
+		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
 			return -1
 		}
 		return r
@@ -86,10 +88,10 @@ func wasmDesignConfirmPrompt(resourceType string, details []BuyConfirmDetail, no
 // content (minus its color and leading blank line, which suit a scrolling TTY
 // rather than a discrete prompt payload). Lines use \r\n because the host renders
 // prompt messages on a terminal that is not in convertEol mode, so a bare \n
-// would stair-step the summary. Detail values are sanitized: they can be
-// user-supplied (e.g. a resource name).
+// would stair-step the summary. The resource type and detail values are
+// sanitized: they can be user-supplied (e.g. a resource name).
 func buildConfirmSummary(header, resourceType string, details []BuyConfirmDetail, question string) string {
-	lines := []string{header, fmt.Sprintf("  Resource Type: %s", resourceType)}
+	lines := []string{header, fmt.Sprintf("  Resource Type: %s", sanitizeForTerminal(resourceType))}
 	for _, d := range details {
 		if d.Value != "" {
 			lines = append(lines, fmt.Sprintf("  %s: %s", d.Key, sanitizeForTerminal(d.Value)))
@@ -156,7 +158,7 @@ func (c *wasmPromptContext) flush() {
 	if len(c.lines) == 0 {
 		return
 	}
-	wasm.WasmOutputBuffer.Write([]byte(strings.Join(c.lines, "\n") + "\n"))
+	_, _ = wasm.WasmOutputBuffer.Write([]byte(strings.Join(c.lines, "\n") + "\n"))
 	c.lines = nil
 }
 

--- a/internal/utils/prompts_wasm.go
+++ b/internal/utils/prompts_wasm.go
@@ -5,6 +5,7 @@ package utils
 import (
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/megaport/megaport-cli/internal/wasm"
 )
@@ -29,7 +30,7 @@ const promptLineBreak = "\r\n"
 // sanitizing, so they are preserved.
 func sanitizeForTerminal(s string) string {
 	return strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+		if unicode.IsControl(r) {
 			return -1
 		}
 		return r
@@ -117,49 +118,49 @@ func wasmSecretResourcePrompt(resourceType string, msg string, noColor bool) (st
 	return wasm.PromptForInput(msg, "password", resourceType)
 }
 
-// wasmPromptContext accumulates informational lines (instructions, warnings,
+// wasmPromptBuffer accumulates informational lines (instructions, warnings,
 // per-tag echoes) and folds them into the next prompt message, so they reach
 // the live prompt channel instead of os.Stdout, which the browser routes to the
 // console. Trailing lines with no following prompt are flushed to the output
 // buffer instead.
-type wasmPromptContext struct {
+type wasmPromptBuffer struct {
 	lines []string
 }
 
-func (c *wasmPromptContext) add(line string) {
-	c.lines = append(c.lines, sanitizeForTerminal(line))
+func (b *wasmPromptBuffer) add(line string) {
+	b.lines = append(b.lines, sanitizeForTerminal(line))
 }
 
-// prompt prepends any accumulated context to msg, sends it over the live prompt
-// channel, and clears the context.
-func (c *wasmPromptContext) prompt(msg string, noColor bool) (string, error) {
-	return wasmPrompt(c.take(msg), noColor)
+// prompt prepends any buffered lines to msg, sends it over the live prompt
+// channel, and clears the buffer.
+func (b *wasmPromptBuffer) prompt(msg string, noColor bool) (string, error) {
+	return wasmPrompt(b.take(msg), noColor)
 }
 
-// confirm prepends any accumulated context to question, asks it over the live
-// prompt channel, and clears the context.
-func (c *wasmPromptContext) confirm(question string, noColor bool) bool {
-	return wasmConfirmPrompt(c.take(question), noColor)
+// confirm prepends any buffered lines to question, asks it over the live
+// prompt channel, and clears the buffer.
+func (b *wasmPromptBuffer) confirm(question string, noColor bool) bool {
+	return wasmConfirmPrompt(b.take(question), noColor)
 }
 
-func (c *wasmPromptContext) take(msg string) string {
+func (b *wasmPromptBuffer) take(msg string) string {
 	msg = sanitizeForTerminal(msg)
-	if len(c.lines) == 0 {
+	if len(b.lines) == 0 {
 		return msg
 	}
-	prefix := strings.Join(c.lines, promptLineBreak)
-	c.lines = nil
+	prefix := strings.Join(b.lines, promptLineBreak)
+	b.lines = nil
 	return prefix + promptLineBreak + msg
 }
 
-// flush writes any remaining context (no following prompt) to the output buffer
-// so it is captured rather than lost to the console.
-func (c *wasmPromptContext) flush() {
-	if len(c.lines) == 0 {
+// flush writes any remaining buffered lines (no following prompt) to the output
+// buffer so they are captured rather than lost to the console.
+func (b *wasmPromptBuffer) flush() {
+	if len(b.lines) == 0 {
 		return
 	}
-	_, _ = wasm.WasmOutputBuffer.Write([]byte(strings.Join(c.lines, "\n") + "\n"))
-	c.lines = nil
+	_, _ = wasm.WasmOutputBuffer.Write([]byte(strings.Join(b.lines, "\n") + "\n"))
+	b.lines = nil
 }
 
 func wasmResourceTagsPrompt(noColor bool) (map[string]string, error) {
@@ -169,13 +170,13 @@ func wasmResourceTagsPrompt(noColor bool) (map[string]string, error) {
 	}
 
 	tags := make(map[string]string)
-	var ctx wasmPromptContext
+	var buf wasmPromptBuffer
 
 	// Inform user how to finish entering tags; shown with the first key prompt.
-	ctx.add("Enter tags (key and value). Enter empty key to finish.")
+	buf.add("Enter tags (key and value). Enter empty key to finish.")
 
 	for {
-		key, err := ctx.prompt("Tag key (empty to finish):", noColor)
+		key, err := buf.prompt("Tag key (empty to finish):", noColor)
 		if err != nil {
 			return nil, err
 		}
@@ -184,7 +185,7 @@ func wasmResourceTagsPrompt(noColor bool) (map[string]string, error) {
 			break
 		}
 
-		value, err := ctx.prompt(fmt.Sprintf("Tag value for '%s':", key), noColor)
+		value, err := buf.prompt(fmt.Sprintf("Tag value for '%s':", key), noColor)
 		if err != nil {
 			return nil, err
 		}
@@ -193,32 +194,32 @@ func wasmResourceTagsPrompt(noColor bool) (map[string]string, error) {
 	}
 
 	if len(tags) > 0 {
-		ctx.add("Tags added:")
+		buf.add("Tags added:")
 		for k, v := range tags {
-			ctx.add(fmt.Sprintf("  %s: %s", k, v))
+			buf.add(fmt.Sprintf("  %s: %s", k, v))
 		}
 	}
-	ctx.flush()
+	buf.flush()
 
 	return tags, nil
 }
 
 func wasmUpdateResourceTagsPrompt(existingTags map[string]string, noColor bool) (map[string]string, error) {
-	var ctx wasmPromptContext
+	var buf wasmPromptBuffer
 
 	// Warning about replacing tags; shown with the continue prompt.
-	ctx.add("⚠️  Warning: This operation will replace all existing tags with the new set of tags you define.")
+	buf.add("⚠️  Warning: This operation will replace all existing tags with the new set of tags you define.")
 
 	if len(existingTags) > 0 {
-		ctx.add("Current tags:")
+		buf.add("Current tags:")
 		for k, v := range existingTags {
-			ctx.add(fmt.Sprintf("  %s: %s", k, v))
+			buf.add(fmt.Sprintf("  %s: %s", k, v))
 		}
 	} else {
-		ctx.add("No existing tags found.")
+		buf.add("No existing tags found.")
 	}
 
-	proceed := ctx.confirm("Do you want to continue with updating tags?", noColor)
+	proceed := buf.confirm("Do you want to continue with updating tags?", noColor)
 	if !proceed {
 		return nil, fmt.Errorf("tag update cancelled by user")
 	}
@@ -230,12 +231,12 @@ func wasmUpdateResourceTagsPrompt(existingTags map[string]string, noColor bool) 
 
 	tags := make(map[string]string)
 
-	ctx.add("")
-	ctx.add("Choose how you want to update tags:")
-	ctx.add("1. Start with a clean slate (remove all existing tags)")
-	ctx.add("2. Start with existing tags and modify them")
+	buf.add("")
+	buf.add("Choose how you want to update tags:")
+	buf.add("1. Start with a clean slate (remove all existing tags)")
+	buf.add("2. Start with existing tags and modify them")
 
-	choice, err := ctx.prompt("Enter choice (1 or 2):", noColor)
+	choice, err := buf.prompt("Enter choice (1 or 2):", noColor)
 	if err != nil {
 		return nil, err
 	}
@@ -245,17 +246,17 @@ func wasmUpdateResourceTagsPrompt(existingTags map[string]string, noColor bool) 
 			tags[k] = v
 		}
 
-		ctx.add("")
-		ctx.add("You can now modify, add, or remove tags.")
-		ctx.add("To remove a tag, enter its key and an empty value.")
+		buf.add("")
+		buf.add("You can now modify, add, or remove tags.")
+		buf.add("To remove a tag, enter its key and an empty value.")
 	} else if choice != "1" {
 		return nil, fmt.Errorf("invalid choice: %s", choice)
 	}
 
-	ctx.add("")
-	ctx.add("Enter tags (key and value). Enter empty key to finish.")
+	buf.add("")
+	buf.add("Enter tags (key and value). Enter empty key to finish.")
 	for {
-		key, err := ctx.prompt("Tag key (empty to finish):", noColor)
+		key, err := buf.prompt("Tag key (empty to finish):", noColor)
 		if err != nil {
 			return nil, err
 		}
@@ -264,7 +265,7 @@ func wasmUpdateResourceTagsPrompt(existingTags map[string]string, noColor bool) 
 			break
 		}
 
-		value, err := ctx.prompt(fmt.Sprintf("Tag value for '%s' (empty to remove):", key), noColor)
+		value, err := buf.prompt(fmt.Sprintf("Tag value for '%s' (empty to remove):", key), noColor)
 		if err != nil {
 			return nil, err
 		}
@@ -272,24 +273,24 @@ func wasmUpdateResourceTagsPrompt(existingTags map[string]string, noColor bool) 
 		// Empty value means remove the tag
 		if value == "" && tags[key] != "" {
 			delete(tags, key)
-			ctx.add(fmt.Sprintf("  Removed tag: %s", key))
+			buf.add(fmt.Sprintf("  Removed tag: %s", key))
 		} else if value != "" {
 			tags[key] = value
-			ctx.add(fmt.Sprintf("  Updated tag: %s: %s", key, value))
+			buf.add(fmt.Sprintf("  Updated tag: %s: %s", key, value))
 		}
 	}
 
-	ctx.add("")
-	ctx.add("Final tags that will be applied:")
+	buf.add("")
+	buf.add("Final tags that will be applied:")
 	if len(tags) > 0 {
 		for k, v := range tags {
-			ctx.add(fmt.Sprintf("  %s: %s", k, v))
+			buf.add(fmt.Sprintf("  %s: %s", k, v))
 		}
 	} else {
-		ctx.add("  No tags - all existing tags will be removed")
+		buf.add("  No tags - all existing tags will be removed")
 	}
 
-	confirmApply := ctx.confirm("Apply these changes?", noColor)
+	confirmApply := buf.confirm("Apply these changes?", noColor)
 	if !confirmApply {
 		return nil, fmt.Errorf("tag update cancelled by user")
 	}

--- a/internal/utils/prompts_wasm.go
+++ b/internal/utils/prompts_wasm.go
@@ -12,10 +12,34 @@ import (
 // WASM versions of the prompt functions that use JavaScript callbacks
 // instead of stdin/stdout
 
+// promptLineBreak separates lines inside a prompt message. The host renders
+// prompt messages straight to a terminal that is not in convertEol mode, so a
+// bare \n would move down without returning to column 0 (a stair-step). Buffer
+// output (see flush) uses a plain \n because its renderer converts EOLs.
+const promptLineBreak = "\r\n"
+
+// sanitizeForTerminal strips C0 control characters and DEL from text that is
+// folded into a terminal-bound message. The host writes prompt messages to
+// xterm without escaping, so a crafted resource name or tag value could
+// otherwise inject cursor/erase sequences that rewrite the purchase summary
+// shown before the [y/N]. Only display copies are sanitized; the values stored
+// on the order come from the prompt responses, which are untouched. Structural
+// line breaks are inserted by callers after sanitizing, so they are preserved.
+func sanitizeForTerminal(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, s)
+}
+
 func init() {
 	// Override the default prompt functions with WASM-specific ones
 	SetPrompt(wasmPrompt)
 	SetConfirmPrompt(wasmConfirmPrompt)
+	SetBuyConfirmPrompt(wasmBuyConfirmPrompt)
+	SetDesignConfirmPrompt(wasmDesignConfirmPrompt)
 	SetPasswordPrompt(wasmPasswordPrompt)
 	SetResourcePrompt(wasmResourcePrompt)
 	SetSecretResourcePrompt(wasmSecretResourcePrompt)
@@ -41,6 +65,40 @@ func wasmConfirmPrompt(question string, noColor bool) bool {
 	return response == "y" || response == "yes"
 }
 
+// wasmBuyConfirmPrompt folds the purchase summary into the live prompt message
+// so the customer sees every detail before the [y/N]. On the WASM target the
+// native printConfirmSummary writes to os.Stdout, which the browser routes to
+// the console (invisible to the terminal), so the summary must travel on the
+// prompt channel instead.
+func wasmBuyConfirmPrompt(resourceType string, details []BuyConfirmDetail, noColor bool) bool {
+	msg := buildConfirmSummary("Purchase Summary:", resourceType, details, "Proceed with purchase?")
+	return wasmConfirmPrompt(msg, noColor)
+}
+
+func wasmDesignConfirmPrompt(resourceType string, details []BuyConfirmDetail, noColor bool) bool {
+	msg := buildConfirmSummary("Design Summary:", resourceType, details, "Proceed with creation?")
+	return wasmConfirmPrompt(msg, noColor)
+}
+
+// buildConfirmSummary renders the summary block and question as a single string
+// for delivery over the prompt channel: header, resource type, non-empty detail
+// lines, a blank line, then the question, matching the native printConfirmSummary
+// content (minus its color and leading blank line, which suit a scrolling TTY
+// rather than a discrete prompt payload). Lines use \r\n because the host renders
+// prompt messages on a terminal that is not in convertEol mode, so a bare \n
+// would stair-step the summary. Detail values are sanitized: they can be
+// user-supplied (e.g. a resource name).
+func buildConfirmSummary(header, resourceType string, details []BuyConfirmDetail, question string) string {
+	lines := []string{header, fmt.Sprintf("  Resource Type: %s", resourceType)}
+	for _, d := range details {
+		if d.Value != "" {
+			lines = append(lines, fmt.Sprintf("  %s: %s", d.Key, sanitizeForTerminal(d.Value)))
+		}
+	}
+	lines = append(lines, "", question)
+	return strings.Join(lines, promptLineBreak)
+}
+
 func wasmPasswordPrompt(msg string, noColor bool) (string, error) {
 	return wasm.PromptForInput(msg, "password", "")
 }
@@ -57,6 +115,51 @@ func wasmSecretResourcePrompt(resourceType string, msg string, noColor bool) (st
 	return wasm.PromptForInput(msg, "password", resourceType)
 }
 
+// wasmPromptContext accumulates informational lines (instructions, warnings,
+// per-tag echoes) and folds them into the next prompt message, so they reach
+// the live prompt channel instead of os.Stdout, which the browser routes to the
+// console. Trailing lines with no following prompt are flushed to the output
+// buffer instead.
+type wasmPromptContext struct {
+	lines []string
+}
+
+func (c *wasmPromptContext) add(line string) {
+	c.lines = append(c.lines, sanitizeForTerminal(line))
+}
+
+// prompt prepends any accumulated context to msg, sends it over the live prompt
+// channel, and clears the context.
+func (c *wasmPromptContext) prompt(msg string, noColor bool) (string, error) {
+	return wasmPrompt(c.take(msg), noColor)
+}
+
+// confirm prepends any accumulated context to question, asks it over the live
+// prompt channel, and clears the context.
+func (c *wasmPromptContext) confirm(question string, noColor bool) bool {
+	return wasmConfirmPrompt(c.take(question), noColor)
+}
+
+func (c *wasmPromptContext) take(msg string) string {
+	msg = sanitizeForTerminal(msg)
+	if len(c.lines) == 0 {
+		return msg
+	}
+	prefix := strings.Join(c.lines, promptLineBreak)
+	c.lines = nil
+	return prefix + promptLineBreak + msg
+}
+
+// flush writes any remaining context (no following prompt) to the output buffer
+// so it is captured rather than lost to the console.
+func (c *wasmPromptContext) flush() {
+	if len(c.lines) == 0 {
+		return
+	}
+	wasm.WasmOutputBuffer.Write([]byte(strings.Join(c.lines, "\n") + "\n"))
+	c.lines = nil
+}
+
 func wasmResourceTagsPrompt(noColor bool) (map[string]string, error) {
 	addTags := wasmConfirmPrompt("Would you like to add resource tags?", noColor)
 	if !addTags {
@@ -64,24 +167,22 @@ func wasmResourceTagsPrompt(noColor bool) (map[string]string, error) {
 	}
 
 	tags := make(map[string]string)
+	var ctx wasmPromptContext
 
-	// Inform user how to finish entering tags
-	fmt.Println("Enter tags (key and value). Enter empty key to finish.")
+	// Inform user how to finish entering tags; shown with the first key prompt.
+	ctx.add("Enter tags (key and value). Enter empty key to finish.")
 
 	for {
-		// Prompt for tag key
-		key, err := wasmPrompt("Tag key (empty to finish):", noColor)
+		key, err := ctx.prompt("Tag key (empty to finish):", noColor)
 		if err != nil {
 			return nil, err
 		}
 
-		// Empty key means we're done
 		if key == "" {
 			break
 		}
 
-		// Prompt for tag value
-		value, err := wasmPrompt(fmt.Sprintf("Tag value for '%s':", key), noColor)
+		value, err := ctx.prompt(fmt.Sprintf("Tag value for '%s':", key), noColor)
 		if err != nil {
 			return nil, err
 		}
@@ -90,79 +191,78 @@ func wasmResourceTagsPrompt(noColor bool) (map[string]string, error) {
 	}
 
 	if len(tags) > 0 {
-		fmt.Println("Tags added:")
+		ctx.add("Tags added:")
 		for k, v := range tags {
-			fmt.Printf("  %s: %s\n", k, v)
+			ctx.add(fmt.Sprintf("  %s: %s", k, v))
 		}
 	}
+	ctx.flush()
 
 	return tags, nil
 }
 
 func wasmUpdateResourceTagsPrompt(existingTags map[string]string, noColor bool) (map[string]string, error) {
-	// Display warning about replacing tags
-	fmt.Println("⚠️  Warning: This operation will replace all existing tags with the new set of tags you define.")
+	var ctx wasmPromptContext
 
-	// Show existing tags if any
+	// Warning about replacing tags; shown with the continue prompt.
+	ctx.add("⚠️  Warning: This operation will replace all existing tags with the new set of tags you define.")
+
 	if len(existingTags) > 0 {
-		fmt.Println("Current tags:")
+		ctx.add("Current tags:")
 		for k, v := range existingTags {
-			fmt.Printf("  %s: %s\n", k, v)
+			ctx.add(fmt.Sprintf("  %s: %s", k, v))
 		}
 	} else {
-		fmt.Println("No existing tags found.")
+		ctx.add("No existing tags found.")
 	}
 
-	// Ask if they want to proceed
-	proceed := wasmConfirmPrompt("Do you want to continue with updating tags?", noColor)
+	proceed := ctx.confirm("Do you want to continue with updating tags?", noColor)
 	if !proceed {
 		return nil, fmt.Errorf("tag update cancelled by user")
 	}
 
-	// Options for common tag operations
-	tags := make(map[string]string)
-
-	if len(existingTags) > 0 {
-		fmt.Println("\nChoose how you want to update tags:")
-		fmt.Println("1. Start with a clean slate (remove all existing tags)")
-		fmt.Println("2. Start with existing tags and modify them")
-
-		choice, err := wasmPrompt("Enter choice (1 or 2):", noColor)
-		if err != nil {
-			return nil, err
-		}
-
-		// Start with existing tags if requested
-		if choice == "2" {
-			// Copy existing tags
-			for k, v := range existingTags {
-				tags[k] = v
-			}
-
-			// Allow modifying existing tags
-			fmt.Println("\nYou can now modify, add, or remove tags.")
-			fmt.Println("To remove a tag, enter its key and an empty value.")
-		} else if choice != "1" {
-			return nil, fmt.Errorf("invalid choice: %s", choice)
-		}
+	// With no existing tags, defer to the add flow (mirrors the native path).
+	if len(existingTags) == 0 {
+		return wasmResourceTagsPrompt(noColor)
 	}
 
-	// Now prompt for new/updated tags
-	fmt.Println("\nEnter tags (key and value). Enter empty key to finish.")
+	tags := make(map[string]string)
+
+	ctx.add("")
+	ctx.add("Choose how you want to update tags:")
+	ctx.add("1. Start with a clean slate (remove all existing tags)")
+	ctx.add("2. Start with existing tags and modify them")
+
+	choice, err := ctx.prompt("Enter choice (1 or 2):", noColor)
+	if err != nil {
+		return nil, err
+	}
+
+	if choice == "2" {
+		for k, v := range existingTags {
+			tags[k] = v
+		}
+
+		ctx.add("")
+		ctx.add("You can now modify, add, or remove tags.")
+		ctx.add("To remove a tag, enter its key and an empty value.")
+	} else if choice != "1" {
+		return nil, fmt.Errorf("invalid choice: %s", choice)
+	}
+
+	ctx.add("")
+	ctx.add("Enter tags (key and value). Enter empty key to finish.")
 	for {
-		// Prompt for tag key
-		key, err := wasmPrompt("Tag key (empty to finish):", noColor)
+		key, err := ctx.prompt("Tag key (empty to finish):", noColor)
 		if err != nil {
 			return nil, err
 		}
 
-		// Empty key means we're done
 		if key == "" {
 			break
 		}
 
-		// Prompt for tag value
-		value, err := wasmPrompt(fmt.Sprintf("Tag value for '%s' (empty to remove):", key), noColor)
+		value, err := ctx.prompt(fmt.Sprintf("Tag value for '%s' (empty to remove):", key), noColor)
 		if err != nil {
 			return nil, err
 		}
@@ -170,24 +270,24 @@ func wasmUpdateResourceTagsPrompt(existingTags map[string]string, noColor bool) 
 		// Empty value means remove the tag
 		if value == "" && tags[key] != "" {
 			delete(tags, key)
-			fmt.Printf("  Removed tag: %s\n", key)
+			ctx.add(fmt.Sprintf("  Removed tag: %s", key))
 		} else if value != "" {
 			tags[key] = value
-			fmt.Printf("  Updated tag: %s: %s\n", key, value)
+			ctx.add(fmt.Sprintf("  Updated tag: %s: %s", key, value))
 		}
 	}
 
-	fmt.Println("\nFinal tags that will be applied:")
+	ctx.add("")
+	ctx.add("Final tags that will be applied:")
 	if len(tags) > 0 {
 		for k, v := range tags {
-			fmt.Printf("  %s: %s\n", k, v)
+			ctx.add(fmt.Sprintf("  %s: %s", k, v))
 		}
 	} else {
-		fmt.Println("  No tags - all existing tags will be removed")
+		ctx.add("  No tags - all existing tags will be removed")
 	}
 
-	// Final confirmation
-	confirmApply := wasmConfirmPrompt("Apply these changes?", noColor)
+	confirmApply := ctx.confirm("Apply these changes?", noColor)
 	if !confirmApply {
 		return nil, fmt.Errorf("tag update cancelled by user")
 	}

--- a/internal/utils/prompts_wasm_test.go
+++ b/internal/utils/prompts_wasm_test.go
@@ -549,7 +549,7 @@ func TestWasmBuyConfirmPromptSanitizesDetails(t *testing.T) {
 	// cursor-home sequence (via ESC and the C1 CSI byte 0x9b) must not reach the
 	// terminal, or they could rewrite the summary shown before the [y/N].
 	evilValue := "port\x1b[2K\x1b[Hspoofed"
-	evilType := "Port\x9b2Kspoofed"
+	evilType := "Port\u009b2Kspoofed"
 	wasmBuyConfirmPrompt(evilType, []BuyConfirmDetail{{Key: "Name", Value: evilValue}}, true)
 
 	msg := captured()

--- a/internal/utils/prompts_wasm_test.go
+++ b/internal/utils/prompts_wasm_test.go
@@ -3,6 +3,8 @@
 package utils
 
 import (
+	"strings"
+	"sync"
 	"syscall/js"
 	"testing"
 	"time"
@@ -454,6 +456,112 @@ func TestWasmUpdateResourceTagsPrompt(t *testing.T) {
 	}
 }
 
+func TestWasmBuyConfirmPromptDeliversSummary(t *testing.T) {
+	tests := []struct {
+		name         string
+		fn           func(string, []BuyConfirmDetail, bool) bool
+		resourceType string
+		details      []BuyConfirmDetail
+		mockResponse string
+		wantHeader   string
+		wantQuestion string
+		wantConfirm  bool
+	}{
+		{
+			name:         "buy summary confirmed with y",
+			fn:           wasmBuyConfirmPrompt,
+			resourceType: "MVE",
+			details: []BuyConfirmDetail{
+				{Key: "Name", Value: "test-mve"},
+				{Key: "Term", Value: "12 months"},
+				{Key: "Skipped", Value: ""},
+			},
+			mockResponse: "y",
+			wantHeader:   "Purchase Summary:",
+			wantQuestion: "Proceed with purchase?",
+			wantConfirm:  true,
+		},
+		{
+			name:         "design summary declined with n",
+			fn:           wasmDesignConfirmPrompt,
+			resourceType: "NAT Gateway",
+			details: []BuyConfirmDetail{
+				{Key: "Name", Value: "test-nat"},
+			},
+			mockResponse: "n",
+			wantHeader:   "Design Summary:",
+			wantQuestion: "Proceed with creation?",
+			wantConfirm:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture the message delivered to the live prompt channel.
+			captured := setupCapturingMockPromptHandler(t, tt.mockResponse)
+			defer cleanupMockPromptHandler()
+
+			result := tt.fn(tt.resourceType, tt.details, true)
+
+			if result != tt.wantConfirm {
+				t.Errorf("Expected confirm result %v, got %v", tt.wantConfirm, result)
+			}
+
+			msg := captured()
+			// Multi-line prompt messages must use \r\n so the host terminal
+			// (no convertEol) renders the summary as a left-aligned block.
+			if !strings.Contains(msg, "\r\n") {
+				t.Errorf("Prompt message should separate lines with \\r\\n; got:\n%q", msg)
+			}
+			if strings.Contains(strings.ReplaceAll(msg, "\r\n", ""), "\n") {
+				t.Errorf("Prompt message contains a bare \\n (missing \\r); got:\n%q", msg)
+			}
+			// The summary must reach the prompt channel, not os.Stdout.
+			for _, want := range []string{
+				tt.wantHeader,
+				"Resource Type: " + tt.resourceType,
+				tt.wantQuestion,
+			} {
+				if !strings.Contains(msg, want) {
+					t.Errorf("Prompt message missing %q; got:\n%s", want, msg)
+				}
+			}
+			for _, d := range tt.details {
+				if d.Value == "" {
+					if strings.Contains(msg, d.Key+":") {
+						t.Errorf("Prompt message should omit empty-value detail %q; got:\n%s", d.Key, msg)
+					}
+					continue
+				}
+				if !strings.Contains(msg, d.Key+": "+d.Value) {
+					t.Errorf("Prompt message missing detail %q; got:\n%s", d.Key+": "+d.Value, msg)
+				}
+			}
+		})
+	}
+}
+
+func TestWasmBuyConfirmPromptSanitizesDetails(t *testing.T) {
+	captured := setupCapturingMockPromptHandler(t, "y")
+	defer cleanupMockPromptHandler()
+
+	// A crafted resource name carrying an ANSI erase-line + cursor-home
+	// sequence must not reach the terminal, or it could rewrite the summary
+	// shown before the [y/N].
+	evil := "port\x1b[2K\x1b[Hspoofed"
+	wasmBuyConfirmPrompt("Port", []BuyConfirmDetail{{Key: "Name", Value: evil}}, true)
+
+	msg := captured()
+	// The ESC that arms the escape sequence must be gone; the surrounding
+	// printable text is harmless and is preserved.
+	if strings.ContainsRune(msg, 0x1b) {
+		t.Errorf("Prompt message must not contain ESC (0x1b); got:\n%q", msg)
+	}
+	if !strings.Contains(msg, "port") || !strings.Contains(msg, "spoofed") {
+		t.Errorf("Sanitized value should keep printable characters; got:\n%q", msg)
+	}
+}
+
 // Helper functions for testing
 
 var responseQueue []string
@@ -514,6 +622,45 @@ func setupSequentialMockPromptHandler(t *testing.T, responses []string) {
 	})
 
 	wasm.RegisterPromptCallback(callback.Value)
+}
+
+// setupCapturingMockPromptHandler registers a callback that records the message
+// delivered on the prompt channel and auto-responds. The returned accessor
+// yields the captured message after the prompt completes.
+func setupCapturingMockPromptHandler(t *testing.T, response string) func() string {
+	t.Helper()
+
+	var mu sync.Mutex
+	var message string
+
+	callback := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		if len(args) > 0 {
+			promptData := args[0]
+			promptID := promptData.Get("id").String()
+
+			mu.Lock()
+			message = promptData.Get("message").String()
+			mu.Unlock()
+
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				jsArgs := []js.Value{
+					js.ValueOf(promptID),
+					js.ValueOf(response),
+				}
+				wasm.SubmitPromptResponse(js.Undefined(), jsArgs)
+			}()
+		}
+		return nil
+	})
+
+	wasm.RegisterPromptCallback(callback.Value)
+
+	return func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		return message
+	}
 }
 
 func cleanupMockPromptHandler() {

--- a/internal/utils/prompts_wasm_test.go
+++ b/internal/utils/prompts_wasm_test.go
@@ -545,17 +545,20 @@ func TestWasmBuyConfirmPromptSanitizesDetails(t *testing.T) {
 	captured := setupCapturingMockPromptHandler(t, "y")
 	defer cleanupMockPromptHandler()
 
-	// A crafted resource name carrying an ANSI erase-line + cursor-home
-	// sequence must not reach the terminal, or it could rewrite the summary
-	// shown before the [y/N].
-	evil := "port\x1b[2K\x1b[Hspoofed"
-	wasmBuyConfirmPrompt("Port", []BuyConfirmDetail{{Key: "Name", Value: evil}}, true)
+	// A crafted resource name and resource type carrying an ANSI erase-line +
+	// cursor-home sequence (via ESC and the C1 CSI byte 0x9b) must not reach the
+	// terminal, or they could rewrite the summary shown before the [y/N].
+	evilValue := "port\x1b[2K\x1b[Hspoofed"
+	evilType := "Port\x9b2Kspoofed"
+	wasmBuyConfirmPrompt(evilType, []BuyConfirmDetail{{Key: "Name", Value: evilValue}}, true)
 
 	msg := captured()
-	// The ESC that arms the escape sequence must be gone; the surrounding
-	// printable text is harmless and is preserved.
-	if strings.ContainsRune(msg, 0x1b) {
-		t.Errorf("Prompt message must not contain ESC (0x1b); got:\n%q", msg)
+	// The control bytes that arm the escape sequences must be gone; the
+	// surrounding printable text is harmless and is preserved.
+	for _, r := range []rune{0x1b, 0x9b} {
+		if strings.ContainsRune(msg, r) {
+			t.Errorf("Prompt message must not contain control byte %#x; got:\n%q", r, msg)
+		}
 	}
 	if !strings.Contains(msg, "port") || !strings.Contains(msg, "spoofed") {
 		t.Errorf("Sanitized value should keep printable characters; got:\n%q", msg)
@@ -591,6 +594,7 @@ func setupMockPromptHandler(t *testing.T, response string) {
 	})
 
 	wasm.RegisterPromptCallback(callback.Value)
+	t.Cleanup(callback.Release)
 }
 
 func setupSequentialMockPromptHandler(t *testing.T, responses []string) {
@@ -622,6 +626,7 @@ func setupSequentialMockPromptHandler(t *testing.T, responses []string) {
 	})
 
 	wasm.RegisterPromptCallback(callback.Value)
+	t.Cleanup(callback.Release)
 }
 
 // setupCapturingMockPromptHandler registers a callback that records the message
@@ -655,6 +660,7 @@ func setupCapturingMockPromptHandler(t *testing.T, response string) func() strin
 	})
 
 	wasm.RegisterPromptCallback(callback.Value)
+	t.Cleanup(callback.Release)
 
 	return func() string {
 		mu.Lock()


### PR DESCRIPTION
In the browser build, interactive buy/design confirmation summaries and tag-prompt context were printed to `os.Stdout`, which the browser routes to the console. Customers saw only the `[y/N]` question, so they were confirming billable orders with the purchase summary invisible.

This moves that text onto the live prompt channel so it renders in the terminal alongside the question. The native path is unchanged.

- WASM buy/design confirm now folds the full summary into the prompt message
- Interactive tag prompts carry their instructions/warnings/echoes on the prompt channel too; trailing lines flush to the output buffer
- Prompt messages use CRLF (the host terminal is not in convertEol mode, so a bare `\n` stair-steps)
- Display values are sanitized to strip control chars that could inject cursor/erase sequences
- WASM `tags update` with no existing tags now delegates to the add flow, matching native (also fixes a pre-existing hanging test)

ESD-1577
