### PR TITLE
ESD-1593-fix(wasm): enable consistent ANSI color in browser output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 ## [Unreleased]
 
 ### Fixed
-- enable consistent ANSI color in the browser (WASM) build: cell values, status badges, and success/error lines now match the colored table chrome, and `--no-color` strips all of it including the table style (ESD-1593)
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
 - `mve buy` and `mve validate` now apply `resourceTags` from JSON input, and interactive `mve buy` now prompts for tags, matching MCR. Previously the JSON path silently dropped the documented `resourceTags` field and interactive mode never asked. The JSON path shares the same value and empty-key validation as the flags path, so non-string values and empty keys return a usage error before the order is placed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 ## [Unreleased]
 
 ### Fixed
+- enable consistent ANSI color in the browser (WASM) build: cell values, status badges, and success/error lines now match the colored table chrome, and `--no-color` strips all of it including the table style (ESD-1593)
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
 - `mve buy` and `mve validate` now apply `resourceTags` from JSON input, and interactive `mve buy` now prompts for tags, matching MCR. Previously the JSON path silently dropped the documented `resourceTags` field and interactive mode never asked. The JSON path shares the same value and empty-key validation as the flags path, so non-string values and empty keys return a usage error before the order is placed
 

--- a/cmd/megaport/colors_wasm_test.go
+++ b/cmd/megaport/colors_wasm_test.go
@@ -1,0 +1,63 @@
+//go:build js && wasm
+
+package megaport
+
+import (
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/megaport/megaport-cli/internal/wasm"
+	"github.com/stretchr/testify/assert"
+)
+
+// ESD-1593: fatih/color's global NoColor defaults to true under js/wasm (isatty
+// is always false), which stripped every colorized value/badge/status line while
+// go-pretty still colored the table chrome. These tests drive the real command
+// path (ExecuteWithArgs -> PersistentPreRunE) so they fail if the color wiring is
+// reverted. Each command reaches PersistentPreRunE and then returns on an offline
+// usage error (invalid --output), so no network call is made.
+
+// TestWasmColor_DefaultRunEnablesColor covers AC1: a normal run leaves color
+// enabled (NoColor false) in the browser.
+func TestWasmColor_DefaultRunEnablesColor(t *testing.T) {
+	orig := color.NoColor
+	defer func() { color.NoColor = orig }()
+	color.NoColor = true // start from the hostile js/wasm default
+
+	wasm.ResetOutputBuffers()
+	ExecuteWithArgs([]string{"megaport-cli", "ports", "list", "--output", "invalid"})
+
+	assert.False(t, color.NoColor, "a default run should enable fatih color in the browser")
+}
+
+// TestWasmColor_NoColorFlagDisablesColor covers AC2: --no-color disables fatih
+// color. This is the guard on the PersistentPreRunE flag sync; without it the
+// per-invocation default (false) would leave color on.
+func TestWasmColor_NoColorFlagDisablesColor(t *testing.T) {
+	orig := color.NoColor
+	defer func() { color.NoColor = orig }()
+	color.NoColor = false
+
+	wasm.ResetOutputBuffers()
+	ExecuteWithArgs([]string{"megaport-cli", "ports", "list", "--no-color", "--output", "invalid"})
+
+	assert.True(t, color.NoColor, "--no-color should disable fatih color")
+}
+
+// TestWasmColor_NoStaleFlagAcrossRuns guards the per-invocation reset in
+// ExecuteWithArgs: a --no-color run must not bleed into a later run that skips
+// PersistentPreRunE (e.g. --help), which would otherwise keep color disabled.
+func TestWasmColor_NoStaleFlagAcrossRuns(t *testing.T) {
+	orig := color.NoColor
+	defer func() { color.NoColor = orig }()
+
+	wasm.ResetOutputBuffers()
+	ExecuteWithArgs([]string{"megaport-cli", "ports", "list", "--no-color", "--output", "invalid"})
+	assert.True(t, color.NoColor, "sanity: --no-color run disables color")
+
+	// --help returns before PersistentPreRunE runs, so only the ExecuteWithArgs
+	// reset can clear the prior run's flag.
+	wasm.ResetOutputBuffers()
+	ExecuteWithArgs([]string{"megaport-cli", "ports", "list", "--help"})
+	assert.False(t, color.NoColor, "a subsequent non --no-color run must re-enable color")
+}

--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/base/registry"
@@ -95,6 +96,12 @@ func InitializeCommon() {
 	// Validate retry flags in WASM builds too.
 	existingPreRunE := rootCmd.PersistentPreRunE
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		// fatih/color's global NoColor defaults to true under js/wasm (isatty is
+		// always false), which strips every color.*String/colorizeValue/colorizeStatus
+		// while go-pretty still colors the table chrome. xterm.js renders ANSI, so
+		// mirror the --no-color flag here to keep coloring all-or-nothing.
+		color.NoColor = noColor
+
 		verbosity := "normal"
 		if quiet {
 			verbosity = "quiet"

--- a/cmd/megaport/megaport_wasm.go
+++ b/cmd/megaport/megaport_wasm.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/base/help"
 	"github.com/megaport/megaport-cli/internal/base/output"
@@ -22,6 +23,14 @@ func ExecuteWithArgs(args []string) {
 	// after parsing, and this state persists when the same command tree is reused
 	// across multiple WASM invocations.
 	resetAllFlags(rootCmd)
+
+	// Default to colored output each invocation. fatih/color derives its global
+	// NoColor from isatty, always false under js/wasm, so it would otherwise strip
+	// every colorized value/badge/status line while go-pretty still colors the
+	// table chrome. Resetting here (not just in PersistentPreRunE) keeps paths that
+	// skip PersistentPreRunE, e.g. --help, from inheriting a prior run's flag.
+	// PersistentPreRunE re-applies --no-color for the command actually running.
+	color.NoColor = false
 
 	// Direct output to our WASM buffer
 	rootCmd.SetOut(wasm.WasmOutputBuffer)


### PR DESCRIPTION
In the browser (WASM) build, table borders and headers were colored but every cell value, status badge, and success/error line rendered as plain text. fatih/color derives its global `NoColor` from isatty, which is always false under js/wasm, so it defaulted to true and stripped all fatih-colored output, while go-pretty colored the table chrome on its own. xterm.js renders ANSI fine, so the output just looked half-colored.

The fix makes both color engines follow the same switch:

- Set `color.NoColor = false` per invocation in `ExecuteWithArgs`, so paths that skip `PersistentPreRunE` (e.g. `--help`) don't inherit a prior run's flag in the long-lived WASM module.
- Set `color.NoColor` to the `--no-color` flag in the root `PersistentPreRunE`, so it governs the command actually running.
- Colored by default, all color stripped (fatih + go-pretty table style) under `--no-color`.
- Adds WASM-tagged regression tests driving `ExecuteWithArgs` (mutation-tested: they fail if either fix line is reverted).

Native color behavior is unchanged (both edited files are `//go:build js && wasm`).

Closes ESD-1593.