### PR TITLE
ESD-1597-fix(wasm): align prompt timeout with the command budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 ### Fixed
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
 - `mve buy` and `mve validate` now apply `resourceTags` from JSON input, and interactive `mve buy` now prompts for tags, matching MCR. Previously the JSON path silently dropped the documented `resourceTags` field and interactive mode never asked. The JSON path shares the same value and empty-key validation as the flags path, so non-string values and empty keys return a usage error before the order is placed
+- WASM interactive prompts no longer time out before the command's own 10-minute budget expires. A single unanswered prompt used to fail after a hardcoded 5 minutes even though the async command wrapper allowed 10, discarding everything the user had entered so far. Both timeouts now share one constant, and the timeout error states how long it waited and that the host can cancel via `cancelPrompt` (ESD-1597)
 
 ## [v1.0.0-beta.1] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 ### Fixed
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
 - `mve buy` and `mve validate` now apply `resourceTags` from JSON input, and interactive `mve buy` now prompts for tags, matching MCR. Previously the JSON path silently dropped the documented `resourceTags` field and interactive mode never asked. The JSON path shares the same value and empty-key validation as the flags path, so non-string values and empty keys return a usage error before the order is placed
-- WASM interactive prompts no longer time out before the command's own 10-minute budget expires. A single unanswered prompt used to fail after a hardcoded 5 minutes even though the async command wrapper allowed 10, discarding everything the user had entered so far. Both timeouts now share one constant, and the timeout error states how long it waited and that the host can cancel via `cancelPrompt` (ESD-1597)
 
 ## [v1.0.0-beta.1] - 2026-07-01
 

--- a/internal/wasm/prompts.go
+++ b/internal/wasm/prompts.go
@@ -10,6 +10,12 @@ import (
 	"time"
 )
 
+// CommandTimeout is the maximum duration an async CLI command may run (see
+// main_wasm.go's asyncCommandTimeout) and the ceiling PromptForInput waits
+// for a single prompt response. The two must stay equal: a shorter prompt
+// timeout would fail an interactive command before its own budget expires.
+const CommandTimeout = 10 * time.Minute
+
 var (
 	// promptCallback is the JavaScript function to call when prompting for input.
 	// Protected by promptCallbackMu.
@@ -22,6 +28,11 @@ var (
 
 	// promptCounter generates unique IDs for each prompt
 	promptCounter atomic.Int64
+
+	// promptTimeout is the effective per-prompt wait ceiling. It defaults to
+	// CommandTimeout but is a var (rather than using CommandTimeout directly)
+	// so tests can shrink it instead of waiting out the full command budget.
+	promptTimeout = CommandTimeout
 )
 
 // PromptRequest represents a pending prompt waiting for user input
@@ -112,13 +123,13 @@ func PromptForInput(message string, promptType string, resourceType string) (str
 		js.Global().Get("console").Call("error", fmt.Sprintf("❌ Error for %s: %v", promptID, err))
 		return "", err
 
-	case <-time.After(5 * time.Minute):
+	case <-time.After(promptTimeout):
 		// Timeout
 		pendingMutex.Lock()
 		delete(pendingPrompts, promptID)
 		pendingMutex.Unlock()
 
-		return "", fmt.Errorf("prompt timeout: no response received")
+		return "", fmt.Errorf("prompt timeout: no response received after %s; the host can cancel a pending prompt via cancelPrompt", promptTimeout)
 	}
 }
 

--- a/internal/wasm/prompts.go
+++ b/internal/wasm/prompts.go
@@ -103,7 +103,12 @@ func PromptForInput(message string, promptType string, resourceType string) (str
 		"resourceType": resourceType,
 	})
 
-	// Wait for response with timeout
+	// Wait for response with timeout. A stoppable timer (rather than time.After)
+	// is stopped as soon as a response/error arrives so it isn't left running in
+	// the runtime's timer heap for up to promptTimeout on every answered prompt.
+	timer := time.NewTimer(promptTimeout)
+	defer timer.Stop()
+
 	select {
 	case response := <-responseChan:
 		// Clean up
@@ -123,7 +128,7 @@ func PromptForInput(message string, promptType string, resourceType string) (str
 		js.Global().Get("console").Call("error", fmt.Sprintf("❌ Error for %s: %v", promptID, err))
 		return "", err
 
-	case <-time.After(promptTimeout):
+	case <-timer.C:
 		// Timeout
 		pendingMutex.Lock()
 		delete(pendingPrompts, promptID)

--- a/internal/wasm/prompts_test.go
+++ b/internal/wasm/prompts_test.go
@@ -4,6 +4,7 @@ package wasm
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"syscall/js"
 	"testing"
@@ -396,73 +397,218 @@ func TestGetPendingPrompts(t *testing.T) {
 	}
 }
 
-func TestPromptTimeout(t *testing.T) {
-	// This test verifies that prompts can be created and the timeout mechanism is in place
-	// We don't actually wait for the full 5-minute timeout
+// withScaledPromptTimeout temporarily overrides promptTimeout for a test and
+// restores it afterward. promptTimeout defaults to CommandTimeout (10
+// minutes), far too long to wait out in a unit test.
+func withScaledPromptTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := promptTimeout
+	promptTimeout = d
+	t.Cleanup(func() { promptTimeout = orig })
+}
 
-	// Setup
+// findPendingPromptID polls pendingPrompts until an entry appears or the
+// deadline passes, returning "" on timeout. It takes no *testing.T and never
+// fails a test directly, since it is called from non-test goroutines where
+// t.Fatal is unsafe; callers must check for "" on the main test goroutine.
+func findPendingPromptID(deadline time.Duration) string {
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		pendingMutex.Lock()
+		for id := range pendingPrompts {
+			pendingMutex.Unlock()
+			return id
+		}
+		pendingMutex.Unlock()
+		time.Sleep(time.Millisecond)
+	}
+	return ""
+}
+
+// TestPromptForInput_RespondsPastOldFiveMinuteMark is a regression test for
+// the original bug: PromptForInput's per-prompt timeout (hardcoded 5
+// minutes) fired before main_wasm.go's 10-minute asyncCommandTimeout,
+// killing a command whose prompt was still within the command's own budget.
+// promptTimeout is scaled down here so the test runs in milliseconds, but
+// the response arrives well past the halfway point of the budget (mirroring
+// "answered at minute 6 of a 10-minute budget") and must still succeed now
+// that both timeouts share one source of truth.
+func TestPromptForInput_RespondsPastOldFiveMinuteMark(t *testing.T) {
+	withScaledPromptTimeout(t, 200*time.Millisecond)
+
 	fn := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-		// Don't respond - simulating user inaction
 		return nil
 	})
 	promptCallback = fn.Value
-	defer func() {
-		promptCallback = js.Undefined()
-	}()
+	defer func() { promptCallback = js.Undefined() }()
 
 	pendingMutex.Lock()
 	pendingPrompts = make(map[string]*PromptRequest)
 	pendingMutex.Unlock()
 
-	// Register a prompt directly (without blocking via PromptForInput)
-	pendingMutex.Lock()
-	promptCounter.Add(1)
-	promptID := fmt.Sprintf("timeout_test_%d", time.Now().UnixNano())
+	go func() {
+		promptID := findPendingPromptID(time.Second)
+		if promptID == "" {
+			return
+		}
+		time.Sleep(120 * time.Millisecond) // 60% of the scaled budget
+		args := []js.Value{js.ValueOf(promptID), js.ValueOf("late-but-in-budget")}
+		submitPromptResponse(js.Undefined(), args)
+	}()
 
-	request := &PromptRequest{
-		ID:           promptID,
-		Message:      "Test",
-		PromptType:   "text",
-		ResourceType: "",
-		ResponseChan: make(chan string, 1),
-		ErrorChan:    make(chan error, 1),
+	result, err := PromptForInput("Enter name:", "text", "")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
-	pendingPrompts[promptID] = request
+	if result != "late-but-in-budget" {
+		t.Errorf("expected %q, got %q", "late-but-in-budget", result)
+	}
+}
+
+// TestPromptForInput_TimeoutErrorMessage verifies the timeout error states
+// how long PromptForInput waited and that the host can cancel via
+// cancelPrompt, and that the timed-out prompt is cleaned up.
+func TestPromptForInput_TimeoutErrorMessage(t *testing.T) {
+	withScaledPromptTimeout(t, 20*time.Millisecond)
+
+	fn := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		return nil // never respond
+	})
+	promptCallback = fn.Value
+	defer func() { promptCallback = js.Undefined() }()
+
+	pendingMutex.Lock()
+	pendingPrompts = make(map[string]*PromptRequest)
 	pendingMutex.Unlock()
 
-	// Verify prompt exists
-	pendingMutex.Lock()
-	promptCount := len(pendingPrompts)
-	pendingMutex.Unlock()
-
-	if promptCount != 1 {
-		t.Errorf("Expected 1 pending prompt, got %d", promptCount)
+	_, err := PromptForInput("Enter name:", "text", "")
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
 	}
 
-	// Verify the prompt has the expected properties
-	pendingMutex.Lock()
-	registeredRequest, exists := pendingPrompts[promptID]
-	pendingMutex.Unlock()
-
-	if !exists {
-		t.Error("Expected prompt to be registered")
-		return
+	msg := err.Error()
+	if !strings.Contains(msg, promptTimeout.String()) {
+		t.Errorf("expected error to state the duration waited (%s), got: %s", promptTimeout, msg)
+	}
+	if !strings.Contains(msg, "cancelPrompt") {
+		t.Errorf("expected error to mention cancelPrompt, got: %s", msg)
 	}
 
-	if registeredRequest.Message != "Test" {
-		t.Errorf("Expected message 'Test', got '%s'", registeredRequest.Message)
-	}
-
-	// Clean up - send a response to avoid any blocking
-	registeredRequest.ResponseChan <- "cleanup"
-
-	// Clean up registered prompt
 	pendingMutex.Lock()
-	delete(pendingPrompts, promptID)
+	remaining := len(pendingPrompts)
+	pendingMutex.Unlock()
+	if remaining != 0 {
+		t.Errorf("expected timed-out prompt to be cleaned up, got %d pending", remaining)
+	}
+}
+
+// TestPromptForInput_LateSubmitAfterTimeoutStaysClean verifies a
+// submitPromptResponse that arrives after a prompt has already timed out
+// (and been cleaned up) returns a clean "Prompt not found" without blocking
+// or panicking.
+func TestPromptForInput_LateSubmitAfterTimeoutStaysClean(t *testing.T) {
+	withScaledPromptTimeout(t, 20*time.Millisecond)
+
+	fn := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		return nil // never respond
+	})
+	promptCallback = fn.Value
+	defer func() { promptCallback = js.Undefined() }()
+
+	pendingMutex.Lock()
+	pendingPrompts = make(map[string]*PromptRequest)
 	pendingMutex.Unlock()
 
-	// Note: Full timeout test would take 5 minutes, so we just verify the mechanism is in place
-	// In production, you'd want to make timeout configurable for testing
+	promptIDCh := make(chan string, 1)
+	go func() { promptIDCh <- findPendingPromptID(time.Second) }()
+
+	_, err := PromptForInput("Enter name:", "text", "")
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	promptID := <-promptIDCh
+	if promptID == "" {
+		t.Fatal("timed out waiting for a pending prompt to be registered")
+	}
+
+	args := []js.Value{js.ValueOf(promptID), js.ValueOf("too-late")}
+	done := make(chan interface{}, 1)
+	go func() { done <- submitPromptResponse(js.Undefined(), args) }()
+
+	select {
+	case result := <-done:
+		resultMap, ok := result.(map[string]interface{})
+		if !ok {
+			t.Fatal("expected result to be a map")
+		}
+		if _, hasError := resultMap["error"]; !hasError {
+			t.Error("expected error in result for late submit after timeout")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("late submitPromptResponse blocked instead of returning cleanly")
+	}
+}
+
+// TestPromptForInput_LateSubmitAfterCancelStaysClean verifies a
+// submitPromptResponse that arrives after a prompt has been cancelled (and
+// cleaned up) returns a clean "Prompt not found" without blocking or
+// panicking.
+func TestPromptForInput_LateSubmitAfterCancelStaysClean(t *testing.T) {
+	// Safety net: cancelPrompt is what should unblock PromptForInput here, not
+	// the timeout. A scaled-down promptTimeout keeps a broken cancel path from
+	// hanging the test for the full 10-minute default.
+	withScaledPromptTimeout(t, 5*time.Second)
+
+	fn := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		return nil
+	})
+	promptCallback = fn.Value
+	defer func() { promptCallback = js.Undefined() }()
+
+	pendingMutex.Lock()
+	pendingPrompts = make(map[string]*PromptRequest)
+	pendingMutex.Unlock()
+
+	promptIDCh := make(chan string, 1)
+	go func() {
+		promptID := findPendingPromptID(time.Second)
+		promptIDCh <- promptID
+		if promptID != "" {
+			cancelPrompt(js.Undefined(), []js.Value{js.ValueOf(promptID)})
+		}
+	}()
+
+	_, err := PromptForInput("Enter name:", "text", "")
+	if err == nil {
+		t.Fatal("expected cancellation error, got nil")
+	}
+	// Pin down that cancelPrompt (not the 5-second timeout fallback) is what
+	// unblocked PromptForInput, so a broken cancel path can't slip through as
+	// a false-negative pass.
+	if !strings.Contains(err.Error(), "cancelled") {
+		t.Fatalf("expected a cancellation error, got: %v", err)
+	}
+	promptID := <-promptIDCh
+	if promptID == "" {
+		t.Fatal("timed out waiting for a pending prompt to be registered")
+	}
+
+	args := []js.Value{js.ValueOf(promptID), js.ValueOf("too-late")}
+	done := make(chan interface{}, 1)
+	go func() { done <- submitPromptResponse(js.Undefined(), args) }()
+
+	select {
+	case result := <-done:
+		resultMap, ok := result.(map[string]interface{})
+		if !ok {
+			t.Fatal("expected result to be a map")
+		}
+		if _, hasError := resultMap["error"]; !hasError {
+			t.Error("expected error in result for late submit after cancel")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("late submitPromptResponse blocked instead of returning cleanly")
+	}
 }
 
 func TestConcurrentPrompts(t *testing.T) {

--- a/internal/wasm/prompts_test.go
+++ b/internal/wasm/prompts_test.go
@@ -407,22 +407,18 @@ func withScaledPromptTimeout(t *testing.T, d time.Duration) {
 	t.Cleanup(func() { promptTimeout = orig })
 }
 
-// findPendingPromptID polls pendingPrompts until an entry appears or the
-// deadline passes, returning "" on timeout. It takes no *testing.T and never
-// fails a test directly, since it is called from non-test goroutines where
-// t.Fatal is unsafe; callers must check for "" on the main test goroutine.
-func findPendingPromptID(deadline time.Duration) string {
-	end := time.Now().Add(deadline)
-	for time.Now().Before(end) {
-		pendingMutex.Lock()
-		for id := range pendingPrompts {
-			pendingMutex.Unlock()
-			return id
-		}
-		pendingMutex.Unlock()
-		time.Sleep(time.Millisecond)
-	}
-	return ""
+// capturingPromptCallback returns a mock JS prompt callback and a channel
+// that receives the prompt ID the moment PromptForInput invokes it.
+// PromptForInput calls the callback synchronously before it enters its
+// timeout select, so reading from the returned channel is deterministic and
+// never races the timeout, unlike polling pendingPrompts from a goroutine.
+func capturingPromptCallback() (js.Func, <-chan string) {
+	idCh := make(chan string, 1)
+	fn := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		idCh <- args[0].Get("id").String()
+		return nil
+	})
+	return fn, idCh
 }
 
 // TestPromptForInput_RespondsPastOldFiveMinuteMark is a regression test for
@@ -436,9 +432,7 @@ func findPendingPromptID(deadline time.Duration) string {
 func TestPromptForInput_RespondsPastOldFiveMinuteMark(t *testing.T) {
 	withScaledPromptTimeout(t, 200*time.Millisecond)
 
-	fn := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-		return nil
-	})
+	fn, promptIDCh := capturingPromptCallback()
 	promptCallback = fn.Value
 	defer func() { promptCallback = js.Undefined() }()
 
@@ -447,10 +441,7 @@ func TestPromptForInput_RespondsPastOldFiveMinuteMark(t *testing.T) {
 	pendingMutex.Unlock()
 
 	go func() {
-		promptID := findPendingPromptID(time.Second)
-		if promptID == "" {
-			return
-		}
+		promptID := <-promptIDCh
 		time.Sleep(120 * time.Millisecond) // 60% of the scaled budget
 		args := []js.Value{js.ValueOf(promptID), js.ValueOf("late-but-in-budget")}
 		submitPromptResponse(js.Undefined(), args)
@@ -509,9 +500,7 @@ func TestPromptForInput_TimeoutErrorMessage(t *testing.T) {
 func TestPromptForInput_LateSubmitAfterTimeoutStaysClean(t *testing.T) {
 	withScaledPromptTimeout(t, 20*time.Millisecond)
 
-	fn := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-		return nil // never respond
-	})
+	fn, promptIDCh := capturingPromptCallback()
 	promptCallback = fn.Value
 	defer func() { promptCallback = js.Undefined() }()
 
@@ -519,17 +508,11 @@ func TestPromptForInput_LateSubmitAfterTimeoutStaysClean(t *testing.T) {
 	pendingPrompts = make(map[string]*PromptRequest)
 	pendingMutex.Unlock()
 
-	promptIDCh := make(chan string, 1)
-	go func() { promptIDCh <- findPendingPromptID(time.Second) }()
-
 	_, err := PromptForInput("Enter name:", "text", "")
 	if err == nil {
 		t.Fatal("expected timeout error, got nil")
 	}
 	promptID := <-promptIDCh
-	if promptID == "" {
-		t.Fatal("timed out waiting for a pending prompt to be registered")
-	}
 
 	args := []js.Value{js.ValueOf(promptID), js.ValueOf("too-late")}
 	done := make(chan interface{}, 1)
@@ -559,9 +542,7 @@ func TestPromptForInput_LateSubmitAfterCancelStaysClean(t *testing.T) {
 	// hanging the test for the full 10-minute default.
 	withScaledPromptTimeout(t, 5*time.Second)
 
-	fn := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-		return nil
-	})
+	fn, promptIDCh := capturingPromptCallback()
 	promptCallback = fn.Value
 	defer func() { promptCallback = js.Undefined() }()
 
@@ -569,13 +550,15 @@ func TestPromptForInput_LateSubmitAfterCancelStaysClean(t *testing.T) {
 	pendingPrompts = make(map[string]*PromptRequest)
 	pendingMutex.Unlock()
 
-	promptIDCh := make(chan string, 1)
+	// lateIDCh receives the prompt ID once cancelPrompt has already been
+	// called with it, so reading it after PromptForInput returns is
+	// guaranteed to see a value: the send happens-before the cancellation
+	// that unblocks PromptForInput.
+	lateIDCh := make(chan string, 1)
 	go func() {
-		promptID := findPendingPromptID(time.Second)
-		promptIDCh <- promptID
-		if promptID != "" {
-			cancelPrompt(js.Undefined(), []js.Value{js.ValueOf(promptID)})
-		}
+		promptID := <-promptIDCh
+		lateIDCh <- promptID
+		cancelPrompt(js.Undefined(), []js.Value{js.ValueOf(promptID)})
 	}()
 
 	_, err := PromptForInput("Enter name:", "text", "")
@@ -588,10 +571,7 @@ func TestPromptForInput_LateSubmitAfterCancelStaysClean(t *testing.T) {
 	if !strings.Contains(err.Error(), "cancelled") {
 		t.Fatalf("expected a cancellation error, got: %v", err)
 	}
-	promptID := <-promptIDCh
-	if promptID == "" {
-		t.Fatal("timed out waiting for a pending prompt to be registered")
-	}
+	promptID := <-lateIDCh
 
 	args := []js.Value{js.ValueOf(promptID), js.ValueOf("too-late")}
 	done := make(chan interface{}, 1)

--- a/internal/wasm/prompts_test.go
+++ b/internal/wasm/prompts_test.go
@@ -433,6 +433,7 @@ func TestPromptForInput_RespondsPastOldFiveMinuteMark(t *testing.T) {
 	withScaledPromptTimeout(t, 200*time.Millisecond)
 
 	fn, promptIDCh := capturingPromptCallback()
+	t.Cleanup(fn.Release)
 	promptCallback = fn.Value
 	defer func() { promptCallback = js.Undefined() }()
 
@@ -465,6 +466,7 @@ func TestPromptForInput_TimeoutErrorMessage(t *testing.T) {
 	fn := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 		return nil // never respond
 	})
+	t.Cleanup(fn.Release)
 	promptCallback = fn.Value
 	defer func() { promptCallback = js.Undefined() }()
 
@@ -501,6 +503,7 @@ func TestPromptForInput_LateSubmitAfterTimeoutStaysClean(t *testing.T) {
 	withScaledPromptTimeout(t, 20*time.Millisecond)
 
 	fn, promptIDCh := capturingPromptCallback()
+	t.Cleanup(fn.Release)
 	promptCallback = fn.Value
 	defer func() { promptCallback = js.Undefined() }()
 
@@ -543,6 +546,7 @@ func TestPromptForInput_LateSubmitAfterCancelStaysClean(t *testing.T) {
 	withScaledPromptTimeout(t, 5*time.Second)
 
 	fn, promptIDCh := capturingPromptCallback()
+	t.Cleanup(fn.Release)
 	promptCallback = fn.Value
 	defer func() { promptCallback = js.Undefined() }()
 

--- a/main_wasm.go
+++ b/main_wasm.go
@@ -74,10 +74,13 @@ func executeMegaportCommandAsync(this js.Value, args []js.Value) interface{} {
 	}
 
 	// asyncCommandTimeout is the maximum time an async command may run before
-	// the callback is invoked with a timeout error. The inner goroutine may still
-	// be running after the timeout (Go goroutines cannot be forcibly cancelled),
-	// but the JS caller will not be left waiting indefinitely.
-	const asyncCommandTimeout = 10 * time.Minute
+	// the callback is invoked with a timeout error. It is wasm.CommandTimeout,
+	// the same budget PromptForInput waits for a single prompt response, so an
+	// interactive command's pending prompt cannot time out before the command
+	// itself does. The inner goroutine may still be running after the timeout
+	// (Go goroutines cannot be forcibly cancelled), but the JS caller will not
+	// be left waiting indefinitely.
+	const asyncCommandTimeout = wasm.CommandTimeout
 
 	// once ensures the callback is invoked exactly once even if both the timeout
 	// and the normal completion path race.


### PR DESCRIPTION
`PromptForInput` timed out a single interactive prompt after a hardcoded 5 minutes, while the async command wrapper allowed the command itself 10. A user who paused mid-form for more than 5 minutes (e.g. to look up a location ID) lost the whole command even though its own budget hadn't expired.

- Both timeouts now derive from one shared constant (`wasm.CommandTimeout`, 10 minutes)
- The timeout error states how long it waited and that the host can cancel via `cancelPrompt`
- Added tests for: a response arriving well past the old 5-minute mark still succeeding, the timeout message content, and a late `submitPromptResponse` after timeout/cancel staying clean

Closes ESD-1597.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/wasm/...` (native)
- [x] `GOOS=js GOARCH=wasm go test -tags js,wasm -run 'TestPrompt|TestSubmitPromptResponse|TestCancelPrompt'` (node runtime)
- [x] `GOOS=js GOARCH=wasm go build -tags js,wasm .`
- [x] `golangci-lint run`
