### PR TITLE
ESD-1598-feat(wasm): retire the synchronous command entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 
 ## [Unreleased]
 
+### Changed
+- **Breaking (WASM):** `window.executeMegaportCommand` no longer executes commands. A synchronous call blocked the JS event loop while the CLI waited on the browser's fetch transport, hanging the tab, and bypassed the mutex that guards the shared output buffers. It is kept as a deprecated stub for one release and always returns `{ error: "synchronous execution is not supported; use executeMegaportCommandAsync" }`. Use `window.executeMegaportCommandAsync` instead (ESD-1598)
+
 ### Fixed
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
 - `mve buy` and `mve validate` now apply `resourceTags` from JSON input, and interactive `mve buy` now prompts for tags, matching MCR. Previously the JSON path silently dropped the documented `resourceTags` field and interactive mode never asked. The JSON path shares the same value and empty-key validation as the flags path, so non-string values and empty keys return a usage error before the order is placed

--- a/WASM_README.md
+++ b/WASM_README.md
@@ -71,6 +71,31 @@ token, or API proxy.
 Credentials and tokens live only in browser memory and are cleared on reload or when the
 page calls `clearAuthCredentials`.
 
+## JavaScript API
+
+The WASM binary exposes command execution on `window`:
+
+```javascript
+window.executeMegaportCommandAsync(command, callback)
+```
+
+- `command` - full command string, e.g. `"port list --output json"`
+- `callback` - called once with the result: `{ output?: string, error?: string }`
+
+This is the only supported entrypoint for running commands. Execution has to be
+asynchronous: a synchronous call would block the JS event loop while the CLI waits on the
+browser's fetch-based transport, hanging the tab until the request times out. Internally,
+`executeMegaportCommandAsync` runs the command on a goroutine and serializes access to the
+shared output buffers so concurrent calls don't race each other.
+
+`window.executeMegaportCommand` (no `Async` suffix) is a deprecated stub kept for one
+release as a soft landing for hosts still detecting or calling it. It performs no work and
+always returns `{ error: "synchronous execution is not supported; use executeMegaportCommandAsync" }`.
+It will be removed in a future release; new integrations should not call it.
+
+Full type definitions for the whole JS surface (auth, config file, prompts, telemetry)
+live in [`frontend-integration/types/megaport-wasm.d.ts`](frontend-integration/types/megaport-wasm.d.ts).
+
 ## Building
 
 The browser CLI is two pieces: the WASM binary and the Vue front end that hosts it.

--- a/frontend-integration/__tests__/improvements.test.ts
+++ b/frontend-integration/__tests__/improvements.test.ts
@@ -1037,10 +1037,15 @@ describe('Frontend Improvements and Maintainability', () => {
       ).toBe(true);
       expect(isMegaportPromptRequest({ id: '123' })).toBe(false);
 
-      // Test WASM functions detection
+      // Test WASM functions detection - only the async entrypoint counts;
+      // the deprecated sync stub alone should not report WASM as ready
+      delete (window as any).executeMegaportCommandAsync;
       (window as any).executeMegaportCommand = () => {};
-      expect(hasWASMFunctions(window)).toBe(true);
+      expect(hasWASMFunctions(window)).toBe(false);
       delete (window as any).executeMegaportCommand;
+
+      (window as any).executeMegaportCommandAsync = () => {};
+      expect(hasWASMFunctions(window)).toBe(true);
 
       // Test WebAssembly support
       expect(hasWebAssemblySupport()).toBe(true);

--- a/frontend-integration/__tests__/setup.ts
+++ b/frontend-integration/__tests__/setup.ts
@@ -14,7 +14,6 @@ beforeEach(() => {
 
   // Mock window WASM functions
   (window as any).executeMegaportCommandAsync = vi.fn();
-  (window as any).executeMegaportCommand = vi.fn();
   (window as any).setAuthCredentials = vi.fn(() => ({ success: true }));
   (window as any).clearAuthCredentials = vi.fn(() => ({ success: true }));
   (window as any).resetWasmOutput = vi.fn();

--- a/frontend-integration/composables/useMegaportWASM.ts
+++ b/frontend-integration/composables/useMegaportWASM.ts
@@ -235,7 +235,6 @@ export function useMegaportWASM(config: MegaportWASMConfig = {}) {
 
         log('✅ Megaport WASM ready (direct mode)');
         log('Available functions:', {
-          executeMegaportCommand: typeof window.executeMegaportCommand,
           executeMegaportCommandAsync:
             typeof window.executeMegaportCommandAsync,
           debugAuthInfo: typeof window.debugAuthInfo,
@@ -298,44 +297,21 @@ export function useMegaportWASM(config: MegaportWASMConfig = {}) {
       try {
         log(`🚀 Executing command: ${command}`);
 
-        // Use async version for better reliability
-        if (window.executeMegaportCommandAsync) {
-          window.executeMegaportCommandAsync(command, (result) => {
-            const duration = Date.now() - startTime;
+        if (!window.executeMegaportCommandAsync) {
+          const duration = Date.now() - startTime;
+          emitTelemetry(
+            'command_execute_error',
+            {
+              command,
+              error: 'No WASM execute function available',
+            },
+            duration
+          );
+          reject(new Error('No WASM execute function available'));
+          return;
+        }
 
-            // Validate result with type guard
-            if (!isMegaportCommandResult(result)) {
-              const error = 'Invalid command result received from WASM';
-              warn('⚠️ Invalid result:', result);
-              emitTelemetry(
-                'command_execute_error',
-                { command, error },
-                duration
-              );
-              reject(new Error(error));
-              return;
-            }
-
-            log('📦 Command result:', result);
-
-            if (result.error) {
-              emitTelemetry(
-                'command_execute_error',
-                {
-                  command,
-                  error: result.error,
-                },
-                duration
-              );
-            } else {
-              emitTelemetry('command_execute_success', { command }, duration);
-            }
-
-            resolve(result);
-          });
-        } else if (window.executeMegaportCommand) {
-          // Fallback to sync version
-          const result = window.executeMegaportCommand(command);
+        window.executeMegaportCommandAsync(command, (result) => {
           const duration = Date.now() - startTime;
 
           // Validate result with type guard
@@ -351,6 +327,8 @@ export function useMegaportWASM(config: MegaportWASMConfig = {}) {
             return;
           }
 
+          log('📦 Command result:', result);
+
           if (result.error) {
             emitTelemetry(
               'command_execute_error',
@@ -365,18 +343,7 @@ export function useMegaportWASM(config: MegaportWASMConfig = {}) {
           }
 
           resolve(result);
-        } else {
-          const duration = Date.now() - startTime;
-          emitTelemetry(
-            'command_execute_error',
-            {
-              command,
-              error: 'No WASM execute function available',
-            },
-            duration
-          );
-          reject(new Error('No WASM execute function available'));
-        }
+        });
       } catch (err) {
         const duration = Date.now() - startTime;
         emitTelemetry(
@@ -396,7 +363,6 @@ export function useMegaportWASM(config: MegaportWASMConfig = {}) {
    * Set authentication credentials (secure, in-memory only)
    *
    * Available WASM functions:
-   * - executeMegaportCommand: 'function' - Synchronous command execution
    * - executeMegaportCommandAsync: 'function' - Asynchronous command execution with callback
    * - debugAuthInfo: 'function' - Get current auth state for debugging
    * - setAuthCredentials: 'function' - Secure in-memory credential storage

--- a/frontend-integration/composables/useMegaportWASM.ts
+++ b/frontend-integration/composables/useMegaportWASM.ts
@@ -303,11 +303,11 @@ export function useMegaportWASM(config: MegaportWASMConfig = {}) {
             'command_execute_error',
             {
               command,
-              error: 'No WASM execute function available',
+              error: 'executeMegaportCommandAsync is not available on window',
             },
             duration
           );
-          reject(new Error('No WASM execute function available'));
+          reject(new Error('executeMegaportCommandAsync is not available on window'));
           return;
         }
 

--- a/frontend-integration/composables/useMegaportWASM.ts
+++ b/frontend-integration/composables/useMegaportWASM.ts
@@ -297,7 +297,7 @@ export function useMegaportWASM(config: MegaportWASMConfig = {}) {
       try {
         log(`🚀 Executing command: ${command}`);
 
-        if (!window.executeMegaportCommandAsync) {
+        if (typeof window.executeMegaportCommandAsync !== 'function') {
           const duration = Date.now() - startTime;
           emitTelemetry(
             'command_execute_error',

--- a/frontend-integration/types/megaport-wasm.d.ts
+++ b/frontend-integration/types/megaport-wasm.d.ts
@@ -75,10 +75,12 @@ export type TelemetryCallback = (event: TelemetryEvent) => void;
  */
 export interface MegaportWASM {
   /**
-   * Execute a CLI command synchronously (LEGACY - may not work with async operations)
-   * @param command - Full command string (e.g., "port list --output json")
-   * @returns Result object with output or error
-   * @deprecated Use executeMegaportCommandAsync for better reliability
+   * Deprecated stub kept for one release as a soft landing for hosts that
+   * still detect or call it. It no longer executes commands and always
+   * returns an immediate error result.
+   * @param command - Ignored
+   * @returns An error result pointing to executeMegaportCommandAsync
+   * @deprecated Use executeMegaportCommandAsync instead; this function does not run commands
    */
   executeMegaportCommand(command: string): MegaportCommandResult;
 

--- a/frontend-integration/utils/type-guards.ts
+++ b/frontend-integration/utils/type-guards.ts
@@ -168,13 +168,12 @@ export function isTelemetryEvent(value: unknown): value is TelemetryEvent {
 }
 
 /**
- * Type guard for Window WASM functions availability
+ * Type guard for Window WASM functions availability. Only the async
+ * entrypoint is checked: executeMegaportCommand is a deprecated stub that no
+ * longer executes commands, so its presence alone doesn't mean WASM is ready.
  */
 export function hasWASMFunctions(win: Window): boolean {
-  return (
-    typeof win.executeMegaportCommand === 'function' ||
-    typeof win.executeMegaportCommandAsync === 'function'
-  );
+  return typeof win.executeMegaportCommandAsync === 'function';
 }
 
 /**

--- a/frontend-integration/utils/type-guards.ts
+++ b/frontend-integration/utils/type-guards.ts
@@ -168,7 +168,7 @@ export function isTelemetryEvent(value: unknown): value is TelemetryEvent {
 }
 
 /**
- * Type guard for Window WASM functions availability. Only the async
+ * Checks whether Window exposes the WASM async entrypoint. Only the async
  * entrypoint is checked: executeMegaportCommand is a deprecated stub that no
  * longer executes commands, so its presence alone doesn't mean WASM is ready.
  */

--- a/main_wasm.go
+++ b/main_wasm.go
@@ -22,37 +22,16 @@ var embeddedDocs embed.FS
 // the shared global output buffers.
 var asyncCommandMu sync.Mutex
 
-// executeMegaportCommand runs CLI commands from JavaScript (LEGACY SYNC VERSION)
-// This is kept for backwards compatibility but may not work with async operations
+// executeMegaportCommand is retained so host pages that still detect or call
+// it get an immediate, well-formed response instead of a broken function.
+// It no longer executes commands: running a command synchronously blocks the
+// JS event loop while Cobra waits on the async fetch/prompt transport, which
+// hangs the tab until the transport times out, and it bypasses asyncCommandMu,
+// letting a sync call race an in-flight async command over the shared output
+// buffers. Use executeMegaportCommandAsync instead.
 func executeMegaportCommand(this js.Value, args []js.Value) interface{} {
-	if len(args) < 1 {
-		return map[string]interface{}{
-			"error": "No command provided",
-		}
-	}
-
-	// Get command string from JavaScript
-	cmdString := args[0].String()
-
-	// Reset all output buffers
-	wasm.ResetOutputBuffers()
-
-	// Split the command string into arguments
-	cmdArgs := wasm.SplitArgs(cmdString)
-
-	// Create a new slice with the program name
-	originalArgs := append([]string{"megaport-cli"}, cmdArgs...)
-
-	// Use our new tracing function
-	wasm.TraceCommand(cmdString, originalArgs)
-
-	// Ensure Cobra gets all our commands
-	megaport.EnsureRootCommandOutput(wasm.WasmOutputBuffer)
-
-	megaport.ExecuteWithArgs(originalArgs)
-
 	return map[string]interface{}{
-		"output": wasm.GetCapturedOutput(),
+		"error": "synchronous execution is not supported; use executeMegaportCommandAsync",
 	}
 }
 
@@ -176,7 +155,9 @@ func main() {
 	// Initialize the prompt system for interactive mode
 	wasm.InitPromptSystem()
 
-	// Export both sync (legacy) and async (preferred) versions
+	// executeMegaportCommand is a deprecated stub kept for one release as a soft
+	// landing for hosts still detecting/calling it; executeMegaportCommandAsync
+	// is the only supported entrypoint.
 	js.Global().Set("executeMegaportCommand", js.FuncOf(executeMegaportCommand))
 	js.Global().Set("executeMegaportCommandAsync", js.FuncOf(executeMegaportCommandAsync))
 

--- a/main_wasm_test.go
+++ b/main_wasm_test.go
@@ -3,13 +3,38 @@
 package main
 
 import (
+	"os"
 	"syscall/js"
 	"testing"
 	"time"
 
+	"github.com/megaport/megaport-cli/internal/base/cmdbuilder"
+	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/wasm"
 	"github.com/stretchr/testify/assert"
 )
+
+// TestMain mirrors main()'s registration (minus the blocking channel wait):
+// go test never calls a package main's main(), so without this the
+// JS globals these tests depend on (executeMegaportCommand*,
+// resetWasmOutput, etc.) are never registered and every test here fails.
+func TestMain(m *testing.M) {
+	wasm.RegisterOutputStateReset(func() {
+		output.ResetState()
+	})
+	cmdbuilder.RegisterEmbeddedDocs(embeddedDocs)
+	// Unlike main(), always enable debug mode here: TestWasmHelperFunctions
+	// asserts every helper (including debug-only ones like debugAuthInfo and
+	// wasmDebug) is registered.
+	wasm.EnableDebugMode()
+	wasm.RegisterJSFunctions()
+	wasm.SetupIO()
+	wasm.InitPromptSystem()
+	js.Global().Set("executeMegaportCommand", js.FuncOf(executeMegaportCommand))
+	js.Global().Set("executeMegaportCommandAsync", js.FuncOf(executeMegaportCommandAsync))
+
+	os.Exit(m.Run())
+}
 
 // TestWasmInitialization verifies WASM module initializes correctly
 func TestWasmInitialization(t *testing.T) {

--- a/main_wasm_test.go
+++ b/main_wasm_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"syscall/js"
 	"testing"
+	"time"
 
 	"github.com/megaport/megaport-cli/internal/wasm"
 	"github.com/stretchr/testify/assert"
@@ -62,20 +63,34 @@ func TestExecuteMegaportCommand_Deprecated(t *testing.T) {
 }
 
 // invokeAsyncAndWait calls executeMegaportCommandAsync and blocks until the
-// callback fires, returning the result object.
-func invokeAsyncAndWait(cmd string) js.Value {
+// callback fires, returning the result object. Fails the test instead of
+// hanging forever if the callback never fires or fires without a result.
+func invokeAsyncAndWait(t *testing.T, cmd string) js.Value {
+	t.Helper()
 	executeMegaportCmdAsync := js.Global().Get("executeMegaportCommandAsync")
 
 	resultCh := make(chan js.Value, 1)
 	var callback js.Func
 	callback = js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		defer callback.Release()
+		if len(args) < 1 {
+			t.Errorf("executeMegaportCommandAsync callback invoked with no arguments for command %q", cmd)
+			resultCh <- js.Undefined()
+			return nil
+		}
 		resultCh <- args[0]
-		callback.Release()
 		return nil
 	})
 
 	executeMegaportCmdAsync.Invoke(js.ValueOf(cmd), callback)
-	return <-resultCh
+
+	select {
+	case result := <-resultCh:
+		return result
+	case <-time.After(30 * time.Second):
+		t.Fatalf("executeMegaportCommandAsync callback never fired for command %q", cmd)
+		return js.Undefined()
+	}
 }
 
 // TestExecuteMegaportCommandAsync_Callback verifies async command with callback
@@ -133,8 +148,8 @@ func TestExecuteMegaportCommandAsync_InvalidCallback(t *testing.T) {
 
 // TestOutputBufferReset verifies output buffers reset between commands
 func TestOutputBufferReset(t *testing.T) {
-	output1 := invokeAsyncAndWait("version").Get("output").String()
-	output2 := invokeAsyncAndWait("--help").Get("output").String()
+	output1 := invokeAsyncAndWait(t, "version").Get("output").String()
+	output2 := invokeAsyncAndWait(t, "--help").Get("output").String()
 
 	// Outputs should be different (buffers were reset)
 	assert.NotEqual(t, output1, output2)
@@ -188,7 +203,7 @@ func TestCommandArgumentParsing(t *testing.T) {
 			wasm.ResetOutputBuffers()
 
 			assert.NotPanics(t, func() {
-				result := invokeAsyncAndWait(tt.command)
+				result := invokeAsyncAndWait(t, tt.command)
 				assert.Equal(t, js.TypeObject, result.Type())
 			})
 		})
@@ -299,15 +314,15 @@ func TestDumpBuffers(t *testing.T) {
 func TestErrorRecovery(t *testing.T) {
 	// These should not cause the WASM module to crash
 	assert.NotPanics(t, func() {
-		invokeAsyncAndWait("nonexistent")
+		invokeAsyncAndWait(t, "nonexistent")
 	})
 
 	assert.NotPanics(t, func() {
-		invokeAsyncAndWait("")
+		invokeAsyncAndWait(t, "")
 	})
 
 	assert.NotPanics(t, func() {
-		invokeAsyncAndWait("invalid command with many args that don't make sense")
+		invokeAsyncAndWait(t, "invalid command with many args that don't make sense")
 	})
 }
 
@@ -325,8 +340,13 @@ func TestConcurrentCommands(t *testing.T) {
 	invoke := func(cmd string) {
 		var callback js.Func
 		callback = js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+			defer callback.Release()
+			if len(args) < 1 {
+				t.Errorf("executeMegaportCommandAsync callback invoked with no arguments for command %q", cmd)
+				resultCh <- namedResult{cmd: cmd}
+				return nil
+			}
 			resultCh <- namedResult{cmd: cmd, output: args[0].Get("output").String()}
-			callback.Release()
 			return nil
 		})
 		executeMegaportCmdAsync.Invoke(js.ValueOf(cmd), callback)
@@ -337,8 +357,12 @@ func TestConcurrentCommands(t *testing.T) {
 
 	results := make(map[string]string, 2)
 	for i := 0; i < 2; i++ {
-		r := <-resultCh
-		results[r.cmd] = r.output
+		select {
+		case r := <-resultCh:
+			results[r.cmd] = r.output
+		case <-time.After(30 * time.Second):
+			t.Fatalf("timed out waiting for concurrent command result %d/2", i+1)
+		}
 	}
 
 	assert.NotEmpty(t, results["version"])

--- a/main_wasm_test.go
+++ b/main_wasm_test.go
@@ -69,13 +69,20 @@ func invokeAsyncAndWait(t *testing.T, cmd string) js.Value {
 	t.Helper()
 	executeMegaportCmdAsync := js.Global().Get("executeMegaportCommandAsync")
 
+	// errResult builds a well-formed result object so callers that immediately
+	// do result.Get("output") on the return value fail the assertion cleanly
+	// instead of panicking on an undefined value.
+	errResult := func(msg string) js.Value {
+		return js.ValueOf(map[string]interface{}{"error": msg})
+	}
+
 	resultCh := make(chan js.Value, 1)
 	var callback js.Func
 	callback = js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 		defer callback.Release()
 		if len(args) < 1 {
 			t.Errorf("executeMegaportCommandAsync callback invoked with no arguments for command %q", cmd)
-			resultCh <- js.Undefined()
+			resultCh <- errResult("test helper: callback invoked with no arguments")
 			return nil
 		}
 		resultCh <- args[0]
@@ -89,7 +96,7 @@ func invokeAsyncAndWait(t *testing.T, cmd string) js.Value {
 		return result
 	case <-time.After(30 * time.Second):
 		t.Fatalf("executeMegaportCommandAsync callback never fired for command %q", cmd)
-		return js.Undefined()
+		return errResult("test helper: callback never fired")
 	}
 }
 

--- a/main_wasm_test.go
+++ b/main_wasm_test.go
@@ -180,8 +180,13 @@ func TestExecuteMegaportCommandAsync_InvalidCallback(t *testing.T) {
 
 // TestOutputBufferReset verifies output buffers reset between commands
 func TestOutputBufferReset(t *testing.T) {
-	output1 := invokeAsyncAndWait(t, "version").Get("output").String()
-	output2 := invokeAsyncAndWait(t, "--help").Get("output").String()
+	result1 := invokeAsyncAndWait(t, "version")
+	assert.True(t, result1.Get("error").IsUndefined(), "version command returned an error: %v", result1.Get("error"))
+	output1 := result1.Get("output").String()
+
+	result2 := invokeAsyncAndWait(t, "--help")
+	assert.True(t, result2.Get("error").IsUndefined(), "--help command returned an error: %v", result2.Get("error"))
+	output2 := result2.Get("output").String()
 
 	// Outputs should be different (buffers were reset)
 	assert.NotEqual(t, output1, output2)
@@ -378,7 +383,11 @@ func TestConcurrentCommands(t *testing.T) {
 				resultCh <- namedResult{cmd: cmd}
 				return nil
 			}
-			resultCh <- namedResult{cmd: cmd, output: args[0].Get("output").String()}
+			result := args[0]
+			if err := result.Get("error"); !err.IsUndefined() {
+				t.Errorf("executeMegaportCommandAsync returned an error for command %q: %v", cmd, err)
+			}
+			resultCh <- namedResult{cmd: cmd, output: result.Get("output").String()}
 			return nil
 		})
 		executeMegaportCmdAsync.Invoke(js.ValueOf(cmd), callback)

--- a/main_wasm_test.go
+++ b/main_wasm_test.go
@@ -43,79 +43,39 @@ func TestWasmHelperFunctions(t *testing.T) {
 	}
 }
 
-// TestExecuteMegaportCommand_Help verifies help command execution
-func TestExecuteMegaportCommand_Help(t *testing.T) {
-	wasm.ResetOutputBuffers()
-
-	// Call the sync version with help command
+// TestExecuteMegaportCommand_Deprecated verifies the legacy sync entrypoint no
+// longer executes commands and always returns an immediate error pointing
+// callers at executeMegaportCommandAsync, regardless of the command given.
+func TestExecuteMegaportCommand_Deprecated(t *testing.T) {
 	executeMegaportCmd := js.Global().Get("executeMegaportCommand")
-	result := executeMegaportCmd.Invoke(js.ValueOf("--help"))
 
-	// Verify result structure
-	assert.Equal(t, js.TypeObject, result.Type())
-	output := result.Get("output")
-	assert.False(t, output.IsUndefined())
+	for _, cmd := range []string{"--help", "version", "nonexistent-command", "", "version --format json"} {
+		result := executeMegaportCmd.Invoke(js.ValueOf(cmd))
 
-	outputStr := output.String()
-	assert.NotEmpty(t, outputStr)
-	assert.Contains(t, outputStr, "Megaport CLI")
+		assert.Equal(t, js.TypeObject, result.Type())
+		assert.True(t, result.Get("output").IsUndefined(), "sync entrypoint should not produce output for %q", cmd)
+
+		errMsg := result.Get("error")
+		assert.False(t, errMsg.IsUndefined())
+		assert.Contains(t, errMsg.String(), "executeMegaportCommandAsync")
+	}
 }
 
-// TestExecuteMegaportCommand_Version verifies version command
-func TestExecuteMegaportCommand_Version(t *testing.T) {
-	wasm.ResetOutputBuffers()
+// invokeAsyncAndWait calls executeMegaportCommandAsync and blocks until the
+// callback fires, returning the result object.
+func invokeAsyncAndWait(cmd string) js.Value {
+	executeMegaportCmdAsync := js.Global().Get("executeMegaportCommandAsync")
 
-	executeMegaportCmd := js.Global().Get("executeMegaportCommand")
-	result := executeMegaportCmd.Invoke(js.ValueOf("version"))
+	resultCh := make(chan js.Value, 1)
+	var callback js.Func
+	callback = js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		resultCh <- args[0]
+		callback.Release()
+		return nil
+	})
 
-	assert.Equal(t, js.TypeObject, result.Type())
-	output := result.Get("output")
-	assert.False(t, output.IsUndefined())
-
-	outputStr := output.String()
-	assert.NotEmpty(t, outputStr)
-}
-
-// TestExecuteMegaportCommand_InvalidCommand verifies error handling
-func TestExecuteMegaportCommand_InvalidCommand(t *testing.T) {
-	wasm.ResetOutputBuffers()
-
-	executeMegaportCmd := js.Global().Get("executeMegaportCommand")
-	result := executeMegaportCmd.Invoke(js.ValueOf("nonexistent-command"))
-
-	assert.Equal(t, js.TypeObject, result.Type())
-	output := result.Get("output")
-
-	// Should have error output
-	outputStr := output.String()
-	assert.NotEmpty(t, outputStr)
-}
-
-// TestExecuteMegaportCommand_EmptyCommand verifies empty command handling
-func TestExecuteMegaportCommand_EmptyCommand(t *testing.T) {
-	wasm.ResetOutputBuffers()
-
-	executeMegaportCmd := js.Global().Get("executeMegaportCommand")
-	result := executeMegaportCmd.Invoke(js.ValueOf(""))
-
-	assert.Equal(t, js.TypeObject, result.Type())
-	output := result.Get("output")
-	assert.False(t, output.IsUndefined())
-}
-
-// TestExecuteMegaportCommand_WithFlags verifies flag parsing
-func TestExecuteMegaportCommand_WithFlags(t *testing.T) {
-	wasm.ResetOutputBuffers()
-
-	executeMegaportCmd := js.Global().Get("executeMegaportCommand")
-	result := executeMegaportCmd.Invoke(js.ValueOf("version --format json"))
-
-	assert.Equal(t, js.TypeObject, result.Type())
-	output := result.Get("output")
-	assert.False(t, output.IsUndefined())
-
-	outputStr := output.String()
-	assert.NotEmpty(t, outputStr)
+	executeMegaportCmdAsync.Invoke(js.ValueOf(cmd), callback)
+	return <-resultCh
 }
 
 // TestExecuteMegaportCommandAsync_Callback verifies async command with callback
@@ -171,16 +131,10 @@ func TestExecuteMegaportCommandAsync_InvalidCallback(t *testing.T) {
 	})
 }
 
-// TestOutputBufferReset verifies output buffer reset between commands
+// TestOutputBufferReset verifies output buffers reset between commands
 func TestOutputBufferReset(t *testing.T) {
-	// Execute first command
-	executeMegaportCmd := js.Global().Get("executeMegaportCommand")
-	result1 := executeMegaportCmd.Invoke(js.ValueOf("version"))
-	output1 := result1.Get("output").String()
-
-	// Execute second command
-	result2 := executeMegaportCmd.Invoke(js.ValueOf("--help"))
-	output2 := result2.Get("output").String()
+	output1 := invokeAsyncAndWait("version").Get("output").String()
+	output2 := invokeAsyncAndWait("--help").Get("output").String()
 
 	// Outputs should be different (buffers were reset)
 	assert.NotEqual(t, output1, output2)
@@ -233,10 +187,8 @@ func TestCommandArgumentParsing(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wasm.ResetOutputBuffers()
 
-			executeMegaportCmd := js.Global().Get("executeMegaportCommand")
-
 			assert.NotPanics(t, func() {
-				result := executeMegaportCmd.Invoke(js.ValueOf(tt.command))
+				result := invokeAsyncAndWait(tt.command)
 				assert.Equal(t, js.TypeObject, result.Type())
 			})
 		})
@@ -342,40 +294,54 @@ func TestDumpBuffers(t *testing.T) {
 	assert.False(t, direct.IsUndefined())
 }
 
-// TestErrorRecovery verifies panic recovery
+// TestErrorRecovery verifies panic recovery in the async execution path,
+// which is now the only path that actually runs commands.
 func TestErrorRecovery(t *testing.T) {
-	executeMegaportCmd := js.Global().Get("executeMegaportCommand")
-
 	// These should not cause the WASM module to crash
 	assert.NotPanics(t, func() {
-		executeMegaportCmd.Invoke(js.ValueOf("nonexistent"))
+		invokeAsyncAndWait("nonexistent")
 	})
 
 	assert.NotPanics(t, func() {
-		executeMegaportCmd.Invoke(js.ValueOf(""))
+		invokeAsyncAndWait("")
 	})
 
 	assert.NotPanics(t, func() {
-		executeMegaportCmd.Invoke(js.ValueOf("invalid command with many args that don't make sense"))
+		invokeAsyncAndWait("invalid command with many args that don't make sense")
 	})
 }
 
-// TestConcurrentCommands verifies multiple commands don't interfere
+// TestConcurrentCommands verifies concurrent async commands don't interfere
+// with each other's output (asyncCommandMu serializes execution).
 func TestConcurrentCommands(t *testing.T) {
-	executeMegaportCmd := js.Global().Get("executeMegaportCommand")
+	executeMegaportCmdAsync := js.Global().Get("executeMegaportCommandAsync")
 
-	// Execute multiple commands
-	result1 := executeMegaportCmd.Invoke(js.ValueOf("version"))
-	result2 := executeMegaportCmd.Invoke(js.ValueOf("--help"))
+	type namedResult struct {
+		cmd    string
+		output string
+	}
+	resultCh := make(chan namedResult, 2)
 
-	// Both should succeed
-	assert.Equal(t, js.TypeObject, result1.Type())
-	assert.Equal(t, js.TypeObject, result2.Type())
+	invoke := func(cmd string) {
+		var callback js.Func
+		callback = js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+			resultCh <- namedResult{cmd: cmd, output: args[0].Get("output").String()}
+			callback.Release()
+			return nil
+		})
+		executeMegaportCmdAsync.Invoke(js.ValueOf(cmd), callback)
+	}
 
-	output1 := result1.Get("output").String()
-	output2 := result2.Get("output").String()
+	invoke("version")
+	invoke("--help")
 
-	assert.NotEmpty(t, output1)
-	assert.NotEmpty(t, output2)
-	assert.NotEqual(t, output1, output2)
+	results := make(map[string]string, 2)
+	for i := 0; i < 2; i++ {
+		r := <-resultCh
+		results[r.cmd] = r.output
+	}
+
+	assert.NotEmpty(t, results["version"])
+	assert.NotEmpty(t, results["--help"])
+	assert.NotEqual(t, results["version"], results["--help"])
 }


### PR DESCRIPTION
`window.executeMegaportCommand` ran commands synchronously, which blocks the JS event loop while the CLI waits on the async fetch/prompt transport, hanging the tab until the transport times out. It also bypassed `asyncCommandMu`, letting a sync call race an in-flight async command over the shared output buffers.

It's now a deprecated stub for one release: it takes no action and immediately returns `{"error": "synchronous execution is not supported; use executeMegaportCommandAsync"}` instead of disappearing outright, as a soft landing for any host that still detects or calls it.

- `main_wasm.go`: sync entrypoint no longer executes commands
- `frontend-integration`: `hasWASMFunctions` only checks the async entrypoint now; removed the dead sync-fallback branch in `useMegaportWASM`'s `execute()`
- `WASM_README.md`: documents the async-only JS API
- Tests updated to match (Go + Vitest)

**Consumer audit** (nothing depends on sync execution):
- `frontend-integration`: async-first with a sync fallback that's now removed from source; the fallback was already dead code since both functions are always registered together. `web/vue-demo` (the checked-in static build of `frontend-integration`) still contains the old fallback because it's a manually rebuilt/published artifact that already lagged behind source before this PR (last rebuilt several unrelated commits ago) - rebuilding it is a separate, out-of-scope publishing step. The fallback in that stale bundle is unreachable dead code regardless, same as in source, since `executeMegaportCommandAsync` is always registered alongside `executeMegaportCommand`
- Portal integration (`web-monorepo`, Pedro's team): same async-first/sync-fallback pattern in `apps/portal/src/composables/megaport-cli/useMegaportCLI.ts`; same dead-fallback situation. Not edited (out of scope) - will notify the team of the stub behavior change
- `Phil-Browne/cli-tutorial`: same pattern, not edited (separate repo)

**Validated:**
- `go build ./...` and `go test ./internal/wasm/...`
- `GOOS=js GOARCH=wasm go build -tags js,wasm -o /tmp/megaport.wasm .`
- `cd frontend-integration && npm test` (274 passed)