### PR TITLE
ESD-1599-fix(wasm): surface spinner success messages in captured output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 ### Fixed
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
 - `mve buy` and `mve validate` now apply `resourceTags` from JSON input, and interactive `mve buy` now prompts for tags, matching MCR. Previously the JSON path silently dropped the documented `resourceTags` field and interactive mode never asked. The JSON path shares the same value and empty-key validation as the flags path, so non-string values and empty keys return a usage error before the order is placed
-- spinner success messages (e.g. "Successfully logged in to Megaport") now reach the WASM browser output instead of vanishing into the DevTools console (ESD-1599)
 
 ## [v1.0.0-beta.1] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 ### Fixed
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
 - `mve buy` and `mve validate` now apply `resourceTags` from JSON input, and interactive `mve buy` now prompts for tags, matching MCR. Previously the JSON path silently dropped the documented `resourceTags` field and interactive mode never asked. The JSON path shares the same value and empty-key validation as the flags path, so non-string values and empty keys return a usage error before the order is placed
+- spinner success messages (e.g. "Successfully logged in to Megaport") now reach the WASM browser output instead of vanishing into the DevTools console (ESD-1599)
 
 ## [v1.0.0-beta.1] - 2026-07-01
 

--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -248,8 +248,8 @@ func (s *Spinner) nonInteractive() bool {
 	return s.machineReadableFormat() || !IsTerminal()
 }
 
-// machineReadableFormat reports whether the spinner's output format is a
-// structured, machine-readable one (json/csv/xml) rather than table/empty.
+// machineReadableFormat reports whether the spinner's output format is any
+// non-table format (json/csv/xml/go-template) rather than table/empty.
 func (s *Spinner) machineReadableFormat() bool {
 	return s.outputFormat != "" && s.outputFormat != "table"
 }

--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -329,7 +329,8 @@ func (s *Spinner) StopWithSuccess(msg string) {
 		return
 	}
 	// If WASM spinner is available, delegate to it so the message reaches
-	// the captured output buffer instead of os.Stderr/os.Stdout.
+	// the captured output buffer instead of os.Stderr/os.Stdout. Safe to
+	// call Stop() again here: WasmSpinner.Stop() is idempotent (sync.Once).
 	if s.wasmSpinner != nil {
 		s.wasmSpinner.StopWithSuccess(msg)
 		return

--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -185,6 +185,7 @@ type Spinner struct {
 type SpinnerInterface interface {
 	Start(message string)
 	Stop()
+	StopWithSuccess(msg string)
 }
 
 func NewSpinner(noColor bool) *Spinner {
@@ -325,6 +326,12 @@ func (s *Spinner) Stop() {
 func (s *Spinner) StopWithSuccess(msg string) {
 	s.Stop()
 	if IsQuiet() {
+		return
+	}
+	// If WASM spinner is available, delegate to it so the message reaches
+	// the captured output buffer instead of os.Stderr/os.Stdout.
+	if s.wasmSpinner != nil {
+		s.wasmSpinner.StopWithSuccess(msg)
 		return
 	}
 	// Write success message to stderr for non-interactive sinks to avoid

--- a/internal/base/output/messages.go
+++ b/internal/base/output/messages.go
@@ -245,7 +245,13 @@ func (s *Spinner) renderFrame(i int) string {
 // sinks the carriage-return/clear-line escapes don't collapse anything, so the
 // spinner emits a single plain status line rather than animating frame-by-frame.
 func (s *Spinner) nonInteractive() bool {
-	return (s.outputFormat != "" && s.outputFormat != "table") || !IsTerminal()
+	return s.machineReadableFormat() || !IsTerminal()
+}
+
+// machineReadableFormat reports whether the spinner's output format is a
+// structured, machine-readable one (json/csv/xml) rather than table/empty.
+func (s *Spinner) machineReadableFormat() bool {
+	return s.outputFormat != "" && s.outputFormat != "table"
 }
 
 // runLoop is the shared spinner goroutine logic. If startTime is non-nil,
@@ -328,10 +334,16 @@ func (s *Spinner) StopWithSuccess(msg string) {
 	if IsQuiet() {
 		return
 	}
-	// If WASM spinner is available, delegate to it so the message reaches
-	// the captured output buffer instead of os.Stderr/os.Stdout. Safe to
-	// call Stop() again here: WasmSpinner.Stop() is idempotent (sync.Once).
-	if s.wasmSpinner != nil {
+	// If WASM spinner is available and the output format is table/empty,
+	// delegate to it so the message reaches the captured output buffer
+	// instead of os.Stderr/os.Stdout. Safe to call Stop() again here:
+	// WasmSpinner.Stop() is idempotent (sync.Once). For machine-readable
+	// formats, fall through to the stderr branch below instead: WASM has
+	// no TTY, so nonInteractive() is always true there, but the captured
+	// output buffer has no separate stdout/stderr split, so writing the
+	// success line into it risks it becoming the entire captured response
+	// for commands that don't otherwise populate a structured output buffer.
+	if s.wasmSpinner != nil && !s.machineReadableFormat() {
 		s.wasmSpinner.StopWithSuccess(msg)
 		return
 	}

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -652,6 +652,25 @@ func TestSpinnerStopWithSuccessQuietSkipsWasmDelegate(t *testing.T) {
 	assert.Empty(t, fake.stopWithSuccessCalls)
 }
 
+// TestSpinnerStopWithSuccessMachineFormatSkipsWasmDelegate verifies that
+// machine-readable output formats (json/csv/xml) skip WASM delegation and
+// fall through to the stderr branch, so a success line can never become the
+// entire captured response for a command that otherwise reports no output.
+func TestSpinnerStopWithSuccessMachineFormatSkipsWasmDelegate(t *testing.T) {
+	t.Cleanup(func() { ResetState() })
+	SetVerbosity("normal")
+	fake := &fakeSpinnerInterface{}
+	spinner := &Spinner{stop: make(chan bool, 1), wasmSpinner: fake, outputFormat: "json"}
+
+	output := captureStderr(t, func() {
+		spinner.StopWithSuccess("Operation completed")
+	})
+
+	assert.Equal(t, 1, fake.stopCalls)
+	assert.Empty(t, fake.stopWithSuccessCalls, "machine-readable formats must not delegate to the WASM spinner")
+	assert.Contains(t, output, "Operation completed")
+}
+
 func TestShouldSuppressSpinner(t *testing.T) {
 	t.Cleanup(func() { ResetState() })
 

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -610,6 +610,47 @@ func TestSpinnerStopWithSuccess(t *testing.T) {
 	assert.Contains(t, output, "✓ Operation completed")
 }
 
+// fakeSpinnerInterface is a native-buildable SpinnerInterface stand-in used to
+// verify Spinner.StopWithSuccess delegates to it, without depending on the
+// real (WASM-only) WasmSpinner implementation.
+type fakeSpinnerInterface struct {
+	stopCalls            int
+	stopWithSuccessCalls []string
+}
+
+func (f *fakeSpinnerInterface) Start(string) {}
+
+func (f *fakeSpinnerInterface) Stop() {
+	f.stopCalls++
+}
+
+func (f *fakeSpinnerInterface) StopWithSuccess(msg string) {
+	f.stopWithSuccessCalls = append(f.stopWithSuccessCalls, msg)
+}
+
+func TestSpinnerStopWithSuccessDelegatesToWasmSpinner(t *testing.T) {
+	SetVerbosity("normal")
+	fake := &fakeSpinnerInterface{}
+	spinner := &Spinner{stop: make(chan bool, 1), wasmSpinner: fake}
+
+	spinner.StopWithSuccess("Operation completed")
+
+	assert.Equal(t, 1, fake.stopCalls)
+	assert.Equal(t, []string{"Operation completed"}, fake.stopWithSuccessCalls)
+}
+
+func TestSpinnerStopWithSuccessQuietSkipsWasmDelegate(t *testing.T) {
+	SetVerbosity("quiet")
+	defer SetVerbosity("normal")
+	fake := &fakeSpinnerInterface{}
+	spinner := &Spinner{stop: make(chan bool, 1), wasmSpinner: fake}
+
+	spinner.StopWithSuccess("Operation completed")
+
+	assert.Equal(t, 1, fake.stopCalls)
+	assert.Empty(t, fake.stopWithSuccessCalls)
+}
+
 func TestShouldSuppressSpinner(t *testing.T) {
 	t.Cleanup(func() { ResetState() })
 

--- a/internal/base/output/messages_test.go
+++ b/internal/base/output/messages_test.go
@@ -629,6 +629,7 @@ func (f *fakeSpinnerInterface) StopWithSuccess(msg string) {
 }
 
 func TestSpinnerStopWithSuccessDelegatesToWasmSpinner(t *testing.T) {
+	t.Cleanup(func() { ResetState() })
 	SetVerbosity("normal")
 	fake := &fakeSpinnerInterface{}
 	spinner := &Spinner{stop: make(chan bool, 1), wasmSpinner: fake}
@@ -640,8 +641,8 @@ func TestSpinnerStopWithSuccessDelegatesToWasmSpinner(t *testing.T) {
 }
 
 func TestSpinnerStopWithSuccessQuietSkipsWasmDelegate(t *testing.T) {
+	t.Cleanup(func() { ResetState() })
 	SetVerbosity("quiet")
-	defer SetVerbosity("normal")
 	fake := &fakeSpinnerInterface{}
 	spinner := &Spinner{stop: make(chan bool, 1), wasmSpinner: fake}
 

--- a/internal/base/output/spinner_wasm.go
+++ b/internal/base/output/spinner_wasm.go
@@ -69,7 +69,9 @@ func (s *WasmSpinner) StopWithSuccess(msg string) {
 
 	// In WASM mode, success messages are handled separately
 	// Do not output here to avoid duplication
-	PrintSuccess(msg, s.noColor)
+	// msg is passed as an arg (not the format string) so a literal "%" in
+	// caller-supplied text isn't interpreted as a missing verb.
+	PrintSuccess("%s", s.noColor, msg)
 }
 
 // Override spinner functions to use WASM-specific implementation

--- a/internal/base/output/spinner_wasm.go
+++ b/internal/base/output/spinner_wasm.go
@@ -67,8 +67,6 @@ func (s *WasmSpinner) Stop() {
 func (s *WasmSpinner) StopWithSuccess(msg string) {
 	s.Stop()
 
-	// In WASM mode, success messages are handled separately
-	// Do not output here to avoid duplication
 	// msg is passed as an arg (not the format string) so a literal "%" in
 	// caller-supplied text isn't interpreted as a missing verb.
 	PrintSuccess("%s", s.noColor, msg)

--- a/internal/base/output/spinner_wasm_test.go
+++ b/internal/base/output/spinner_wasm_test.go
@@ -1,0 +1,51 @@
+//go:build js && wasm
+
+package output
+
+import (
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/wasm"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestWasmSpinner_StopWithSuccess verifies the WasmSpinner implementation
+// writes the success message to the captured output buffer.
+func TestWasmSpinner_StopWithSuccess(t *testing.T) {
+	wasm.WasmOutputBuffer.Reset()
+	SetVerbosity("normal")
+
+	spinner := NewWasmSpinner("Working...", true, "table")
+	spinner.StopWithSuccess("Successfully logged in to Megaport")
+
+	assert.Contains(t, wasm.WasmOutputBuffer.String(), "Successfully logged in to Megaport")
+	wasm.WasmOutputBuffer.Reset()
+}
+
+// TestSpinner_StopWithSuccess_DelegatesToWasm verifies that Spinner.StopWithSuccess,
+// reached only through SpinnerInterface, routes into the captured buffer rather
+// than os.Stderr. This guards against the interface regressing to only Start/Stop.
+func TestSpinner_StopWithSuccess_DelegatesToWasm(t *testing.T) {
+	wasm.WasmOutputBuffer.Reset()
+	SetVerbosity("normal")
+
+	spinner := NewSpinnerWithOutput(true, "table")
+	spinner.StopWithSuccess("Found location with ID: 123")
+
+	assert.Contains(t, wasm.WasmOutputBuffer.String(), "Found location with ID: 123")
+	wasm.WasmOutputBuffer.Reset()
+}
+
+// TestSpinner_StopWithSuccess_QuietSuppressesWasm verifies quiet mode still
+// suppresses the success message when delegating to the WASM spinner.
+func TestSpinner_StopWithSuccess_QuietSuppressesWasm(t *testing.T) {
+	wasm.WasmOutputBuffer.Reset()
+	SetVerbosity("quiet")
+	defer SetVerbosity("normal")
+
+	spinner := NewSpinnerWithOutput(true, "table")
+	spinner.StopWithSuccess("done")
+
+	assert.Empty(t, wasm.WasmOutputBuffer.String(), "StopWithSuccess should produce no output in quiet mode")
+	wasm.WasmOutputBuffer.Reset()
+}

--- a/internal/base/output/spinner_wasm_test.go
+++ b/internal/base/output/spinner_wasm_test.go
@@ -12,6 +12,10 @@ import (
 // TestWasmSpinner_StopWithSuccess verifies the WasmSpinner implementation
 // writes the success message to the captured output buffer.
 func TestWasmSpinner_StopWithSuccess(t *testing.T) {
+	t.Cleanup(func() {
+		ResetState()
+		wasm.WasmOutputBuffer.Reset()
+	})
 	wasm.WasmOutputBuffer.Reset()
 	SetVerbosity("normal")
 
@@ -19,7 +23,6 @@ func TestWasmSpinner_StopWithSuccess(t *testing.T) {
 	spinner.StopWithSuccess("Successfully logged in to Megaport")
 
 	assert.Contains(t, wasm.WasmOutputBuffer.String(), "Successfully logged in to Megaport")
-	wasm.WasmOutputBuffer.Reset()
 }
 
 // TestSpinner_StopWithSuccess_DelegatesToWasm verifies that Spinner.StopWithSuccess
@@ -27,6 +30,10 @@ func TestWasmSpinner_StopWithSuccess(t *testing.T) {
 // the captured buffer rather than os.Stderr. This guards against the interface
 // regressing to only Start/Stop, which would make delegation impossible.
 func TestSpinner_StopWithSuccess_DelegatesToWasm(t *testing.T) {
+	t.Cleanup(func() {
+		ResetState()
+		wasm.WasmOutputBuffer.Reset()
+	})
 	wasm.WasmOutputBuffer.Reset()
 	SetVerbosity("normal")
 
@@ -34,19 +41,20 @@ func TestSpinner_StopWithSuccess_DelegatesToWasm(t *testing.T) {
 	spinner.StopWithSuccess("Found location with ID: 123")
 
 	assert.Contains(t, wasm.WasmOutputBuffer.String(), "Found location with ID: 123")
-	wasm.WasmOutputBuffer.Reset()
 }
 
 // TestSpinner_StopWithSuccess_QuietSuppressesWasm verifies quiet mode still
 // suppresses the success message when delegating to the WASM spinner.
 func TestSpinner_StopWithSuccess_QuietSuppressesWasm(t *testing.T) {
+	t.Cleanup(func() {
+		ResetState()
+		wasm.WasmOutputBuffer.Reset()
+	})
 	wasm.WasmOutputBuffer.Reset()
 	SetVerbosity("quiet")
-	defer SetVerbosity("normal")
 
 	spinner := NewSpinnerWithOutput(true, "table")
 	spinner.StopWithSuccess("done")
 
 	assert.Empty(t, wasm.WasmOutputBuffer.String(), "StopWithSuccess should produce no output in quiet mode")
-	wasm.WasmOutputBuffer.Reset()
 }

--- a/internal/base/output/spinner_wasm_test.go
+++ b/internal/base/output/spinner_wasm_test.go
@@ -25,6 +25,25 @@ func TestWasmSpinner_StopWithSuccess(t *testing.T) {
 	assert.Contains(t, wasm.WasmOutputBuffer.String(), "Successfully logged in to Megaport")
 }
 
+// TestWasmSpinner_StopWithSuccess_LiteralPercent is a regression test for the
+// fix where msg was passed as PrintSuccess's format string: a literal "%" in
+// caller-supplied text must render as-is, not as a missing fmt verb.
+func TestWasmSpinner_StopWithSuccess_LiteralPercent(t *testing.T) {
+	t.Cleanup(func() {
+		ResetState()
+		wasm.WasmOutputBuffer.Reset()
+	})
+	wasm.WasmOutputBuffer.Reset()
+	SetVerbosity("normal")
+
+	spinner := NewWasmSpinner("Working...", true, "table")
+	spinner.StopWithSuccess("Progress: 100% complete")
+
+	output := wasm.WasmOutputBuffer.String()
+	assert.Contains(t, output, "Progress: 100% complete")
+	assert.NotContains(t, output, "%!")
+}
+
 // TestSpinner_StopWithSuccess_DelegatesToWasm verifies that Spinner.StopWithSuccess
 // delegates to its wasmSpinner field (typed as SpinnerInterface) and routes into
 // the captured buffer rather than os.Stderr. This guards against the interface

--- a/internal/base/output/spinner_wasm_test.go
+++ b/internal/base/output/spinner_wasm_test.go
@@ -22,9 +22,10 @@ func TestWasmSpinner_StopWithSuccess(t *testing.T) {
 	wasm.WasmOutputBuffer.Reset()
 }
 
-// TestSpinner_StopWithSuccess_DelegatesToWasm verifies that Spinner.StopWithSuccess,
-// reached only through SpinnerInterface, routes into the captured buffer rather
-// than os.Stderr. This guards against the interface regressing to only Start/Stop.
+// TestSpinner_StopWithSuccess_DelegatesToWasm verifies that Spinner.StopWithSuccess
+// delegates to its wasmSpinner field (typed as SpinnerInterface) and routes into
+// the captured buffer rather than os.Stderr. This guards against the interface
+// regressing to only Start/Stop, which would make delegation impossible.
 func TestSpinner_StopWithSuccess_DelegatesToWasm(t *testing.T) {
 	wasm.WasmOutputBuffer.Reset()
 	SetVerbosity("normal")


### PR DESCRIPTION
Success messages ended up on `os.Stderr` (routed to the browser's DevTools console) instead of the captured output buffer returned to the WASM host, because `SpinnerInterface` only declared `Start`/`Stop`, so `Spinner.StopWithSuccess` had no way to reach `WasmSpinner.StopWithSuccess`.

- add `StopWithSuccess` to `SpinnerInterface` and delegate to it from `Spinner.StopWithSuccess`, mirroring the existing `Stop()` delegation pattern
- fix a pre-existing footgun this change newly exposes: `WasmSpinner.StopWithSuccess` was passing the caller's message as a format string; now it's passed as an argument so a literal `%` in the message renders correctly
- add a WASM-tagged test covering the delegation and quiet-mode suppression

Native spinner behavior is unchanged (`wasmSpinner` is always `nil` on native builds, so the new branch is unreachable there).

Closes ESD-1599.
