### PR TITLE
feat: distinguish portal/WASM CLI traffic with x-app: cli-wasm

### DIFF
--- a/internal/commands/config/config_headers.go
+++ b/internal/commands/config/config_headers.go
@@ -1,0 +1,6 @@
+//go:build !js || !wasm
+
+package config
+
+// cliHeaders identifies native CLI traffic to the Megaport API.
+var cliHeaders = map[string]string{"x-app": "cli"}

--- a/internal/commands/config/config_headers_wasm.go
+++ b/internal/commands/config/config_headers_wasm.go
@@ -1,0 +1,6 @@
+//go:build js && wasm
+
+package config
+
+// cliHeaders identifies portal/WASM CLI traffic to the Megaport API.
+var cliHeaders = map[string]string{"x-app": "cli-wasm"}

--- a/internal/commands/config/config_headers_wasm_test.go
+++ b/internal/commands/config/config_headers_wasm_test.go
@@ -1,0 +1,11 @@
+//go:build js && wasm
+
+package config
+
+import "testing"
+
+func TestCLIHeadersWasm(t *testing.T) {
+	if got := cliHeaders["x-app"]; got != "cli-wasm" {
+		t.Errorf("cliHeaders[\"x-app\"] = %q, want %q", got, "cli-wasm")
+	}
+}

--- a/internal/commands/config/config_shared.go
+++ b/internal/commands/config/config_shared.go
@@ -6,9 +6,6 @@ import (
 	megaport "github.com/megaport/megaportgo"
 )
 
-// cliHeaders identifies CLI traffic to the Megaport API.
-var cliHeaders = map[string]string{"x-app": "cli"}
-
 // ConfigManager handles configuration operations
 type ConfigManager struct {
 	config     *ConfigFile

--- a/internal/commands/config/login_test.go
+++ b/internal/commands/config/login_test.go
@@ -1,3 +1,5 @@
+//go:build !js && !wasm
+
 package config
 
 import (


### PR DESCRIPTION
Native and WASM (portal) builds both sent the same `x-app: cli` header, so the API can't tell portal traffic from the native CLI. This splits the header value by build tag so each identifies itself distinctly.

- Native CLI keeps sending `x-app: cli`
- WASM/portal CLI now sends `x-app: cli-wasm`
- Split the shared `cliHeaders` var out of `config_shared.go` into build-tag-specific files (`config_headers.go` / `config_headers_wasm.go`), matching the existing native/wasm file-pairing convention in this package
