### PR TITLE
ESD-1592-fix(users): default JSON-created users to active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 - **Breaking (WASM):** `window.executeMegaportCommand` no longer executes commands. A synchronous call blocked the JS event loop while the CLI waited on the browser's fetch transport, hanging the tab, and bypassed the mutex that guards the shared output buffers. It is kept as a deprecated stub for one release and always returns `{ error: "synchronous execution is not supported; use executeMegaportCommandAsync" }`. Use `window.executeMegaportCommandAsync` instead (ESD-1598)
 
 ### Fixed
+- default JSON-created users to active when `active` is omitted, matching the flags and interactive paths; an explicit `active: false` is still honored (ESD-1592)
 - repair the `js/wasm` build of `./...` (the WASM config manager was missing `GetProfile`, which `auth status` needs) and enforce the full wasm build, vet, test compilation, and wasm-tagged linting in CI so wasm code stops rotting silently (ESD-1578)
 - require Cisco FMC fields only when not managing locally on the `mve buy` and `mve validate` flags and JSON paths, matching the validator (ESD-1571)
 - `mve buy` and `mve validate` now apply `resourceTags` from JSON input, and interactive `mve buy` now prompts for tags, matching MCR. Previously the JSON path silently dropped the documented `resourceTags` field and interactive mode never asked. The JSON path shares the same value and empty-key validation as the flags path, so non-string values and empty keys return a usage error before the order is placed

--- a/internal/commands/users/users_inputs.go
+++ b/internal/commands/users/users_inputs.go
@@ -9,18 +9,41 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// createUserJSONInput mirrors megaport.CreateUserRequest but keeps Active nilable
+// so an omitted "active" field can be distinguished from an explicit "active": false.
+type createUserJSONInput struct {
+	FirstName string                `json:"firstName"`
+	LastName  string                `json:"lastName"`
+	Active    *bool                 `json:"active"`
+	Email     string                `json:"email"`
+	Phone     string                `json:"phone"`
+	Position  megaport.UserPosition `json:"position"`
+}
+
 func processJSONCreateUserInput(jsonStr, jsonFile string) (*megaport.CreateUserRequest, error) {
 	jsonData, err := utils.ReadJSONInput(jsonStr, jsonFile)
 	if err != nil {
 		return nil, err
 	}
 
-	req := &megaport.CreateUserRequest{}
-	if err := json.Unmarshal(jsonData, req); err != nil {
+	input := &createUserJSONInput{}
+	if err := json.Unmarshal(jsonData, input); err != nil {
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
-	return req, nil
+	active := true
+	if input.Active != nil {
+		active = *input.Active
+	}
+
+	return &megaport.CreateUserRequest{
+		FirstName: input.FirstName,
+		LastName:  input.LastName,
+		Active:    active,
+		Email:     input.Email,
+		Phone:     input.Phone,
+		Position:  input.Position,
+	}, nil
 }
 
 func processFlagCreateUserInput(cmd *cobra.Command) (*megaport.CreateUserRequest, error) {

--- a/internal/commands/users/users_inputs.go
+++ b/internal/commands/users/users_inputs.go
@@ -31,6 +31,10 @@ func processJSONCreateUserInput(jsonStr, jsonFile string) (*megaport.CreateUserR
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
+	if input.Position != "" && !input.Position.IsValid() {
+		return nil, fmt.Errorf("invalid position: %s. Valid positions: %s", input.Position, input.Position.ValidPositions())
+	}
+
 	active := true
 	if input.Active != nil {
 		active = *input.Active

--- a/internal/commands/users/users_inputs_test.go
+++ b/internal/commands/users/users_inputs_test.go
@@ -112,6 +112,11 @@ func TestProcessJSONCreateUserInput(t *testing.T) {
 			name:      "valid JSON file",
 			writeFile: `{"firstName":"Jane","lastName":"Doe","email":"jane@example.com","position":"Finance","active":true}`,
 		},
+		{
+			name:          "invalid position",
+			jsonStr:       `{"firstName":"John","lastName":"Doe","email":"john@example.com","position":"Super Admin"}`,
+			expectedError: "invalid position",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/commands/users/users_inputs_test.go
+++ b/internal/commands/users/users_inputs_test.go
@@ -139,6 +139,39 @@ func TestProcessJSONCreateUserInput(t *testing.T) {
 	}
 }
 
+func TestProcessJSONCreateUserInputActiveDefault(t *testing.T) {
+	tests := []struct {
+		name           string
+		jsonStr        string
+		expectedActive bool
+	}{
+		{
+			name:           "omitted active defaults to true",
+			jsonStr:        `{"firstName":"John","lastName":"Doe","email":"john@example.com","position":"Technical Admin"}`,
+			expectedActive: true,
+		},
+		{
+			name:           "explicit active true is honored",
+			jsonStr:        `{"firstName":"John","lastName":"Doe","email":"john@example.com","position":"Technical Admin","active":true}`,
+			expectedActive: true,
+		},
+		{
+			name:           "explicit active false is honored",
+			jsonStr:        `{"firstName":"John","lastName":"Doe","email":"john@example.com","position":"Technical Admin","active":false}`,
+			expectedActive: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := processJSONCreateUserInput(tt.jsonStr, "")
+			require.NoError(t, err)
+			require.NotNil(t, req)
+			assert.Equal(t, tt.expectedActive, req.Active)
+		})
+	}
+}
+
 func TestProcessJSONUpdateUserInput(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
Fixes a bug where `users create --json` (or `--json-file`) silently made a new user inactive whenever the JSON body omitted the `active` field, including the command's own documented example. The flags and interactive paths already default to active; this brings the JSON path in line.

- Unmarshal JSON into a CLI-side struct with a nilable `active` field, so omitted and explicit `false` can be told apart
- Default omitted `active` to `true` before building the SDK request; an explicit `false` is still honored
- Add tests for omitted/true/false `active` in the JSON path

Ref: ESD-1592
