### PR TITLE
ESD-1591-feat(servicekeys): add JSON and interactive input modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ workflow (scripts/update-changelog.sh). Don't hand-edit them or add entries unde
 
 ## [Unreleased]
 
+### Added
+- `servicekeys create` and `servicekeys update` now support `--json`/`--json-file` and `--interactive` input modes, matching the input-mode contract used elsewhere in the CLI. The update path's merge behavior (unset fields keep their current value rather than being cleared) is preserved across all three input modes (ESD-1591)
+
 ### Changed
 - **Breaking (WASM):** `window.executeMegaportCommand` no longer executes commands. A synchronous call blocked the JS event loop while the CLI waited on the browser's fetch transport, hanging the tab, and bypassed the mutex that guards the shared output buffers. It is kept as a deprecated stub for one release and always returns `{ error: "synchronous execution is not supported; use executeMegaportCommandAsync" }`. Use `window.executeMegaportCommandAsync` instead (ESD-1598)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Megaport CLI Documentation
 
-> Generated on July 5, 2026 for version v1.0.0-beta.1
+> Generated on July 7, 2026 for version v1.0.0-beta.1
 
 ## Available Commands
 

--- a/docs/megaport-cli_servicekeys_create.md
+++ b/docs/megaport-cli_servicekeys_create.md
@@ -8,12 +8,33 @@ Create a new service key for interacting with the Megaport API.
 
 This command generates a new service key and displays its details.
 
+### Important Notes
+  - Provide either productUid or productId, not both
+
 ### Example Usage
 
 ```sh
   megaport-cli servicekeys create --product-uid "product-uid" --description "My service key"
   megaport-cli servicekeys create --product-uid "product-uid" --single-use --max-speed 1000 --description "Single-use key"
   megaport-cli servicekeys create --product-uid "product-uid" --start-date "2023-01-01" --end-date "2023-12-31"
+  megaport-cli servicekeys create --interactive
+  megaport-cli servicekeys create --json '{"productUid":"product-uid","description":"My service key"}'
+  megaport-cli servicekeys create --json-file ./servicekey-config.json
+```
+### JSON Format Example
+```json
+{
+  "productUid": "product-uid",
+  "singleUse": false,
+  "maxSpeed": 1000,
+  "description": "My service key",
+  "active": true,
+  "preApproved": false,
+  "vlan": 100,
+  "startDate": "2023-01-01",
+  "endDate": "2023-12-31"
+}
+
 ```
 
 ## Usage
@@ -33,6 +54,10 @@ megaport-cli servicekeys create [flags]
 | `--active` |  | `false` | Make the service key available immediately | false |
 | `--description` |  |  | Description for the service key | false |
 | `--end-date` |  |  | End date (YYYY-MM-DD) | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
+| `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
+| `--json` |  |  | JSON string containing configuration | false |
+| `--json-file` |  |  | Path to JSON file containing configuration | false |
 | `--max-speed` |  | `0` | Maximum speed for the service key | false |
 | `--pre-approved` |  | `false` | Pre-approve the service key for use | false |
 | `--product-id` |  | `0` | Product ID for the service key | false |

--- a/docs/megaport-cli_servicekeys_update.md
+++ b/docs/megaport-cli_servicekeys_update.md
@@ -8,12 +8,26 @@ Update an existing service key for the Megaport API.
 
 This command allows you to modify the details of an existing service key. You need to specify the key identifier as an argument, and provide any updated values as flags.
 
+### Important Notes
+  - Only specified fields will be updated; unspecified fields will remain unchanged
+
 ### Example Usage
 
 ```sh
   megaport-cli servicekeys update a1b2c3d4-e5f6-7890-1234-567890abcdef --active
   megaport-cli servicekeys update a1b2c3d4-e5f6-7890-1234-567890abcdef --active=false
   megaport-cli servicekeys update a1b2c3d4-e5f6-7890-1234-567890abcdef --product-uid "new-product-uid"
+  megaport-cli servicekeys update a1b2c3d4-e5f6-7890-1234-567890abcdef --interactive
+  megaport-cli servicekeys update a1b2c3d4-e5f6-7890-1234-567890abcdef --json '{"active":false}'
+```
+### JSON Format Example
+```json
+{
+  "productUid": "new-product-uid",
+  "singleUse": false,
+  "active": false
+}
+
 ```
 
 ## Usage
@@ -31,6 +45,10 @@ megaport-cli servicekeys update [flags]
 | Name | Shorthand | Default | Description | Required |
 |------|-----------|---------|-------------|----------|
 | `--active` |  | `false` | Activate or deactivate the service key | false |
+| `--generate-skeleton` |  | `false` | Print a JSON skeleton template for --json or --json-file input and exit | false |
+| `--interactive` | `-i` | `false` | Use interactive mode with prompts | false |
+| `--json` |  |  | JSON string containing configuration | false |
+| `--json-file` |  |  | Path to JSON file containing configuration | false |
 | `--product-id` |  | `0` | Product ID for the service key | false |
 | `--product-uid` |  |  | Product UID for the service key | false |
 | `--single-use` |  | `false` | Single-use service key | false |

--- a/internal/commands/servicekeys/servicekeys.go
+++ b/internal/commands/servicekeys/servicekeys.go
@@ -19,9 +19,25 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithLongDesc("Create a new service key for interacting with the Megaport API.\n\nThis command generates a new service key and displays its details.").
 		WithColorAwareRunFunc(CreateServiceKey).
 		WithServiceKeyCreateFlags().
+		WithStandardInputFlags().
 		WithExample("megaport-cli servicekeys create --product-uid \"product-uid\" --description \"My service key\"").
 		WithExample("megaport-cli servicekeys create --product-uid \"product-uid\" --single-use --max-speed 1000 --description \"Single-use key\"").
 		WithExample("megaport-cli servicekeys create --product-uid \"product-uid\" --start-date \"2023-01-01\" --end-date \"2023-12-31\"").
+		WithExample("megaport-cli servicekeys create --interactive").
+		WithExample("megaport-cli servicekeys create --json '{\"productUid\":\"product-uid\",\"description\":\"My service key\"}'").
+		WithExample("megaport-cli servicekeys create --json-file ./servicekey-config.json").
+		WithJSONExample(`{
+  "productUid": "product-uid",
+  "singleUse": false,
+  "maxSpeed": 1000,
+  "description": "My service key",
+  "active": true,
+  "preApproved": false,
+  "vlan": 100,
+  "startDate": "2023-01-01",
+  "endDate": "2023-12-31"
+}`).
+		WithImportantNote("Provide either productUid or productId, not both").
 		WithRootCmd(rootCmd).
 		Build()
 
@@ -30,9 +46,18 @@ func AddCommandsTo(rootCmd *cobra.Command) {
 		WithLongDesc("Update an existing service key for the Megaport API.\n\nThis command allows you to modify the details of an existing service key. You need to specify the key identifier as an argument, and provide any updated values as flags.").
 		WithColorAwareRunFunc(UpdateServiceKey).
 		WithServiceKeyUpdateFlags().
+		WithStandardInputFlags().
 		WithExample("megaport-cli servicekeys update a1b2c3d4-e5f6-7890-1234-567890abcdef --active").
 		WithExample("megaport-cli servicekeys update a1b2c3d4-e5f6-7890-1234-567890abcdef --active=false").
 		WithExample("megaport-cli servicekeys update a1b2c3d4-e5f6-7890-1234-567890abcdef --product-uid \"new-product-uid\"").
+		WithExample("megaport-cli servicekeys update a1b2c3d4-e5f6-7890-1234-567890abcdef --interactive").
+		WithExample("megaport-cli servicekeys update a1b2c3d4-e5f6-7890-1234-567890abcdef --json '{\"active\":false}'").
+		WithJSONExample(`{
+  "productUid": "new-product-uid",
+  "singleUse": false,
+  "active": false
+}`).
+		WithImportantNote("Only specified fields will be updated; unspecified fields will remain unchanged").
 		WithRootCmd(rootCmd).
 		Build()
 

--- a/internal/commands/servicekeys/servicekeys_actions.go
+++ b/internal/commands/servicekeys/servicekeys_actions.go
@@ -74,10 +74,6 @@ func UpdateServiceKey(cmd *cobra.Command, args []string, noColor bool) error {
 		return err
 	}
 
-	if cmd.Flags().Changed("product-uid") && cmd.Flags().Changed("product-id") {
-		return fmt.Errorf("--product-uid and --product-id cannot both be set")
-	}
-
 	ctx, cancel, client, err := utils.LoginClient(cmd, 90*time.Second, config.Login)
 	if err != nil {
 		output.PrintError("Failed to log in: %v", noColor, err)
@@ -116,7 +112,11 @@ func UpdateServiceKey(cmd *cobra.Command, args []string, noColor bool) error {
 			return err
 		}
 	default:
-		req = buildUpdateServiceKeyRequestFromFlags(cmd, key, current)
+		req, err = buildUpdateServiceKeyRequestFromFlags(cmd, key, current)
+		if err != nil {
+			output.PrintError("Failed to process flags: %v", noColor, err)
+			return err
+		}
 	}
 
 	spinner := output.PrintResourceUpdating("Service Key", key, noColor)

--- a/internal/commands/servicekeys/servicekeys_actions.go
+++ b/internal/commands/servicekeys/servicekeys_actions.go
@@ -7,40 +7,32 @@ import (
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/commands/config"
 	"github.com/megaport/megaport-cli/internal/utils"
-	"github.com/megaport/megaport-cli/internal/validation"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 )
 
+func buildCreateServiceKeyRequest(cmd *cobra.Command, noColor bool) (*megaport.CreateServiceKeyRequest, error) {
+	return utils.ResolveInput(utils.InputConfig[*megaport.CreateServiceKeyRequest]{
+		ResourceName: "service key",
+		Cmd:          cmd,
+		NoColor:      noColor,
+		FlagsProvided: func() bool {
+			return cmd.Flags().Changed("product-uid") || cmd.Flags().Changed("product-id") ||
+				cmd.Flags().Changed("single-use") || cmd.Flags().Changed("max-speed") ||
+				cmd.Flags().Changed("description") || cmd.Flags().Changed("start-date") ||
+				cmd.Flags().Changed("end-date") || cmd.Flags().Changed("active") ||
+				cmd.Flags().Changed("pre-approved") || cmd.Flags().Changed("vlan")
+		},
+		FromJSON:   processJSONCreateServiceKeyInput,
+		FromFlags:  func() (*megaport.CreateServiceKeyRequest, error) { return processFlagCreateServiceKeyInput(cmd) },
+		FromPrompt: func() (*megaport.CreateServiceKeyRequest, error) { return promptForCreateServiceKeyDetails(noColor) },
+	})
+}
+
 func CreateServiceKey(cmd *cobra.Command, args []string, noColor bool) error {
-	// Flag read errors are intentionally ignored — flags are registered by the command builder.
-	productUID, _ := cmd.Flags().GetString("product-uid")
-	productID, _ := cmd.Flags().GetInt("product-id")
-	singleUse, _ := cmd.Flags().GetBool("single-use")
-	maxSpeed, _ := cmd.Flags().GetInt("max-speed")
-	description, _ := cmd.Flags().GetString("description")
-	startDate, _ := cmd.Flags().GetString("start-date")
-	endDate, _ := cmd.Flags().GetString("end-date")
-
-	if err := validation.ValidateDateRange(startDate, endDate); err != nil {
-		output.PrintError("Failed to validate date range: %v", noColor, err)
+	req, err := buildCreateServiceKeyRequest(cmd, noColor)
+	if err != nil {
 		return err
-	}
-
-	var validFor *megaport.ValidFor
-	if startDate != "" && endDate != "" {
-		startTime, err := time.Parse("2006-01-02", startDate)
-		if err != nil {
-			return fmt.Errorf("invalid start date %q: %w", startDate, err)
-		}
-		endTime, err := time.Parse("2006-01-02", endDate)
-		if err != nil {
-			return fmt.Errorf("invalid end date %q: %w", endDate, err)
-		}
-		validFor = &megaport.ValidFor{
-			StartTime: &megaport.Time{Time: startTime},
-			EndTime:   &megaport.Time{Time: endTime},
-		}
 	}
 
 	ctx, cancel, client, err := utils.LoginClient(cmd, 90*time.Second, config.Login)
@@ -50,23 +42,7 @@ func CreateServiceKey(cmd *cobra.Command, args []string, noColor bool) error {
 	}
 	defer cancel()
 
-	active, _ := cmd.Flags().GetBool("active")
-	preApproved, _ := cmd.Flags().GetBool("pre-approved")
-	vlan, _ := cmd.Flags().GetInt("vlan")
-
-	req := &megaport.CreateServiceKeyRequest{
-		ProductUID:  productUID,
-		ProductID:   productID,
-		SingleUse:   singleUse,
-		MaxSpeed:    maxSpeed,
-		Description: description,
-		ValidFor:    validFor,
-		Active:      active,
-		PreApproved: preApproved,
-		VLAN:        vlan,
-	}
-
-	spinner := output.PrintResourceCreating("Service Key", description, noColor)
+	spinner := output.PrintResourceCreating("Service Key", req.Description, noColor)
 
 	resp, err := client.ServiceKeyService.CreateServiceKey(ctx, req)
 
@@ -89,6 +65,15 @@ func CreateServiceKey(cmd *cobra.Command, args []string, noColor bool) error {
 func UpdateServiceKey(cmd *cobra.Command, args []string, noColor bool) error {
 	key := args[0]
 
+	interactive, _ := cmd.Flags().GetBool("interactive")
+	jsonStr, _ := cmd.Flags().GetString("json")
+	jsonFile, _ := cmd.Flags().GetString("json-file")
+
+	if err := utils.CheckInteractiveConflict(interactive, utils.HasConflictingInputFlags(cmd)); err != nil {
+		output.PrintError("%v", noColor, err)
+		return err
+	}
+
 	if cmd.Flags().Changed("product-uid") && cmd.Flags().Changed("product-id") {
 		return fmt.Errorf("--product-uid and --product-id cannot both be set")
 	}
@@ -101,8 +86,8 @@ func UpdateServiceKey(cmd *cobra.Command, args []string, noColor bool) error {
 	defer cancel()
 
 	// SingleUse and Active are always serialized by the SDK (no omitempty),
-	// so merge from the current key to avoid resetting fields the user
-	// didn't ask to change.
+	// so every input mode merges from the current key to avoid resetting
+	// fields the user didn't ask to change.
 	current, err := client.ServiceKeyService.GetServiceKey(ctx, key)
 	if err != nil {
 		output.PrintError("Failed to fetch current service key: %v", noColor, err)
@@ -114,26 +99,24 @@ func UpdateServiceKey(cmd *cobra.Command, args []string, noColor bool) error {
 		return fmt.Errorf("empty response from API")
 	}
 
-	req := &megaport.UpdateServiceKeyRequest{
-		Key:       key,
-		SingleUse: current.SingleUse,
-		Active:    current.Active,
-	}
-	if cmd.Flags().Changed("single-use") {
-		req.SingleUse, _ = cmd.Flags().GetBool("single-use")
-	}
-	if cmd.Flags().Changed("active") {
-		req.Active, _ = cmd.Flags().GetBool("active")
-	}
-	// The SDK rejects requests with both ProductUID and ProductID set, so
-	// preserve the current ProductUID only when the user provided neither.
+	var req *megaport.UpdateServiceKeyRequest
 	switch {
-	case cmd.Flags().Changed("product-uid"):
-		req.ProductUID, _ = cmd.Flags().GetString("product-uid")
-	case cmd.Flags().Changed("product-id"):
-		req.ProductID, _ = cmd.Flags().GetInt("product-id")
+	case jsonStr != "" || jsonFile != "":
+		output.PrintInfo("Using JSON input", noColor)
+		req, err = buildUpdateServiceKeyRequestFromJSON(jsonStr, jsonFile, key, current)
+		if err != nil {
+			output.PrintError("Failed to process JSON input: %v", noColor, err)
+			return err
+		}
+	case interactive:
+		output.PrintInfo("Starting interactive mode", noColor)
+		req, err = promptForUpdateServiceKeyDetails(key, current, noColor)
+		if err != nil {
+			output.PrintError("Interactive input failed: %v", noColor, err)
+			return err
+		}
 	default:
-		req.ProductUID = current.ProductUID
+		req = buildUpdateServiceKeyRequestFromFlags(cmd, key, current)
 	}
 
 	spinner := output.PrintResourceUpdating("Service Key", key, noColor)

--- a/internal/commands/servicekeys/servicekeys_actions_test.go
+++ b/internal/commands/servicekeys/servicekeys_actions_test.go
@@ -202,6 +202,15 @@ func TestCreateServiceKey_JSONMode(t *testing.T) {
 			json:          `{invalid}`,
 			expectedError: "failed to parse JSON",
 		},
+		{
+			name: "raw validFor key is ignored",
+			json: `{"productUid":"json-prod-uid","validFor":{"start":111,"end":222}}`,
+			check: func(t *testing.T, req *megaport.CreateServiceKeyRequest) {
+				assert.Equal(t, "json-prod-uid", req.ProductUID)
+				assert.Nil(t, req.ValidFor)
+				assert.Nil(t, req.OrderValidFor)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -691,6 +700,13 @@ func TestUpdateServiceKey_JSONMode(t *testing.T) {
 			json:          `{invalid}`,
 			expectedError: "failed to parse JSON",
 		},
+		{
+			name:              "raw validFor key is ignored",
+			json:              `{"active":false,"validFor":{"start":111,"end":222}}`,
+			expectedSingleUse: true,
+			expectedActive:    false,
+			expectedUID:       "current-prod-uid",
+		},
 	}
 
 	for _, tt := range tests {
@@ -725,6 +741,8 @@ func TestUpdateServiceKey_JSONMode(t *testing.T) {
 				assert.Equal(t, tt.expectedActive, req.Active)
 				assert.Equal(t, tt.expectedUID, req.ProductUID)
 				assert.Equal(t, tt.expectedID, req.ProductID)
+				assert.Nil(t, req.ValidFor)
+				assert.Nil(t, req.OrderValidFor)
 			}
 		})
 	}

--- a/internal/commands/servicekeys/servicekeys_actions_test.go
+++ b/internal/commands/servicekeys/servicekeys_actions_test.go
@@ -48,7 +48,6 @@ func TestCreateServiceKey_FlagsPropagated(t *testing.T) {
 
 	testutil.SetFlags(t, cmd, map[string]string{
 		"product-uid":  "prod-uid-123",
-		"product-id":   "42",
 		"single-use":   "true",
 		"max-speed":    "1000",
 		"description":  "test key",
@@ -67,13 +66,36 @@ func TestCreateServiceKey_FlagsPropagated(t *testing.T) {
 
 	req := mockService.CapturedCreateServiceKeyRequest
 	assert.Equal(t, "prod-uid-123", req.ProductUID)
-	assert.Equal(t, 42, req.ProductID)
+	assert.Equal(t, 0, req.ProductID)
 	assert.True(t, req.SingleUse)
 	assert.Equal(t, 1000, req.MaxSpeed)
 	assert.Equal(t, "test key", req.Description)
 	assert.True(t, req.Active)
 	assert.True(t, req.PreApproved)
 	assert.Equal(t, 100, req.VLAN)
+}
+
+func TestCreateServiceKey_BothProductFlagsRejected(t *testing.T) {
+	mockService := &MockServiceKeyService{}
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {
+		c.ServiceKeyService = mockService
+	})
+	defer cleanup()
+
+	cmd := newCreateServiceKeyCmd()
+	testutil.SetFlags(t, cmd, map[string]string{
+		"product-uid": "prod-uid-123",
+		"product-id":  "42",
+	})
+
+	var err error
+	output.CaptureOutput(func() {
+		err = cmd.RunE(cmd, []string{})
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot both be set")
+	assert.Nil(t, mockService.CapturedCreateServiceKeyRequest)
 }
 
 func TestCreateServiceKey_NilResponse(t *testing.T) {
@@ -201,6 +223,11 @@ func TestCreateServiceKey_JSONMode(t *testing.T) {
 			name:          "invalid JSON syntax",
 			json:          `{invalid}`,
 			expectedError: "failed to parse JSON",
+		},
+		{
+			name:          "product uid and product id both set",
+			json:          `{"productUid":"json-prod-uid","productId":42}`,
+			expectedError: "productUid and productId cannot both be set",
 		},
 		{
 			name: "raw validFor key is ignored",

--- a/internal/commands/servicekeys/servicekeys_actions_test.go
+++ b/internal/commands/servicekeys/servicekeys_actions_test.go
@@ -12,18 +12,14 @@ import (
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/commands/config"
 	"github.com/megaport/megaport-cli/internal/testutil"
+	"github.com/megaport/megaport-cli/internal/utils"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestCreateServiceKey_FlagsPropagated(t *testing.T) {
-	mockService := &MockServiceKeyService{}
-	cleanup := testutil.SetupLogin(func(c *megaport.Client) {
-		c.ServiceKeyService = mockService
-	})
-	defer cleanup()
-
+func newCreateServiceKeyCmd() *cobra.Command {
 	cmd := testutil.NewCommand("create", testutil.NoColorAdapter(CreateServiceKey))
 	cmd.Flags().String("product-uid", "", "")
 	cmd.Flags().Int("product-id", 0, "")
@@ -35,6 +31,20 @@ func TestCreateServiceKey_FlagsPropagated(t *testing.T) {
 	cmd.Flags().Bool("active", false, "")
 	cmd.Flags().Bool("pre-approved", false, "")
 	cmd.Flags().Int("vlan", 0, "")
+	cmd.Flags().BoolP("interactive", "i", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	return cmd
+}
+
+func TestCreateServiceKey_FlagsPropagated(t *testing.T) {
+	mockService := &MockServiceKeyService{}
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {
+		c.ServiceKeyService = mockService
+	})
+	defer cleanup()
+
+	cmd := newCreateServiceKeyCmd()
 
 	testutil.SetFlags(t, cmd, map[string]string{
 		"product-uid":  "prod-uid-123",
@@ -73,17 +83,7 @@ func TestCreateServiceKey_NilResponse(t *testing.T) {
 	})
 	defer cleanup()
 
-	cmd := testutil.NewCommand("create", testutil.NoColorAdapter(CreateServiceKey))
-	cmd.Flags().String("product-uid", "", "")
-	cmd.Flags().Int("product-id", 0, "")
-	cmd.Flags().Bool("single-use", false, "")
-	cmd.Flags().Int("max-speed", 0, "")
-	cmd.Flags().String("description", "", "")
-	cmd.Flags().String("start-date", "", "")
-	cmd.Flags().String("end-date", "", "")
-	cmd.Flags().Bool("active", false, "")
-	cmd.Flags().Bool("pre-approved", false, "")
-	cmd.Flags().Int("vlan", 0, "")
+	cmd := newCreateServiceKeyCmd()
 
 	testutil.SetFlags(t, cmd, map[string]string{
 		"product-uid": "prod-uid-123",
@@ -144,17 +144,7 @@ func TestCreateServiceKey_InvalidDateParsing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := testutil.NewCommand("create", testutil.NoColorAdapter(CreateServiceKey))
-			cmd.Flags().String("product-uid", "", "")
-			cmd.Flags().Int("product-id", 0, "")
-			cmd.Flags().Bool("single-use", false, "")
-			cmd.Flags().Int("max-speed", 0, "")
-			cmd.Flags().String("description", "", "")
-			cmd.Flags().String("start-date", "", "")
-			cmd.Flags().String("end-date", "", "")
-			cmd.Flags().Bool("active", false, "")
-			cmd.Flags().Bool("pre-approved", false, "")
-			cmd.Flags().Int("vlan", 0, "")
+			cmd := newCreateServiceKeyCmd()
 
 			testutil.SetFlags(t, cmd, map[string]string{
 				"product-uid": "prod-123",
@@ -171,6 +161,171 @@ func TestCreateServiceKey_InvalidDateParsing(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.expectedError)
 		})
 	}
+}
+
+func TestCreateServiceKey_JSONMode(t *testing.T) {
+	tests := []struct {
+		name          string
+		json          string
+		useFile       bool
+		expectedError string
+		check         func(t *testing.T, req *megaport.CreateServiceKeyRequest)
+	}{
+		{
+			name: "json string success",
+			json: `{"productUid":"json-prod-uid","description":"JSON key","singleUse":true,"maxSpeed":500,"active":true,"preApproved":true,"vlan":50,"startDate":"2025-01-01","endDate":"2025-12-31"}`,
+			check: func(t *testing.T, req *megaport.CreateServiceKeyRequest) {
+				assert.Equal(t, "json-prod-uid", req.ProductUID)
+				assert.Equal(t, "JSON key", req.Description)
+				assert.True(t, req.SingleUse)
+				assert.Equal(t, 500, req.MaxSpeed)
+				assert.True(t, req.Active)
+				assert.True(t, req.PreApproved)
+				assert.Equal(t, 50, req.VLAN)
+				if assert.NotNil(t, req.ValidFor) {
+					assert.Equal(t, "2025-01-01", req.ValidFor.StartTime.Format("2006-01-02"))
+					assert.Equal(t, "2025-12-31", req.ValidFor.EndTime.Format("2006-01-02"))
+				}
+			},
+		},
+		{
+			name:    "json file success",
+			json:    `{"productUid":"json-file-prod-uid","description":"JSON file key"}`,
+			useFile: true,
+			check: func(t *testing.T, req *megaport.CreateServiceKeyRequest) {
+				assert.Equal(t, "json-file-prod-uid", req.ProductUID)
+				assert.Equal(t, "JSON file key", req.Description)
+			},
+		},
+		{
+			name:          "invalid JSON syntax",
+			json:          `{invalid}`,
+			expectedError: "failed to parse JSON",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockService := &MockServiceKeyService{}
+			cleanup := testutil.SetupLogin(func(c *megaport.Client) {
+				c.ServiceKeyService = mockService
+			})
+			defer cleanup()
+
+			cmd := newCreateServiceKeyCmd()
+
+			if tt.useFile {
+				tmpFile, tmpErr := os.CreateTemp("", "servicekey-create-*.json")
+				require.NoError(t, tmpErr)
+				defer os.Remove(tmpFile.Name())
+				_, tmpErr = tmpFile.WriteString(tt.json)
+				require.NoError(t, tmpErr)
+				require.NoError(t, tmpFile.Close())
+				testutil.SetFlags(t, cmd, map[string]string{"json-file": tmpFile.Name()})
+			} else {
+				testutil.SetFlags(t, cmd, map[string]string{"json": tt.json})
+			}
+
+			var err error
+			output.CaptureOutput(func() {
+				err = cmd.RunE(cmd, []string{})
+			})
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				return
+			}
+
+			assert.NoError(t, err)
+			if assert.NotNil(t, mockService.CapturedCreateServiceKeyRequest) {
+				tt.check(t, mockService.CapturedCreateServiceKeyRequest)
+			}
+		})
+	}
+}
+
+func TestCreateServiceKey_InteractiveMode(t *testing.T) {
+	originalResourcePrompt := utils.GetResourcePrompt()
+	originalConfirmPrompt := utils.GetConfirmPrompt()
+	defer func() {
+		utils.SetResourcePrompt(originalResourcePrompt)
+		utils.SetConfirmPrompt(originalConfirmPrompt)
+	}()
+
+	mockService := &MockServiceKeyService{
+		CreateServiceKeyResult: &megaport.CreateServiceKeyResponse{ServiceKeyUID: "sk-interactive"},
+	}
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {
+		c.ServiceKeyService = mockService
+	})
+	defer cleanup()
+
+	resourcePrompts := []string{
+		"prod-uid-interactive", // product UID
+		"1500",                 // max speed
+		"Interactive key",      // description
+		"2025-01-01",           // start date
+		"2025-12-31",           // end date
+		"200",                  // VLAN
+	}
+	promptIndex := 0
+	utils.SetResourcePrompt(func(_, _ string, _ bool) (string, error) {
+		resp := resourcePrompts[promptIndex]
+		promptIndex++
+		return resp, nil
+	})
+
+	confirmResponses := []bool{true, true, false} // single-use, active, pre-approved
+	confirmIndex := 0
+	utils.SetConfirmPrompt(func(_ string, _ bool) bool {
+		resp := confirmResponses[confirmIndex]
+		confirmIndex++
+		return resp
+	})
+
+	cmd := newCreateServiceKeyCmd()
+	testutil.SetFlags(t, cmd, map[string]string{"interactive": "true"})
+
+	var err error
+	output.CaptureOutput(func() {
+		err = cmd.RunE(cmd, []string{})
+	})
+
+	assert.NoError(t, err)
+	req := mockService.CapturedCreateServiceKeyRequest
+	if assert.NotNil(t, req) {
+		assert.Equal(t, "prod-uid-interactive", req.ProductUID)
+		assert.True(t, req.SingleUse)
+		assert.Equal(t, 1500, req.MaxSpeed)
+		assert.Equal(t, "Interactive key", req.Description)
+		assert.True(t, req.Active)
+		assert.False(t, req.PreApproved)
+		assert.Equal(t, 200, req.VLAN)
+		if assert.NotNil(t, req.ValidFor) {
+			assert.Equal(t, "2025-01-01", req.ValidFor.StartTime.Format("2006-01-02"))
+			assert.Equal(t, "2025-12-31", req.ValidFor.EndTime.Format("2006-01-02"))
+		}
+	}
+}
+
+func TestCreateServiceKey_InteractiveConflict(t *testing.T) {
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {})
+	defer cleanup()
+
+	cmd := newCreateServiceKeyCmd()
+	testutil.SetFlags(t, cmd, map[string]string{
+		"interactive": "true",
+		"json":        `{"productUid":"prod-uid"}`,
+	})
+
+	var err error
+	output.CaptureOutput(func() {
+		err = cmd.RunE(cmd, []string{})
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be combined with")
 }
 
 func TestListServiceKeys_ProductUIDFilter(t *testing.T) {
@@ -241,6 +396,9 @@ func newUpdateServiceKeyCmd() *cobra.Command {
 	cmd.Flags().Int("product-id", 0, "")
 	cmd.Flags().Bool("single-use", false, "")
 	cmd.Flags().Bool("active", false, "")
+	cmd.Flags().BoolP("interactive", "i", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
 	return cmd
 }
 
@@ -468,6 +626,239 @@ func TestUpdateServiceKey_MergesUnsetFlags(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUpdateServiceKey_JSONMode(t *testing.T) {
+	currentKey := &megaport.ServiceKey{
+		Key:        "test-key-123",
+		ProductUID: "current-prod-uid",
+		SingleUse:  true,
+		Active:     true,
+	}
+
+	tests := []struct {
+		name              string
+		json              string
+		expectedError     string
+		expectedSingleUse bool
+		expectedActive    bool
+		expectedUID       string
+		expectedID        int
+	}{
+		{
+			name:              "empty object preserves current values",
+			json:              `{}`,
+			expectedSingleUse: true,
+			expectedActive:    true,
+			expectedUID:       "current-prod-uid",
+		},
+		{
+			name:              "product uid only preserves bools",
+			json:              `{"productUid":"new-prod-uid"}`,
+			expectedSingleUse: true,
+			expectedActive:    true,
+			expectedUID:       "new-prod-uid",
+		},
+		{
+			name:              "explicit active false is honored",
+			json:              `{"active":false}`,
+			expectedSingleUse: true,
+			expectedActive:    false,
+			expectedUID:       "current-prod-uid",
+		},
+		{
+			name:              "explicit single-use false is honored",
+			json:              `{"singleUse":false}`,
+			expectedSingleUse: false,
+			expectedActive:    true,
+			expectedUID:       "current-prod-uid",
+		},
+		{
+			name:              "product id replaces current product uid",
+			json:              `{"productId":42}`,
+			expectedSingleUse: true,
+			expectedActive:    true,
+			expectedUID:       "",
+			expectedID:        42,
+		},
+		{
+			name:          "product uid and product id both set",
+			json:          `{"productUid":"new-prod-uid","productId":42}`,
+			expectedError: "productUid and productId cannot both be set",
+		},
+		{
+			name:          "invalid JSON syntax",
+			json:          `{invalid}`,
+			expectedError: "failed to parse JSON",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockService := &MockServiceKeyService{
+				GetServiceKeyResult: currentKey,
+			}
+			cleanup := testutil.SetupLogin(func(c *megaport.Client) {
+				c.ServiceKeyService = mockService
+			})
+			defer cleanup()
+
+			cmd := newUpdateServiceKeyCmd()
+			testutil.SetFlags(t, cmd, map[string]string{"json": tt.json})
+
+			var err error
+			output.CaptureOutput(func() {
+				err = cmd.RunE(cmd, []string{"test-key-123"})
+			})
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				return
+			}
+
+			assert.NoError(t, err)
+			req := mockService.CapturedUpdateServiceKeyRequest
+			if assert.NotNil(t, req) {
+				assert.Equal(t, "test-key-123", req.Key)
+				assert.Equal(t, tt.expectedSingleUse, req.SingleUse)
+				assert.Equal(t, tt.expectedActive, req.Active)
+				assert.Equal(t, tt.expectedUID, req.ProductUID)
+				assert.Equal(t, tt.expectedID, req.ProductID)
+			}
+		})
+	}
+}
+
+func TestUpdateServiceKey_InteractiveMode(t *testing.T) {
+	currentKey := &megaport.ServiceKey{
+		Key:        "test-key-123",
+		ProductUID: "current-prod-uid",
+		SingleUse:  true,
+		Active:     true,
+	}
+
+	tests := []struct {
+		name              string
+		resourcePrompts   []string
+		confirmResponses  []bool
+		expectedSingleUse bool
+		expectedActive    bool
+		expectedUID       string
+		expectedID        int
+	}{
+		{
+			name:              "skipping every prompt preserves current values",
+			resourcePrompts:   []string{"", "", "no", "no"},
+			expectedSingleUse: true,
+			expectedActive:    true,
+			expectedUID:       "current-prod-uid",
+		},
+		{
+			name:              "new product uid preserves bools",
+			resourcePrompts:   []string{"new-prod-uid", "no", "no"},
+			expectedSingleUse: true,
+			expectedActive:    true,
+			expectedUID:       "new-prod-uid",
+		},
+		{
+			name:              "new product id replaces current product uid",
+			resourcePrompts:   []string{"", "42", "no", "no"},
+			expectedSingleUse: true,
+			expectedActive:    true,
+			expectedUID:       "",
+			expectedID:        42,
+		},
+		{
+			name:              "explicit active false is honored",
+			resourcePrompts:   []string{"", "", "no", "yes"},
+			confirmResponses:  []bool{false},
+			expectedSingleUse: true,
+			expectedActive:    false,
+			expectedUID:       "current-prod-uid",
+		},
+		{
+			name:              "explicit single-use false is honored",
+			resourcePrompts:   []string{"", "", "yes", "no"},
+			confirmResponses:  []bool{false},
+			expectedSingleUse: false,
+			expectedActive:    true,
+			expectedUID:       "current-prod-uid",
+		},
+	}
+
+	originalResourcePrompt := utils.GetResourcePrompt()
+	originalConfirmPrompt := utils.GetConfirmPrompt()
+	defer func() {
+		utils.SetResourcePrompt(originalResourcePrompt)
+		utils.SetConfirmPrompt(originalConfirmPrompt)
+	}()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockService := &MockServiceKeyService{
+				GetServiceKeyResult: currentKey,
+			}
+			cleanup := testutil.SetupLogin(func(c *megaport.Client) {
+				c.ServiceKeyService = mockService
+			})
+			defer cleanup()
+
+			promptIndex := 0
+			utils.SetResourcePrompt(func(_, _ string, _ bool) (string, error) {
+				resp := tt.resourcePrompts[promptIndex]
+				promptIndex++
+				return resp, nil
+			})
+
+			confirmIndex := 0
+			utils.SetConfirmPrompt(func(_ string, _ bool) bool {
+				resp := tt.confirmResponses[confirmIndex]
+				confirmIndex++
+				return resp
+			})
+
+			cmd := newUpdateServiceKeyCmd()
+			testutil.SetFlags(t, cmd, map[string]string{"interactive": "true"})
+
+			var err error
+			output.CaptureOutput(func() {
+				err = cmd.RunE(cmd, []string{"test-key-123"})
+			})
+
+			assert.NoError(t, err)
+			req := mockService.CapturedUpdateServiceKeyRequest
+			if assert.NotNil(t, req) {
+				assert.Equal(t, "test-key-123", req.Key)
+				assert.Equal(t, tt.expectedSingleUse, req.SingleUse)
+				assert.Equal(t, tt.expectedActive, req.Active)
+				assert.Equal(t, tt.expectedUID, req.ProductUID)
+				assert.Equal(t, tt.expectedID, req.ProductID)
+			}
+		})
+	}
+}
+
+func TestUpdateServiceKey_InteractiveConflict(t *testing.T) {
+	mockService := &MockServiceKeyService{}
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {
+		c.ServiceKeyService = mockService
+	})
+	defer cleanup()
+
+	cmd := newUpdateServiceKeyCmd()
+	testutil.SetFlags(t, cmd, map[string]string{
+		"interactive": "true",
+		"json":        `{"active":false}`,
+	})
+
+	var err error
+	output.CaptureOutput(func() {
+		err = cmd.RunE(cmd, []string{"test-key-123"})
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be combined with")
 }
 
 func TestGetServiceKey(t *testing.T) {

--- a/internal/commands/servicekeys/servicekeys_actions_test.go
+++ b/internal/commands/servicekeys/servicekeys_actions_test.go
@@ -775,6 +775,38 @@ func TestUpdateServiceKey_JSONMode(t *testing.T) {
 	}
 }
 
+func TestUpdateServiceKey_JSONModeIgnoresProductFlagConflict(t *testing.T) {
+	currentKey := &megaport.ServiceKey{
+		Key:        "test-key-123",
+		ProductUID: "current-prod-uid",
+		SingleUse:  true,
+		Active:     true,
+	}
+	mockService := &MockServiceKeyService{GetServiceKeyResult: currentKey}
+	cleanup := testutil.SetupLogin(func(c *megaport.Client) {
+		c.ServiceKeyService = mockService
+	})
+	defer cleanup()
+
+	cmd := newUpdateServiceKeyCmd()
+	testutil.SetFlags(t, cmd, map[string]string{
+		"json":        `{"productUid":"json-prod-uid"}`,
+		"product-uid": "flag-prod-uid",
+		"product-id":  "42",
+	})
+
+	var err error
+	output.CaptureOutput(func() {
+		err = cmd.RunE(cmd, []string{"test-key-123"})
+	})
+
+	assert.NoError(t, err)
+	req := mockService.CapturedUpdateServiceKeyRequest
+	if assert.NotNil(t, req) {
+		assert.Equal(t, "json-prod-uid", req.ProductUID)
+	}
+}
+
 func TestUpdateServiceKey_InteractiveMode(t *testing.T) {
 	currentKey := &megaport.ServiceKey{
 		Key:        "test-key-123",

--- a/internal/commands/servicekeys/servicekeys_inputs.go
+++ b/internal/commands/servicekeys/servicekeys_inputs.go
@@ -49,6 +49,10 @@ func processFlagCreateServiceKeyInput(cmd *cobra.Command) (*megaport.CreateServi
 	preApproved, _ := cmd.Flags().GetBool("pre-approved")
 	vlan, _ := cmd.Flags().GetInt("vlan")
 
+	if productUID != "" && productID != 0 {
+		return nil, fmt.Errorf("--product-uid and --product-id cannot both be set")
+	}
+
 	validFor, err := parseServiceKeyValidFor(startDate, endDate)
 	if err != nil {
 		return nil, err
@@ -80,6 +84,9 @@ func processJSONCreateServiceKeyInput(jsonStr, jsonFile string) (*megaport.Creat
 	req := &megaport.CreateServiceKeyRequest{}
 	if err := json.Unmarshal(jsonData, req); err != nil {
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+	if req.ProductUID != "" && req.ProductID != 0 {
+		return nil, fmt.Errorf("productUid and productId cannot both be set")
 	}
 	// A raw "validFor" key unmarshals onto OrderValidFor (raw epoch millis),
 	// bypassing startDate/endDate validation below. Discard it so startDate/

--- a/internal/commands/servicekeys/servicekeys_inputs.go
+++ b/internal/commands/servicekeys/servicekeys_inputs.go
@@ -1,0 +1,168 @@
+package servicekeys
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/megaport/megaport-cli/internal/utils"
+	"github.com/megaport/megaport-cli/internal/validation"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/spf13/cobra"
+)
+
+// parseServiceKeyValidFor builds a ValidFor from YYYY-MM-DD date strings.
+// Returns nil if both dates are empty.
+func parseServiceKeyValidFor(startDate, endDate string) (*megaport.ValidFor, error) {
+	if err := validation.ValidateDateRange(startDate, endDate); err != nil {
+		return nil, err
+	}
+	if startDate == "" || endDate == "" {
+		return nil, nil
+	}
+
+	startTime, err := time.Parse("2006-01-02", startDate)
+	if err != nil {
+		return nil, fmt.Errorf("invalid start date %q: %w", startDate, err)
+	}
+	endTime, err := time.Parse("2006-01-02", endDate)
+	if err != nil {
+		return nil, fmt.Errorf("invalid end date %q: %w", endDate, err)
+	}
+
+	return &megaport.ValidFor{
+		StartTime: &megaport.Time{Time: startTime},
+		EndTime:   &megaport.Time{Time: endTime},
+	}, nil
+}
+
+func processFlagCreateServiceKeyInput(cmd *cobra.Command) (*megaport.CreateServiceKeyRequest, error) {
+	// Flag read errors are intentionally ignored — flags are registered by the command builder.
+	productUID, _ := cmd.Flags().GetString("product-uid")
+	productID, _ := cmd.Flags().GetInt("product-id")
+	singleUse, _ := cmd.Flags().GetBool("single-use")
+	maxSpeed, _ := cmd.Flags().GetInt("max-speed")
+	description, _ := cmd.Flags().GetString("description")
+	startDate, _ := cmd.Flags().GetString("start-date")
+	endDate, _ := cmd.Flags().GetString("end-date")
+	active, _ := cmd.Flags().GetBool("active")
+	preApproved, _ := cmd.Flags().GetBool("pre-approved")
+	vlan, _ := cmd.Flags().GetInt("vlan")
+
+	validFor, err := parseServiceKeyValidFor(startDate, endDate)
+	if err != nil {
+		return nil, err
+	}
+
+	return &megaport.CreateServiceKeyRequest{
+		ProductUID:  productUID,
+		ProductID:   productID,
+		SingleUse:   singleUse,
+		MaxSpeed:    maxSpeed,
+		Description: description,
+		ValidFor:    validFor,
+		Active:      active,
+		PreApproved: preApproved,
+		VLAN:        vlan,
+	}, nil
+}
+
+// processJSONCreateServiceKeyInput parses a create request from JSON. Most
+// fields unmarshal directly onto CreateServiceKeyRequest since the SDK's JSON
+// tags already match the desired field names; startDate/endDate are read
+// separately since the SDK has no user-friendly date fields.
+func processJSONCreateServiceKeyInput(jsonStr, jsonFile string) (*megaport.CreateServiceKeyRequest, error) {
+	jsonData, err := utils.ReadJSONInput(jsonStr, jsonFile)
+	if err != nil {
+		return nil, err
+	}
+
+	req := &megaport.CreateServiceKeyRequest{}
+	if err := json.Unmarshal(jsonData, req); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	var dates struct {
+		StartDate string `json:"startDate"`
+		EndDate   string `json:"endDate"`
+	}
+	if err := json.Unmarshal(jsonData, &dates); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	validFor, err := parseServiceKeyValidFor(dates.StartDate, dates.EndDate)
+	if err != nil {
+		return nil, err
+	}
+	req.ValidFor = validFor
+
+	return req, nil
+}
+
+// buildUpdateServiceKeyRequestFromFlags mirrors the flag-only update path
+// that shipped with the ESD-1272/ESD-1417 merge fix: SingleUse and Active
+// default to the current key's values because the SDK serializes them
+// unconditionally (no omitempty), so an unset flag must not clobber them.
+func buildUpdateServiceKeyRequestFromFlags(cmd *cobra.Command, key string, current *megaport.ServiceKey) *megaport.UpdateServiceKeyRequest {
+	req := &megaport.UpdateServiceKeyRequest{
+		Key:       key,
+		SingleUse: current.SingleUse,
+		Active:    current.Active,
+	}
+	if cmd.Flags().Changed("single-use") {
+		req.SingleUse, _ = cmd.Flags().GetBool("single-use")
+	}
+	if cmd.Flags().Changed("active") {
+		req.Active, _ = cmd.Flags().GetBool("active")
+	}
+	// The SDK rejects requests with both ProductUID and ProductID set, so
+	// preserve the current ProductUID only when the user provided neither.
+	switch {
+	case cmd.Flags().Changed("product-uid"):
+		req.ProductUID, _ = cmd.Flags().GetString("product-uid")
+	case cmd.Flags().Changed("product-id"):
+		req.ProductID, _ = cmd.Flags().GetInt("product-id")
+	default:
+		req.ProductUID = current.ProductUID
+	}
+	return req
+}
+
+// buildUpdateServiceKeyRequestFromJSON applies the same current-state merge
+// as buildUpdateServiceKeyRequestFromFlags, using presence in the raw JSON
+// map to distinguish "not provided" from an explicit false/empty value.
+func buildUpdateServiceKeyRequestFromJSON(jsonStr, jsonFile, key string, current *megaport.ServiceKey) (*megaport.UpdateServiceKeyRequest, error) {
+	jsonData, err := utils.ReadJSONInput(jsonStr, jsonFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(jsonData, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	_, hasProductUID := raw["productUid"]
+	_, hasProductID := raw["productId"]
+	if hasProductUID && hasProductID {
+		return nil, fmt.Errorf("productUid and productId cannot both be set")
+	}
+
+	req := &megaport.UpdateServiceKeyRequest{}
+	if err := json.Unmarshal(jsonData, req); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+	req.Key = key
+
+	if _, ok := raw["singleUse"]; !ok {
+		req.SingleUse = current.SingleUse
+	}
+	if _, ok := raw["active"]; !ok {
+		req.Active = current.Active
+	}
+	if !hasProductUID && !hasProductID {
+		req.ProductUID = current.ProductUID
+	}
+
+	return req, nil
+}

--- a/internal/commands/servicekeys/servicekeys_inputs.go
+++ b/internal/commands/servicekeys/servicekeys_inputs.go
@@ -114,7 +114,11 @@ func processJSONCreateServiceKeyInput(jsonStr, jsonFile string) (*megaport.Creat
 // that shipped with the ESD-1272/ESD-1417 merge fix: SingleUse and Active
 // default to the current key's values because the SDK serializes them
 // unconditionally (no omitempty), so an unset flag must not clobber them.
-func buildUpdateServiceKeyRequestFromFlags(cmd *cobra.Command, key string, current *megaport.ServiceKey) *megaport.UpdateServiceKeyRequest {
+func buildUpdateServiceKeyRequestFromFlags(cmd *cobra.Command, key string, current *megaport.ServiceKey) (*megaport.UpdateServiceKeyRequest, error) {
+	if cmd.Flags().Changed("product-uid") && cmd.Flags().Changed("product-id") {
+		return nil, fmt.Errorf("--product-uid and --product-id cannot both be set")
+	}
+
 	req := &megaport.UpdateServiceKeyRequest{
 		Key:       key,
 		SingleUse: current.SingleUse,
@@ -136,7 +140,7 @@ func buildUpdateServiceKeyRequestFromFlags(cmd *cobra.Command, key string, curre
 	default:
 		req.ProductUID = current.ProductUID
 	}
-	return req
+	return req, nil
 }
 
 // buildUpdateServiceKeyRequestFromJSON applies the same current-state merge

--- a/internal/commands/servicekeys/servicekeys_inputs.go
+++ b/internal/commands/servicekeys/servicekeys_inputs.go
@@ -81,6 +81,10 @@ func processJSONCreateServiceKeyInput(jsonStr, jsonFile string) (*megaport.Creat
 	if err := json.Unmarshal(jsonData, req); err != nil {
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
+	// A raw "validFor" key unmarshals onto OrderValidFor (raw epoch millis),
+	// bypassing startDate/endDate validation below. Discard it so startDate/
+	// endDate are the only supported way to set the validity window.
+	req.OrderValidFor = nil
 
 	var dates struct {
 		StartDate string `json:"startDate"`
@@ -153,6 +157,11 @@ func buildUpdateServiceKeyRequestFromJSON(jsonStr, jsonFile, key string, current
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 	req.Key = key
+	// Update has no supported way to change the validity window (no
+	// startDate/endDate flags either), so discard a raw "validFor" key
+	// rather than sending it to the API unvalidated.
+	req.OrderValidFor = nil
+	req.ValidFor = nil
 
 	if _, ok := raw["singleUse"]; !ok {
 		req.SingleUse = current.SingleUse

--- a/internal/commands/servicekeys/servicekeys_prompts.go
+++ b/internal/commands/servicekeys/servicekeys_prompts.go
@@ -1,0 +1,146 @@
+package servicekeys
+
+import (
+	"strings"
+
+	"github.com/megaport/megaport-cli/internal/utils"
+	"github.com/megaport/megaport-cli/internal/validation"
+	megaport "github.com/megaport/megaportgo"
+)
+
+func promptForCreateServiceKeyDetails(noColor bool) (*megaport.CreateServiceKeyRequest, error) {
+	productUID, err := utils.ResourcePrompt("service key", "Enter product UID (leave empty to use product ID instead): ", noColor)
+	if err != nil {
+		return nil, err
+	}
+
+	var productID int
+	if productUID == "" {
+		productIDStr, err := utils.ResourcePrompt("service key", "Enter product ID (leave empty to skip): ", noColor)
+		if err != nil {
+			return nil, err
+		}
+		if productIDStr != "" {
+			productID, err = validation.ParseInt("product ID", productIDStr)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	singleUse := utils.ConfirmPrompt("Make this a single-use service key?", noColor)
+
+	maxSpeedStr, err := utils.ResourcePrompt("service key", "Enter max speed in Mbps (leave empty to skip): ", noColor)
+	if err != nil {
+		return nil, err
+	}
+	var maxSpeed int
+	if maxSpeedStr != "" {
+		maxSpeed, err = validation.ParseInt("max speed", maxSpeedStr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	description, err := utils.ResourcePrompt("service key", "Enter description (leave empty to skip): ", noColor)
+	if err != nil {
+		return nil, err
+	}
+
+	startDate, err := utils.ResourcePrompt("service key", "Enter start date, YYYY-MM-DD (leave empty to skip): ", noColor)
+	if err != nil {
+		return nil, err
+	}
+
+	endDate, err := utils.ResourcePrompt("service key", "Enter end date, YYYY-MM-DD (leave empty to skip): ", noColor)
+	if err != nil {
+		return nil, err
+	}
+
+	validFor, err := parseServiceKeyValidFor(startDate, endDate)
+	if err != nil {
+		return nil, err
+	}
+
+	active := utils.ConfirmPrompt("Make the service key available immediately?", noColor)
+	preApproved := utils.ConfirmPrompt("Pre-approve the service key for use?", noColor)
+
+	vlanStr, err := utils.ResourcePrompt("service key", "Enter VLAN ID, required for single-use keys (leave empty to skip): ", noColor)
+	if err != nil {
+		return nil, err
+	}
+	var vlan int
+	if vlanStr != "" {
+		vlan, err = validation.ParseInt("VLAN ID", vlanStr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &megaport.CreateServiceKeyRequest{
+		ProductUID:  productUID,
+		ProductID:   productID,
+		SingleUse:   singleUse,
+		MaxSpeed:    maxSpeed,
+		Description: description,
+		ValidFor:    validFor,
+		Active:      active,
+		PreApproved: preApproved,
+		VLAN:        vlan,
+	}, nil
+}
+
+// promptForUpdateServiceKeyDetails mirrors the flag/JSON update paths: fields
+// the user skips default to the current key's values rather than the zero
+// value, preserving the ESD-1272/ESD-1417 merge behavior.
+func promptForUpdateServiceKeyDetails(key string, current *megaport.ServiceKey, noColor bool) (*megaport.UpdateServiceKeyRequest, error) {
+	req := &megaport.UpdateServiceKeyRequest{
+		Key:        key,
+		SingleUse:  current.SingleUse,
+		Active:     current.Active,
+		ProductUID: current.ProductUID,
+	}
+
+	productUID, err := utils.ResourcePrompt("service key", "Enter new product UID (leave empty to skip): ", noColor)
+	if err != nil {
+		return nil, err
+	}
+
+	var productIDStr string
+	if productUID == "" {
+		productIDStr, err = utils.ResourcePrompt("service key", "Enter new product ID (leave empty to skip): ", noColor)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	switch {
+	case productUID != "":
+		req.ProductUID = productUID
+	case productIDStr != "":
+		productID, err := validation.ParseInt("product ID", productIDStr)
+		if err != nil {
+			return nil, err
+		}
+		req.ProductUID = ""
+		req.ProductID = productID
+	}
+
+	singleUseAns, err := utils.ResourcePrompt("service key", "Update single-use setting? (yes/no, leave empty to skip): ", noColor)
+	if err != nil {
+		return nil, err
+	}
+	if strings.ToLower(singleUseAns) == "yes" {
+		req.SingleUse = utils.ConfirmPrompt("Enable single-use?", noColor)
+	}
+
+	activeAns, err := utils.ResourcePrompt("service key", "Update active setting? (yes/no, leave empty to skip): ", noColor)
+	if err != nil {
+		return nil, err
+	}
+	if strings.ToLower(activeAns) == "yes" {
+		req.Active = utils.ConfirmPrompt("Make the service key active?", noColor)
+	}
+
+	return req, nil
+}

--- a/internal/commands/servicekeys/servicekeys_prompts_test.go
+++ b/internal/commands/servicekeys/servicekeys_prompts_test.go
@@ -1,0 +1,170 @@
+package servicekeys
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/utils"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/stretchr/testify/assert"
+)
+
+func mockServiceKeyPromptSequence(responses []string) func(string, string, bool) (string, error) {
+	idx := 0
+	return func(_, _ string, _ bool) (string, error) {
+		if idx >= len(responses) {
+			return "", fmt.Errorf("unexpected prompt call #%d", idx)
+		}
+		val := responses[idx]
+		idx++
+		return val, nil
+	}
+}
+
+func TestPromptForCreateServiceKeyDetails_ProductUIDPromptError(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(originalPrompt)
+
+	utils.SetResourcePrompt(mockServiceKeyPromptSequence(nil))
+
+	_, err := promptForCreateServiceKeyDetails(true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected prompt call")
+}
+
+func TestPromptForCreateServiceKeyDetails_InvalidProductID(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(originalPrompt)
+
+	// productUID empty enters the product ID prompt, which fails to parse.
+	utils.SetResourcePrompt(mockServiceKeyPromptSequence([]string{"", "not-a-number"}))
+
+	_, err := promptForCreateServiceKeyDetails(true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not a valid whole number")
+}
+
+func TestPromptForCreateServiceKeyDetails_ValidProductID(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	originalConfirm := utils.GetConfirmPrompt()
+	defer func() {
+		utils.SetResourcePrompt(originalPrompt)
+		utils.SetConfirmPrompt(originalConfirm)
+	}()
+
+	// productUID empty, productID "77"; skip max speed/description/dates/vlan.
+	utils.SetResourcePrompt(mockServiceKeyPromptSequence([]string{"", "77", "", "", "", "", ""}))
+	utils.SetConfirmPrompt(func(_ string, _ bool) bool { return false })
+
+	req, err := promptForCreateServiceKeyDetails(true)
+	assert.NoError(t, err)
+	if assert.NotNil(t, req) {
+		assert.Empty(t, req.ProductUID)
+		assert.Equal(t, 77, req.ProductID)
+	}
+}
+
+func TestPromptForCreateServiceKeyDetails_InvalidMaxSpeed(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	originalConfirm := utils.GetConfirmPrompt()
+	defer func() {
+		utils.SetResourcePrompt(originalPrompt)
+		utils.SetConfirmPrompt(originalConfirm)
+	}()
+
+	utils.SetResourcePrompt(mockServiceKeyPromptSequence([]string{"prod-uid", "not-a-number"}))
+	utils.SetConfirmPrompt(func(_ string, _ bool) bool { return false })
+
+	_, err := promptForCreateServiceKeyDetails(true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not a valid whole number")
+}
+
+func TestPromptForCreateServiceKeyDetails_InvalidDateRange(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	originalConfirm := utils.GetConfirmPrompt()
+	defer func() {
+		utils.SetResourcePrompt(originalPrompt)
+		utils.SetConfirmPrompt(originalConfirm)
+	}()
+
+	// productUID, maxSpeed(skip), description(skip), startDate, endDate (end before start).
+	utils.SetResourcePrompt(mockServiceKeyPromptSequence([]string{
+		"prod-uid", "", "", "2025-12-31", "2025-01-01",
+	}))
+	utils.SetConfirmPrompt(func(_ string, _ bool) bool { return false })
+
+	_, err := promptForCreateServiceKeyDetails(true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "end date must be after start date")
+}
+
+func TestPromptForCreateServiceKeyDetails_InvalidVLAN(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	originalConfirm := utils.GetConfirmPrompt()
+	defer func() {
+		utils.SetResourcePrompt(originalPrompt)
+		utils.SetConfirmPrompt(originalConfirm)
+	}()
+
+	// productUID, maxSpeed(skip), description(skip), startDate(skip), endDate(skip), vlan.
+	utils.SetResourcePrompt(mockServiceKeyPromptSequence([]string{
+		"prod-uid", "", "", "", "", "not-a-number",
+	}))
+	utils.SetConfirmPrompt(func(_ string, _ bool) bool { return false })
+
+	_, err := promptForCreateServiceKeyDetails(true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not a valid whole number")
+}
+
+func TestPromptForUpdateServiceKeyDetails_ProductUIDPromptError(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(originalPrompt)
+
+	utils.SetResourcePrompt(mockServiceKeyPromptSequence(nil))
+
+	current := &megaport.ServiceKey{ProductUID: "current-prod-uid"}
+	_, err := promptForUpdateServiceKeyDetails("key-123", current, true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected prompt call")
+}
+
+func TestPromptForUpdateServiceKeyDetails_InvalidProductID(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(originalPrompt)
+
+	// productUID empty enters the product ID prompt, which fails to parse.
+	utils.SetResourcePrompt(mockServiceKeyPromptSequence([]string{"", "not-a-number"}))
+
+	current := &megaport.ServiceKey{ProductUID: "current-prod-uid"}
+	_, err := promptForUpdateServiceKeyDetails("key-123", current, true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not a valid whole number")
+}
+
+func TestPromptForUpdateServiceKeyDetails_SingleUseAnsPromptError(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(originalPrompt)
+
+	// productUID skip, single-use answer prompt fails.
+	utils.SetResourcePrompt(mockServiceKeyPromptSequence([]string{"new-prod-uid"}))
+
+	current := &megaport.ServiceKey{ProductUID: "current-prod-uid"}
+	_, err := promptForUpdateServiceKeyDetails("key-123", current, true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected prompt call")
+}
+
+func TestPromptForUpdateServiceKeyDetails_ActiveAnsPromptError(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer utils.SetResourcePrompt(originalPrompt)
+
+	// productUID, single-use answer skip, active answer prompt fails.
+	utils.SetResourcePrompt(mockServiceKeyPromptSequence([]string{"new-prod-uid", "no"}))
+
+	current := &megaport.ServiceKey{ProductUID: "current-prod-uid"}
+	_, err := promptForUpdateServiceKeyDetails("key-123", current, true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected prompt call")
+}

--- a/internal/commands/servicekeys/servicekeys_test.go
+++ b/internal/commands/servicekeys/servicekeys_test.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/megaport/megaport-cli/internal/base/output"
 	megaport "github.com/megaport/megaportgo"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var mockServiceKeys = []*megaport.ServiceKey{
@@ -230,6 +232,25 @@ func TestServiceKeyOutput_CSV(t *testing.T) {
 
 func boolPtr(b bool) *bool {
 	return &b
+}
+
+func TestAddCommandsTo_InputModeFlags(t *testing.T) {
+	root := &cobra.Command{Use: "megaport-cli"}
+	AddCommandsTo(root)
+
+	createCmd, _, err := root.Find([]string{"servicekeys", "create"})
+	require.NoError(t, err)
+	require.NotNil(t, createCmd)
+	assert.NotNil(t, createCmd.Flags().Lookup("interactive"))
+	assert.NotNil(t, createCmd.Flags().Lookup("json"))
+	assert.NotNil(t, createCmd.Flags().Lookup("json-file"))
+
+	updateCmd, _, err := root.Find([]string{"servicekeys", "update"})
+	require.NoError(t, err)
+	require.NotNil(t, updateCmd)
+	assert.NotNil(t, updateCmd.Flags().Lookup("interactive"))
+	assert.NotNil(t, updateCmd.Flags().Lookup("json"))
+	assert.NotNil(t, updateCmd.Flags().Lookup("json-file"))
 }
 
 func init() {


### PR DESCRIPTION
servicekeys create and update only supported CLI flags, unlike every other mutating command in the CLI. This adds --json/--json-file and --interactive support to both, matching the rest of the CLI's input-mode contract.

- Reuses the existing validation for both commands
- Preserves the update merge behavior (unset fields keep their current value rather than being cleared) across all three input modes
- Regenerates the CLI docs for the new flags
- Discards a raw validFor key in JSON input so it can't bypass startDate/endDate validation

ESD-1591