### PR TITLE
ESD-1552-fix(mcr): wire --marketplace-visibility into mcr buy and validate

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Megaport CLI Documentation
 
-> Generated on July 7, 2026 for version v1.0.0-beta.1
+> Generated on July 8, 2026 for version v1.0.0-beta.1
 
 ## Available Commands
 

--- a/docs/megaport-cli_mcr_buy.md
+++ b/docs/megaport-cli_mcr_buy.md
@@ -31,13 +31,14 @@ This command allows you to purchase an MCR by providing the necessary details.
   - Resource tags allow you to categorize resources for organization and billing purposes
   - Required flags (name, term, port-speed, location-id, marketplace-visibility) can be skipped when using --interactive, --json, or --json-file
   - IPSec add-on (--ipsec-tunnel-count) is not prompted in interactive mode; use --ipsec-tunnel-count flag or include 'tunnelCount' in the JSON input
+  - Use --marketplace-visibility=true or --marketplace-visibility=false (with an equals sign); a space-separated value is not consumed by the flag and is rejected as an unexpected argument
 
 ### Example Usage
 
 ```sh
   megaport-cli mcr buy --interactive
-  megaport-cli mcr buy --name "My MCR" --term 12 --port-speed 5000 --location-id 123 --marketplace-visibility true --mcr-asn 65000
-  megaport-cli mcr buy --name "My MCR" --term 12 --port-speed 5000 --location-id 123 --marketplace-visibility true --resource-tags '{"env":"prod","owner":"network-team"}'
+  megaport-cli mcr buy --name "My MCR" --term 12 --port-speed 5000 --location-id 123 --marketplace-visibility=true --mcr-asn 65000
+  megaport-cli mcr buy --name "My MCR" --term 12 --port-speed 5000 --location-id 123 --marketplace-visibility=true --resource-tags '{"env":"prod","owner":"network-team"}'
   megaport-cli mcr buy --json '{"name":"My MCR","term":12,"portSpeed":5000,"locationId":123,"mcrAsn":65000,"marketplaceVisibility":true}'
   megaport-cli mcr buy --json-file ./mcr-config.json
 ```
@@ -86,7 +87,7 @@ megaport-cli mcr buy [flags]
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |
 | `--location-id` |  | `0` | The ID of the location where the MCR will be provisioned | true |
-| `--marketplace-visibility` |  |  | Whether the MCR should be visible in the marketplace (true or false) | true |
+| `--marketplace-visibility` |  | `false` | Whether the MCR should be visible in the marketplace (true or false) | true |
 | `--mcr-asn` |  | `0` | The ASN for the MCR (64512-65534 for private ASN, or a public ASN) | false |
 | `--name` |  |  | The name of the MCR (1-64 characters) | true |
 | `--no-wait` |  | `false` | Do not wait for provisioning to complete | false |

--- a/docs/megaport-cli_mcr_validate.md
+++ b/docs/megaport-cli_mcr_validate.md
@@ -25,11 +25,12 @@ Use this for dry-run validation before purchasing, or in CI pipelines to check c
 
 ### Important Notes
   - This command only validates the configuration — no resources are created and no charges are incurred
+  - Use --marketplace-visibility=true or --marketplace-visibility=false (with an equals sign); a space-separated value is not consumed by the flag and is rejected as an unexpected argument
 
 ### Example Usage
 
 ```sh
-  megaport-cli mcr validate --name "My MCR" --term 12 --port-speed 5000 --location-id 123 --marketplace-visibility true
+  megaport-cli mcr validate --name "My MCR" --term 12 --port-speed 5000 --location-id 123 --marketplace-visibility=true
   megaport-cli mcr validate --json-file ./mcr-config.json
 ```
 
@@ -53,7 +54,7 @@ megaport-cli mcr validate [flags]
 | `--json` |  |  | JSON string containing configuration | false |
 | `--json-file` |  |  | Path to JSON file containing configuration | false |
 | `--location-id` |  | `0` | The ID of the location where the MCR will be provisioned | true |
-| `--marketplace-visibility` |  |  | Whether the MCR should be visible in the marketplace (true or false) | true |
+| `--marketplace-visibility` |  | `false` | Whether the MCR should be visible in the marketplace (true or false) | true |
 | `--mcr-asn` |  | `0` | The ASN for the MCR (64512-65534 for private ASN, or a public ASN) | false |
 | `--name` |  |  | The name of the MCR (1-64 characters) | true |
 | `--port-speed` |  | `0` | The speed of the MCR (1000, 2500, 5000, 10000, 25000, 50000, or 100000 Mbps) | true |

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/jedib0t/go-pretty/v6 v6.8.2
 	github.com/jmespath/go-jmespath v0.4.0
-	github.com/megaport/megaportgo v1.14.1
+	github.com/megaport/megaportgo v1.15.0
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.17 h1:78v8ZlW0bP43XfmAfPsdXcoNCelfMHsDmd/pkENfrjQ=
 github.com/mattn/go-runewidth v0.0.17/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/megaport/megaportgo v1.14.1 h1:yhR4MFLyWyF29HTUCKZaujaCUgZBcrqUYlFkNEz/SuU=
-github.com/megaport/megaportgo v1.14.1/go.mod h1:dF1MxT8/kD6FWb4/ojrklWinIUp5exn8v8xYJVUB3Zc=
+github.com/megaport/megaportgo v1.15.0 h1:e1l/0lJcr0RQ1kPdEeLuBHPGbvjgXUa1FAeFkc8K4mE=
+github.com/megaport/megaportgo v1.15.0/go.mod h1:dF1MxT8/kD6FWb4/ojrklWinIUp5exn8v8xYJVUB3Zc=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=

--- a/internal/base/cmdbuilder/flagsets_test.go
+++ b/internal/base/cmdbuilder/flagsets_test.go
@@ -221,6 +221,20 @@ func TestWithMCRCreateFlags(t *testing.T) {
 		f := cmd.Flags().Lookup(flag)
 		assert.NotNil(t, f, "MCR creation flag %q should exist", flag)
 	}
+
+	expectedTypes := map[string]string{
+		"term":                   "int",
+		"port-speed":             "int",
+		"location-id":            "int",
+		"mcr-asn":                "int",
+		"marketplace-visibility": "bool",
+	}
+	for name, expectedType := range expectedTypes {
+		f := cmd.Flags().Lookup(name)
+		if f != nil {
+			assert.Equal(t, expectedType, f.Value.Type(), "MCR creation flag %q type", name)
+		}
+	}
 }
 
 func TestWithVXCCreateFlags(t *testing.T) {

--- a/internal/base/cmdbuilder/mcr_flagsets.go
+++ b/internal/base/cmdbuilder/mcr_flagsets.go
@@ -18,7 +18,7 @@ func (b *CommandBuilder) WithMCRCreateFlags() *CommandBuilder {
 		WithOptionalFlag("diversity-zone", "The diversity zone for the MCR").
 		WithFlag("cost-centre", "", "The cost centre for billing purposes").
 		WithOptionalFlag("cost-centre", "The cost centre for billing purposes").
-		WithFlag("marketplace-visibility", "", "Whether the MCR is visible in the marketplace (true/false)").
+		WithBoolFlag("marketplace-visibility", false, "Whether the MCR is visible in the marketplace (true/false)").
 		WithFlag("promo-code", "", "A promotional code for discounts").
 		WithOptionalFlag("promo-code", "A promotional code for discounts").WithResourceTagFlags()
 	return b

--- a/internal/commands/mcr/mcr.go
+++ b/internal/commands/mcr/mcr.go
@@ -62,6 +62,7 @@ func buildMCRCommands(rootCmd *cobra.Command) (get, buy, update, del, restore, l
 
 	// Create buy MCR command
 	buy = cmdbuilder.NewCommand("buy", "Buy an MCR through the Megaport API").
+		WithArgs(cobra.NoArgs).
 		WithColorAwareRunFunc(BuyMCR).
 		WithNoWaitFlag().
 		WithBuyConfirmFlags().
@@ -220,6 +221,7 @@ func buildMCRCommands(rootCmd *cobra.Command) (get, buy, update, del, restore, l
 		Build()
 
 	validate = cmdbuilder.NewCommand("validate", "Validate an MCR order without purchasing").
+		WithArgs(cobra.NoArgs).
 		WithColorAwareRunFunc(ValidateMCR).
 		WithMCRCreateFlags().
 		WithStandardInputFlags().

--- a/internal/commands/mcr/mcr.go
+++ b/internal/commands/mcr/mcr.go
@@ -82,8 +82,8 @@ func buildMCRCommands(rootCmd *cobra.Command) (get, buy, update, del, restore, l
 		WithIntFlag("ipsec-tunnel-count", 0, "IPSec tunnel count for an add-on (10, 20, or 30)").
 		WithOptionalFlag("ipsec-tunnel-count", "IPSec tunnel count for an add-on (10, 20, or 30); omit to skip IPSec; set to 0 to include with API default (10)").
 		WithExample("megaport-cli mcr buy --interactive").
-		WithExample("megaport-cli mcr buy --name \"My MCR\" --term 12 --port-speed 5000 --location-id 123 --marketplace-visibility true --mcr-asn 65000").
-		WithExample("megaport-cli mcr buy --name \"My MCR\" --term 12 --port-speed 5000 --location-id 123 --marketplace-visibility true --resource-tags '{\"env\":\"prod\",\"owner\":\"network-team\"}'").
+		WithExample("megaport-cli mcr buy --name \"My MCR\" --term 12 --port-speed 5000 --location-id 123 --marketplace-visibility=true --mcr-asn 65000").
+		WithExample("megaport-cli mcr buy --name \"My MCR\" --term 12 --port-speed 5000 --location-id 123 --marketplace-visibility=true --resource-tags '{\"env\":\"prod\",\"owner\":\"network-team\"}'").
 		WithExample("megaport-cli mcr buy --json '{\"name\":\"My MCR\",\"term\":12,\"portSpeed\":5000,\"locationId\":123,\"mcrAsn\":65000,\"marketplaceVisibility\":true}'").
 		WithExample("megaport-cli mcr buy --json-file ./mcr-config.json").
 		WithJSONExample(`{
@@ -110,6 +110,7 @@ func buildMCRCommands(rootCmd *cobra.Command) (get, buy, update, del, restore, l
 		WithImportantNote("Resource tags allow you to categorize resources for organization and billing purposes").
 		WithImportantNote("Required flags (name, term, port-speed, location-id, marketplace-visibility) can be skipped when using --interactive, --json, or --json-file").
 		WithImportantNote("IPSec add-on (--ipsec-tunnel-count) is not prompted in interactive mode; use --ipsec-tunnel-count flag or include 'tunnelCount' in the JSON input").
+		WithImportantNote("Use --marketplace-visibility=true or --marketplace-visibility=false (with an equals sign); a space-separated value is not consumed by the flag and is rejected as an unexpected argument").
 		WithRootCmd(rootCmd).
 		WithConditionalRequirements("name", "term", "port-speed", "location-id", "marketplace-visibility").
 		Build()
@@ -231,9 +232,10 @@ func buildMCRCommands(rootCmd *cobra.Command) (get, buy, update, del, restore, l
 		WithDocumentedRequiredFlag("port-speed", "The speed of the MCR (1000, 2500, 5000, 10000, 25000, 50000, or 100000 Mbps)").
 		WithDocumentedRequiredFlag("location-id", "The ID of the location where the MCR will be provisioned").
 		WithDocumentedRequiredFlag("marketplace-visibility", "Whether the MCR should be visible in the marketplace (true or false)").
-		WithExample(`megaport-cli mcr validate --name "My MCR" --term 12 --port-speed 5000 --location-id 123 --marketplace-visibility true`).
+		WithExample(`megaport-cli mcr validate --name "My MCR" --term 12 --port-speed 5000 --location-id 123 --marketplace-visibility=true`).
 		WithExample("megaport-cli mcr validate --json-file ./mcr-config.json").
 		WithImportantNote("This command only validates the configuration — no resources are created and no charges are incurred").
+		WithImportantNote("Use --marketplace-visibility=true or --marketplace-visibility=false (with an equals sign); a space-separated value is not consumed by the flag and is rejected as an unexpected argument").
 		WithRootCmd(rootCmd).
 		WithConditionalRequirements("name", "term", "port-speed", "location-id", "marketplace-visibility").
 		Build()

--- a/internal/commands/mcr/mcr_actions_test.go
+++ b/internal/commands/mcr/mcr_actions_test.go
@@ -1061,6 +1061,7 @@ func TestBuyMCRCmd_WithMockClient(t *testing.T) {
 				"12",
 				"10000",
 				"123",
+				"true",
 				"65000",
 				"red",
 				"cost-123",
@@ -1076,14 +1077,15 @@ func TestBuyMCRCmd_WithMockClient(t *testing.T) {
 		{
 			name: "flag mode success",
 			flags: map[string]string{
-				"name":           "Flag MCR",
-				"term":           "12",
-				"port-speed":     "10000",
-				"location-id":    "123",
-				"mcr-asn":        "65000",
-				"diversity-zone": "blue",
-				"cost-centre":    "cost-456",
-				"promo-code":     "FLAGPROMO",
+				"name":                   "Flag MCR",
+				"term":                   "12",
+				"port-speed":             "10000",
+				"location-id":            "123",
+				"mcr-asn":                "65000",
+				"diversity-zone":         "blue",
+				"cost-centre":            "cost-456",
+				"promo-code":             "FLAGPROMO",
+				"marketplace-visibility": "true",
 			},
 			setupMock: func(m *MockMCRService) {
 				m.BuyMCRResult = &megaport.BuyMCRResponse{
@@ -1095,7 +1097,7 @@ func TestBuyMCRCmd_WithMockClient(t *testing.T) {
 		{
 			name: "JSON string mode success",
 			flags: map[string]string{
-				"json": `{"name":"JSON MCR","term":24,"portSpeed":10000,"locationId":123,"mcrAsn":65000,"diversityZone":"green","costCentre":"cost-789","promoCode":"JSONPROMO"}`,
+				"json": `{"name":"JSON MCR","term":24,"portSpeed":10000,"locationId":123,"mcrAsn":65000,"diversityZone":"green","costCentre":"cost-789","promoCode":"JSONPROMO","marketplaceVisibility":true}`,
 			},
 			setupMock: func(m *MockMCRService) {
 				m.BuyMCRResult = &megaport.BuyMCRResponse{
@@ -1231,6 +1233,7 @@ func TestBuyMCRCmd_WithMockClient(t *testing.T) {
 			cmd.Flags().String("diversity-zone", "", "Diversity zone for the MCR")
 			cmd.Flags().String("cost-centre", "", "Cost centre for billing")
 			cmd.Flags().String("promo-code", "", "Promotional code for discounts")
+			cmd.Flags().Bool("marketplace-visibility", false, "Whether the MCR is visible in the marketplace")
 			cmd.Flags().String("json", "", "JSON string containing MCR configuration")
 			cmd.Flags().String("json-file", "", "Path to JSON file containing MCR configuration")
 			cmd.Flags().Int("ipsec-tunnel-count", 0, "Number of IPsec tunnels to provision")
@@ -1274,6 +1277,8 @@ func TestBuyMCRCmd_WithMockClient(t *testing.T) {
 						assert.Equal(t, "green", req.DiversityZone)
 						assert.Equal(t, "cost-789", req.CostCentre)
 						assert.Equal(t, "JSONPROMO", req.PromoCode)
+						require.NotNil(t, req.MarketplaceVisibility)
+						assert.True(t, *req.MarketplaceVisibility)
 					} else if tt.flags != nil {
 						assert.Equal(t, "Flag MCR", req.Name)
 						assert.Equal(t, 12, req.Term)
@@ -1283,6 +1288,8 @@ func TestBuyMCRCmd_WithMockClient(t *testing.T) {
 						assert.Equal(t, "blue", req.DiversityZone)
 						assert.Equal(t, "cost-456", req.CostCentre)
 						assert.Equal(t, "FLAGPROMO", req.PromoCode)
+						require.NotNil(t, req.MarketplaceVisibility)
+						assert.True(t, *req.MarketplaceVisibility)
 					} else if len(tt.prompts) > 0 {
 						assert.Equal(t, "Test MCR", req.Name)
 						assert.Equal(t, 12, req.Term)
@@ -1292,6 +1299,8 @@ func TestBuyMCRCmd_WithMockClient(t *testing.T) {
 						assert.Equal(t, "red", req.DiversityZone)
 						assert.Equal(t, "cost-123", req.CostCentre)
 						assert.Equal(t, "MCRPROMO2025", req.PromoCode)
+						require.NotNil(t, req.MarketplaceVisibility)
+						assert.True(t, *req.MarketplaceVisibility)
 					}
 				}
 			}
@@ -3298,6 +3307,11 @@ func TestValidateMCR(t *testing.T) {
 				assert.NoError(t, err)
 				if tt.expectedContains != "" {
 					assert.Contains(t, capturedOutput, tt.expectedContains)
+				}
+				if tt.expectedContains == "validation passed" {
+					require.NotNil(t, mockService.CapturedValidateMCROrderRequest)
+					require.NotNil(t, mockService.CapturedValidateMCROrderRequest.MarketplaceVisibility)
+					assert.True(t, *mockService.CapturedValidateMCROrderRequest.MarketplaceVisibility)
 				}
 			}
 		})

--- a/internal/commands/mcr/mcr_inputs.go
+++ b/internal/commands/mcr/mcr_inputs.go
@@ -95,6 +95,11 @@ func processFlagMCRInput(cmd *cobra.Command) (*megaport.BuyMCRRequest, error) {
 		ResourceTags:  resourceTags,
 	}
 
+	if cmd.Flags().Changed("marketplace-visibility") {
+		marketplaceVisibility, _ := cmd.Flags().GetBool("marketplace-visibility")
+		req.MarketplaceVisibility = &marketplaceVisibility
+	}
+
 	if cmd.Flags().Changed("ipsec-tunnel-count") {
 		ipsecTunnelCount, _ := cmd.Flags().GetInt("ipsec-tunnel-count")
 		if ipsecTunnelCount < 0 {

--- a/internal/commands/mcr/mcr_inputs_test.go
+++ b/internal/commands/mcr/mcr_inputs_test.go
@@ -660,6 +660,33 @@ func TestProcessFlagMCRInput_IPSec(t *testing.T) {
 	})
 }
 
+func TestProcessFlagMCRInput_MarketplaceVisibilityUnsetWhenFlagAbsent(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("name", "test-mcr", "")
+	cmd.Flags().Int("term", 12, "")
+	cmd.Flags().Int("port-speed", 5000, "")
+	cmd.Flags().Int("location-id", 1, "")
+	cmd.Flags().Int("mcr-asn", 0, "")
+	cmd.Flags().Bool("marketplace-visibility", false, "")
+	cmd.Flags().String("cost-centre", "", "")
+	cmd.Flags().String("promo-code", "", "")
+	cmd.Flags().String("diversity-zone", "", "")
+	cmd.Flags().String("resource-tags", "", "")
+	cmd.Flags().Int("ipsec-tunnel-count", 0, "")
+
+	req, err := processFlagMCRInput(cmd)
+	assert.NoError(t, err)
+	require.NotNil(t, req)
+	assert.Nil(t, req.MarketplaceVisibility, "MarketplaceVisibility should remain nil when --marketplace-visibility flag is not provided, so the API applies its own default")
+}
+
+func TestProcessJSONMCRInput_MarketplaceVisibilityUnsetWhenKeyAbsent(t *testing.T) {
+	req, err := processJSONMCRInput(`{"name":"test","term":12,"portSpeed":5000,"locationId":1}`, "")
+	assert.NoError(t, err)
+	require.NotNil(t, req)
+	assert.Nil(t, req.MarketplaceVisibility, "MarketplaceVisibility should remain nil when marketplaceVisibility key is absent, so the API applies its own default")
+}
+
 func TestProcessJSONMCRInput_InvalidTunnelCount(t *testing.T) {
 	_, err := processJSONMCRInput(`{"name":"test","term":12,"portSpeed":5000,"locationId":1,"marketplaceVisibility":true,"tunnelCount":5}`, "")
 	assert.Error(t, err)

--- a/internal/commands/mcr/mcr_mock.go
+++ b/internal/commands/mcr/mcr_mock.go
@@ -12,6 +12,7 @@ type MockMCRService struct {
 	BuyMCRErr                             error
 	CapturedBuyMCRRequest                 *megaport.BuyMCRRequest
 	ValidateMCROrderErr                   error
+	CapturedValidateMCROrderRequest       *megaport.BuyMCRRequest
 	GetMCRResult                          *megaport.MCR
 	GetMCRErr                             error
 	ListMCRsResult                        []*megaport.MCR
@@ -74,6 +75,7 @@ func (m *MockMCRService) BuyMCR(ctx context.Context, req *megaport.BuyMCRRequest
 }
 
 func (m *MockMCRService) ValidateMCROrder(ctx context.Context, req *megaport.BuyMCRRequest) error {
+	m.CapturedValidateMCROrderRequest = req
 	return m.ValidateMCROrderErr
 }
 
@@ -283,11 +285,36 @@ func (m *MockMCRLookingGlassService) WaitForAsyncBGPNeighborRoutes(ctx context.C
 	return nil, nil
 }
 
+func (m *MockMCRLookingGlassService) PingMCR(ctx context.Context, req *megaport.MCRPingRequest) (string, error) {
+	return "", nil
+}
+
+func (m *MockMCRLookingGlassService) TracerouteMCR(ctx context.Context, req *megaport.MCRTracerouteRequest) (string, error) {
+	return "", nil
+}
+
+func (m *MockMCRLookingGlassService) GetMCRPingResult(ctx context.Context, mcrUID, operationID string) (*megaport.LookingGlassPingResult, error) {
+	return nil, nil
+}
+
+func (m *MockMCRLookingGlassService) GetMCRTracerouteResult(ctx context.Context, mcrUID, operationID string) (*megaport.LookingGlassTracerouteResult, error) {
+	return nil, nil
+}
+
+func (m *MockMCRLookingGlassService) WaitForMCRPing(ctx context.Context, mcrUID, operationID string) (*megaport.LookingGlassPingResult, error) {
+	return nil, nil
+}
+
+func (m *MockMCRLookingGlassService) WaitForMCRTraceroute(ctx context.Context, mcrUID, operationID string) (*megaport.LookingGlassTracerouteResult, error) {
+	return nil, nil
+}
+
 func (m *MockMCRService) Reset() {
 	m.BuyMCRResult = nil
 	m.BuyMCRErr = nil
 	m.CapturedBuyMCRRequest = nil
 	m.ValidateMCROrderErr = nil
+	m.CapturedValidateMCROrderRequest = nil
 	m.GetMCRResult = nil
 	m.GetMCRErr = nil
 	m.ListMCRsResult = nil

--- a/internal/commands/mcr/mcr_prompts.go
+++ b/internal/commands/mcr/mcr_prompts.go
@@ -185,6 +185,15 @@ func promptForMCRDetails(noColor bool) (*megaport.BuyMCRRequest, error) {
 		return nil, err
 	}
 
+	marketplaceVisibilityStr, err := utils.ResourcePrompt("mcr", "Enter marketplace visibility (true/false) (required): ", noColor)
+	if err != nil {
+		return nil, err
+	}
+	marketplaceVisibility, err := strconv.ParseBool(marketplaceVisibilityStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid marketplace visibility, must be true or false")
+	}
+
 	asnStr, err := utils.ResourcePrompt("mcr", "Enter MCR ASN (optional): ", noColor)
 	if err != nil {
 		return nil, err
@@ -220,15 +229,16 @@ func promptForMCRDetails(noColor bool) (*megaport.BuyMCRRequest, error) {
 	}
 
 	req := &megaport.BuyMCRRequest{
-		Name:          name,
-		Term:          term,
-		PortSpeed:     portSpeed,
-		LocationID:    locationID,
-		MCRAsn:        asn,
-		DiversityZone: diversityZone,
-		CostCentre:    costCentre,
-		PromoCode:     promoCode,
-		ResourceTags:  resourceTags,
+		Name:                  name,
+		Term:                  term,
+		PortSpeed:             portSpeed,
+		LocationID:            locationID,
+		MCRAsn:                asn,
+		DiversityZone:         diversityZone,
+		CostCentre:            costCentre,
+		PromoCode:             promoCode,
+		ResourceTags:          resourceTags,
+		MarketplaceVisibility: &marketplaceVisibility,
 	}
 
 	if err := validation.ValidateMCRRequest(req); err != nil {

--- a/internal/commands/mcr/mcr_prompts_test.go
+++ b/internal/commands/mcr/mcr_prompts_test.go
@@ -31,9 +31,9 @@ func TestPromptForMCRDetails_Success(t *testing.T) {
 		utils.SetResourceTagsPrompt(originalTagsPrompt)
 	}()
 
-	// name, term, portSpeed, locationID, asn, diversityZone, costCentre, promoCode
+	// name, term, portSpeed, locationID, marketplaceVisibility, asn, diversityZone, costCentre, promoCode
 	utils.SetResourcePrompt(mockPromptSequence([]string{
-		"Test MCR", "12", "5000", "1", "65000", "blue", "IT-2024", "PROMO",
+		"Test MCR", "12", "5000", "1", "true", "65000", "blue", "IT-2024", "PROMO",
 	}))
 	utils.SetResourceTagsPrompt(func(noColor bool) (map[string]string, error) {
 		return map[string]string{"env": "test"}, nil
@@ -45,6 +45,8 @@ func TestPromptForMCRDetails_Success(t *testing.T) {
 	assert.Equal(t, 12, req.Term)
 	assert.Equal(t, 5000, req.PortSpeed)
 	assert.Equal(t, 1, req.LocationID)
+	require.NotNil(t, req.MarketplaceVisibility)
+	assert.True(t, *req.MarketplaceVisibility)
 	assert.Equal(t, 65000, req.MCRAsn)
 	assert.Equal(t, "blue", req.DiversityZone)
 	assert.Equal(t, "IT-2024", req.CostCentre)
@@ -106,11 +108,22 @@ func TestPromptForMCRDetails_InvalidPortSpeedNotNumeric(t *testing.T) {
 	assert.NotContains(t, err.Error(), "strconv")
 }
 
+func TestPromptForMCRDetails_InvalidMarketplaceVisibility(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+	utils.SetResourcePrompt(mockPromptSequence([]string{"MCR", "12", "5000", "1", "maybe"}))
+
+	_, err := promptForMCRDetails(true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid marketplace visibility, must be true or false")
+}
+
 func TestPromptForMCRDetails_InvalidASN(t *testing.T) {
 	originalPrompt := utils.GetResourcePrompt()
 	defer func() { utils.SetResourcePrompt(originalPrompt) }()
 
-	utils.SetResourcePrompt(mockPromptSequence([]string{"MCR", "12", "5000", "1", "abc"}))
+	utils.SetResourcePrompt(mockPromptSequence([]string{"MCR", "12", "5000", "1", "true", "abc"}))
 
 	_, err := promptForMCRDetails(true)
 	assert.Error(t, err)

--- a/internal/commands/mcr/mcr_prompts_test.go
+++ b/internal/commands/mcr/mcr_prompts_test.go
@@ -96,6 +96,27 @@ func TestPromptForMCRDetails_InvalidLocationID(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid location ID")
 }
 
+func TestPromptForMCRDetails_MarketplaceVisibilityPromptError(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+	// name, term, portSpeed, locationID succeed; marketplaceVisibility prompt (5th) fails.
+	idx := 0
+	responses := []string{"MCR", "12", "5000", "1"}
+	utils.SetResourcePrompt(func(resourceType, msg string, noColor bool) (string, error) {
+		if idx >= len(responses) {
+			return "", fmt.Errorf("prompt failure on marketplace visibility")
+		}
+		val := responses[idx]
+		idx++
+		return val, nil
+	})
+
+	_, err := promptForMCRDetails(true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "prompt failure on marketplace visibility")
+}
+
 func TestPromptForMCRDetails_InvalidPortSpeedNotNumeric(t *testing.T) {
 	originalPrompt := utils.GetResourcePrompt()
 	defer func() { utils.SetResourcePrompt(originalPrompt) }()

--- a/internal/commands/mcr/mcr_test.go
+++ b/internal/commands/mcr/mcr_test.go
@@ -382,6 +382,18 @@ func TestMCRListHasTagFlag(t *testing.T) {
 	require.NotNil(t, list.Flags().Lookup("tag"), "list command should have --tag flag")
 }
 
+func TestMCRBuyAndValidateRejectPositionalArgs(t *testing.T) {
+	_, buy, _, _, _, _, _, _, _, validate := buildMCRCommands(nil)
+
+	require.NotNil(t, buy.Args, "buy command should restrict positional args")
+	assert.Error(t, buy.Args(buy, []string{"false"}),
+		"buy should reject a stray positional arg, e.g. from --marketplace-visibility false being parsed as --marketplace-visibility=true plus a bare \"false\" token")
+
+	require.NotNil(t, validate.Args, "validate command should restrict positional args")
+	assert.Error(t, validate.Args(validate, []string{"false"}),
+		"validate should reject a stray positional arg, e.g. from --marketplace-visibility false being parsed as --marketplace-visibility=true plus a bare \"false\" token")
+}
+
 func TestMCRModule(t *testing.T) {
 	m := NewModule()
 	assert.Equal(t, "mcr", m.Name())


### PR DESCRIPTION
`mcr buy` and `mcr validate` marked `--marketplace-visibility` as required, then threw the value away — the buy/validate request builders never read it. Bumps `megaportgo` to v1.15.0, which adds the field to `BuyMCRRequest`, and wires the flag through.

- Wire the flag/JSON/interactive value into the buy and validate requests
- Leave the field nil when not provided, so the API applies its own default (matches port behavior)
- Fix the flag's type (was a dead string flag, now a real bool flag)
- Add `WithArgs(cobra.NoArgs)` to buy/validate — a Cobra bool flag has no way to consume a space-separated value, so `--marketplace-visibility false` was silently parsing as `true`; this makes that loudly fail instead. Examples/docs now use `--marketplace-visibility=true` syntax.
- Add unit test coverage across all three input modes, including the omitted-flag/omitted-key case

ESD-1552