### PR TITLE
ESD-1615: add matrix-aware NAT gateway speed/session validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/jedib0t/go-pretty/v6 v6.8.2
 	github.com/jmespath/go-jmespath v0.4.0
-	github.com/megaport/megaportgo v1.14.1
+	github.com/megaport/megaportgo v1.15.0
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.17 h1:78v8ZlW0bP43XfmAfPsdXcoNCelfMHsDmd/pkENfrjQ=
 github.com/mattn/go-runewidth v0.0.17/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/megaport/megaportgo v1.14.1 h1:yhR4MFLyWyF29HTUCKZaujaCUgZBcrqUYlFkNEz/SuU=
-github.com/megaport/megaportgo v1.14.1/go.mod h1:dF1MxT8/kD6FWb4/ojrklWinIUp5exn8v8xYJVUB3Zc=
+github.com/megaport/megaportgo v1.15.0 h1:e1l/0lJcr0RQ1kPdEeLuBHPGbvjgXUa1FAeFkc8K4mE=
+github.com/megaport/megaportgo v1.15.0/go.mod h1:dF1MxT8/kD6FWb4/ojrklWinIUp5exn8v8xYJVUB3Zc=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=

--- a/internal/commands/mcr/mcr_mock.go
+++ b/internal/commands/mcr/mcr_mock.go
@@ -283,6 +283,30 @@ func (m *MockMCRLookingGlassService) WaitForAsyncBGPNeighborRoutes(ctx context.C
 	return nil, nil
 }
 
+func (m *MockMCRLookingGlassService) PingMCR(ctx context.Context, req *megaport.MCRPingRequest) (string, error) {
+	return "", nil
+}
+
+func (m *MockMCRLookingGlassService) TracerouteMCR(ctx context.Context, req *megaport.MCRTracerouteRequest) (string, error) {
+	return "", nil
+}
+
+func (m *MockMCRLookingGlassService) GetMCRPingResult(ctx context.Context, mcrUID, operationID string) (*megaport.LookingGlassPingResult, error) {
+	return nil, nil
+}
+
+func (m *MockMCRLookingGlassService) GetMCRTracerouteResult(ctx context.Context, mcrUID, operationID string) (*megaport.LookingGlassTracerouteResult, error) {
+	return nil, nil
+}
+
+func (m *MockMCRLookingGlassService) WaitForMCRPing(ctx context.Context, mcrUID, operationID string) (*megaport.LookingGlassPingResult, error) {
+	return nil, nil
+}
+
+func (m *MockMCRLookingGlassService) WaitForMCRTraceroute(ctx context.Context, mcrUID, operationID string) (*megaport.LookingGlassTracerouteResult, error) {
+	return nil, nil
+}
+
 func (m *MockMCRService) Reset() {
 	m.BuyMCRResult = nil
 	m.BuyMCRErr = nil

--- a/internal/commands/nat_gateway/nat_gateway_actions.go
+++ b/internal/commands/nat_gateway/nat_gateway_actions.go
@@ -128,6 +128,9 @@ func validateNATGatewaySpeedSessionMatrix(ctx context.Context, client *megaport.
 	if !result.SpeedSupported {
 		return validation.NewValidationError("speed", req.Speed, fmt.Sprintf("not supported; supported speeds (Mbps): %v", result.SupportedSpeeds))
 	}
+	if req.Config.SessionCount == 0 {
+		return nil
+	}
 	return validation.NewValidationError("session count", req.Config.SessionCount,
 		fmt.Sprintf("not supported for %d Mbps; valid session counts: %v", req.Speed, result.SessionsAtSpeed))
 }

--- a/internal/commands/nat_gateway/nat_gateway_actions.go
+++ b/internal/commands/nat_gateway/nat_gateway_actions.go
@@ -61,6 +61,11 @@ func CreateNATGateway(cmd *cobra.Command, args []string, noColor bool) error {
 		return err
 	}
 
+	if err := validateNATGatewaySpeedSessionMatrix(ctx, client, req, noColor); err != nil {
+		output.PrintError("Validation failed: %v", noColor, err)
+		return err
+	}
+
 	if !yes && jsonStr == "" && jsonFile == "" {
 		details := []utils.BuyConfirmDetail{
 			{Key: "Name", Value: req.ProductName},
@@ -99,6 +104,32 @@ func CreateNATGateway(cmd *cobra.Command, args []string, noColor bool) error {
 
 	output.PrintResourceCreated("NAT Gateway", gw.ProductUID, noColor)
 	return nil
+}
+
+// validateNATGatewaySpeedSessionMatrix rejects a speed/session-count pair
+// that the live NAT Gateway availability matrix does not support. A matrix
+// fetch failure or an empty matrix is treated as non-fatal (fail open): the
+// API still enforces the same rule at order time, matching the Terraform
+// provider's handling.
+func validateNATGatewaySpeedSessionMatrix(ctx context.Context, client *megaport.Client, req *megaport.CreateNATGatewayRequest, noColor bool) error {
+	matrix, err := listNATGatewaySessionsFunc(ctx, client)
+	if err != nil {
+		output.PrintWarning("Could not validate speed/session count against the availability matrix: %v", noColor, err)
+		return nil
+	}
+	if len(matrix) == 0 {
+		return nil
+	}
+
+	result := megaport.NATGatewaySpeedSessionSupported(matrix, req.Speed, req.Config.SessionCount)
+	if result.Supported {
+		return nil
+	}
+	if !result.SpeedSupported {
+		return validation.NewValidationError("speed", req.Speed, fmt.Sprintf("not supported; supported speeds (Mbps): %v", result.SupportedSpeeds))
+	}
+	return validation.NewValidationError("session count", req.Config.SessionCount,
+		fmt.Sprintf("not supported for %d Mbps; valid session counts: %v", req.Speed, result.SessionsAtSpeed))
 }
 
 // GetNATGateway handles the nat-gateway get command.

--- a/internal/commands/nat_gateway/nat_gateway_test.go
+++ b/internal/commands/nat_gateway/nat_gateway_test.go
@@ -234,6 +234,27 @@ func TestCreateNATGateway_MatrixFetchFailureFallsThrough(t *testing.T) {
 	require.NotNil(t, mock.CapturedCreateReq)
 }
 
+func TestCreateNATGateway_MatrixBypassesSessionCountZero(t *testing.T) {
+	mock := &MockNATGatewayService{
+		SessionsResult: []*megaport.NATGatewaySession{
+			{SpeedMbps: 1000, SessionCount: []int{1, 2, 4}},
+		},
+	}
+	defer setupMockNATGateway(mock)()
+
+	cmd := newTestCmd("create")
+	require.NoError(t, cmd.Flags().Set("name", "My NAT GW"))
+	require.NoError(t, cmd.Flags().Set("term", "12"))
+	require.NoError(t, cmd.Flags().Set("speed", "1000"))
+	require.NoError(t, cmd.Flags().Set("location-id", "123"))
+	require.NoError(t, cmd.Flags().Set("yes", "true"))
+
+	err := CreateNATGateway(cmd, nil, true)
+	assert.NoError(t, err)
+	require.NotNil(t, mock.CapturedCreateReq)
+	assert.Equal(t, 0, mock.CapturedCreateReq.Config.SessionCount)
+}
+
 // ---- Get ----
 
 func TestGetNATGateway(t *testing.T) {

--- a/internal/commands/nat_gateway/nat_gateway_test.go
+++ b/internal/commands/nat_gateway/nat_gateway_test.go
@@ -152,6 +152,88 @@ func TestCreateNATGateway_LoginError(t *testing.T) {
 	assert.Contains(t, err.Error(), "auth failed")
 }
 
+func TestCreateNATGateway_MatrixRejectsUnsupportedSpeed(t *testing.T) {
+	mock := &MockNATGatewayService{
+		SessionsResult: []*megaport.NATGatewaySession{
+			{SpeedMbps: 1000, SessionCount: []int{1, 2, 4}},
+		},
+	}
+	defer setupMockNATGateway(mock)()
+
+	cmd := newTestCmd("create")
+	require.NoError(t, cmd.Flags().Set("name", "My NAT GW"))
+	require.NoError(t, cmd.Flags().Set("term", "12"))
+	require.NoError(t, cmd.Flags().Set("speed", "5000"))
+	require.NoError(t, cmd.Flags().Set("location-id", "123"))
+	require.NoError(t, cmd.Flags().Set("yes", "true"))
+
+	err := CreateNATGateway(cmd, nil, true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "speed")
+	assert.Contains(t, err.Error(), "1000")
+	assert.Nil(t, mock.CapturedCreateReq)
+}
+
+func TestCreateNATGateway_MatrixRejectsUnsupportedSessionCount(t *testing.T) {
+	mock := &MockNATGatewayService{
+		SessionsResult: []*megaport.NATGatewaySession{
+			{SpeedMbps: 1000, SessionCount: []int{1, 2, 4}},
+		},
+	}
+	defer setupMockNATGateway(mock)()
+
+	cmd := newTestCmd("create")
+	require.NoError(t, cmd.Flags().Set("name", "My NAT GW"))
+	require.NoError(t, cmd.Flags().Set("term", "12"))
+	require.NoError(t, cmd.Flags().Set("speed", "1000"))
+	require.NoError(t, cmd.Flags().Set("location-id", "123"))
+	require.NoError(t, cmd.Flags().Set("session-count", "3"))
+	require.NoError(t, cmd.Flags().Set("yes", "true"))
+
+	err := CreateNATGateway(cmd, nil, true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "session count")
+	assert.Contains(t, err.Error(), "[1 2 4]")
+	assert.Nil(t, mock.CapturedCreateReq)
+}
+
+func TestCreateNATGateway_MatrixAllowsSupportedPair(t *testing.T) {
+	mock := &MockNATGatewayService{
+		SessionsResult: []*megaport.NATGatewaySession{
+			{SpeedMbps: 1000, SessionCount: []int{1, 2, 4}},
+		},
+	}
+	defer setupMockNATGateway(mock)()
+
+	cmd := newTestCmd("create")
+	require.NoError(t, cmd.Flags().Set("name", "My NAT GW"))
+	require.NoError(t, cmd.Flags().Set("term", "12"))
+	require.NoError(t, cmd.Flags().Set("speed", "1000"))
+	require.NoError(t, cmd.Flags().Set("location-id", "123"))
+	require.NoError(t, cmd.Flags().Set("session-count", "2"))
+	require.NoError(t, cmd.Flags().Set("yes", "true"))
+
+	err := CreateNATGateway(cmd, nil, true)
+	assert.NoError(t, err)
+	require.NotNil(t, mock.CapturedCreateReq)
+}
+
+func TestCreateNATGateway_MatrixFetchFailureFallsThrough(t *testing.T) {
+	mock := &MockNATGatewayService{SessionsErr: fmt.Errorf("matrix unavailable")}
+	defer setupMockNATGateway(mock)()
+
+	cmd := newTestCmd("create")
+	require.NoError(t, cmd.Flags().Set("name", "My NAT GW"))
+	require.NoError(t, cmd.Flags().Set("term", "12"))
+	require.NoError(t, cmd.Flags().Set("speed", "5000"))
+	require.NoError(t, cmd.Flags().Set("location-id", "123"))
+	require.NoError(t, cmd.Flags().Set("yes", "true"))
+
+	err := CreateNATGateway(cmd, nil, true)
+	assert.NoError(t, err)
+	require.NotNil(t, mock.CapturedCreateReq)
+}
+
 // ---- Get ----
 
 func TestGetNATGateway(t *testing.T) {


### PR DESCRIPTION
NAT gateway `create` only checked that speed and session count were positive, so an unsupported speed/session combination reached the API instead of failing pre-flight. This bumps `megaportgo` to v1.15.0 and uses its `NATGatewaySpeedSessionSupported` helper to check the pair against the live availability matrix before ordering, listing the valid speeds and session counts if it's rejected.

- Fetch the matrix via `ListNATGatewaySessions` and validate the requested speed/session pair against it in `nat-gateway create`
- Fail open on a matrix fetch failure or empty matrix (the API still enforces the rule at order time), matching the Terraform provider's handling
- Add stub mock methods for the new MCR ping/traceroute interface methods that came in with the same SDK bump, so `mcr` keeps compiling (the commands themselves are ESD-1614)
