### PR TITLE
fix(build): bump Go toolchain to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/megaport/megaport-cli
 
 go 1.25.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/andybalholm/brotli v1.2.2


### PR DESCRIPTION
Bumps the Go toolchain from 1.26.4 to 1.26.5 to pick up the crypto/tls fix for GO-2026-5856 (Encrypted Client Hello privacy leak) flagged by govulncheck.