### PR TITLE
ESD-1626: Fix interactive VXC buy dropping the B-End VLAN

### DIFF
--- a/internal/commands/vxc/vxc_prompts.go
+++ b/internal/commands/vxc/vxc_prompts.go
@@ -147,7 +147,7 @@ var buildVXCRequestFromPrompt = func(ctx context.Context, svc megaport.VXCServic
 		if err := validation.ValidateVXCEndVLAN(bEndVLAN); err != nil {
 			return nil, err
 		}
-		req.BEndConfiguration.VLAN = bEndVLAN
+		bEndConfig.VLAN = bEndVLAN
 	}
 
 	bEndInnerVLANStr, err := utils.ResourcePrompt("vxc", fmt.Sprintf("B-End Inner VLAN (optional, %s, press Enter to skip): ", validation.InnerVLANHelpText()), noColor)

--- a/internal/commands/vxc/vxc_prompts_test.go
+++ b/internal/commands/vxc/vxc_prompts_test.go
@@ -857,7 +857,61 @@ func TestBuildVXCRequestFromPrompt(t *testing.T) {
 				assert.Equal(t, 12, req.Term)
 				assert.Equal(t, 100, req.AEndConfiguration.VLAN)
 				assert.Equal(t, "port-a-123", req.PortUID)
+				assert.Equal(t, 200, req.BEndConfiguration.VLAN)
 				assert.Equal(t, "port-b-456", req.BEndConfiguration.ProductUID)
+			},
+		},
+		{
+			// Regression: the entered B-End VLAN was written to the request's
+			// zero-value struct and then overwritten by the assembled bEndConfig,
+			// so it never reached the submitted order.
+			name: "entered B-End VLAN survives onto the request",
+			responses: []string{
+				"Test VXC",   // name
+				"100",        // rate limit
+				"12",         // term
+				"100",        // A-End VLAN
+				"",           // A-End inner VLAN
+				"",           // A-End vNIC index
+				"no",         // A-End partner config
+				"port-a-123", // A-End product UID
+				"3021",       // B-End VLAN
+				"",           // B-End inner VLAN
+				"",           // B-End vNIC index
+				"no",         // B-End partner config
+				"port-b-456", // B-End product UID
+				"",           // promo code
+				"",           // service key
+				"",           // cost centre
+			},
+			verify: func(t *testing.T, req *megaport.BuyVXCRequest) {
+				assert.Equal(t, 3021, req.BEndConfiguration.VLAN)
+			},
+		},
+		{
+			// Skipping the B-End VLAN prompt must leave the VLAN unset so the API
+			// assigns one.
+			name: "empty B-End VLAN leaves the VLAN unset",
+			responses: []string{
+				"Test VXC",   // name
+				"100",        // rate limit
+				"12",         // term
+				"100",        // A-End VLAN
+				"",           // A-End inner VLAN
+				"",           // A-End vNIC index
+				"no",         // A-End partner config
+				"port-a-123", // A-End product UID
+				"",           // B-End VLAN (skipped)
+				"",           // B-End inner VLAN
+				"",           // B-End vNIC index
+				"no",         // B-End partner config
+				"port-b-456", // B-End product UID
+				"",           // promo code
+				"",           // service key
+				"",           // cost centre
+			},
+			verify: func(t *testing.T, req *megaport.BuyVXCRequest) {
+				assert.Equal(t, 0, req.BEndConfiguration.VLAN)
 			},
 		},
 		{


### PR DESCRIPTION
The interactive VXC buy prompt collected a B-End VLAN, then wrote it to the request's zero-value `BEndConfiguration`. A few lines later that struct is overwritten by the assembled `bEndConfig`, so the entered VLAN was silently dropped and the API assigned one instead. The flag and JSON buy paths were unaffected.

- Assign the entered B-End VLAN to `bEndConfig` (the struct actually submitted), matching the A-End path.
- Add regression tests: an entered B-End VLAN now survives onto the request, and skipping the prompt leaves it unset.