### PR TITLE
ESD-1627: Stop MVE update from wiping the existing cost centre

### DIFF
--- a/internal/commands/mve/mve_actions.go
+++ b/internal/commands/mve/mve_actions.go
@@ -330,21 +330,27 @@ func UpdateMVE(cmd *cobra.Command, args []string, noColor bool) error {
 
 	var req *megaport.ModifyMVERequest
 
+	// The cost centre is re-applied for flag and JSON input when the user
+	// didn't provide one, so an update that touches other fields doesn't wipe
+	// it. The interactive path preserves it internally via the prompt default.
+	currentCostCentre := originalMVE.CostCentre
+	costCentreProvided := false
+
 	if jsonStr != "" || jsonFile != "" {
-		req, err = processJSONUpdateMVEInput(jsonStr, jsonFile, mveUID)
+		req, costCentreProvided, err = processJSONUpdateMVEInput(jsonStr, jsonFile, mveUID)
 		if err != nil {
 			output.PrintError("Failed to process JSON input: %v", noColor, err)
 			return fmt.Errorf("failed to process JSON input: %w", err)
 		}
 	} else if flagsProvided {
-		req, err = processFlagUpdateMVEInput(cmd, mveUID)
+		req, costCentreProvided, err = processFlagUpdateMVEInput(cmd, mveUID)
 		if err != nil {
 			output.PrintError("Failed to process flag input: %v", noColor, err)
 			return fmt.Errorf("failed to process flag input: %w", err)
 		}
 	} else if interactive {
 		output.PrintInfo("Starting interactive mode for MVE %s", noColor, formattedUID)
-		req, err = promptForUpdateMVEDetails(mveUID, originalMVE.NetworkInterfaces, noColor)
+		req, err = promptForUpdateMVEDetails(mveUID, currentCostCentre, originalMVE.NetworkInterfaces, noColor)
 		if err != nil {
 			output.PrintError("Failed to get MVE details interactively: %v", noColor, err)
 			return fmt.Errorf("failed to get MVE details interactively: %w", err)
@@ -352,6 +358,10 @@ func UpdateMVE(cmd *cobra.Command, args []string, noColor bool) error {
 	} else {
 		output.PrintError("No input provided", noColor)
 		return fmt.Errorf("no input provided, use --interactive, --json, or flags to specify MVE update details")
+	}
+
+	if !interactive && !costCentreProvided {
+		req.CostCentre = currentCostCentre
 	}
 
 	if req.Vnics != nil && len(req.Vnics) != len(originalMVE.NetworkInterfaces) {

--- a/internal/commands/mve/mve_actions_test.go
+++ b/internal/commands/mve/mve_actions_test.go
@@ -406,6 +406,87 @@ func TestUpdateMVE(t *testing.T) {
 			},
 		},
 		{
+			name: "flag update without cost-centre preserves the existing one",
+			args: []string{"mve-123"},
+			flags: map[string]string{
+				"name": "Renamed MVE",
+			},
+			mockSetup: func(m *MockMVEService) {
+				m.ModifyMVEResult = &megaport.ModifyMVEResponse{MVEUpdated: true}
+				m.GetMVEResult = &megaport.MVE{Name: "Mock MVE", CostCentre: "Existing CC"}
+			},
+			expectedOutput: "MVE updated mve-123",
+			validateRequest: func(t *testing.T, req *megaport.ModifyMVERequest) {
+				assert.Equal(t, "Renamed MVE", req.Name)
+				assert.Equal(t, "Existing CC", req.CostCentre)
+			},
+		},
+		{
+			name: "flag update with empty cost-centre clears it",
+			args: []string{"mve-123"},
+			flags: map[string]string{
+				"cost-centre": "",
+			},
+			mockSetup: func(m *MockMVEService) {
+				m.ModifyMVEResult = &megaport.ModifyMVEResponse{MVEUpdated: true}
+				m.GetMVEResult = &megaport.MVE{Name: "Mock MVE", CostCentre: "Existing CC"}
+			},
+			expectedOutput: "MVE updated mve-123",
+			validateRequest: func(t *testing.T, req *megaport.ModifyMVERequest) {
+				assert.Empty(t, req.CostCentre)
+			},
+		},
+		{
+			name: "json update without cost-centre preserves the existing one",
+			args: []string{"mve-123"},
+			flags: map[string]string{
+				"json": `{"name":"JSON Renamed"}`,
+			},
+			mockSetup: func(m *MockMVEService) {
+				m.ModifyMVEResult = &megaport.ModifyMVEResponse{MVEUpdated: true}
+				m.GetMVEResult = &megaport.MVE{Name: "Mock MVE", CostCentre: "Existing CC"}
+			},
+			expectedOutput: "MVE updated mve-123",
+			validateRequest: func(t *testing.T, req *megaport.ModifyMVERequest) {
+				assert.Equal(t, "JSON Renamed", req.Name)
+				assert.Equal(t, "Existing CC", req.CostCentre)
+			},
+		},
+		{
+			name: "json update with empty cost-centre clears it",
+			args: []string{"mve-123"},
+			flags: map[string]string{
+				"json": `{"costCentre":""}`,
+			},
+			mockSetup: func(m *MockMVEService) {
+				m.ModifyMVEResult = &megaport.ModifyMVEResponse{MVEUpdated: true}
+				m.GetMVEResult = &megaport.MVE{Name: "Mock MVE", CostCentre: "Existing CC"}
+			},
+			expectedOutput: "MVE updated mve-123",
+			validateRequest: func(t *testing.T, req *megaport.ModifyMVERequest) {
+				assert.Empty(t, req.CostCentre)
+			},
+		},
+		{
+			name:        "interactive update preserves cost-centre when skipped",
+			args:        []string{"mve-123"},
+			interactive: true,
+			prompts: []string{
+				"Renamed MVE",
+				"",
+				"",
+			},
+			mockSetup: func(m *MockMVEService) {
+				m.ModifyMVEResult = &megaport.ModifyMVEResponse{MVEUpdated: true}
+				m.GetMVEResult = &megaport.MVE{Name: "Mock MVE", CostCentre: "Existing CC"}
+			},
+			expectedOutput: "MVE updated mve-123",
+			validateRequest: func(t *testing.T, req *megaport.ModifyMVERequest) {
+				assert.Equal(t, "Renamed MVE", req.Name)
+				assert.Equal(t, "Existing CC", req.CostCentre)
+			},
+		},
+		{
 			name:          "no input provided",
 			args:          []string{"mve-123"},
 			expectedError: "no input provided",

--- a/internal/commands/mve/mve_inputs.go
+++ b/internal/commands/mve/mve_inputs.go
@@ -670,15 +670,15 @@ func getBoolFromMap(m map[string]interface{}, key string) (bool, bool) {
 	return b, ok
 }
 
-func processJSONUpdateMVEInput(jsonStr, jsonFilePath, mveUID string) (*megaport.ModifyMVERequest, error) {
+func processJSONUpdateMVEInput(jsonStr, jsonFilePath, mveUID string) (*megaport.ModifyMVERequest, bool, error) {
 	var jsonData map[string]interface{}
 
 	rawBytes, err := utils.ReadJSONInput(jsonStr, jsonFilePath)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if err := json.Unmarshal(rawBytes, &jsonData); err != nil {
-		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+		return nil, false, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
 	req := &megaport.ModifyMVERequest{
@@ -686,19 +686,23 @@ func processJSONUpdateMVEInput(jsonStr, jsonFilePath, mveUID string) (*megaport.
 	}
 
 	if name, present, err := utils.JSONString(jsonData, "name"); err != nil {
-		return nil, err
+		return nil, false, err
 	} else if present && name != "" {
 		req.Name = name
 	}
 
-	if costCentre, present, err := utils.JSONString(jsonData, "costCentre"); err != nil {
-		return nil, err
-	} else if present && costCentre != "" {
+	// A present key (even empty) is applied as given, so an explicit "" clears
+	// it. When absent, the caller re-applies the current cost centre.
+	costCentre, costCentreProvided, err := utils.JSONString(jsonData, "costCentre")
+	if err != nil {
+		return nil, false, err
+	}
+	if costCentreProvided {
 		req.CostCentre = costCentre
 	}
 
 	if contractTermMonths, present, err := utils.JSONNumber(jsonData, "contractTermMonths"); err != nil {
-		return nil, err
+		return nil, false, err
 	} else if present {
 		termMonths := int(contractTermMonths)
 		req.ContractTermMonths = &termMonths
@@ -707,23 +711,34 @@ func processJSONUpdateMVEInput(jsonStr, jsonFilePath, mveUID string) (*megaport.
 	if rawVnics, exists := jsonData["vnics"]; exists {
 		vnicsData, ok := rawVnics.([]interface{})
 		if !ok {
-			return nil, fmt.Errorf("vnics must be an array of objects with a description field")
+			return nil, false, fmt.Errorf("vnics must be an array of objects with a description field")
 		}
 		vnics, err := parseVnicUpdates(vnicsData)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		req.Vnics = vnics
 	}
 
-	if err := validation.ValidateUpdateMVERequest(req); err != nil {
-		return nil, err
+	if needsUpdateMVEValidation(req, costCentreProvided) {
+		if err := validation.ValidateUpdateMVERequest(req); err != nil {
+			return nil, false, err
+		}
 	}
 
-	return req, nil
+	return req, costCentreProvided, nil
 }
 
-func processFlagUpdateMVEInput(cmd *cobra.Command, mveUID string) (*megaport.ModifyMVERequest, error) {
+// needsUpdateMVEValidation reports whether the request has fields the
+// value-based ValidateUpdateMVERequest can meaningfully check. A pure
+// cost-centre change (set or explicit clear) has none, and the validator can't
+// tell a cleared cost centre from an absent one, so it's skipped in that case
+// to avoid rejecting a legitimate clear-only update as "no fields".
+func needsUpdateMVEValidation(req *megaport.ModifyMVERequest, costCentreProvided bool) bool {
+	return req.Name != "" || req.ContractTermMonths != nil || len(req.Vnics) != 0 || !costCentreProvided
+}
+
+func processFlagUpdateMVEInput(cmd *cobra.Command, mveUID string) (*megaport.ModifyMVERequest, bool, error) {
 	name, _ := cmd.Flags().GetString("name")
 	costCentre, _ := cmd.Flags().GetString("cost-centre")
 	contractTerm, _ := cmd.Flags().GetInt("term")
@@ -737,7 +752,11 @@ func processFlagUpdateMVEInput(cmd *cobra.Command, mveUID string) (*megaport.Mod
 		req.Name = name
 	}
 
-	if costCentre != "" {
+	// Apply whatever the user passed, including an explicit empty value to
+	// clear it. When the flag wasn't set, the caller re-applies the current
+	// cost centre so the update doesn't wipe it.
+	costCentreProvided := cmd.Flags().Changed("cost-centre")
+	if costCentreProvided {
 		req.CostCentre = costCentre
 	}
 
@@ -747,24 +766,26 @@ func processFlagUpdateMVEInput(cmd *cobra.Command, mveUID string) (*megaport.Mod
 
 	if cmd.Flags().Changed("vnics") {
 		if strings.TrimSpace(vnicsStr) == "" {
-			return nil, fmt.Errorf("vnics must be a non-empty JSON array of objects with a description field")
+			return nil, false, fmt.Errorf("vnics must be a non-empty JSON array of objects with a description field")
 		}
 		var vnicsData []interface{}
 		if err := json.Unmarshal([]byte(vnicsStr), &vnicsData); err != nil {
-			return nil, fmt.Errorf("failed to parse vnics JSON string: %w", err)
+			return nil, false, fmt.Errorf("failed to parse vnics JSON string: %w", err)
 		}
 		vnics, err := parseVnicUpdates(vnicsData)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		req.Vnics = vnics
 	}
 
-	if err := validation.ValidateUpdateMVERequest(req); err != nil {
-		return nil, err
+	if needsUpdateMVEValidation(req, costCentreProvided) {
+		if err := validation.ValidateUpdateMVERequest(req); err != nil {
+			return nil, false, err
+		}
 	}
 
-	return req, nil
+	return req, costCentreProvided, nil
 }
 
 // parseVnicUpdates decodes a slice of {description: string} maps into

--- a/internal/commands/mve/mve_inputs_test.go
+++ b/internal/commands/mve/mve_inputs_test.go
@@ -338,7 +338,7 @@ func TestProcessJSONUpdateMVEInput(t *testing.T) {
 				jsonFile = tmpFile.Name()
 			}
 
-			req, err := processJSONUpdateMVEInput(tt.jsonStr, jsonFile, "mve-123")
+			req, _, err := processJSONUpdateMVEInput(tt.jsonStr, jsonFile, "mve-123")
 			if tt.expectedError != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
@@ -618,7 +618,7 @@ func TestProcessFlagUpdateMVEInput(t *testing.T) {
 				require.NoError(t, cmd.Flags().Set("term", "24"))
 			}
 
-			req, err := processFlagUpdateMVEInput(cmd, "mve-123")
+			req, _, err := processFlagUpdateMVEInput(cmd, "mve-123")
 			if tt.expectedError != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
@@ -628,6 +628,58 @@ func TestProcessFlagUpdateMVEInput(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProcessFlagUpdateMVEInput_CostCentreProvided(t *testing.T) {
+	t.Run("flag not set reports not provided", func(t *testing.T) {
+		cmd := createTestCmd()
+		require.NoError(t, cmd.Flags().Set("name", "renamed"))
+		req, provided, err := processFlagUpdateMVEInput(cmd, "mve-123")
+		require.NoError(t, err)
+		assert.False(t, provided)
+		assert.Empty(t, req.CostCentre)
+	})
+
+	t.Run("flag set to a value reports provided", func(t *testing.T) {
+		cmd := createTestCmd()
+		require.NoError(t, cmd.Flags().Set("cost-centre", "CC-1"))
+		req, provided, err := processFlagUpdateMVEInput(cmd, "mve-123")
+		require.NoError(t, err)
+		assert.True(t, provided)
+		assert.Equal(t, "CC-1", req.CostCentre)
+	})
+
+	t.Run("flag set to empty reports provided and empty", func(t *testing.T) {
+		cmd := createTestCmd()
+		require.NoError(t, cmd.Flags().Set("cost-centre", ""))
+		req, provided, err := processFlagUpdateMVEInput(cmd, "mve-123")
+		require.NoError(t, err)
+		assert.True(t, provided)
+		assert.Empty(t, req.CostCentre)
+	})
+}
+
+func TestProcessJSONUpdateMVEInput_CostCentreProvided(t *testing.T) {
+	t.Run("key absent reports not provided", func(t *testing.T) {
+		req, provided, err := processJSONUpdateMVEInput(`{"name":"renamed"}`, "", "mve-123")
+		require.NoError(t, err)
+		assert.False(t, provided)
+		assert.Empty(t, req.CostCentre)
+	})
+
+	t.Run("key present with value reports provided", func(t *testing.T) {
+		req, provided, err := processJSONUpdateMVEInput(`{"costCentre":"CC-1"}`, "", "mve-123")
+		require.NoError(t, err)
+		assert.True(t, provided)
+		assert.Equal(t, "CC-1", req.CostCentre)
+	})
+
+	t.Run("key present but empty reports provided and empty", func(t *testing.T) {
+		req, provided, err := processJSONUpdateMVEInput(`{"costCentre":""}`, "", "mve-123")
+		require.NoError(t, err)
+		assert.True(t, provided)
+		assert.Empty(t, req.CostCentre)
+	})
 }
 
 func createTestCmd() *cobra.Command {
@@ -640,7 +692,7 @@ func createTestCmd() *cobra.Command {
 }
 
 func TestProcessJSONUpdateMVEInput_Vnics(t *testing.T) {
-	req, err := processJSONUpdateMVEInput(`{"vnics":[{"description":"Data Plane"},{"description":"Management"}]}`, "", "mve-123")
+	req, _, err := processJSONUpdateMVEInput(`{"vnics":[{"description":"Data Plane"},{"description":"Management"}]}`, "", "mve-123")
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	require.Len(t, req.Vnics, 2)
@@ -649,7 +701,7 @@ func TestProcessJSONUpdateMVEInput_Vnics(t *testing.T) {
 }
 
 func TestProcessJSONUpdateMVEInput_VnicMissingDescription(t *testing.T) {
-	_, err := processJSONUpdateMVEInput(`{"vnics":[{}]}`, "", "mve-123")
+	_, _, err := processJSONUpdateMVEInput(`{"vnics":[{}]}`, "", "mve-123")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "vnics[0].description")
 }
@@ -658,7 +710,7 @@ func TestProcessFlagUpdateMVEInput_Vnics(t *testing.T) {
 	cmd := createTestCmd()
 	require.NoError(t, cmd.Flags().Set("vnics", `[{"description":"Data Plane"}]`))
 
-	req, err := processFlagUpdateMVEInput(cmd, "mve-123")
+	req, _, err := processFlagUpdateMVEInput(cmd, "mve-123")
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	require.Len(t, req.Vnics, 1)
@@ -669,13 +721,13 @@ func TestProcessFlagUpdateMVEInput_VnicsInvalidJSON(t *testing.T) {
 	cmd := createTestCmd()
 	require.NoError(t, cmd.Flags().Set("vnics", `[{`))
 
-	_, err := processFlagUpdateMVEInput(cmd, "mve-123")
+	_, _, err := processFlagUpdateMVEInput(cmd, "mve-123")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse vnics JSON")
 }
 
 func TestProcessJSONUpdateMVEInput_VnicEntryNotObject(t *testing.T) {
-	_, err := processJSONUpdateMVEInput(`{"vnics":["not-an-object"]}`, "", "mve-123")
+	_, _, err := processJSONUpdateMVEInput(`{"vnics":["not-an-object"]}`, "", "mve-123")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "vnics[0] must be an object")
 }
@@ -684,7 +736,7 @@ func TestProcessFlagUpdateMVEInput_VnicEntryNotObject(t *testing.T) {
 	cmd := createTestCmd()
 	require.NoError(t, cmd.Flags().Set("vnics", `["not-an-object"]`))
 
-	_, err := processFlagUpdateMVEInput(cmd, "mve-123")
+	_, _, err := processFlagUpdateMVEInput(cmd, "mve-123")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "vnics[0] must be an object")
 }
@@ -697,7 +749,7 @@ func TestProcessJSONUpdateMVEInput_VnicsNotArray(t *testing.T) {
 	}
 	for _, in := range cases {
 		t.Run(in, func(t *testing.T) {
-			_, err := processJSONUpdateMVEInput(in, "", "mve-123")
+			_, _, err := processJSONUpdateMVEInput(in, "", "mve-123")
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "vnics must be an array")
 		})
@@ -705,7 +757,7 @@ func TestProcessJSONUpdateMVEInput_VnicsNotArray(t *testing.T) {
 }
 
 func TestProcessJSONUpdateMVEInput_VnicUnsupportedKey(t *testing.T) {
-	_, err := processJSONUpdateMVEInput(`{"vnics":[{"description":"Data Plane","vlan":100}]}`, "", "mve-123")
+	_, _, err := processJSONUpdateMVEInput(`{"vnics":[{"description":"Data Plane","vlan":100}]}`, "", "mve-123")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "vnics[0].vlan is not supported")
 }
@@ -717,7 +769,7 @@ func TestProcessJSONUpdateMVEInput_VnicEmptyDescription(t *testing.T) {
 	}
 	for _, in := range cases {
 		t.Run(in, func(t *testing.T) {
-			_, err := processJSONUpdateMVEInput(in, "", "mve-123")
+			_, _, err := processJSONUpdateMVEInput(in, "", "mve-123")
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "vnics[0].description must not be empty")
 		})
@@ -725,7 +777,7 @@ func TestProcessJSONUpdateMVEInput_VnicEmptyDescription(t *testing.T) {
 }
 
 func TestProcessJSONUpdateMVEInput_VnicTrimsDescription(t *testing.T) {
-	req, err := processJSONUpdateMVEInput(`{"vnics":[{"description":"  Data Plane  "}]}`, "", "mve-123")
+	req, _, err := processJSONUpdateMVEInput(`{"vnics":[{"description":"  Data Plane  "}]}`, "", "mve-123")
 	require.NoError(t, err)
 	require.NotNil(t, req)
 	require.Len(t, req.Vnics, 1)
@@ -733,7 +785,7 @@ func TestProcessJSONUpdateMVEInput_VnicTrimsDescription(t *testing.T) {
 }
 
 func TestProcessJSONUpdateMVEInput_VnicsEmptyArray(t *testing.T) {
-	_, err := processJSONUpdateMVEInput(`{"vnics":[]}`, "", "mve-123")
+	_, _, err := processJSONUpdateMVEInput(`{"vnics":[]}`, "", "mve-123")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "vnics must contain at least one object")
 }
@@ -742,7 +794,7 @@ func TestProcessFlagUpdateMVEInput_VnicsEmptyArray(t *testing.T) {
 	cmd := createTestCmd()
 	require.NoError(t, cmd.Flags().Set("vnics", `[]`))
 
-	_, err := processFlagUpdateMVEInput(cmd, "mve-123")
+	_, _, err := processFlagUpdateMVEInput(cmd, "mve-123")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "vnics must contain at least one object")
 }
@@ -751,13 +803,13 @@ func TestProcessFlagUpdateMVEInput_TermZeroIsValidationError(t *testing.T) {
 	cmd := createTestCmd()
 	require.NoError(t, cmd.Flags().Set("term", "0"))
 
-	_, err := processFlagUpdateMVEInput(cmd, "mve-123")
+	_, _, err := processFlagUpdateMVEInput(cmd, "mve-123")
 	assert.Error(t, err)
 	assert.NotContains(t, err.Error(), "at least one field must be provided")
 }
 
 func TestProcessJSONUpdateMVEInput_TermZeroIsValidationError(t *testing.T) {
-	_, err := processJSONUpdateMVEInput(`{"contractTermMonths":0}`, "", "mve-123")
+	_, _, err := processJSONUpdateMVEInput(`{"contractTermMonths":0}`, "", "mve-123")
 	assert.Error(t, err)
 	assert.NotContains(t, err.Error(), "at least one field must be provided")
 }
@@ -766,7 +818,7 @@ func TestProcessFlagUpdateMVEInput_VnicsEmptyString(t *testing.T) {
 	cmd := createTestCmd()
 	require.NoError(t, cmd.Flags().Set("vnics", ""))
 
-	_, err := processFlagUpdateMVEInput(cmd, "mve-123")
+	_, _, err := processFlagUpdateMVEInput(cmd, "mve-123")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "vnics must be a non-empty JSON array")
 }
@@ -775,7 +827,7 @@ func TestProcessFlagUpdateMVEInput_VnicsWhitespaceString(t *testing.T) {
 	cmd := createTestCmd()
 	require.NoError(t, cmd.Flags().Set("vnics", "   "))
 
-	_, err := processFlagUpdateMVEInput(cmd, "mve-123")
+	_, _, err := processFlagUpdateMVEInput(cmd, "mve-123")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "vnics must be a non-empty JSON array")
 }

--- a/internal/commands/mve/mve_prompts.go
+++ b/internal/commands/mve/mve_prompts.go
@@ -405,7 +405,7 @@ func promptMVEVnics(noColor bool) ([]megaport.MVENetworkInterface, error) {
 	return vnics, nil
 }
 
-func promptForUpdateMVEDetails(mveUID string, currentVnics []*megaport.MVENetworkInterface, noColor bool) (*megaport.ModifyMVERequest, error) {
+func promptForUpdateMVEDetails(mveUID, currentCostCentre string, currentVnics []*megaport.MVENetworkInterface, noColor bool) (*megaport.ModifyMVERequest, error) {
 	req := &megaport.ModifyMVERequest{
 		MVEID: mveUID,
 	}
@@ -418,7 +418,11 @@ func promptForUpdateMVEDetails(mveUID string, currentVnics []*megaport.MVENetwor
 		req.Name = name
 	}
 
-	costCentre, err := utils.ResourcePrompt("mve", "Enter new cost centre (leave empty to keep current): ", noColor)
+	costCentrePrompt := "Enter new cost centre (leave empty to keep current): "
+	if currentCostCentre != "" {
+		costCentrePrompt = fmt.Sprintf("Enter new cost centre (current: %q, leave empty to keep): ", currentCostCentre)
+	}
+	costCentre, err := utils.ResourcePrompt("mve", costCentrePrompt, noColor)
 	if err != nil {
 		return nil, err
 	}
@@ -475,6 +479,13 @@ func promptForUpdateMVEDetails(mveUID string, currentVnics []*megaport.MVENetwor
 
 	if err := validation.ValidateUpdateMVERequest(req); err != nil {
 		return nil, err
+	}
+
+	// Re-send the current cost centre when the user skipped the prompt, so the
+	// update doesn't wipe it. Done after validation so an update that changes
+	// nothing else is still rejected rather than silently re-sending.
+	if req.CostCentre == "" {
+		req.CostCentre = currentCostCentre
 	}
 
 	return req, nil

--- a/internal/commands/mve/mve_prompts_test.go
+++ b/internal/commands/mve/mve_prompts_test.go
@@ -190,7 +190,7 @@ func TestPromptForUpdateMVEDetails_Success(t *testing.T) {
 		"NewName", "", "",
 	}))
 
-	req, err := promptForUpdateMVEDetails("mve-123", nil, true)
+	req, err := promptForUpdateMVEDetails("mve-123", "", nil, true)
 	assert.NoError(t, err)
 	assert.Equal(t, "mve-123", req.MVEID)
 	assert.Equal(t, "NewName", req.Name)
@@ -204,7 +204,7 @@ func TestPromptForUpdateMVEDetails_NoChanges(t *testing.T) {
 
 	utils.SetResourcePrompt(mockPromptSequence([]string{"", "", ""}))
 
-	_, err := promptForUpdateMVEDetails("mve-123", nil, true)
+	_, err := promptForUpdateMVEDetails("mve-123", "", nil, true)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "at least one field must be provided for update")
 }
@@ -215,7 +215,7 @@ func TestPromptForUpdateMVEDetails_InvalidContractTerm(t *testing.T) {
 
 	utils.SetResourcePrompt(mockPromptSequence([]string{"", "", "abc"}))
 
-	_, err := promptForUpdateMVEDetails("mve-123", nil, true)
+	_, err := promptForUpdateMVEDetails("mve-123", "", nil, true)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid contract term")
 }
@@ -235,7 +235,7 @@ func TestPromptForUpdateMVEDetails_UpdateVnicDescriptions(t *testing.T) {
 		{Description: "Data Plane"},
 		{Description: "Mgmt"},
 	}
-	req, err := promptForUpdateMVEDetails("mve-123", currentVnics, true)
+	req, err := promptForUpdateMVEDetails("mve-123", "", currentVnics, true)
 	require.NoError(t, err)
 	require.Len(t, req.Vnics, 2)
 	assert.Equal(t, "New Data Plane", req.Vnics[0].Description)
@@ -253,7 +253,7 @@ func TestPromptForUpdateMVEDetails_DeclineVnicUpdate(t *testing.T) {
 	}))
 
 	currentVnics := []*megaport.MVENetworkInterface{{Description: "Data Plane"}}
-	req, err := promptForUpdateMVEDetails("mve-123", currentVnics, true)
+	req, err := promptForUpdateMVEDetails("mve-123", "", currentVnics, true)
 	require.NoError(t, err)
 	assert.Equal(t, "NewName", req.Name)
 	assert.Empty(t, req.Vnics)
@@ -274,7 +274,7 @@ func TestPromptForUpdateMVEDetails_VnicYesNoPromptError(t *testing.T) {
 	})
 
 	currentVnics := []*megaport.MVENetworkInterface{{Description: "Data Plane"}}
-	_, err := promptForUpdateMVEDetails("mve-123", currentVnics, true)
+	_, err := promptForUpdateMVEDetails("mve-123", "", currentVnics, true)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "stdin closed")
 }
@@ -298,7 +298,7 @@ func TestPromptForUpdateMVEDetails_VnicDescriptionPromptError(t *testing.T) {
 	})
 
 	currentVnics := []*megaport.MVENetworkInterface{{Description: "Data Plane"}}
-	_, err := promptForUpdateMVEDetails("mve-123", currentVnics, true)
+	_, err := promptForUpdateMVEDetails("mve-123", "", currentVnics, true)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "stdin closed")
 }
@@ -315,7 +315,7 @@ func TestPromptForUpdateMVEDetails_VnicNilEntryDefaultsToEmpty(t *testing.T) {
 	}))
 
 	currentVnics := []*megaport.MVENetworkInterface{nil}
-	req, err := promptForUpdateMVEDetails("mve-123", currentVnics, true)
+	req, err := promptForUpdateMVEDetails("mve-123", "", currentVnics, true)
 	require.NoError(t, err)
 	require.Len(t, req.Vnics, 1)
 	assert.Equal(t, "New Description", req.Vnics[0].Description)
@@ -333,7 +333,7 @@ func TestPromptForUpdateMVEDetails_VnicEmptyCurrentEmptyInputErrors(t *testing.T
 	}))
 
 	currentVnics := []*megaport.MVENetworkInterface{{Description: ""}}
-	_, err := promptForUpdateMVEDetails("mve-123", currentVnics, true)
+	_, err := promptForUpdateMVEDetails("mve-123", "", currentVnics, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "vnics[0].description must not be empty")
 }

--- a/internal/validation/mve.go
+++ b/internal/validation/mve.go
@@ -126,7 +126,10 @@ func ValidateBuyMVERequest(req *megaport.BuyMVERequest) error {
 //   - A ValidationError if any validation check fails
 //   - nil if all validation checks pass
 func ValidateUpdateMVERequest(req *megaport.ModifyMVERequest) error {
-	// Check if any update fields are provided
+	// This field-count check is value-based, so it can't tell an explicitly
+	// cleared cost centre ("") from an absent one. Callers that must allow a
+	// clear-only update (see processFlagUpdateMVEInput) skip this validator for
+	// that case; any new caller has to do the same.
 	if req.Name == "" && req.CostCentre == "" && req.ContractTermMonths == nil && len(req.Vnics) == 0 {
 		return NewValidationError("update request", req, "at least one field must be provided for update")
 	}


### PR DESCRIPTION
`mve update` was blanking the cost centre whenever you ran it without `--cost-centre`. The SDK sends an empty cost centre as `"costCentre":""` (no `omitempty`), and the API reads that as "clear it", so an update that only changed the name also wiped the cost centre on a billable service.

Now the current cost centre is fetched and re-applied when you don't provide one, while an explicit clear still works. Mirrors how ports and MCR already handle it.

Changes:
- Flag and JSON update: preserve the existing cost centre when the key/flag is absent; apply `--cost-centre ""` or `{"costCentre":""}` as an intentional clear.
- Interactive update: show the current cost centre as the default and keep it when left blank.
- Skip the value-based update validator for a pure cost-centre change so a clear-only update isn't rejected as "no fields"; documented the shared validator's blind spot.
- Tests for preserve / clear / set across all three input modes.

Known limitation: the interactive prompt can't explicitly clear the cost centre (blank means keep), same as the ports interactive path. Use `--cost-centre ""` to clear.
