### PR TITLE
ESD-1633-fix(wasm): stop SplitArgs deleting a literal megaport argument

### DIFF
--- a/internal/wasm/wasm.go
+++ b/internal/wasm/wasm.go
@@ -736,14 +736,12 @@ func SplitArgs(cmd string) []string {
 		args = append(args, currentArg.String())
 	}
 
-	// Remove program name if user included it.
-	// The main_wasm.go will add it back, so we don't want duplicates.
-	var cleanedArgs []string
-	for _, arg := range args {
-		if arg == "megaport-cli" || arg == "./megaport-cli" || arg == "megaport" {
-			continue
-		}
-		cleanedArgs = append(cleanedArgs, arg)
+	// Remove a leading program-name token if the user included it.
+	// Only the first token is checked: a later argument, flag value, or
+	// positional equal to "megaport" is a real value and must be kept.
+	cleanedArgs := args
+	if len(cleanedArgs) > 0 && (cleanedArgs[0] == "megaport-cli" || cleanedArgs[0] == "./megaport-cli" || cleanedArgs[0] == "megaport") {
+		cleanedArgs = cleanedArgs[1:]
 	}
 
 	if debugMode.Load() {

--- a/internal/wasm/wasm_test.go
+++ b/internal/wasm/wasm_test.go
@@ -236,6 +236,11 @@ func TestSplitArgs(t *testing.T) {
 			expected: []string{"tag", "megaport", "ports"},
 		},
 		{
+			name:     "removes leading program name but preserves later megaport flag value",
+			input:    "megaport-cli ports update abc123 --name megaport",
+			expected: []string{"ports", "update", "abc123", "--name", "megaport"},
+		},
+		{
 			name:     "empty string",
 			input:    "",
 			expected: nil,

--- a/internal/wasm/wasm_test.go
+++ b/internal/wasm/wasm_test.go
@@ -221,6 +221,21 @@ func TestSplitArgs(t *testing.T) {
 			expected: []string{"locations", "list"},
 		},
 		{
+			name:     "removes leading program name literal megaport",
+			input:    "megaport locations list",
+			expected: []string{"locations", "list"},
+		},
+		{
+			name:     "preserves megaport as a flag value",
+			input:    "ports update abc123 --name megaport",
+			expected: []string{"ports", "update", "abc123", "--name", "megaport"},
+		},
+		{
+			name:     "preserves megaport as a positional argument",
+			input:    "tag megaport ports",
+			expected: []string{"tag", "megaport", "ports"},
+		},
+		{
 			name:     "empty string",
 			input:    "",
 			expected: nil,


### PR DESCRIPTION
Fixes a WASM-only bug where `SplitArgs` dropped any argument equal to `megaport`, `megaport-cli`, or `./megaport-cli`, not just a leading program name. That meant a command like `ports update <uid> --name megaport` silently lost the flag value.

- Only strip a program-name token when it's the first token, leaving later flag values and positionals intact.
- Added test cases covering a `megaport`-valued flag, a positional, and a leading token combined with a later literal value.

Ran `go build`, `go test ./...`, the WASM build, WASM package tests, and lint locally; all pass.
