### PR TITLE
ESD-1634: Reject unknown flags in the WASM build

### DIFF
--- a/cmd/megaport/cobra_helpers.go
+++ b/cmd/megaport/cobra_helpers.go
@@ -31,9 +31,14 @@ func resetFlag(f *pflag.Flag) {
 
 // enableTraversalForAllCommands enables subcommand traversal on all commands
 // in the tree recursively.
+//
+// It does not touch ParseErrorsAllowlist.UnknownFlags: Cobra's ParseFlags
+// unconditionally overwrites a command's FlagSet.ParseErrorsAllowlist from
+// the command's own FParseErrWhitelist field just before parsing, so setting
+// the FlagSet field directly here has no effect on unknown-flag handling.
+// Unknown flags are rejected the same way traversal or not.
 func enableTraversalForAllCommands(cmd *cobra.Command) {
 	cmd.TraverseChildren = true
-	cmd.Flags().ParseErrorsAllowlist.UnknownFlags = true
 
 	for _, subCmd := range cmd.Commands() {
 		enableTraversalForAllCommands(subCmd)

--- a/cmd/megaport/cobra_helpers_test.go
+++ b/cmd/megaport/cobra_helpers_test.go
@@ -215,3 +215,50 @@ func TestEnableTraversalForAllCommands(t *testing.T) {
 	assert.True(t, level1.TraverseChildren, "child should have traversal enabled")
 	assert.True(t, level2.TraverseChildren, "grandchild should have traversal enabled")
 }
+
+// TestEnableTraversalForAllCommands_RejectsUnknownFlags is the direct
+// regression test for ESD-1634: a WASM-style tree with traversal enabled
+// must still reject an unrecognized flag rather than silently discarding it.
+// Cobra's ParseFlags overwrites FlagSet.ParseErrorsAllowlist from the
+// command's FParseErrWhitelist field on every parse, so poking the FlagSet
+// field directly (the old code) never actually allowed anything through;
+// this test guards against that allowlist being reintroduced (correctly
+// this time, via FParseErrWhitelist) in a way that would resurrect the bug.
+func TestEnableTraversalForAllCommands_RejectsUnknownFlags(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("output", "table", "output format")
+	child := &cobra.Command{Use: "child", RunE: func(cmd *cobra.Command, args []string) error { return nil }}
+	child.Flags().String("name", "", "name")
+	root.AddCommand(child)
+
+	enableTraversalForAllCommands(root)
+	root.TraverseChildren = true
+
+	root.SetArgs([]string{"child", "--totally-unknown-flag", "value"})
+	err := root.Execute()
+	require.Error(t, err, "an unrecognized flag must not be silently dropped")
+	assert.Contains(t, err.Error(), "unknown flag")
+}
+
+// TestEnableTraversalForAllCommands_ValidTraversalStillResolves guards the
+// other half of ESD-1634's acceptance criteria: removing the dead
+// UnknownFlags allowlist assignment must not break subcommand resolution
+// when a persistent flag precedes the subcommand name.
+func TestEnableTraversalForAllCommands_ValidTraversalStillResolves(t *testing.T) {
+	var ran bool
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("output", "table", "output format")
+	child := &cobra.Command{Use: "child", RunE: func(cmd *cobra.Command, args []string) error {
+		ran = true
+		return nil
+	}}
+	root.AddCommand(child)
+
+	enableTraversalForAllCommands(root)
+	root.TraverseChildren = true
+
+	root.SetArgs([]string{"--output", "json", "child"})
+	err := root.Execute()
+	require.NoError(t, err)
+	assert.True(t, ran, "child command should have been resolved and executed")
+}

--- a/cmd/megaport/cobra_helpers_test.go
+++ b/cmd/megaport/cobra_helpers_test.go
@@ -233,6 +233,8 @@ func TestEnableTraversalForAllCommands_RejectsUnknownFlags(t *testing.T) {
 
 	enableTraversalForAllCommands(root)
 	root.TraverseChildren = true
+	root.SilenceErrors = true
+	root.SilenceUsage = true
 
 	root.SetArgs([]string{"child", "--totally-unknown-flag", "value"})
 	err := root.Execute()

--- a/cmd/megaport/megaport_wasm.go
+++ b/cmd/megaport/megaport_wasm.go
@@ -36,8 +36,9 @@ func ExecuteWithArgs(args []string) {
 	rootCmd.SetOut(wasm.WasmOutputBuffer)
 	rootCmd.SetErr(wasm.WasmOutputBuffer)
 
-	// Enable traversal for subcommand flags
-	rootCmd.PersistentFlags().ParseErrorsAllowlist.UnknownFlags = true
+	// Enable traversal so a subcommand is still resolved when persistent
+	// flags precede it (e.g. "--output json ports list"). This does not
+	// relax unknown-flag handling; see enableTraversalForAllCommands.
 	rootCmd.TraverseChildren = true
 
 	// Enable subcommand traversal for ALL commands, not just root

--- a/cmd/megaport/unknown_flags_wasm_test.go
+++ b/cmd/megaport/unknown_flags_wasm_test.go
@@ -44,13 +44,16 @@ func TestExecuteWithArgs_RejectsUnknownFlags(t *testing.T) {
 // network call is made.
 func TestExecuteWithArgs_ValidTraversalStillResolves(t *testing.T) {
 	cases := []struct {
-		name  string
-		args  []string
+		name string
+		args []string
+		// usage anchors on the "Usage:" block so a parent's "Example usage"
+		// prose (e.g. the root help's Examples list) can't satisfy the match
+		// if traversal actually failed and root help was shown instead.
 		usage string
 	}{
-		{"persistent flag before subcommand", []string{"megaport-cli", "--no-color", "locations", "list", "--help"}, "megaport-cli locations list"},
-		{"persistent flag between subcommand levels", []string{"megaport-cli", "locations", "--no-color", "list", "--help"}, "megaport-cli locations list"},
-		{"deeply nested subcommand", []string{"megaport-cli", "ports", "buy", "--help"}, "megaport-cli ports buy"},
+		{"persistent flag before subcommand", []string{"megaport-cli", "--no-color", "locations", "list", "--help"}, "Usage:\n  megaport-cli locations list"},
+		{"persistent flag between subcommand levels", []string{"megaport-cli", "locations", "--no-color", "list", "--help"}, "Usage:\n  megaport-cli locations list"},
+		{"deeply nested subcommand", []string{"megaport-cli", "ports", "buy", "--help"}, "Usage:\n  megaport-cli ports buy"},
 	}
 
 	for _, tc := range cases {

--- a/cmd/megaport/unknown_flags_wasm_test.go
+++ b/cmd/megaport/unknown_flags_wasm_test.go
@@ -12,18 +12,20 @@ import (
 // TestExecuteWithArgs_RejectsUnknownFlags is the ESD-1634 regression test:
 // the WASM entrypoint must report an unknown flag as an error, matching the
 // native build, instead of silently dropping it and either proceeding or
-// failing later with a misleading "required flag not set" message. Cases are
-// help-only or otherwise non-mutating by design so no network call happens
-// and no real order is placed.
+// failing later with a misleading "required flag not set" message. Each case
+// also carries --help: flag parsing fails before Cobra ever checks --help, so
+// this has no effect while the fix holds, but it keeps the case side-effect
+// free (no real network call or order placed) if the rejection ever
+// regresses and the args are actually executed.
 func TestExecuteWithArgs_RejectsUnknownFlags(t *testing.T) {
 	cases := []struct {
 		name string
 		args []string
 	}{
-		{"unknown flag on a leaf command", []string{"megaport-cli", "locations", "list", "--totally-bogus-flag"}},
-		{"unknown flag before the subcommand", []string{"megaport-cli", "--totally-bogus-flag", "locations", "list"}},
-		{"unknown flag between subcommand levels", []string{"megaport-cli", "locations", "--totally-bogus-flag", "list"}},
-		{"ticket repro: typo'd boolean flag on a buy command", []string{"megaport-cli", "ports", "buy", "--marketplace-visability", "false"}},
+		{"unknown flag on a leaf command", []string{"megaport-cli", "locations", "list", "--help", "--totally-bogus-flag"}},
+		{"unknown flag before the subcommand", []string{"megaport-cli", "--totally-bogus-flag", "locations", "list", "--help"}},
+		{"unknown flag between subcommand levels", []string{"megaport-cli", "locations", "--totally-bogus-flag", "list", "--help"}},
+		{"ticket repro: typo'd boolean flag on a buy command", []string{"megaport-cli", "ports", "buy", "--help", "--marketplace-visability", "false"}},
 	}
 
 	for _, tc := range cases {

--- a/cmd/megaport/unknown_flags_wasm_test.go
+++ b/cmd/megaport/unknown_flags_wasm_test.go
@@ -1,0 +1,66 @@
+//go:build js && wasm
+
+package megaport
+
+import (
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/wasm"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestExecuteWithArgs_RejectsUnknownFlags is the ESD-1634 regression test:
+// the WASM entrypoint must report an unknown flag as an error, matching the
+// native build, instead of silently dropping it and either proceeding or
+// failing later with a misleading "required flag not set" message. Cases are
+// help-only or otherwise non-mutating by design so no network call happens
+// and no real order is placed.
+func TestExecuteWithArgs_RejectsUnknownFlags(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"unknown flag on a leaf command", []string{"megaport-cli", "locations", "list", "--totally-bogus-flag"}},
+		{"unknown flag before the subcommand", []string{"megaport-cli", "--totally-bogus-flag", "locations", "list"}},
+		{"unknown flag between subcommand levels", []string{"megaport-cli", "locations", "--totally-bogus-flag", "list"}},
+		{"ticket repro: typo'd boolean flag on a buy command", []string{"megaport-cli", "ports", "buy", "--marketplace-visability", "false"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wasm.ResetOutputBuffers()
+			ExecuteWithArgs(tc.args)
+			out := wasm.GetCapturedOutput()
+			assert.Contains(t, out, "unknown flag", "%v should report the unknown flag", tc.args)
+			assert.NotContains(t, out, "required flag(s)", "%v should not fall through to a required-flag error", tc.args)
+		})
+	}
+}
+
+// TestExecuteWithArgs_ValidTraversalStillResolves guards the other half of
+// ESD-1634: removing the dead UnknownFlags allowlist must not break
+// subcommand resolution when a persistent flag precedes the subcommand, or
+// when help is requested at a nested command. Cases are help-only so no
+// network call is made.
+func TestExecuteWithArgs_ValidTraversalStillResolves(t *testing.T) {
+	cases := []struct {
+		name  string
+		args  []string
+		usage string
+	}{
+		{"persistent flag before subcommand", []string{"megaport-cli", "--no-color", "locations", "list", "--help"}, "megaport-cli locations list"},
+		{"persistent flag between subcommand levels", []string{"megaport-cli", "locations", "--no-color", "list", "--help"}, "megaport-cli locations list"},
+		{"deeply nested subcommand", []string{"megaport-cli", "ports", "buy", "--help"}, "megaport-cli ports buy"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wasm.ResetOutputBuffers()
+			ExecuteWithArgs(tc.args)
+			out := wasm.GetCapturedOutput()
+			assert.NotContains(t, out, "unknown flag", "%v should not be treated as an unknown flag", tc.args)
+			assert.NotContains(t, out, "unknown command", "%v should be a registered command", tc.args)
+			assert.Contains(t, out, tc.usage, "%v help should show its usage path", tc.args)
+		})
+	}
+}


### PR DESCRIPTION
The WASM entrypoint set `ParseErrorsAllowlist.UnknownFlags = true` directly on each command's flag set to keep subcommand traversal working, which made it look like unknown flags were silently accepted (e.g. `ports buy --marketplace-visability false`).

That assignment turned out to be dead code: Cobra's `ParseFlags` always overwrites `FlagSet.ParseErrorsAllowlist` from the command's `FParseErrWhitelist` field right before parsing, and `FParseErrWhitelist` was never set here. So unknown flags were already being rejected the same way in both native and WASM builds. Verified this with throwaway probe tests before touching anything, including the exact typo from the ticket.

- Removed the two dead `ParseErrorsAllowlist.UnknownFlags = true` assignments, keeping `TraverseChildren = true`
- Added regression tests covering unknown flags at various positions (leaf command, before subcommand, mid-traversal, and the ticket's literal repro) and confirming valid traversal still resolves

## Test plan
- [x] `go build ./...` and `go test ./...`
- [x] `GOOS=js GOARCH=wasm go build -tags js,wasm -o /tmp/megaport.wasm .`
- [x] `GOOS=js GOARCH=wasm go test -tags js,wasm ./cmd/megaport ./internal/base/output ./internal/wasm`
- [x] `golangci-lint run`
