### PR TITLE
ESD-1637: Reject contract term 0 consistently in VXC and port updates

### DIFF
--- a/internal/commands/ports/ports_inputs.go
+++ b/internal/commands/ports/ports_inputs.go
@@ -120,12 +120,10 @@ func processFlagUpdatePortInput(cmd *cobra.Command, portUID string) (*megaport.M
 
 	if termSet {
 		term, _ := cmd.Flags().GetInt("term")
-		if term != 0 {
-			if err := validation.ValidateContractTerm(term); err != nil {
-				return nil, false, err
-			}
-			req.ContractTermMonths = &term
+		if err := validation.ValidateContractTerm(term); err != nil {
+			return nil, false, err
 		}
+		req.ContractTermMonths = &term
 	}
 
 	return req, ccSet, nil

--- a/internal/commands/ports/ports_inputs_test.go
+++ b/internal/commands/ports/ports_inputs_test.go
@@ -362,11 +362,13 @@ func TestProcessJSONUpdatePortInput(t *testing.T) {
 }
 
 func TestProcessFlagUpdatePortInput(t *testing.T) {
+	term24 := 24
+
 	tests := []struct {
-		name          string
-		flags         map[string]string
-		expectedError string
-		checkReq      func(*testing.T, *cobra.Command)
+		name               string
+		flags              map[string]string
+		expectedError      string
+		expectContractTerm *int
 	}{
 		{
 			name:          "no flags changed",
@@ -386,12 +388,18 @@ func TestProcessFlagUpdatePortInput(t *testing.T) {
 			flags: map[string]string{"cost-centre": "IT-2024"},
 		},
 		{
-			name:  "term only",
-			flags: map[string]string{"term": "24"},
+			name:               "term only",
+			flags:              map[string]string{"term": "24"},
+			expectContractTerm: &term24,
 		},
 		{
 			name:          "invalid term",
 			flags:         map[string]string{"term": "99"},
+			expectedError: "Invalid contract term",
+		},
+		{
+			name:          "term zero rejected",
+			flags:         map[string]string{"term": "0"},
 			expectedError: "Invalid contract term",
 		},
 		{
@@ -424,6 +432,10 @@ func TestProcessFlagUpdatePortInput(t *testing.T) {
 				assert.NoError(t, err)
 				assert.NotNil(t, req)
 				assert.Equal(t, "port-uid-123", req.PortID)
+				if tt.expectContractTerm != nil {
+					require.NotNil(t, req.ContractTermMonths)
+					assert.Equal(t, *tt.expectContractTerm, *req.ContractTermMonths)
+				}
 			}
 		})
 	}

--- a/internal/commands/ports/ports_inputs_test.go
+++ b/internal/commands/ports/ports_inputs_test.go
@@ -1,9 +1,11 @@
 package ports
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
+	"github.com/megaport/megaport-cli/internal/validation"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -437,8 +439,27 @@ func TestProcessFlagUpdatePortInput(t *testing.T) {
 				if tt.expectContractTerm != nil {
 					require.NotNil(t, req.ContractTermMonths)
 					assert.Equal(t, *tt.expectContractTerm, *req.ContractTermMonths)
+				} else {
+					assert.Nil(t, req.ContractTermMonths)
 				}
 			}
+		})
+	}
+
+	for _, term := range validation.ValidContractTerms {
+		t.Run(fmt.Sprintf("term %d is accepted", term), func(t *testing.T) {
+			cmd := &cobra.Command{Use: "test"}
+			cmd.Flags().String("name", "", "")
+			cmd.Flags().Bool("marketplace-visibility", false, "")
+			cmd.Flags().String("cost-centre", "", "")
+			cmd.Flags().Int("term", 0, "")
+			require.NoError(t, cmd.Flags().Set("term", fmt.Sprintf("%d", term)))
+
+			req, _, err := processFlagUpdatePortInput(cmd, "port-uid-123")
+			require.NoError(t, err)
+			require.NotNil(t, req)
+			require.NotNil(t, req.ContractTermMonths)
+			assert.Equal(t, term, *req.ContractTermMonths)
 		})
 	}
 }

--- a/internal/commands/ports/ports_inputs_test.go
+++ b/internal/commands/ports/ports_inputs_test.go
@@ -362,6 +362,7 @@ func TestProcessJSONUpdatePortInput(t *testing.T) {
 }
 
 func TestProcessFlagUpdatePortInput(t *testing.T) {
+	term12 := 12
 	term24 := 24
 
 	tests := []struct {
@@ -409,6 +410,7 @@ func TestProcessFlagUpdatePortInput(t *testing.T) {
 				"cost-centre": "IT-2024",
 				"term":        "12",
 			},
+			expectContractTerm: &term12,
 		},
 	}
 

--- a/internal/commands/vxc/vxc_actions_test.go
+++ b/internal/commands/vxc/vxc_actions_test.go
@@ -1580,6 +1580,7 @@ func TestBuildUpdateVXCRequestFromFlags_Term(t *testing.T) {
 		testutil.SetFlags(t, cmd, map[string]string{"term": "0"})
 		_, err := buildUpdateVXCRequestFromFlags(cmd)
 		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Invalid contract term")
 	})
 
 	for _, term := range []int{1, 12, 24, 36, 48, 60} {

--- a/internal/commands/vxc/vxc_actions_test.go
+++ b/internal/commands/vxc/vxc_actions_test.go
@@ -1553,6 +1553,47 @@ func TestBuildUpdateVXCRequestFromFlags_NewFields(t *testing.T) {
 	}
 }
 
+func TestBuildUpdateVXCRequestFromFlags_Term(t *testing.T) {
+	makeCmd := func() *cobra.Command {
+		cmd := &cobra.Command{Use: "update"}
+		cmd.Flags().String("name", "", "")
+		cmd.Flags().Int("rate-limit", 0, "")
+		cmd.Flags().Int("term", 0, "")
+		cmd.Flags().String("cost-centre", "", "")
+		cmd.Flags().Bool("shutdown", false, "")
+		cmd.Flags().Int("a-end-vlan", 0, "")
+		cmd.Flags().Int("b-end-vlan", 0, "")
+		cmd.Flags().Int("a-end-inner-vlan", 0, "")
+		cmd.Flags().Int("b-end-inner-vlan", 0, "")
+		cmd.Flags().String("a-end-uid", "", "")
+		cmd.Flags().String("b-end-uid", "", "")
+		cmd.Flags().String("a-end-partner-config", "", "")
+		cmd.Flags().String("b-end-partner-config", "", "")
+		cmd.Flags().Bool("is-approved", false, "")
+		cmd.Flags().Int("a-vnic-index", -1, "")
+		cmd.Flags().Int("b-vnic-index", -1, "")
+		return cmd
+	}
+
+	t.Run("term 0 is rejected", func(t *testing.T) {
+		cmd := makeCmd()
+		testutil.SetFlags(t, cmd, map[string]string{"term": "0"})
+		_, err := buildUpdateVXCRequestFromFlags(cmd)
+		assert.Error(t, err)
+	})
+
+	for _, term := range []int{1, 12, 24, 36, 48, 60} {
+		t.Run(fmt.Sprintf("term %d is accepted", term), func(t *testing.T) {
+			cmd := makeCmd()
+			testutil.SetFlags(t, cmd, map[string]string{"term": fmt.Sprintf("%d", term)})
+			req, err := buildUpdateVXCRequestFromFlags(cmd)
+			assert.NoError(t, err)
+			assert.NotNil(t, req.Term)
+			assert.Equal(t, term, *req.Term)
+		})
+	}
+}
+
 func TestHasUpdateVXCNonInteractiveFlags(t *testing.T) {
 	t.Run("no flags set fails the gate", func(t *testing.T) {
 		cmd := cmdbuilder.NewCommand("update", "test").WithVXCUpdateFlags().Build()

--- a/internal/commands/vxc/vxc_actions_test.go
+++ b/internal/commands/vxc/vxc_actions_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/megaport/megaport-cli/internal/commands/config"
 	"github.com/megaport/megaport-cli/internal/testutil"
 	"github.com/megaport/megaport-cli/internal/utils"
+	"github.com/megaport/megaport-cli/internal/validation"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -1583,7 +1584,7 @@ func TestBuildUpdateVXCRequestFromFlags_Term(t *testing.T) {
 		assert.Contains(t, err.Error(), "Invalid contract term")
 	})
 
-	for _, term := range []int{1, 12, 24, 36, 48, 60} {
+	for _, term := range validation.ValidContractTerms {
 		t.Run(fmt.Sprintf("term %d is accepted", term), func(t *testing.T) {
 			cmd := makeCmd()
 			testutil.SetFlags(t, cmd, map[string]string{"term": fmt.Sprintf("%d", term)})

--- a/internal/commands/vxc/vxc_actions_test.go
+++ b/internal/commands/vxc/vxc_actions_test.go
@@ -1589,8 +1589,9 @@ func TestBuildUpdateVXCRequestFromFlags_Term(t *testing.T) {
 			cmd := makeCmd()
 			testutil.SetFlags(t, cmd, map[string]string{"term": fmt.Sprintf("%d", term)})
 			req, err := buildUpdateVXCRequestFromFlags(cmd)
-			assert.NoError(t, err)
-			assert.NotNil(t, req.Term)
+			require.NoError(t, err)
+			require.NotNil(t, req)
+			require.NotNil(t, req.Term)
 			assert.Equal(t, term, *req.Term)
 		})
 	}

--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -1456,6 +1456,22 @@ func TestBuildUpdateVXCRequestFromJSON_WholeRateLimit(t *testing.T) {
 	assert.Equal(t, 2000, *req.RateLimit)
 }
 
+func TestBuildUpdateVXCRequestFromJSON_Term(t *testing.T) {
+	t.Run("term 0 is rejected", func(t *testing.T) {
+		_, err := buildUpdateVXCRequestFromJSON(`{"term":0}`, "")
+		assert.Error(t, err)
+	})
+
+	for _, term := range []int{1, 12, 24, 36, 48, 60} {
+		t.Run(fmt.Sprintf("term %d is accepted", term), func(t *testing.T) {
+			req, err := buildUpdateVXCRequestFromJSON(fmt.Sprintf(`{"term":%d}`, term), "")
+			assert.NoError(t, err)
+			require.NotNil(t, req.Term)
+			assert.Equal(t, term, *req.Term)
+		})
+	}
+}
+
 func TestResolvePartnerPortUID(t *testing.T) {
 	origGetPartnerPortUID := getPartnerPortUID
 	defer func() { getPartnerPortUID = origGetPartnerPortUID }()

--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -1467,7 +1467,8 @@ func TestBuildUpdateVXCRequestFromJSON_Term(t *testing.T) {
 	for _, term := range validation.ValidContractTerms {
 		t.Run(fmt.Sprintf("term %d is accepted", term), func(t *testing.T) {
 			req, err := buildUpdateVXCRequestFromJSON(fmt.Sprintf(`{"term":%d}`, term), "")
-			assert.NoError(t, err)
+			require.NoError(t, err)
+			require.NotNil(t, req)
 			require.NotNil(t, req.Term)
 			assert.Equal(t, term, *req.Term)
 		})

--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -1460,6 +1460,7 @@ func TestBuildUpdateVXCRequestFromJSON_Term(t *testing.T) {
 	t.Run("term 0 is rejected", func(t *testing.T) {
 		_, err := buildUpdateVXCRequestFromJSON(`{"term":0}`, "")
 		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Invalid contract term")
 	})
 
 	for _, term := range []int{1, 12, 24, 36, 48, 60} {

--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/megaport/megaport-cli/internal/base/exitcodes"
+	"github.com/megaport/megaport-cli/internal/validation"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -1463,7 +1464,7 @@ func TestBuildUpdateVXCRequestFromJSON_Term(t *testing.T) {
 		assert.Contains(t, err.Error(), "Invalid contract term")
 	})
 
-	for _, term := range []int{1, 12, 24, 36, 48, 60} {
+	for _, term := range validation.ValidContractTerms {
 		t.Run(fmt.Sprintf("term %d is accepted", term), func(t *testing.T) {
 			req, err := buildUpdateVXCRequestFromJSON(fmt.Sprintf(`{"term":%d}`, term), "")
 			assert.NoError(t, err)

--- a/internal/commands/vxc/vxc_inputs_update.go
+++ b/internal/commands/vxc/vxc_inputs_update.go
@@ -32,10 +32,8 @@ var buildUpdateVXCRequestFromFlags = func(cmd *cobra.Command) (*megaport.UpdateV
 
 	if cmd.Flags().Changed("term") {
 		term, _ := cmd.Flags().GetInt("term")
-		if term != 0 {
-			if err := validation.ValidateContractTerm(term); err != nil {
-				return nil, err
-			}
+		if err := validation.ValidateContractTerm(term); err != nil {
+			return nil, err
 		}
 		req.Term = &term
 	}
@@ -192,10 +190,8 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 			return nil, fmt.Errorf("term must be a whole number, got %v", term)
 		}
 		termInt := int(term)
-		if termInt != 0 {
-			if err := validation.ValidateContractTerm(termInt); err != nil {
-				return nil, err
-			}
+		if err := validation.ValidateContractTerm(termInt); err != nil {
+			return nil, err
 		}
 		req.Term = &termInt
 	}

--- a/internal/commands/vxc/vxc_prompts.go
+++ b/internal/commands/vxc/vxc_prompts.go
@@ -284,7 +284,7 @@ var buildUpdateVXCRequestFromPrompt = func(ctx context.Context, client *megaport
 		return nil, err
 	}
 	if strings.ToLower(updateTerm) == "yes" {
-		termStr, err := utils.ResourcePrompt("vxc", fmt.Sprintf("Enter new term in months (0, %s): ", validation.FormatIntSlice(validation.ValidContractTerms)), noColor)
+		termStr, err := utils.ResourcePrompt("vxc", fmt.Sprintf("Enter new term in months (%s): ", validation.FormatIntSlice(validation.ValidContractTerms)), noColor)
 		if err != nil {
 			return nil, err
 		}
@@ -292,9 +292,8 @@ var buildUpdateVXCRequestFromPrompt = func(ctx context.Context, client *megaport
 		if err != nil {
 			return nil, fmt.Errorf("term must be a valid integer")
 		}
-		if term != 0 && validation.ValidateContractTerm(term) != nil {
-			return nil, validation.NewValidationError("term", term,
-				fmt.Sprintf("must be 0, or one of: %v", validation.ValidContractTerms))
+		if err := validation.ValidateContractTerm(term); err != nil {
+			return nil, err
 		}
 		req.Term = &term
 	}

--- a/internal/commands/vxc/vxc_prompts_test.go
+++ b/internal/commands/vxc/vxc_prompts_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/megaport/megaport-cli/internal/testutil"
 	"github.com/megaport/megaport-cli/internal/utils"
+	"github.com/megaport/megaport-cli/internal/validation"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1108,7 +1109,7 @@ func TestBuildUpdateVXCRequestFromPrompt_TermValidation(t *testing.T) {
 		assert.Contains(t, err.Error(), "Invalid contract term")
 	})
 
-	for _, term := range []int{1, 12, 24, 36, 48, 60} {
+	for _, term := range validation.ValidContractTerms {
 		t.Run(fmt.Sprintf("term %d is accepted", term), func(t *testing.T) {
 			cleanup := mockPrompts(baseResponses(fmt.Sprintf("%d", term)))
 			defer cleanup()

--- a/internal/commands/vxc/vxc_prompts_test.go
+++ b/internal/commands/vxc/vxc_prompts_test.go
@@ -1105,6 +1105,7 @@ func TestBuildUpdateVXCRequestFromPrompt_TermValidation(t *testing.T) {
 
 		_, err := buildUpdateVXCRequestFromPrompt(context.Background(), mockClient, "vxc-uid-123", true)
 		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Invalid contract term")
 	})
 
 	for _, term := range []int{1, 12, 24, 36, 48, 60} {

--- a/internal/commands/vxc/vxc_prompts_test.go
+++ b/internal/commands/vxc/vxc_prompts_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/megaport/megaport-cli/internal/utils"
 	megaport "github.com/megaport/megaportgo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func mockPrompts(responses []string) func() {
@@ -1051,6 +1052,73 @@ func TestBuildUpdateVXCRequestFromPrompt(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, req)
 			tc.verify(t, req)
+		})
+	}
+}
+
+func TestBuildUpdateVXCRequestFromPrompt_TermValidation(t *testing.T) {
+	existingVXC := &megaport.VXC{
+		UID:                "vxc-uid-123",
+		Name:               "Old VXC",
+		RateLimit:          100,
+		ContractTermMonths: 12,
+		CostCentre:         "CC-001",
+		AdminLocked:        false,
+		AEndConfiguration: megaport.VXCEndConfiguration{
+			UID:  "a-end-uid",
+			VLAN: 100,
+		},
+		BEndConfiguration: megaport.VXCEndConfiguration{
+			UID:  "b-end-uid",
+			VLAN: 200,
+		},
+	}
+
+	baseResponses := func(termResponses ...string) []string {
+		responses := []string{
+			"no", // update name
+			"no", // update rate limit
+			"yes",
+		}
+		responses = append(responses, termResponses...)
+		responses = append(responses,
+			"no", // update cost centre
+			"no", // update shutdown
+			"no", // update A-End VLAN
+			"no", // update B-End VLAN
+			"no", // update A-End inner VLAN
+			"no", // update B-End inner VLAN
+			"no", // update A-End UID
+			"no", // update B-End UID
+			"no", // A-End VRouter config
+			"no", // B-End VRouter config
+		)
+		return responses
+	}
+
+	t.Run("term 0 is rejected", func(t *testing.T) {
+		cleanup := mockPrompts(baseResponses("0"))
+		defer cleanup()
+
+		mockSvc := &MockVXCService{GetVXCResponse: existingVXC}
+		mockClient := &megaport.Client{VXCService: mockSvc}
+
+		_, err := buildUpdateVXCRequestFromPrompt(context.Background(), mockClient, "vxc-uid-123", true)
+		assert.Error(t, err)
+	})
+
+	for _, term := range []int{1, 12, 24, 36, 48, 60} {
+		t.Run(fmt.Sprintf("term %d is accepted", term), func(t *testing.T) {
+			cleanup := mockPrompts(baseResponses(fmt.Sprintf("%d", term)))
+			defer cleanup()
+
+			mockSvc := &MockVXCService{GetVXCResponse: existingVXC}
+			mockClient := &megaport.Client{VXCService: mockSvc}
+
+			req, err := buildUpdateVXCRequestFromPrompt(context.Background(), mockClient, "vxc-uid-123", true)
+			assert.NoError(t, err)
+			require.NotNil(t, req.Term)
+			assert.Equal(t, term, *req.Term)
 		})
 	}
 }

--- a/internal/commands/vxc/vxc_prompts_test.go
+++ b/internal/commands/vxc/vxc_prompts_test.go
@@ -1118,7 +1118,8 @@ func TestBuildUpdateVXCRequestFromPrompt_TermValidation(t *testing.T) {
 			mockClient := &megaport.Client{VXCService: mockSvc}
 
 			req, err := buildUpdateVXCRequestFromPrompt(context.Background(), mockClient, "vxc-uid-123", true)
-			assert.NoError(t, err)
+			require.NoError(t, err)
+			require.NotNil(t, req)
 			require.NotNil(t, req.Term)
 			assert.Equal(t, term, *req.Term)
 		})


### PR DESCRIPTION
The VXC and port update paths handled a contract term of 0 inconsistently, and both diverged from how MCR already handles it. A term of 0 could reach the API from the VXC flag path, the VXC JSON path, and the interactive VXC prompt (which offered 0 as a valid choice), and the port update flag path silently dropped `--term 0` as a no-op instead of applying or rejecting it.

- Validate the term unconditionally in the VXC flag and JSON update builders, rejecting 0 before any API call
- Remove 0 from the interactive VXC update prompt's valid-term list
- Validate the term unconditionally in the port update flag path instead of skipping validation when it's 0
- Add table-driven tests covering term 0 rejection and valid terms across all four paths
