### PR TITLE
ESD-1636-fix(wasm): recover around JS callback invocations at the boundary

### DIFF
--- a/internal/wasm/callback.go
+++ b/internal/wasm/callback.go
@@ -6,13 +6,21 @@ import "syscall/js"
 
 // InvokeCallback invokes cb with args, recovering from a panic so a throwing
 // host JS callback cannot escape into the caller. This mirrors the recover
-// pushOutputChunk (see output_handler.go) already applies around its own JS
-// Invoke. It returns the recovered panic value, or nil if the invocation
-// completed normally.
+// that pushOutputChunk (see output_handler.go) already applies around its
+// own JS Invoke. It returns the recovered panic value, or nil if the
+// invocation completed normally.
+//
+// Deliberately do not format the returned value into a log or error message:
+// a failed Invoke panics with a js.Error wrapping the thrown JS value, and
+// js.Error.Error() reads a "message" property back from the JS runtime. If
+// that property is a throwing accessor, js.Value.Get itself has no recover
+// boundary around it (unlike Invoke), so formatting the panic value can
+// crash the whole runtime one call frame past where this recover already
+// returned. A fixed, friendly message avoids ever touching the value again.
 func InvokeCallback(cb js.Value, args ...interface{}) (panicVal interface{}) {
 	defer func() {
 		panicVal = recover()
 	}()
 	cb.Invoke(args...)
-	return nil
+	return
 }

--- a/internal/wasm/callback.go
+++ b/internal/wasm/callback.go
@@ -1,0 +1,18 @@
+//go:build js && wasm
+
+package wasm
+
+import "syscall/js"
+
+// InvokeCallback invokes cb with args, recovering from a panic so a throwing
+// host JS callback cannot escape into the caller. This mirrors the recover
+// pushOutputChunk (see output_handler.go) already applies around its own JS
+// Invoke. It returns the recovered panic value, or nil if the invocation
+// completed normally.
+func InvokeCallback(cb js.Value, args ...interface{}) (panicVal interface{}) {
+	defer func() {
+		panicVal = recover()
+	}()
+	cb.Invoke(args...)
+	return nil
+}

--- a/internal/wasm/callback_test.go
+++ b/internal/wasm/callback_test.go
@@ -1,0 +1,39 @@
+//go:build js && wasm
+
+package wasm
+
+import (
+	"syscall/js"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestInvokeCallbackRecoversPanic verifies a throwing JS callback is recovered
+// and its panic value returned, rather than escaping to the caller.
+func TestInvokeCallbackRecoversPanic(t *testing.T) {
+	throwing := js.Global().Get("Function").New("throw new Error('callback boom')")
+
+	var r interface{}
+	assert.NotPanics(t, func() {
+		r = InvokeCallback(throwing)
+	})
+	assert.NotNil(t, r, "expected the recovered panic value to be returned")
+}
+
+// TestInvokeCallbackCleanInvocation verifies a well-behaved callback runs
+// normally and InvokeCallback returns nil (no panic to report).
+func TestInvokeCallbackCleanInvocation(t *testing.T) {
+	var received string
+	fn := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		if len(args) > 0 {
+			received = args[0].String()
+		}
+		return nil
+	})
+	defer fn.Release()
+
+	r := InvokeCallback(fn.Value, "hello")
+	assert.Nil(t, r)
+	assert.Equal(t, "hello", received)
+}

--- a/internal/wasm/prompts.go
+++ b/internal/wasm/prompts.go
@@ -109,8 +109,8 @@ func PromptForInput(message string, promptType string, resourceType string) (str
 		delete(pendingPrompts, promptID)
 		pendingMutex.Unlock()
 
-		js.Global().Get("console").Call("error", fmt.Sprintf("❌ Prompt callback panicked for %s: %v", promptID, r))
-		return "", fmt.Errorf("prompt callback failed: %v", r)
+		js.Global().Get("console").Call("error", fmt.Sprintf("❌ Prompt callback panicked for %s", promptID))
+		return "", fmt.Errorf("prompt callback threw for prompt %s", promptID)
 	}
 
 	// Wait for response with timeout. A stoppable timer (rather than time.After)

--- a/internal/wasm/prompts.go
+++ b/internal/wasm/prompts.go
@@ -95,13 +95,23 @@ func PromptForInput(message string, promptType string, resourceType string) (str
 	// carry secrets (access keys, passwords) and this ships in the public WASM console.
 	js.Global().Get("console").Call("log", fmt.Sprintf("📝 Requesting input: ID=%s, Type=%s", promptID, promptType))
 
-	// Call the JavaScript callback with the prompt details
-	cb.Invoke(map[string]interface{}{
+	// Call the JavaScript callback with the prompt details. A throwing host
+	// callback is recovered so it cannot leak this pendingPrompts entry or
+	// crash the command; the select below never runs in that case, so cleanup
+	// happens here instead.
+	if r := InvokeCallback(cb, map[string]interface{}{
 		"id":           promptID,
 		"message":      message,
 		"type":         promptType,
 		"resourceType": resourceType,
-	})
+	}); r != nil {
+		pendingMutex.Lock()
+		delete(pendingPrompts, promptID)
+		pendingMutex.Unlock()
+
+		js.Global().Get("console").Call("error", fmt.Sprintf("❌ Prompt callback panicked for %s: %v", promptID, r))
+		return "", fmt.Errorf("prompt callback failed: %v", r)
+	}
 
 	// Wait for response with timeout. A stoppable timer (rather than time.After)
 	// is stopped as soon as a response/error arrives so it isn't left running in

--- a/internal/wasm/prompts_recover_test.go
+++ b/internal/wasm/prompts_recover_test.go
@@ -1,0 +1,40 @@
+//go:build js && wasm
+
+package wasm
+
+import (
+	"syscall/js"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPromptForInputThrowingCallbackRecovered verifies a throwing prompt
+// callback is recovered: PromptForInput returns an error instead of
+// panicking, and the pendingPrompts entry it registered before invoking the
+// callback is cleaned up rather than leaked. Cleanup normally only happens in
+// the response/timeout select in PromptForInput, which a panicking Invoke
+// never reaches, so this exercises the dedicated cleanup path.
+func TestPromptForInputThrowingCallbackRecovered(t *testing.T) {
+	pendingMutex.Lock()
+	pendingPrompts = make(map[string]*PromptRequest)
+	pendingMutex.Unlock()
+
+	throwing := js.Global().Get("Function").New("throw new Error('prompt handler boom')")
+	promptCallback = throwing
+	defer func() { promptCallback = js.Undefined() }()
+
+	var result string
+	var err error
+	assert.NotPanics(t, func() {
+		result, err = PromptForInput("Enter name:", "text", "")
+	})
+
+	assert.Empty(t, result)
+	assert.Error(t, err)
+
+	pendingMutex.Lock()
+	remaining := len(pendingPrompts)
+	pendingMutex.Unlock()
+	assert.Equal(t, 0, remaining, "pendingPrompts entry must not leak when the callback throws")
+}

--- a/main_wasm.go
+++ b/main_wasm.go
@@ -45,7 +45,7 @@ func invokeAsyncTimeoutCallback(callback js.Value, once *sync.Once) {
 		if r := wasm.InvokeCallback(callback, map[string]interface{}{
 			"error": "command timed out",
 		}); r != nil {
-			js.Global().Get("console").Call("error", fmt.Sprintf("Timeout callback panicked: %v", r))
+			js.Global().Get("console").Call("error", "Timeout callback panicked")
 		}
 	})
 }

--- a/main_wasm.go
+++ b/main_wasm.go
@@ -35,6 +35,21 @@ func executeMegaportCommand(this js.Value, args []js.Value) interface{} {
 	}
 }
 
+// invokeAsyncTimeoutCallback fires the completion callback with a timeout
+// error, guarded by once so it never double-fires with the normal completion
+// path. It is factored out of executeMegaportCommandAsync so the recover
+// behavior can be exercised directly in tests without waiting out the real
+// asyncCommandTimeout.
+func invokeAsyncTimeoutCallback(callback js.Value, once *sync.Once) {
+	once.Do(func() {
+		if r := wasm.InvokeCallback(callback, map[string]interface{}{
+			"error": "command timed out",
+		}); r != nil {
+			js.Global().Get("console").Call("error", fmt.Sprintf("Timeout callback panicked: %v", r))
+		}
+	})
+}
+
 // executeMegaportCommandAsync runs CLI commands asynchronously with a callback
 // This is the CORRECT way to handle commands that involve async operations (like auth)
 func executeMegaportCommandAsync(this js.Value, args []js.Value) interface{} {
@@ -118,12 +133,11 @@ func executeMegaportCommandAsync(this js.Value, args []js.Value) interface{} {
 	}()
 
 	// Fire a timeout so the callback is always invoked within asyncCommandTimeout.
+	// This runs on the timer goroutine, not the goroutine above, so it needs its
+	// own recover: a throwing callback here would otherwise terminate the whole
+	// WASM runtime rather than just this command.
 	t := time.AfterFunc(asyncCommandTimeout, func() {
-		once.Do(func() {
-			callback.Invoke(map[string]interface{}{
-				"error": "command timed out",
-			})
-		})
+		invokeAsyncTimeoutCallback(callback, &once)
 	})
 
 	// Stop the timer once the goroutine finishes so it is not kept alive for the

--- a/main_wasm_test.go
+++ b/main_wasm_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"os"
+	"sync"
 	"syscall/js"
 	"testing"
 	"time"
@@ -361,6 +362,43 @@ func TestErrorRecovery(t *testing.T) {
 	assert.NotPanics(t, func() {
 		invokeAsyncAndWait(t, "invalid command with many args that don't make sense")
 	})
+}
+
+// TestInvokeAsyncTimeoutCallback_ThrowingCallbackRecovered verifies a host
+// completion callback that throws on the timeout path is recovered rather
+// than crashing the runtime, and that once is still consumed so a
+// simultaneous normal-completion callback.Invoke would not double-fire.
+func TestInvokeAsyncTimeoutCallback_ThrowingCallbackRecovered(t *testing.T) {
+	throwing := js.Global().Get("Function").New("throw new Error('timeout callback boom')")
+
+	var once sync.Once
+	assert.NotPanics(t, func() {
+		invokeAsyncTimeoutCallback(throwing, &once)
+	})
+
+	fired := false
+	once.Do(func() { fired = true })
+	assert.False(t, fired, "once should already be consumed by the timeout invocation")
+}
+
+// TestInvokeAsyncTimeoutCallback_CleanInvocation verifies the normal
+// (non-throwing) timeout path still delivers the timeout error to the
+// callback.
+func TestInvokeAsyncTimeoutCallback_CleanInvocation(t *testing.T) {
+	var received js.Value
+	fn := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		if len(args) > 0 {
+			received = args[0]
+		}
+		return nil
+	})
+	defer fn.Release()
+
+	var once sync.Once
+	invokeAsyncTimeoutCallback(fn.Value, &once)
+
+	assert.False(t, received.IsUndefined())
+	assert.Equal(t, "command timed out", received.Get("error").String())
 }
 
 // TestConcurrentCommands verifies concurrent async commands don't interfere


### PR DESCRIPTION
Two JS callback invocations at the WASM boundary weren't guarded against a throwing host callback: the prompt callback and the async command timeout callback. A throwing callback here previously either leaked the pending prompt entry or could crash the whole WASM runtime.

- Added an `InvokeCallback` helper (`internal/wasm/callback.go`) that recovers around `js.Value.Invoke`, mirroring the existing guard in `pushOutputChunk`
- Wired it into the prompt callback in `internal/wasm/prompts.go`, cleaning up the pending prompt entry if the callback throws
- Wired it into the async command timeout callback in `main_wasm.go`, extracted into `invokeAsyncTimeoutCallback` for testability
- Added tests covering both recover paths

The recovered panic value is deliberately never formatted into a log or error message. `js.Error.Error()` reads a JS `message` property back from the runtime, and property access has no recover boundary in `wasm_exec.js` (unlike Invoke), so formatting it could crash the runtime in a way Go can't catch. Fixed, friendly strings are logged instead.

Out of scope per the ticket: prompt/timeout durations, and the goroutine's own existing recover in `executeMegaportCommandAsync`, which isn't touched here.