### PR TITLE
ESD-1640: Read VXC shutdown status from the Shutdown field

### DIFF
--- a/internal/commands/vxc/vxc_prompts.go
+++ b/internal/commands/vxc/vxc_prompts.go
@@ -313,7 +313,7 @@ var buildUpdateVXCRequestFromPrompt = func(ctx context.Context, client *megaport
 	}
 
 	shutdownStatus := "No"
-	if vxc.AdminLocked {
+	if vxc.Shutdown {
 		shutdownStatus = "Yes"
 	}
 	fmt.Fprintf(os.Stderr, "Current shutdown status: %s\n", shutdownStatus)

--- a/internal/commands/vxc/vxc_prompts_test.go
+++ b/internal/commands/vxc/vxc_prompts_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/testutil"
 	"github.com/megaport/megaport-cli/internal/utils"
 	megaport "github.com/megaport/megaportgo"
@@ -1051,6 +1052,84 @@ func TestBuildUpdateVXCRequestFromPrompt(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, req)
 			tc.verify(t, req)
+		})
+	}
+}
+
+func TestBuildUpdateVXCRequestFromPromptShutdownStatusDisplay(t *testing.T) {
+	responses := []string{
+		"no", // update name
+		"no", // update rate limit
+		"no", // update term
+		"no", // update cost centre
+		"no", // update shutdown
+		"no", // update A-End VLAN
+		"no", // update B-End VLAN
+		"no", // update A-End inner VLAN
+		"no", // update B-End inner VLAN
+		"no", // update A-End UID
+		"no", // update B-End UID
+		"no", // A-End VRouter config
+		"no", // B-End VRouter config
+	}
+
+	tests := []struct {
+		name           string
+		shutdown       bool
+		adminLocked    bool
+		expectedStatus string
+	}{
+		{
+			name:           "shutdown true but not admin locked shows shutdown status",
+			shutdown:       true,
+			adminLocked:    false,
+			expectedStatus: "Current shutdown status: Yes",
+		},
+		{
+			name:           "shutdown false but admin locked shows enabled status",
+			shutdown:       false,
+			adminLocked:    true,
+			expectedStatus: "Current shutdown status: No",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cleanup := mockPrompts(responses)
+			defer cleanup()
+
+			existingVXC := &megaport.VXC{
+				UID:                "vxc-uid-123",
+				Name:               "Old VXC",
+				RateLimit:          100,
+				ContractTermMonths: 12,
+				CostCentre:         "CC-001",
+				Shutdown:           tc.shutdown,
+				AdminLocked:        tc.adminLocked,
+				AEndConfiguration: megaport.VXCEndConfiguration{
+					UID:  "a-end-uid",
+					VLAN: 100,
+				},
+				BEndConfiguration: megaport.VXCEndConfiguration{
+					UID:  "b-end-uid",
+					VLAN: 200,
+				},
+			}
+
+			mockSvc := &MockVXCService{
+				GetVXCResponse: existingVXC,
+			}
+			mockClient := &megaport.Client{VXCService: mockSvc}
+
+			var req *megaport.UpdateVXCRequest
+			var err error
+			capturedOutput := output.CaptureOutput(func() {
+				req, err = buildUpdateVXCRequestFromPrompt(context.Background(), mockClient, "vxc-uid-123", true)
+			})
+
+			assert.NoError(t, err)
+			assert.NotNil(t, req)
+			assert.Contains(t, capturedOutput, tc.expectedStatus)
 		})
 	}
 }


### PR DESCRIPTION
The VXC interactive update prompt showed the current shutdown status from `AdminLocked` instead of `Shutdown`. Those are separate fields on the SDK VXC type, so a VXC that was shut down but not admin-locked displayed as enabled, which could lead someone to toggle shutdown the wrong way.

- Read `vxc.Shutdown` instead of `vxc.AdminLocked` for the displayed shutdown status
- Added a test covering the shutdown-but-not-locked case and the inverse

The write path already used `req.Shutdown` correctly, so this is a display-only fix.
