### PR TITLE
ESD-1638: Validate VXC update JSON with checked helpers and a field gate

### DIFF
--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -1456,6 +1456,69 @@ func TestBuildUpdateVXCRequestFromJSON_WholeRateLimit(t *testing.T) {
 	assert.Equal(t, 2000, *req.RateLimit)
 }
 
+func TestBuildUpdateVXCRequestFromJSON_TypoKeyIsRejected(t *testing.T) {
+	// "rateLimt" is not a recognized field, so it must not be silently
+	// dropped into an empty, successful update.
+	_, err := buildUpdateVXCRequestFromJSON(`{"rateLimt": 500}`, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one field must be updated")
+}
+
+func TestBuildUpdateVXCRequestFromJSON_WrongTypedValueIsRejected(t *testing.T) {
+	_, err := buildUpdateVXCRequestFromJSON(`{"rateLimit": "500"}`, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rateLimit must be a number")
+}
+
+func TestBuildUpdateVXCRequestFromJSON_EmptyObjectIsRejected(t *testing.T) {
+	_, err := buildUpdateVXCRequestFromJSON(`{}`, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one field must be updated")
+}
+
+func TestBuildUpdateVXCRequestFromJSON_ValidMultiFieldPayload(t *testing.T) {
+	req, err := buildUpdateVXCRequestFromJSON(`{"name":"updated-vxc","rateLimit":1000,"costCentre":"eng","shutdown":true}`, "")
+	require.NoError(t, err)
+	require.NotNil(t, req.Name)
+	assert.Equal(t, "updated-vxc", *req.Name)
+	require.NotNil(t, req.RateLimit)
+	assert.Equal(t, 1000, *req.RateLimit)
+	require.NotNil(t, req.CostCentre)
+	assert.Equal(t, "eng", *req.CostCentre)
+	require.NotNil(t, req.Shutdown)
+	assert.True(t, *req.Shutdown)
+}
+
+func TestBuildUpdateVXCRequestFromJSON_FlatVLANFallback(t *testing.T) {
+	req, err := buildUpdateVXCRequestFromJSON(`{"aEndVlan":100,"bEndVlan":200}`, "")
+	require.NoError(t, err)
+	require.NotNil(t, req.AEndVLAN)
+	assert.Equal(t, 100, *req.AEndVLAN)
+	require.NotNil(t, req.BEndVLAN)
+	assert.Equal(t, 200, *req.BEndVLAN)
+}
+
+func TestBuildUpdateVXCRequestFromJSON_WrongTypedPartnerConfigIsRejected(t *testing.T) {
+	_, err := buildUpdateVXCRequestFromJSON(`{"aEndPartnerConfig":"not-an-object"}`, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aEndPartnerConfig must be an object")
+}
+
+func TestBuildUpdateVXCRequestFromJSON_NestedWrongTypedValueIsRejected(t *testing.T) {
+	_, err := buildUpdateVXCRequestFromJSON(`{"aEndConfiguration":{"vlan":"not-a-number"}}`, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aEndConfiguration.vlan")
+}
+
+func TestBuildUpdateVXCRequestFromJSON_NestedTypoKeyIsRejected(t *testing.T) {
+	// "vln" inside aEndConfiguration is not recognized, so the object is
+	// present but contributes no field, and no flat aEndVlan fallback
+	// applies once aEndConfiguration itself is present.
+	_, err := buildUpdateVXCRequestFromJSON(`{"aEndConfiguration":{"vln":100}}`, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one field must be updated")
+}
+
 func TestResolvePartnerPortUID(t *testing.T) {
 	origGetPartnerPortUID := getPartnerPortUID
 	defer func() { getPartnerPortUID = origGetPartnerPortUID }()

--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -1521,6 +1521,14 @@ func TestBuildUpdateVXCRequestFromJSON_NestedTypoKeyIsRejected(t *testing.T) {
 	_, err := buildUpdateVXCRequestFromJSON(`{"aEndConfiguration":{"vln":100}}`, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "at least one field must be updated")
+	assert.Contains(t, err.Error(), "aEndConfiguration.vln")
+}
+
+func TestBuildUpdateVXCRequestFromJSON_NestedBEndTypoKeyIsRejected(t *testing.T) {
+	_, err := buildUpdateVXCRequestFromJSON(`{"bEndConfiguration":{"vln":100}}`, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one field must be updated")
+	assert.Contains(t, err.Error(), "bEndConfiguration.vln")
 }
 
 func TestBuildUpdateVXCRequestFromJSON_NoInputProvided(t *testing.T) {

--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -1623,6 +1623,16 @@ func TestBuildUpdateVXCRequestFromJSON_FieldCoverage(t *testing.T) {
 			expectedError: "aEndPartnerConfig.connectType",
 		},
 		{
+			name:          "missing aEndPartnerConfig.connectType rejected",
+			json:          `{"aEndPartnerConfig":{"interfaces":[]}}`,
+			expectedError: "aEndPartnerConfig.connectType is required",
+		},
+		{
+			name:          "missing bEndPartnerConfig.connectType rejected",
+			json:          `{"bEndPartnerConfig":{"interfaces":[]}}`,
+			expectedError: "bEndPartnerConfig.connectType is required",
+		},
+		{
 			name:          "wrong-typed flat aEndVlan rejected",
 			json:          `{"aEndVlan":"x"}`,
 			expectedError: "aEndVlan must be a number",

--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -1852,6 +1852,9 @@ func TestBuildUpdateVXCRequestFromJSON_FieldCoverage(t *testing.T) {
 			if tt.expectedError != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
+				var cliErr *exitcodes.CLIError
+				require.ErrorAs(t, err, &cliErr)
+				assert.Equal(t, exitcodes.Usage, cliErr.Code)
 			} else {
 				require.NoError(t, err)
 				if tt.validate != nil {

--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -1519,6 +1519,339 @@ func TestBuildUpdateVXCRequestFromJSON_NestedTypoKeyIsRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "at least one field must be updated")
 }
 
+func TestBuildUpdateVXCRequestFromJSON_NoInputProvided(t *testing.T) {
+	_, err := buildUpdateVXCRequestFromJSON("", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "either json or json-file must be provided")
+}
+
+func TestBuildUpdateVXCRequestFromJSON_MissingJSONFile(t *testing.T) {
+	_, err := buildUpdateVXCRequestFromJSON("", "/nonexistent/path/to/update.json")
+	require.Error(t, err)
+}
+
+func TestBuildUpdateVXCRequestFromJSON_MalformedJSONIsRejected(t *testing.T) {
+	_, err := buildUpdateVXCRequestFromJSON(`{"name":`, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse JSON")
+}
+
+func TestBuildUpdateVXCRequestFromJSON_FieldCoverage(t *testing.T) {
+	tests := []struct {
+		name          string
+		json          string
+		expectedError string
+		validate      func(*testing.T, *megaport.UpdateVXCRequest)
+	}{
+		{
+			name:          "negative rate limit rejected",
+			json:          `{"rateLimit":-5}`,
+			expectedError: "rateLimit must be greater than or equal to 0",
+		},
+		{
+			name:          "wrong-typed term rejected",
+			json:          `{"term":"12"}`,
+			expectedError: "term must be a number",
+		},
+		{
+			name:          "fractional term rejected",
+			json:          `{"term":12.5}`,
+			expectedError: "term must be a whole number",
+		},
+		{
+			name:          "invalid term rejected",
+			json:          `{"term":5}`,
+			expectedError: "contract term",
+		},
+		{
+			name: "valid non-zero term",
+			json: `{"term":12}`,
+			validate: func(t *testing.T, req *megaport.UpdateVXCRequest) {
+				require.NotNil(t, req.Term)
+				assert.Equal(t, 12, *req.Term)
+			},
+		},
+		{
+			name: "valid zero term skips contract term validation",
+			json: `{"term":0}`,
+			validate: func(t *testing.T, req *megaport.UpdateVXCRequest) {
+				require.NotNil(t, req.Term)
+				assert.Equal(t, 0, *req.Term)
+			},
+		},
+		{
+			name:          "wrong-typed cost centre rejected",
+			json:          `{"costCentre":123}`,
+			expectedError: "costCentre must be a string",
+		},
+		{
+			name:          "wrong-typed shutdown rejected",
+			json:          `{"shutdown":"yes"}`,
+			expectedError: "shutdown must be a boolean",
+		},
+		{
+			name:          "wrong-typed aEndConfiguration rejected",
+			json:          `{"aEndConfiguration":"not-an-object"}`,
+			expectedError: "aEndConfiguration must be an object",
+		},
+		{
+			name:          "fractional aEndConfiguration.vlan rejected",
+			json:          `{"aEndConfiguration":{"vlan":100.5}}`,
+			expectedError: "aEndConfiguration.vlan must be a whole number",
+		},
+		{
+			name:          "out-of-range aEndConfiguration.vlan rejected",
+			json:          `{"aEndConfiguration":{"vlan":5000}}`,
+			expectedError: "aEndConfiguration.vlan",
+		},
+		{
+			name: "valid aEndConfiguration.vlan",
+			json: `{"aEndConfiguration":{"vlan":100}}`,
+			validate: func(t *testing.T, req *megaport.UpdateVXCRequest) {
+				require.NotNil(t, req.AEndVLAN)
+				assert.Equal(t, 100, *req.AEndVLAN)
+			},
+		},
+		{
+			name:          "wrong-typed bEndConfiguration.vlan rejected",
+			json:          `{"bEndConfiguration":{"vlan":"x"}}`,
+			expectedError: "bEndConfiguration.vlan: vlan must be a number",
+		},
+		{
+			name:          "wrong-typed aEndPartnerConfig.connectType rejected",
+			json:          `{"aEndPartnerConfig":{"connectType":123}}`,
+			expectedError: "aEndPartnerConfig.connectType",
+		},
+		{
+			name:          "wrong-typed flat aEndVlan rejected",
+			json:          `{"aEndVlan":"x"}`,
+			expectedError: "aEndVlan must be a number",
+		},
+		{
+			name:          "fractional flat aEndVlan rejected",
+			json:          `{"aEndVlan":100.5}`,
+			expectedError: "aEndVlan must be a whole number",
+		},
+		{
+			name:          "out-of-range flat aEndVlan rejected",
+			json:          `{"aEndVlan":5000}`,
+			expectedError: "aEndVlan",
+		},
+		{
+			name:          "wrong-typed bEndConfiguration rejected",
+			json:          `{"bEndConfiguration":"not-an-object"}`,
+			expectedError: "bEndConfiguration must be an object",
+		},
+		{
+			name:          "fractional bEndConfiguration.vlan rejected",
+			json:          `{"bEndConfiguration":{"vlan":200.5}}`,
+			expectedError: "bEndConfiguration.vlan must be a whole number",
+		},
+		{
+			name:          "out-of-range bEndConfiguration.vlan rejected",
+			json:          `{"bEndConfiguration":{"vlan":5000}}`,
+			expectedError: "bEndConfiguration.vlan",
+		},
+		{
+			name: "valid bEndConfiguration.vlan",
+			json: `{"bEndConfiguration":{"vlan":200}}`,
+			validate: func(t *testing.T, req *megaport.UpdateVXCRequest) {
+				require.NotNil(t, req.BEndVLAN)
+				assert.Equal(t, 200, *req.BEndVLAN)
+			},
+		},
+		{
+			name:          "wrong-typed flat bEndVlan rejected",
+			json:          `{"bEndVlan":"x"}`,
+			expectedError: "bEndVlan must be a number",
+		},
+		{
+			name:          "fractional flat bEndVlan rejected",
+			json:          `{"bEndVlan":200.5}`,
+			expectedError: "bEndVlan must be a whole number",
+		},
+		{
+			name:          "out-of-range flat bEndVlan rejected",
+			json:          `{"bEndVlan":5000}`,
+			expectedError: "bEndVlan",
+		},
+		{
+			name:          "wrong-typed name rejected",
+			json:          `{"name":123}`,
+			expectedError: "name must be a string",
+		},
+		{
+			name: "vxcName used when name absent",
+			json: `{"vxcName":"foo"}`,
+			validate: func(t *testing.T, req *megaport.UpdateVXCRequest) {
+				require.NotNil(t, req.Name)
+				assert.Equal(t, "foo", *req.Name)
+			},
+		},
+		{
+			name:          "wrong-typed vxcName rejected",
+			json:          `{"vxcName":123}`,
+			expectedError: "vxcName must be a string",
+		},
+		{
+			name:          "wrong-typed aEndInnerVlan rejected",
+			json:          `{"aEndInnerVlan":"x"}`,
+			expectedError: "aEndInnerVlan must be a number",
+		},
+		{
+			name:          "fractional aEndInnerVlan rejected",
+			json:          `{"aEndInnerVlan":100.5}`,
+			expectedError: "aEndInnerVlan must be a whole number",
+		},
+		{
+			name:          "out-of-range aEndInnerVlan rejected",
+			json:          `{"aEndInnerVlan":5000}`,
+			expectedError: "invalid aEndInnerVlan",
+		},
+		{
+			name: "valid aEndInnerVlan",
+			json: `{"aEndInnerVlan":100}`,
+			validate: func(t *testing.T, req *megaport.UpdateVXCRequest) {
+				require.NotNil(t, req.AEndInnerVLAN)
+				assert.Equal(t, 100, *req.AEndInnerVLAN)
+			},
+		},
+		{
+			name:          "wrong-typed bEndInnerVlan rejected",
+			json:          `{"bEndInnerVlan":"x"}`,
+			expectedError: "bEndInnerVlan must be a number",
+		},
+		{
+			name:          "fractional bEndInnerVlan rejected",
+			json:          `{"bEndInnerVlan":200.5}`,
+			expectedError: "bEndInnerVlan must be a whole number",
+		},
+		{
+			name:          "out-of-range bEndInnerVlan rejected",
+			json:          `{"bEndInnerVlan":5000}`,
+			expectedError: "invalid bEndInnerVlan",
+		},
+		{
+			name: "valid bEndInnerVlan",
+			json: `{"bEndInnerVlan":200}`,
+			validate: func(t *testing.T, req *megaport.UpdateVXCRequest) {
+				require.NotNil(t, req.BEndInnerVLAN)
+				assert.Equal(t, 200, *req.BEndInnerVLAN)
+			},
+		},
+		{
+			name:          "wrong-typed aEndUid rejected",
+			json:          `{"aEndUid":123}`,
+			expectedError: "aEndUid must be a string",
+		},
+		{
+			name: "valid aEndUid",
+			json: `{"aEndUid":"a-end-uid"}`,
+			validate: func(t *testing.T, req *megaport.UpdateVXCRequest) {
+				require.NotNil(t, req.AEndProductUID)
+				assert.Equal(t, "a-end-uid", *req.AEndProductUID)
+			},
+		},
+		{
+			name:          "wrong-typed bEndUid rejected",
+			json:          `{"bEndUid":123}`,
+			expectedError: "bEndUid must be a string",
+		},
+		{
+			name: "valid bEndUid",
+			json: `{"bEndUid":"b-end-uid"}`,
+			validate: func(t *testing.T, req *megaport.UpdateVXCRequest) {
+				require.NotNil(t, req.BEndProductUID)
+				assert.Equal(t, "b-end-uid", *req.BEndProductUID)
+			},
+		},
+		{
+			name:          "wrong-typed bEndPartnerConfig rejected",
+			json:          `{"bEndPartnerConfig":"not-an-object"}`,
+			expectedError: "bEndPartnerConfig must be an object",
+		},
+		{
+			name:          "wrong-typed bEndPartnerConfig.connectType rejected",
+			json:          `{"bEndPartnerConfig":{"connectType":123}}`,
+			expectedError: "bEndPartnerConfig.connectType",
+		},
+		{
+			name:          "wrong-typed isApproved rejected",
+			json:          `{"isApproved":"yes"}`,
+			expectedError: "isApproved must be a boolean",
+		},
+		{
+			name: "valid isApproved",
+			json: `{"isApproved":true}`,
+			validate: func(t *testing.T, req *megaport.UpdateVXCRequest) {
+				require.NotNil(t, req.IsApproved)
+				assert.True(t, *req.IsApproved)
+			},
+		},
+		{
+			name:          "wrong-typed aVnicIndex rejected",
+			json:          `{"aVnicIndex":"x"}`,
+			expectedError: "aVnicIndex must be a number",
+		},
+		{
+			name:          "fractional aVnicIndex rejected",
+			json:          `{"aVnicIndex":1.5}`,
+			expectedError: "aVnicIndex must be a whole number",
+		},
+		{
+			name:          "negative aVnicIndex rejected",
+			json:          `{"aVnicIndex":-1}`,
+			expectedError: "invalid aVnicIndex",
+		},
+		{
+			name: "valid aVnicIndex",
+			json: `{"aVnicIndex":1}`,
+			validate: func(t *testing.T, req *megaport.UpdateVXCRequest) {
+				require.NotNil(t, req.AVnicIndex)
+				assert.Equal(t, 1, *req.AVnicIndex)
+			},
+		},
+		{
+			name:          "wrong-typed bVnicIndex rejected",
+			json:          `{"bVnicIndex":"x"}`,
+			expectedError: "bVnicIndex must be a number",
+		},
+		{
+			name:          "fractional bVnicIndex rejected",
+			json:          `{"bVnicIndex":1.5}`,
+			expectedError: "bVnicIndex must be a whole number",
+		},
+		{
+			name:          "negative bVnicIndex rejected",
+			json:          `{"bVnicIndex":-1}`,
+			expectedError: "invalid bVnicIndex",
+		},
+		{
+			name: "valid bVnicIndex",
+			json: `{"bVnicIndex":1}`,
+			validate: func(t *testing.T, req *megaport.UpdateVXCRequest) {
+				require.NotNil(t, req.BVnicIndex)
+				assert.Equal(t, 1, *req.BVnicIndex)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := buildUpdateVXCRequestFromJSON(tt.json, "")
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+				if tt.validate != nil {
+					tt.validate(t, result)
+				}
+			}
+		})
+	}
+}
+
 func TestResolvePartnerPortUID(t *testing.T) {
 	origGetPartnerPortUID := getPartnerPortUID
 	defer func() { getPartnerPortUID = origGetPartnerPortUID }()

--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -1468,6 +1468,28 @@ func TestBuildUpdateVXCRequestFromJSON_TypoKeyIsRejected(t *testing.T) {
 	assert.Equal(t, exitcodes.Usage, cliErr.Code)
 }
 
+func TestBuildUpdateVXCRequestFromJSON_TypoKeyAlongsideValidFieldIsRejected(t *testing.T) {
+	// A valid field must not let a sibling typo key slip through and get
+	// silently dropped just because fieldSet is already true.
+	_, err := buildUpdateVXCRequestFromJSON(`{"rateLimit":500,"rateLimt":999}`, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unrecognized keys")
+	assert.Contains(t, err.Error(), "rateLimt")
+	var cliErr *exitcodes.CLIError
+	require.ErrorAs(t, err, &cliErr)
+	assert.Equal(t, exitcodes.Usage, cliErr.Code)
+}
+
+func TestBuildUpdateVXCRequestFromJSON_NestedTypoKeyAlongsideValidFieldIsRejected(t *testing.T) {
+	_, err := buildUpdateVXCRequestFromJSON(`{"name":"updated-vxc","aEndConfiguration":{"vlan":100,"vln":200}}`, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unrecognized keys")
+	assert.Contains(t, err.Error(), "aEndConfiguration.vln")
+	var cliErr *exitcodes.CLIError
+	require.ErrorAs(t, err, &cliErr)
+	assert.Equal(t, exitcodes.Usage, cliErr.Code)
+}
+
 func TestBuildUpdateVXCRequestFromJSON_WrongTypedValueIsRejected(t *testing.T) {
 	_, err := buildUpdateVXCRequestFromJSON(`{"rateLimit": "500"}`, "")
 	require.Error(t, err)

--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -1462,6 +1462,10 @@ func TestBuildUpdateVXCRequestFromJSON_TypoKeyIsRejected(t *testing.T) {
 	_, err := buildUpdateVXCRequestFromJSON(`{"rateLimt": 500}`, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "at least one field must be updated")
+	assert.Contains(t, err.Error(), "rateLimt")
+	var cliErr *exitcodes.CLIError
+	require.ErrorAs(t, err, &cliErr)
+	assert.Equal(t, exitcodes.Usage, cliErr.Code)
 }
 
 func TestBuildUpdateVXCRequestFromJSON_WrongTypedValueIsRejected(t *testing.T) {

--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -1472,12 +1472,18 @@ func TestBuildUpdateVXCRequestFromJSON_WrongTypedValueIsRejected(t *testing.T) {
 	_, err := buildUpdateVXCRequestFromJSON(`{"rateLimit": "500"}`, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rateLimit must be a number")
+	var cliErr *exitcodes.CLIError
+	require.ErrorAs(t, err, &cliErr)
+	assert.Equal(t, exitcodes.Usage, cliErr.Code)
 }
 
 func TestBuildUpdateVXCRequestFromJSON_EmptyObjectIsRejected(t *testing.T) {
 	_, err := buildUpdateVXCRequestFromJSON(`{}`, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "at least one field must be updated")
+	var cliErr *exitcodes.CLIError
+	require.ErrorAs(t, err, &cliErr)
+	assert.Equal(t, exitcodes.Usage, cliErr.Code)
 }
 
 func TestBuildUpdateVXCRequestFromJSON_ValidMultiFieldPayload(t *testing.T) {
@@ -1506,6 +1512,9 @@ func TestBuildUpdateVXCRequestFromJSON_WrongTypedPartnerConfigIsRejected(t *test
 	_, err := buildUpdateVXCRequestFromJSON(`{"aEndPartnerConfig":"not-an-object"}`, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "aEndPartnerConfig must be an object")
+	var cliErr *exitcodes.CLIError
+	require.ErrorAs(t, err, &cliErr)
+	assert.Equal(t, exitcodes.Usage, cliErr.Code)
 }
 
 func TestBuildUpdateVXCRequestFromJSON_NestedWrongTypedValueIsRejected(t *testing.T) {

--- a/internal/commands/vxc/vxc_inputs_update.go
+++ b/internal/commands/vxc/vxc_inputs_update.go
@@ -434,37 +434,41 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 		fieldSet = true
 	}
 
-	if !fieldSet {
-		recognizedKeys := map[string]bool{
-			"rateLimit": true, "term": true, "costCentre": true, "shutdown": true,
-			"aEndConfiguration": true, "aEndVlan": true,
-			"bEndConfiguration": true, "bEndVlan": true,
-			"name": true, "vxcName": true,
-			"aEndInnerVlan": true, "bEndInnerVlan": true,
-			"aEndUid": true, "bEndUid": true,
-			"aEndPartnerConfig": true, "bEndPartnerConfig": true,
-			"isApproved": true, "aVnicIndex": true, "bVnicIndex": true,
+	recognizedKeys := map[string]bool{
+		"rateLimit": true, "term": true, "costCentre": true, "shutdown": true,
+		"aEndConfiguration": true, "aEndVlan": true,
+		"bEndConfiguration": true, "bEndVlan": true,
+		"name": true, "vxcName": true,
+		"aEndInnerVlan": true, "bEndInnerVlan": true,
+		"aEndUid": true, "bEndUid": true,
+		"aEndPartnerConfig": true, "bEndPartnerConfig": true,
+		"isApproved": true, "aVnicIndex": true, "bVnicIndex": true,
+	}
+	var unrecognized []string
+	for key := range rawData {
+		if !recognizedKeys[key] {
+			unrecognized = append(unrecognized, key)
 		}
-		var unrecognized []string
-		for key := range rawData {
-			if !recognizedKeys[key] {
-				unrecognized = append(unrecognized, key)
-			}
+	}
+	for key := range aEndConfigMap {
+		if key != "vlan" {
+			unrecognized = append(unrecognized, "aEndConfiguration."+key)
 		}
-		for key := range aEndConfigMap {
-			if key != "vlan" {
-				unrecognized = append(unrecognized, "aEndConfiguration."+key)
-			}
+	}
+	for key := range bEndConfigMap {
+		if key != "vlan" {
+			unrecognized = append(unrecognized, "bEndConfiguration."+key)
 		}
-		for key := range bEndConfigMap {
-			if key != "vlan" {
-				unrecognized = append(unrecognized, "bEndConfiguration."+key)
-			}
-		}
-		if len(unrecognized) > 0 {
-			sort.Strings(unrecognized)
+	}
+	if len(unrecognized) > 0 {
+		sort.Strings(unrecognized)
+		if !fieldSet {
 			return nil, exitcodes.NewUsageError(fmt.Errorf("at least one field must be updated (unrecognized keys: %s)", strings.Join(unrecognized, ", ")))
 		}
+		return nil, exitcodes.NewUsageError(fmt.Errorf("unrecognized keys: %s", strings.Join(unrecognized, ", ")))
+	}
+
+	if !fieldSet {
 		return nil, exitcodes.NewUsageError(fmt.Errorf("at least one field must be updated"))
 	}
 

--- a/internal/commands/vxc/vxc_inputs_update.go
+++ b/internal/commands/vxc/vxc_inputs_update.go
@@ -342,9 +342,12 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 	if aEndPartnerConfigRaw, present, err := utils.JSONObject(rawData, "aEndPartnerConfig"); err != nil {
 		return nil, fmt.Errorf("aEndPartnerConfig: %w", err)
 	} else if present {
-		connectType, _, err := utils.JSONString(aEndPartnerConfigRaw, "connectType")
+		connectType, connectTypePresent, err := utils.JSONString(aEndPartnerConfigRaw, "connectType")
 		if err != nil {
 			return nil, fmt.Errorf("aEndPartnerConfig.connectType: %w", err)
+		}
+		if !connectTypePresent || connectType == "" {
+			return nil, fmt.Errorf("aEndPartnerConfig.connectType is required")
 		}
 		if strings.ToUpper(connectType) != "VROUTER" {
 			return nil, fmt.Errorf("only VRouter partner configurations can be updated")
@@ -367,9 +370,12 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 	if bEndPartnerConfigRaw, present, err := utils.JSONObject(rawData, "bEndPartnerConfig"); err != nil {
 		return nil, fmt.Errorf("bEndPartnerConfig: %w", err)
 	} else if present {
-		connectType, _, err := utils.JSONString(bEndPartnerConfigRaw, "connectType")
+		connectType, connectTypePresent, err := utils.JSONString(bEndPartnerConfigRaw, "connectType")
 		if err != nil {
 			return nil, fmt.Errorf("bEndPartnerConfig.connectType: %w", err)
+		}
+		if !connectTypePresent || connectType == "" {
+			return nil, fmt.Errorf("bEndPartnerConfig.connectType is required")
 		}
 		if strings.ToUpper(connectType) != "VROUTER" {
 			return nil, fmt.Errorf("only VRouter partner configurations can be updated")

--- a/internal/commands/vxc/vxc_inputs_update.go
+++ b/internal/commands/vxc/vxc_inputs_update.go
@@ -224,9 +224,11 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 	}
 
 	// Handle nested configurations in addition to flat fields
+	var aEndConfigMap, bEndConfigMap map[string]interface{}
 	if aEndConfig, present, err := utils.JSONObject(rawData, "aEndConfiguration"); err != nil {
 		return nil, exitcodes.NewUsageError(err)
 	} else if present {
+		aEndConfigMap = aEndConfig
 		if vlan, vlanPresent, err := utils.JSONNumber(aEndConfig, "vlan"); err != nil {
 			return nil, exitcodes.NewUsageError(fmt.Errorf("aEndConfiguration.vlan: %w", err))
 		} else if vlanPresent {
@@ -257,6 +259,7 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 	if bEndConfig, present, err := utils.JSONObject(rawData, "bEndConfiguration"); err != nil {
 		return nil, exitcodes.NewUsageError(err)
 	} else if present {
+		bEndConfigMap = bEndConfig
 		if vlan, vlanPresent, err := utils.JSONNumber(bEndConfig, "vlan"); err != nil {
 			return nil, exitcodes.NewUsageError(fmt.Errorf("bEndConfiguration.vlan: %w", err))
 		} else if vlanPresent {
@@ -446,6 +449,16 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 		for key := range rawData {
 			if !recognizedKeys[key] {
 				unrecognized = append(unrecognized, key)
+			}
+		}
+		for key := range aEndConfigMap {
+			if key != "vlan" {
+				unrecognized = append(unrecognized, "aEndConfiguration."+key)
+			}
+		}
+		for key := range bEndConfigMap {
+			if key != "vlan" {
+				unrecognized = append(unrecognized, "bEndConfiguration."+key)
 			}
 		}
 		if len(unrecognized) > 0 {

--- a/internal/commands/vxc/vxc_inputs_update.go
+++ b/internal/commands/vxc/vxc_inputs_update.go
@@ -228,6 +228,9 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 		if vlan, vlanPresent, err := utils.JSONNumber(aEndConfig, "vlan"); err != nil {
 			return nil, fmt.Errorf("aEndConfiguration.vlan: %w", err)
 		} else if vlanPresent {
+			if vlan != math.Trunc(vlan) {
+				return nil, fmt.Errorf("aEndConfiguration.vlan must be a whole number, got %v", vlan)
+			}
 			vlanInt := int(vlan)
 			if err := validation.ValidateVLAN(vlanInt); err != nil {
 				return nil, fmt.Errorf("aEndConfiguration.vlan: %w", err)
@@ -238,6 +241,9 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 	} else if aEndVLAN, present, err := utils.JSONNumber(rawData, "aEndVlan"); err != nil {
 		return nil, fmt.Errorf("aEndVlan: %w", err)
 	} else if present {
+		if aEndVLAN != math.Trunc(aEndVLAN) {
+			return nil, fmt.Errorf("aEndVlan must be a whole number, got %v", aEndVLAN)
+		}
 		aEndVLANInt := int(aEndVLAN)
 		if err := validation.ValidateVLAN(aEndVLANInt); err != nil {
 			return nil, fmt.Errorf("aEndVlan: %w", err)
@@ -252,6 +258,9 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 		if vlan, vlanPresent, err := utils.JSONNumber(bEndConfig, "vlan"); err != nil {
 			return nil, fmt.Errorf("bEndConfiguration.vlan: %w", err)
 		} else if vlanPresent {
+			if vlan != math.Trunc(vlan) {
+				return nil, fmt.Errorf("bEndConfiguration.vlan must be a whole number, got %v", vlan)
+			}
 			vlanInt := int(vlan)
 			if err := validation.ValidateVLAN(vlanInt); err != nil {
 				return nil, fmt.Errorf("bEndConfiguration.vlan: %w", err)
@@ -262,6 +271,9 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 	} else if bEndVLAN, present, err := utils.JSONNumber(rawData, "bEndVlan"); err != nil {
 		return nil, fmt.Errorf("bEndVlan: %w", err)
 	} else if present {
+		if bEndVLAN != math.Trunc(bEndVLAN) {
+			return nil, fmt.Errorf("bEndVlan must be a whole number, got %v", bEndVLAN)
+		}
 		bEndVLANInt := int(bEndVLAN)
 		if err := validation.ValidateVLAN(bEndVLANInt); err != nil {
 			return nil, fmt.Errorf("bEndVlan: %w", err)
@@ -286,6 +298,9 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 	if aEndInnerVLAN, present, err := utils.JSONNumber(rawData, "aEndInnerVlan"); err != nil {
 		return nil, fmt.Errorf("aEndInnerVlan: %w", err)
 	} else if present {
+		if aEndInnerVLAN != math.Trunc(aEndInnerVLAN) {
+			return nil, fmt.Errorf("aEndInnerVlan must be a whole number, got %v", aEndInnerVLAN)
+		}
 		aEndInnerVLANInt := int(aEndInnerVLAN)
 		if err := validation.ValidateVXCEndInnerVLAN(aEndInnerVLANInt); err != nil {
 			return nil, fmt.Errorf("invalid aEndInnerVlan: %w", err)
@@ -297,6 +312,9 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 	if bEndInnerVLAN, present, err := utils.JSONNumber(rawData, "bEndInnerVlan"); err != nil {
 		return nil, fmt.Errorf("bEndInnerVlan: %w", err)
 	} else if present {
+		if bEndInnerVLAN != math.Trunc(bEndInnerVLAN) {
+			return nil, fmt.Errorf("bEndInnerVlan must be a whole number, got %v", bEndInnerVLAN)
+		}
 		bEndInnerVLANInt := int(bEndInnerVLAN)
 		if err := validation.ValidateVXCEndInnerVLAN(bEndInnerVLANInt); err != nil {
 			return nil, fmt.Errorf("invalid bEndInnerVlan: %w", err)

--- a/internal/commands/vxc/vxc_inputs_update.go
+++ b/internal/commands/vxc/vxc_inputs_update.go
@@ -175,8 +175,11 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 	}
 
 	req := &megaport.UpdateVXCRequest{}
+	fieldSet := false
 
-	if rateLimit, ok := rawData["rateLimit"].(float64); ok {
+	if rateLimit, present, err := utils.JSONNumber(rawData, "rateLimit"); err != nil {
+		return nil, fmt.Errorf("rateLimit: %w", err)
+	} else if present {
 		if rateLimit != math.Trunc(rateLimit) {
 			return nil, fmt.Errorf("rateLimit must be a whole number, got %v", rateLimit)
 		}
@@ -185,9 +188,12 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 			return nil, fmt.Errorf("rateLimit must be greater than or equal to 0")
 		}
 		req.RateLimit = &rateLimitInt
+		fieldSet = true
 	}
 
-	if term, ok := rawData["term"].(float64); ok {
+	if term, present, err := utils.JSONNumber(rawData, "term"); err != nil {
+		return nil, fmt.Errorf("term: %w", err)
+	} else if present {
 		if term != math.Trunc(term) {
 			return nil, fmt.Errorf("term must be a whole number, got %v", term)
 		}
@@ -198,129 +204,183 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 			}
 		}
 		req.Term = &termInt
+		fieldSet = true
 	}
 
-	if costCentre, ok := rawData["costCentre"].(string); ok {
+	if costCentre, present, err := utils.JSONString(rawData, "costCentre"); err != nil {
+		return nil, fmt.Errorf("costCentre: %w", err)
+	} else if present {
 		req.CostCentre = &costCentre
+		fieldSet = true
 	}
 
-	if shutdown, ok := rawData["shutdown"].(bool); ok {
+	if shutdown, present, err := utils.JSONBool(rawData, "shutdown"); err != nil {
+		return nil, fmt.Errorf("shutdown: %w", err)
+	} else if present {
 		req.Shutdown = &shutdown
+		fieldSet = true
 	}
 
 	// Handle nested configurations in addition to flat fields
-	if aEndConfig, ok := rawData["aEndConfiguration"].(map[string]interface{}); ok {
-		if vlan, ok := aEndConfig["vlan"].(float64); ok {
+	if aEndConfig, present, err := utils.JSONObject(rawData, "aEndConfiguration"); err != nil {
+		return nil, fmt.Errorf("aEndConfiguration: %w", err)
+	} else if present {
+		if vlan, vlanPresent, err := utils.JSONNumber(aEndConfig, "vlan"); err != nil {
+			return nil, fmt.Errorf("aEndConfiguration.vlan: %w", err)
+		} else if vlanPresent {
 			vlanInt := int(vlan)
 			if err := validation.ValidateVLAN(vlanInt); err != nil {
 				return nil, fmt.Errorf("aEndConfiguration.vlan: %w", err)
 			}
 			req.AEndVLAN = &vlanInt
+			fieldSet = true
 		}
-	} else {
-		if aEndVLAN, ok := rawData["aEndVlan"].(float64); ok {
-			aEndVLANInt := int(aEndVLAN)
-			if err := validation.ValidateVLAN(aEndVLANInt); err != nil {
-				return nil, fmt.Errorf("aEndVlan: %w", err)
-			}
-			req.AEndVLAN = &aEndVLANInt
+	} else if aEndVLAN, present, err := utils.JSONNumber(rawData, "aEndVlan"); err != nil {
+		return nil, fmt.Errorf("aEndVlan: %w", err)
+	} else if present {
+		aEndVLANInt := int(aEndVLAN)
+		if err := validation.ValidateVLAN(aEndVLANInt); err != nil {
+			return nil, fmt.Errorf("aEndVlan: %w", err)
 		}
+		req.AEndVLAN = &aEndVLANInt
+		fieldSet = true
 	}
 
-	if bEndConfig, ok := rawData["bEndConfiguration"].(map[string]interface{}); ok {
-		if vlan, ok := bEndConfig["vlan"].(float64); ok {
+	if bEndConfig, present, err := utils.JSONObject(rawData, "bEndConfiguration"); err != nil {
+		return nil, fmt.Errorf("bEndConfiguration: %w", err)
+	} else if present {
+		if vlan, vlanPresent, err := utils.JSONNumber(bEndConfig, "vlan"); err != nil {
+			return nil, fmt.Errorf("bEndConfiguration.vlan: %w", err)
+		} else if vlanPresent {
 			vlanInt := int(vlan)
 			if err := validation.ValidateVLAN(vlanInt); err != nil {
 				return nil, fmt.Errorf("bEndConfiguration.vlan: %w", err)
 			}
 			req.BEndVLAN = &vlanInt
+			fieldSet = true
 		}
-	} else {
-		if bEndVLAN, ok := rawData["bEndVlan"].(float64); ok {
-			bEndVLANInt := int(bEndVLAN)
-			if err := validation.ValidateVLAN(bEndVLANInt); err != nil {
-				return nil, fmt.Errorf("bEndVlan: %w", err)
-			}
-			req.BEndVLAN = &bEndVLANInt
+	} else if bEndVLAN, present, err := utils.JSONNumber(rawData, "bEndVlan"); err != nil {
+		return nil, fmt.Errorf("bEndVlan: %w", err)
+	} else if present {
+		bEndVLANInt := int(bEndVLAN)
+		if err := validation.ValidateVLAN(bEndVLANInt); err != nil {
+			return nil, fmt.Errorf("bEndVlan: %w", err)
 		}
+		req.BEndVLAN = &bEndVLANInt
+		fieldSet = true
 	}
 
 	// Handle VXC name field variants
-	if name, ok := rawData["name"].(string); ok {
+	if name, present, err := utils.JSONString(rawData, "name"); err != nil {
+		return nil, fmt.Errorf("name: %w", err)
+	} else if present {
 		req.Name = &name
-	} else if vxcName, ok := rawData["vxcName"].(string); ok {
+		fieldSet = true
+	} else if vxcName, present, err := utils.JSONString(rawData, "vxcName"); err != nil {
+		return nil, fmt.Errorf("vxcName: %w", err)
+	} else if present {
 		req.Name = &vxcName
+		fieldSet = true
 	}
 
-	if aEndInnerVLAN, ok := rawData["aEndInnerVlan"].(float64); ok {
+	if aEndInnerVLAN, present, err := utils.JSONNumber(rawData, "aEndInnerVlan"); err != nil {
+		return nil, fmt.Errorf("aEndInnerVlan: %w", err)
+	} else if present {
 		aEndInnerVLANInt := int(aEndInnerVLAN)
 		if err := validation.ValidateVXCEndInnerVLAN(aEndInnerVLANInt); err != nil {
 			return nil, fmt.Errorf("invalid aEndInnerVlan: %w", err)
 		}
 		req.AEndInnerVLAN = &aEndInnerVLANInt
+		fieldSet = true
 	}
 
-	if bEndInnerVLAN, ok := rawData["bEndInnerVlan"].(float64); ok {
+	if bEndInnerVLAN, present, err := utils.JSONNumber(rawData, "bEndInnerVlan"); err != nil {
+		return nil, fmt.Errorf("bEndInnerVlan: %w", err)
+	} else if present {
 		bEndInnerVLANInt := int(bEndInnerVLAN)
 		if err := validation.ValidateVXCEndInnerVLAN(bEndInnerVLANInt); err != nil {
 			return nil, fmt.Errorf("invalid bEndInnerVlan: %w", err)
 		}
 		req.BEndInnerVLAN = &bEndInnerVLANInt
+		fieldSet = true
 	}
 
 	// Handle product UIDs
-	if aEndUID, ok := rawData["aEndUid"].(string); ok {
+	if aEndUID, present, err := utils.JSONString(rawData, "aEndUid"); err != nil {
+		return nil, fmt.Errorf("aEndUid: %w", err)
+	} else if present {
 		req.AEndProductUID = &aEndUID
+		fieldSet = true
 	}
 
-	if bEndUID, ok := rawData["bEndUid"].(string); ok {
+	if bEndUID, present, err := utils.JSONString(rawData, "bEndUid"); err != nil {
+		return nil, fmt.Errorf("bEndUid: %w", err)
+	} else if present {
 		req.BEndProductUID = &bEndUID
+		fieldSet = true
 	}
 
 	// Handle partner configurations - using direct map access
-	if aEndPartnerConfigRaw, ok := rawData["aEndPartnerConfig"].(map[string]interface{}); ok {
-		if connectType, ok := aEndPartnerConfigRaw["connectType"].(string); ok && strings.ToUpper(connectType) == "VROUTER" {
-			aEndPartnerConfig, err := parsePartnerConfigFromMap(aEndPartnerConfigRaw)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse A-End partner config: %w", err)
-			}
-			vrouterConfigA, ok := aEndPartnerConfig.(*megaport.VXCOrderVrouterPartnerConfig)
-			if !ok {
-				return nil, fmt.Errorf("only VRouter partner configurations can be updated")
-			}
-			if err := validation.ValidateVrouterPartnerConfig(vrouterConfigA); err != nil {
-				return nil, err
-			}
-			req.AEndPartnerConfig = vrouterConfigA
-		} else {
+	if aEndPartnerConfigRaw, present, err := utils.JSONObject(rawData, "aEndPartnerConfig"); err != nil {
+		return nil, fmt.Errorf("aEndPartnerConfig: %w", err)
+	} else if present {
+		connectType, _, err := utils.JSONString(aEndPartnerConfigRaw, "connectType")
+		if err != nil {
+			return nil, fmt.Errorf("aEndPartnerConfig.connectType: %w", err)
+		}
+		if strings.ToUpper(connectType) != "VROUTER" {
 			return nil, fmt.Errorf("only VRouter partner configurations can be updated")
 		}
+		aEndPartnerConfig, err := parsePartnerConfigFromMap(aEndPartnerConfigRaw)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse A-End partner config: %w", err)
+		}
+		vrouterConfigA, ok := aEndPartnerConfig.(*megaport.VXCOrderVrouterPartnerConfig)
+		if !ok {
+			return nil, fmt.Errorf("only VRouter partner configurations can be updated")
+		}
+		if err := validation.ValidateVrouterPartnerConfig(vrouterConfigA); err != nil {
+			return nil, err
+		}
+		req.AEndPartnerConfig = vrouterConfigA
+		fieldSet = true
 	}
 
-	if bEndPartnerConfigRaw, ok := rawData["bEndPartnerConfig"].(map[string]interface{}); ok {
-		if connectType, ok := bEndPartnerConfigRaw["connectType"].(string); ok && strings.ToUpper(connectType) == "VROUTER" {
-			bEndPartnerConfig, err := parsePartnerConfigFromMap(bEndPartnerConfigRaw)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse B-End partner config: %w", err)
-			}
-			vrouterConfigB, ok := bEndPartnerConfig.(*megaport.VXCOrderVrouterPartnerConfig)
-			if !ok {
-				return nil, fmt.Errorf("only VRouter partner configurations can be updated")
-			}
-			if err := validation.ValidateVrouterPartnerConfig(vrouterConfigB); err != nil {
-				return nil, err
-			}
-			req.BEndPartnerConfig = vrouterConfigB
-		} else {
+	if bEndPartnerConfigRaw, present, err := utils.JSONObject(rawData, "bEndPartnerConfig"); err != nil {
+		return nil, fmt.Errorf("bEndPartnerConfig: %w", err)
+	} else if present {
+		connectType, _, err := utils.JSONString(bEndPartnerConfigRaw, "connectType")
+		if err != nil {
+			return nil, fmt.Errorf("bEndPartnerConfig.connectType: %w", err)
+		}
+		if strings.ToUpper(connectType) != "VROUTER" {
 			return nil, fmt.Errorf("only VRouter partner configurations can be updated")
 		}
+		bEndPartnerConfig, err := parsePartnerConfigFromMap(bEndPartnerConfigRaw)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse B-End partner config: %w", err)
+		}
+		vrouterConfigB, ok := bEndPartnerConfig.(*megaport.VXCOrderVrouterPartnerConfig)
+		if !ok {
+			return nil, fmt.Errorf("only VRouter partner configurations can be updated")
+		}
+		if err := validation.ValidateVrouterPartnerConfig(vrouterConfigB); err != nil {
+			return nil, err
+		}
+		req.BEndPartnerConfig = vrouterConfigB
+		fieldSet = true
 	}
 
 	// Handle approval and vNIC index fields from JSON
-	if isApproved, ok := rawData["isApproved"].(bool); ok {
+	if isApproved, present, err := utils.JSONBool(rawData, "isApproved"); err != nil {
+		return nil, fmt.Errorf("isApproved: %w", err)
+	} else if present {
 		req.IsApproved = &isApproved
+		fieldSet = true
 	}
-	if aVnicIndex, ok := rawData["aVnicIndex"].(float64); ok {
+	if aVnicIndex, present, err := utils.JSONNumber(rawData, "aVnicIndex"); err != nil {
+		return nil, fmt.Errorf("aVnicIndex: %w", err)
+	} else if present {
 		if aVnicIndex != math.Trunc(aVnicIndex) {
 			return nil, fmt.Errorf("aVnicIndex must be a whole number, got %v", aVnicIndex)
 		}
@@ -329,8 +389,11 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 			return nil, fmt.Errorf("invalid aVnicIndex: %w", err)
 		}
 		req.AVnicIndex = &idx
+		fieldSet = true
 	}
-	if bVnicIndex, ok := rawData["bVnicIndex"].(float64); ok {
+	if bVnicIndex, present, err := utils.JSONNumber(rawData, "bVnicIndex"); err != nil {
+		return nil, fmt.Errorf("bVnicIndex: %w", err)
+	} else if present {
 		if bVnicIndex != math.Trunc(bVnicIndex) {
 			return nil, fmt.Errorf("bVnicIndex must be a whole number, got %v", bVnicIndex)
 		}
@@ -339,6 +402,11 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 			return nil, fmt.Errorf("invalid bVnicIndex: %w", err)
 		}
 		req.BVnicIndex = &idx
+		fieldSet = true
+	}
+
+	if !fieldSet {
+		return nil, fmt.Errorf("at least one field must be updated")
 	}
 
 	// Set wait for update to true with a reasonable timeout

--- a/internal/commands/vxc/vxc_inputs_update.go
+++ b/internal/commands/vxc/vxc_inputs_update.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/megaport/megaport-cli/internal/base/exitcodes"
 	"github.com/megaport/megaport-cli/internal/utils"
 	"github.com/megaport/megaport-cli/internal/validation"
 	megaport "github.com/megaport/megaportgo"
@@ -160,47 +161,47 @@ var buildUpdateVXCRequestFromFlags = func(cmd *cobra.Command) (*megaport.UpdateV
 
 var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*megaport.UpdateVXCRequest, error) {
 	if jsonStr == "" && jsonFilePath == "" {
-		return nil, fmt.Errorf("either json or json-file must be provided")
+		return nil, exitcodes.NewUsageError(fmt.Errorf("either json or json-file must be provided"))
 	}
 
 	jsonData, err := utils.ReadJSONInput(jsonStr, jsonFilePath)
 	if err != nil {
-		return nil, err
+		return nil, exitcodes.NewUsageError(err)
 	}
 
 	// Parse raw JSON first to handle partner configs
 	var rawData map[string]interface{}
 	if err := json.Unmarshal(jsonData, &rawData); err != nil {
-		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("failed to parse JSON: %w", err))
 	}
 
 	req := &megaport.UpdateVXCRequest{}
 	fieldSet := false
 
 	if rateLimit, present, err := utils.JSONNumber(rawData, "rateLimit"); err != nil {
-		return nil, fmt.Errorf("rateLimit: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("rateLimit: %w", err))
 	} else if present {
 		if rateLimit != math.Trunc(rateLimit) {
-			return nil, fmt.Errorf("rateLimit must be a whole number, got %v", rateLimit)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("rateLimit must be a whole number, got %v", rateLimit))
 		}
 		rateLimitInt := int(rateLimit)
 		if rateLimitInt < 0 {
-			return nil, fmt.Errorf("rateLimit must be greater than or equal to 0")
+			return nil, exitcodes.NewUsageError(fmt.Errorf("rateLimit must be greater than or equal to 0"))
 		}
 		req.RateLimit = &rateLimitInt
 		fieldSet = true
 	}
 
 	if term, present, err := utils.JSONNumber(rawData, "term"); err != nil {
-		return nil, fmt.Errorf("term: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("term: %w", err))
 	} else if present {
 		if term != math.Trunc(term) {
-			return nil, fmt.Errorf("term must be a whole number, got %v", term)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("term must be a whole number, got %v", term))
 		}
 		termInt := int(term)
 		if termInt != 0 {
 			if err := validation.ValidateContractTerm(termInt); err != nil {
-				return nil, err
+				return nil, exitcodes.NewUsageError(err)
 			}
 		}
 		req.Term = &termInt
@@ -208,14 +209,14 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 	}
 
 	if costCentre, present, err := utils.JSONString(rawData, "costCentre"); err != nil {
-		return nil, fmt.Errorf("costCentre: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("costCentre: %w", err))
 	} else if present {
 		req.CostCentre = &costCentre
 		fieldSet = true
 	}
 
 	if shutdown, present, err := utils.JSONBool(rawData, "shutdown"); err != nil {
-		return nil, fmt.Errorf("shutdown: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("shutdown: %w", err))
 	} else if present {
 		req.Shutdown = &shutdown
 		fieldSet = true
@@ -223,60 +224,60 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 
 	// Handle nested configurations in addition to flat fields
 	if aEndConfig, present, err := utils.JSONObject(rawData, "aEndConfiguration"); err != nil {
-		return nil, fmt.Errorf("aEndConfiguration: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("aEndConfiguration: %w", err))
 	} else if present {
 		if vlan, vlanPresent, err := utils.JSONNumber(aEndConfig, "vlan"); err != nil {
-			return nil, fmt.Errorf("aEndConfiguration.vlan: %w", err)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("aEndConfiguration.vlan: %w", err))
 		} else if vlanPresent {
 			if vlan != math.Trunc(vlan) {
-				return nil, fmt.Errorf("aEndConfiguration.vlan must be a whole number, got %v", vlan)
+				return nil, exitcodes.NewUsageError(fmt.Errorf("aEndConfiguration.vlan must be a whole number, got %v", vlan))
 			}
 			vlanInt := int(vlan)
 			if err := validation.ValidateVLAN(vlanInt); err != nil {
-				return nil, fmt.Errorf("aEndConfiguration.vlan: %w", err)
+				return nil, exitcodes.NewUsageError(fmt.Errorf("aEndConfiguration.vlan: %w", err))
 			}
 			req.AEndVLAN = &vlanInt
 			fieldSet = true
 		}
 	} else if aEndVLAN, present, err := utils.JSONNumber(rawData, "aEndVlan"); err != nil {
-		return nil, fmt.Errorf("aEndVlan: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("aEndVlan: %w", err))
 	} else if present {
 		if aEndVLAN != math.Trunc(aEndVLAN) {
-			return nil, fmt.Errorf("aEndVlan must be a whole number, got %v", aEndVLAN)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("aEndVlan must be a whole number, got %v", aEndVLAN))
 		}
 		aEndVLANInt := int(aEndVLAN)
 		if err := validation.ValidateVLAN(aEndVLANInt); err != nil {
-			return nil, fmt.Errorf("aEndVlan: %w", err)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("aEndVlan: %w", err))
 		}
 		req.AEndVLAN = &aEndVLANInt
 		fieldSet = true
 	}
 
 	if bEndConfig, present, err := utils.JSONObject(rawData, "bEndConfiguration"); err != nil {
-		return nil, fmt.Errorf("bEndConfiguration: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("bEndConfiguration: %w", err))
 	} else if present {
 		if vlan, vlanPresent, err := utils.JSONNumber(bEndConfig, "vlan"); err != nil {
-			return nil, fmt.Errorf("bEndConfiguration.vlan: %w", err)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("bEndConfiguration.vlan: %w", err))
 		} else if vlanPresent {
 			if vlan != math.Trunc(vlan) {
-				return nil, fmt.Errorf("bEndConfiguration.vlan must be a whole number, got %v", vlan)
+				return nil, exitcodes.NewUsageError(fmt.Errorf("bEndConfiguration.vlan must be a whole number, got %v", vlan))
 			}
 			vlanInt := int(vlan)
 			if err := validation.ValidateVLAN(vlanInt); err != nil {
-				return nil, fmt.Errorf("bEndConfiguration.vlan: %w", err)
+				return nil, exitcodes.NewUsageError(fmt.Errorf("bEndConfiguration.vlan: %w", err))
 			}
 			req.BEndVLAN = &vlanInt
 			fieldSet = true
 		}
 	} else if bEndVLAN, present, err := utils.JSONNumber(rawData, "bEndVlan"); err != nil {
-		return nil, fmt.Errorf("bEndVlan: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("bEndVlan: %w", err))
 	} else if present {
 		if bEndVLAN != math.Trunc(bEndVLAN) {
-			return nil, fmt.Errorf("bEndVlan must be a whole number, got %v", bEndVLAN)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("bEndVlan must be a whole number, got %v", bEndVLAN))
 		}
 		bEndVLANInt := int(bEndVLAN)
 		if err := validation.ValidateVLAN(bEndVLANInt); err != nil {
-			return nil, fmt.Errorf("bEndVlan: %w", err)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("bEndVlan: %w", err))
 		}
 		req.BEndVLAN = &bEndVLANInt
 		fieldSet = true
@@ -284,40 +285,40 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 
 	// Handle VXC name field variants
 	if name, present, err := utils.JSONString(rawData, "name"); err != nil {
-		return nil, fmt.Errorf("name: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("name: %w", err))
 	} else if present {
 		req.Name = &name
 		fieldSet = true
 	} else if vxcName, present, err := utils.JSONString(rawData, "vxcName"); err != nil {
-		return nil, fmt.Errorf("vxcName: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("vxcName: %w", err))
 	} else if present {
 		req.Name = &vxcName
 		fieldSet = true
 	}
 
 	if aEndInnerVLAN, present, err := utils.JSONNumber(rawData, "aEndInnerVlan"); err != nil {
-		return nil, fmt.Errorf("aEndInnerVlan: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("aEndInnerVlan: %w", err))
 	} else if present {
 		if aEndInnerVLAN != math.Trunc(aEndInnerVLAN) {
-			return nil, fmt.Errorf("aEndInnerVlan must be a whole number, got %v", aEndInnerVLAN)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("aEndInnerVlan must be a whole number, got %v", aEndInnerVLAN))
 		}
 		aEndInnerVLANInt := int(aEndInnerVLAN)
 		if err := validation.ValidateVXCEndInnerVLAN(aEndInnerVLANInt); err != nil {
-			return nil, fmt.Errorf("invalid aEndInnerVlan: %w", err)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("invalid aEndInnerVlan: %w", err))
 		}
 		req.AEndInnerVLAN = &aEndInnerVLANInt
 		fieldSet = true
 	}
 
 	if bEndInnerVLAN, present, err := utils.JSONNumber(rawData, "bEndInnerVlan"); err != nil {
-		return nil, fmt.Errorf("bEndInnerVlan: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("bEndInnerVlan: %w", err))
 	} else if present {
 		if bEndInnerVLAN != math.Trunc(bEndInnerVLAN) {
-			return nil, fmt.Errorf("bEndInnerVlan must be a whole number, got %v", bEndInnerVLAN)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("bEndInnerVlan must be a whole number, got %v", bEndInnerVLAN))
 		}
 		bEndInnerVLANInt := int(bEndInnerVLAN)
 		if err := validation.ValidateVXCEndInnerVLAN(bEndInnerVLANInt); err != nil {
-			return nil, fmt.Errorf("invalid bEndInnerVlan: %w", err)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("invalid bEndInnerVlan: %w", err))
 		}
 		req.BEndInnerVLAN = &bEndInnerVLANInt
 		fieldSet = true
@@ -325,14 +326,14 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 
 	// Handle product UIDs
 	if aEndUID, present, err := utils.JSONString(rawData, "aEndUid"); err != nil {
-		return nil, fmt.Errorf("aEndUid: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("aEndUid: %w", err))
 	} else if present {
 		req.AEndProductUID = &aEndUID
 		fieldSet = true
 	}
 
 	if bEndUID, present, err := utils.JSONString(rawData, "bEndUid"); err != nil {
-		return nil, fmt.Errorf("bEndUid: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("bEndUid: %w", err))
 	} else if present {
 		req.BEndProductUID = &bEndUID
 		fieldSet = true
@@ -340,56 +341,56 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 
 	// Handle partner configurations - using direct map access
 	if aEndPartnerConfigRaw, present, err := utils.JSONObject(rawData, "aEndPartnerConfig"); err != nil {
-		return nil, fmt.Errorf("aEndPartnerConfig: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("aEndPartnerConfig: %w", err))
 	} else if present {
 		connectType, connectTypePresent, err := utils.JSONString(aEndPartnerConfigRaw, "connectType")
 		if err != nil {
-			return nil, fmt.Errorf("aEndPartnerConfig.connectType: %w", err)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("aEndPartnerConfig.connectType: %w", err))
 		}
 		if !connectTypePresent || connectType == "" {
-			return nil, fmt.Errorf("aEndPartnerConfig.connectType is required")
+			return nil, exitcodes.NewUsageError(fmt.Errorf("aEndPartnerConfig.connectType is required"))
 		}
 		if strings.ToUpper(connectType) != "VROUTER" {
-			return nil, fmt.Errorf("only VRouter partner configurations can be updated")
+			return nil, exitcodes.NewUsageError(fmt.Errorf("only VRouter partner configurations can be updated"))
 		}
 		aEndPartnerConfig, err := parsePartnerConfigFromMap(aEndPartnerConfigRaw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse A-End partner config: %w", err)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("failed to parse A-End partner config: %w", err))
 		}
 		vrouterConfigA, ok := aEndPartnerConfig.(*megaport.VXCOrderVrouterPartnerConfig)
 		if !ok {
-			return nil, fmt.Errorf("only VRouter partner configurations can be updated")
+			return nil, exitcodes.NewUsageError(fmt.Errorf("only VRouter partner configurations can be updated"))
 		}
 		if err := validation.ValidateVrouterPartnerConfig(vrouterConfigA); err != nil {
-			return nil, err
+			return nil, exitcodes.NewUsageError(err)
 		}
 		req.AEndPartnerConfig = vrouterConfigA
 		fieldSet = true
 	}
 
 	if bEndPartnerConfigRaw, present, err := utils.JSONObject(rawData, "bEndPartnerConfig"); err != nil {
-		return nil, fmt.Errorf("bEndPartnerConfig: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("bEndPartnerConfig: %w", err))
 	} else if present {
 		connectType, connectTypePresent, err := utils.JSONString(bEndPartnerConfigRaw, "connectType")
 		if err != nil {
-			return nil, fmt.Errorf("bEndPartnerConfig.connectType: %w", err)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("bEndPartnerConfig.connectType: %w", err))
 		}
 		if !connectTypePresent || connectType == "" {
-			return nil, fmt.Errorf("bEndPartnerConfig.connectType is required")
+			return nil, exitcodes.NewUsageError(fmt.Errorf("bEndPartnerConfig.connectType is required"))
 		}
 		if strings.ToUpper(connectType) != "VROUTER" {
-			return nil, fmt.Errorf("only VRouter partner configurations can be updated")
+			return nil, exitcodes.NewUsageError(fmt.Errorf("only VRouter partner configurations can be updated"))
 		}
 		bEndPartnerConfig, err := parsePartnerConfigFromMap(bEndPartnerConfigRaw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse B-End partner config: %w", err)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("failed to parse B-End partner config: %w", err))
 		}
 		vrouterConfigB, ok := bEndPartnerConfig.(*megaport.VXCOrderVrouterPartnerConfig)
 		if !ok {
-			return nil, fmt.Errorf("only VRouter partner configurations can be updated")
+			return nil, exitcodes.NewUsageError(fmt.Errorf("only VRouter partner configurations can be updated"))
 		}
 		if err := validation.ValidateVrouterPartnerConfig(vrouterConfigB); err != nil {
-			return nil, err
+			return nil, exitcodes.NewUsageError(err)
 		}
 		req.BEndPartnerConfig = vrouterConfigB
 		fieldSet = true
@@ -397,40 +398,40 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 
 	// Handle approval and vNIC index fields from JSON
 	if isApproved, present, err := utils.JSONBool(rawData, "isApproved"); err != nil {
-		return nil, fmt.Errorf("isApproved: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("isApproved: %w", err))
 	} else if present {
 		req.IsApproved = &isApproved
 		fieldSet = true
 	}
 	if aVnicIndex, present, err := utils.JSONNumber(rawData, "aVnicIndex"); err != nil {
-		return nil, fmt.Errorf("aVnicIndex: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("aVnicIndex: %w", err))
 	} else if present {
 		if aVnicIndex != math.Trunc(aVnicIndex) {
-			return nil, fmt.Errorf("aVnicIndex must be a whole number, got %v", aVnicIndex)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("aVnicIndex must be a whole number, got %v", aVnicIndex))
 		}
 		idx := int(aVnicIndex)
 		if err := validation.ValidateVNICIndex(idx); err != nil {
-			return nil, fmt.Errorf("invalid aVnicIndex: %w", err)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("invalid aVnicIndex: %w", err))
 		}
 		req.AVnicIndex = &idx
 		fieldSet = true
 	}
 	if bVnicIndex, present, err := utils.JSONNumber(rawData, "bVnicIndex"); err != nil {
-		return nil, fmt.Errorf("bVnicIndex: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("bVnicIndex: %w", err))
 	} else if present {
 		if bVnicIndex != math.Trunc(bVnicIndex) {
-			return nil, fmt.Errorf("bVnicIndex must be a whole number, got %v", bVnicIndex)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("bVnicIndex must be a whole number, got %v", bVnicIndex))
 		}
 		idx := int(bVnicIndex)
 		if err := validation.ValidateVNICIndex(idx); err != nil {
-			return nil, fmt.Errorf("invalid bVnicIndex: %w", err)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("invalid bVnicIndex: %w", err))
 		}
 		req.BVnicIndex = &idx
 		fieldSet = true
 	}
 
 	if !fieldSet {
-		return nil, fmt.Errorf("at least one field must be updated")
+		return nil, exitcodes.NewUsageError(fmt.Errorf("at least one field must be updated"))
 	}
 
 	// Set wait for update to true with a reasonable timeout

--- a/internal/commands/vxc/vxc_inputs_update.go
+++ b/internal/commands/vxc/vxc_inputs_update.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -179,7 +180,7 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 	fieldSet := false
 
 	if rateLimit, present, err := utils.JSONNumber(rawData, "rateLimit"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("rateLimit: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		if rateLimit != math.Trunc(rateLimit) {
 			return nil, exitcodes.NewUsageError(fmt.Errorf("rateLimit must be a whole number, got %v", rateLimit))
@@ -193,7 +194,7 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 	}
 
 	if term, present, err := utils.JSONNumber(rawData, "term"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("term: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		if term != math.Trunc(term) {
 			return nil, exitcodes.NewUsageError(fmt.Errorf("term must be a whole number, got %v", term))
@@ -209,14 +210,14 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 	}
 
 	if costCentre, present, err := utils.JSONString(rawData, "costCentre"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("costCentre: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		req.CostCentre = &costCentre
 		fieldSet = true
 	}
 
 	if shutdown, present, err := utils.JSONBool(rawData, "shutdown"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("shutdown: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		req.Shutdown = &shutdown
 		fieldSet = true
@@ -224,7 +225,7 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 
 	// Handle nested configurations in addition to flat fields
 	if aEndConfig, present, err := utils.JSONObject(rawData, "aEndConfiguration"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("aEndConfiguration: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		if vlan, vlanPresent, err := utils.JSONNumber(aEndConfig, "vlan"); err != nil {
 			return nil, exitcodes.NewUsageError(fmt.Errorf("aEndConfiguration.vlan: %w", err))
@@ -240,7 +241,7 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 			fieldSet = true
 		}
 	} else if aEndVLAN, present, err := utils.JSONNumber(rawData, "aEndVlan"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("aEndVlan: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		if aEndVLAN != math.Trunc(aEndVLAN) {
 			return nil, exitcodes.NewUsageError(fmt.Errorf("aEndVlan must be a whole number, got %v", aEndVLAN))
@@ -254,7 +255,7 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 	}
 
 	if bEndConfig, present, err := utils.JSONObject(rawData, "bEndConfiguration"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("bEndConfiguration: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		if vlan, vlanPresent, err := utils.JSONNumber(bEndConfig, "vlan"); err != nil {
 			return nil, exitcodes.NewUsageError(fmt.Errorf("bEndConfiguration.vlan: %w", err))
@@ -270,7 +271,7 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 			fieldSet = true
 		}
 	} else if bEndVLAN, present, err := utils.JSONNumber(rawData, "bEndVlan"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("bEndVlan: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		if bEndVLAN != math.Trunc(bEndVLAN) {
 			return nil, exitcodes.NewUsageError(fmt.Errorf("bEndVlan must be a whole number, got %v", bEndVLAN))
@@ -285,19 +286,19 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 
 	// Handle VXC name field variants
 	if name, present, err := utils.JSONString(rawData, "name"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("name: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		req.Name = &name
 		fieldSet = true
 	} else if vxcName, present, err := utils.JSONString(rawData, "vxcName"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("vxcName: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		req.Name = &vxcName
 		fieldSet = true
 	}
 
 	if aEndInnerVLAN, present, err := utils.JSONNumber(rawData, "aEndInnerVlan"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("aEndInnerVlan: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		if aEndInnerVLAN != math.Trunc(aEndInnerVLAN) {
 			return nil, exitcodes.NewUsageError(fmt.Errorf("aEndInnerVlan must be a whole number, got %v", aEndInnerVLAN))
@@ -311,7 +312,7 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 	}
 
 	if bEndInnerVLAN, present, err := utils.JSONNumber(rawData, "bEndInnerVlan"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("bEndInnerVlan: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		if bEndInnerVLAN != math.Trunc(bEndInnerVLAN) {
 			return nil, exitcodes.NewUsageError(fmt.Errorf("bEndInnerVlan must be a whole number, got %v", bEndInnerVLAN))
@@ -326,14 +327,14 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 
 	// Handle product UIDs
 	if aEndUID, present, err := utils.JSONString(rawData, "aEndUid"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("aEndUid: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		req.AEndProductUID = &aEndUID
 		fieldSet = true
 	}
 
 	if bEndUID, present, err := utils.JSONString(rawData, "bEndUid"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("bEndUid: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		req.BEndProductUID = &bEndUID
 		fieldSet = true
@@ -341,7 +342,7 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 
 	// Handle partner configurations - using direct map access
 	if aEndPartnerConfigRaw, present, err := utils.JSONObject(rawData, "aEndPartnerConfig"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("aEndPartnerConfig: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		connectType, connectTypePresent, err := utils.JSONString(aEndPartnerConfigRaw, "connectType")
 		if err != nil {
@@ -369,7 +370,7 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 	}
 
 	if bEndPartnerConfigRaw, present, err := utils.JSONObject(rawData, "bEndPartnerConfig"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("bEndPartnerConfig: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		connectType, connectTypePresent, err := utils.JSONString(bEndPartnerConfigRaw, "connectType")
 		if err != nil {
@@ -398,13 +399,13 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 
 	// Handle approval and vNIC index fields from JSON
 	if isApproved, present, err := utils.JSONBool(rawData, "isApproved"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("isApproved: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		req.IsApproved = &isApproved
 		fieldSet = true
 	}
 	if aVnicIndex, present, err := utils.JSONNumber(rawData, "aVnicIndex"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("aVnicIndex: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		if aVnicIndex != math.Trunc(aVnicIndex) {
 			return nil, exitcodes.NewUsageError(fmt.Errorf("aVnicIndex must be a whole number, got %v", aVnicIndex))
@@ -417,7 +418,7 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 		fieldSet = true
 	}
 	if bVnicIndex, present, err := utils.JSONNumber(rawData, "bVnicIndex"); err != nil {
-		return nil, exitcodes.NewUsageError(fmt.Errorf("bVnicIndex: %w", err))
+		return nil, exitcodes.NewUsageError(err)
 	} else if present {
 		if bVnicIndex != math.Trunc(bVnicIndex) {
 			return nil, exitcodes.NewUsageError(fmt.Errorf("bVnicIndex must be a whole number, got %v", bVnicIndex))
@@ -431,6 +432,26 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 	}
 
 	if !fieldSet {
+		recognizedKeys := map[string]bool{
+			"rateLimit": true, "term": true, "costCentre": true, "shutdown": true,
+			"aEndConfiguration": true, "aEndVlan": true,
+			"bEndConfiguration": true, "bEndVlan": true,
+			"name": true, "vxcName": true,
+			"aEndInnerVlan": true, "bEndInnerVlan": true,
+			"aEndUid": true, "bEndUid": true,
+			"aEndPartnerConfig": true, "bEndPartnerConfig": true,
+			"isApproved": true, "aVnicIndex": true, "bVnicIndex": true,
+		}
+		var unrecognized []string
+		for key := range rawData {
+			if !recognizedKeys[key] {
+				unrecognized = append(unrecognized, key)
+			}
+		}
+		if len(unrecognized) > 0 {
+			sort.Strings(unrecognized)
+			return nil, exitcodes.NewUsageError(fmt.Errorf("at least one field must be updated (unrecognized keys: %s)", strings.Join(unrecognized, ", ")))
+		}
 		return nil, exitcodes.NewUsageError(fmt.Errorf("at least one field must be updated"))
 	}
 

--- a/internal/commands/vxc/vxc_inputs_update.go
+++ b/internal/commands/vxc/vxc_inputs_update.go
@@ -343,7 +343,7 @@ var buildUpdateVXCRequestFromJSON = func(jsonStr string, jsonFilePath string) (*
 		fieldSet = true
 	}
 
-	// Handle partner configurations - using direct map access
+	// Handle partner configurations
 	if aEndPartnerConfigRaw, present, err := utils.JSONObject(rawData, "aEndPartnerConfig"); err != nil {
 		return nil, exitcodes.NewUsageError(err)
 	} else if present {


### PR DESCRIPTION
The VXC update JSON builder used raw type assertions, so a misspelled key or a wrong-typed value (e.g. `--json '{"rateLimt": 500}'` or `{"rateLimit": "500"}'`) was silently dropped and the CLI happily reported success on an empty update.

- Swap every raw `rawData[...].(type)` assertion in `buildUpdateVXCRequestFromJSON` for the checked `utils.JSON*` helpers already used by the buy path, so a typo or wrong type now returns a clear error.
- Add an at-least-one-field gate: a payload that resolves to no recognized field (e.g. `{}` or only unknown keys) is rejected before any API call.
- Add tests covering a typo key, a wrong-typed flat and nested value, a wrong-typed partner config, an empty object, the flat `aEndVlan`/`bEndVlan` fallback, and a valid multi-field payload.