### PR TITLE
fix(mcr,mve): error on invalid/empty answers to required yes/no prompts

### DIFF
--- a/internal/commands/mcr/mcr_prompts.go
+++ b/internal/commands/mcr/mcr_prompts.go
@@ -77,24 +77,30 @@ func promptForUpdateMCRDetails(mcrUID, currentCostCentre string, noColor bool) (
 		fieldsUpdated = true
 	}
 
-	marketplaceVisibilityPrompt := "Update marketplace visibility? (yes/no, leave empty to skip): "
+	marketplaceVisibilityPrompt := "Update marketplace visibility? (y/yes/n/no, leave empty to skip): "
 	marketplaceVisibilityStr, err := utils.ResourcePrompt("mcr", marketplaceVisibilityPrompt, noColor)
 	if err != nil {
 		return nil, err
 	}
-	if strings.ToLower(marketplaceVisibilityStr) == "yes" {
-		visibilityValuePrompt := "Enter marketplace visibility (y/yes/n/no): "
-		visibilityValue, err := utils.ResourcePrompt("mcr", visibilityValuePrompt, noColor)
+	if marketplaceVisibilityStr != "" {
+		wantsVisibilityUpdate, err := utils.ParseYesNo(marketplaceVisibilityStr)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("update marketplace visibility: %w", err)
 		}
+		if wantsVisibilityUpdate {
+			visibilityValuePrompt := "Enter marketplace visibility (y/yes/true/n/no/false): "
+			visibilityValue, err := utils.ResourcePrompt("mcr", visibilityValuePrompt, noColor)
+			if err != nil {
+				return nil, err
+			}
 
-		marketplaceVisibility, err := utils.ParseYesNo(visibilityValue)
-		if err != nil {
-			return nil, fmt.Errorf("marketplace visibility: %w", err)
+			marketplaceVisibility, err := utils.ParseYesNo(visibilityValue)
+			if err != nil {
+				return nil, fmt.Errorf("marketplace visibility: %w", err)
+			}
+			req.MarketplaceVisibility = &marketplaceVisibility
+			fieldsUpdated = true
 		}
-		req.MarketplaceVisibility = &marketplaceVisibility
-		fieldsUpdated = true
 	}
 
 	termPrompt := fmt.Sprintf("Enter new term (%s months, leave empty to skip): ", validation.FormatIntSlice(validation.ValidContractTerms))
@@ -329,7 +335,7 @@ func promptUpdateExistingEntries(currentEntries []*megaport.MCRPrefixListEntry, 
 		output.PrintPlain("Entry %d - Current: Action: %s, Prefix: %s, GE: %d, LE: %d", noColor,
 			i+1, entry.Action, entry.Prefix, entry.Ge, entry.Le)
 
-		keepEntryStr, err := utils.ResourcePrompt("mcr", fmt.Sprintf("Keep entry %d? (y/yes/n/no): ", i+1), noColor)
+		keepEntryStr, err := utils.ResourcePrompt("mcr", fmt.Sprintf("Keep entry %d? (y/yes/true/n/no/false): ", i+1), noColor)
 		if err != nil {
 			return nil, err
 		}
@@ -339,7 +345,7 @@ func promptUpdateExistingEntries(currentEntries []*megaport.MCRPrefixListEntry, 
 		}
 
 		if keepEntry {
-			modifyEntryStr, err := utils.ResourcePrompt("mcr", fmt.Sprintf("Modify entry %d? (y/yes/n/no): ", i+1), noColor)
+			modifyEntryStr, err := utils.ResourcePrompt("mcr", fmt.Sprintf("Modify entry %d? (y/yes/true/n/no/false): ", i+1), noColor)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/commands/mcr/mcr_prompts.go
+++ b/internal/commands/mcr/mcr_prompts.go
@@ -77,7 +77,7 @@ func promptForUpdateMCRDetails(mcrUID, currentCostCentre string, noColor bool) (
 		fieldsUpdated = true
 	}
 
-	marketplaceVisibilityPrompt := "Update marketplace visibility? (y/yes/n/no, leave empty to skip): "
+	marketplaceVisibilityPrompt := "Update marketplace visibility? (y/yes/true/n/no/false, leave empty to skip): "
 	marketplaceVisibilityStr, err := utils.ResourcePrompt("mcr", marketplaceVisibilityPrompt, noColor)
 	if err != nil {
 		return nil, err
@@ -88,7 +88,7 @@ func promptForUpdateMCRDetails(mcrUID, currentCostCentre string, noColor bool) (
 			return nil, fmt.Errorf("update marketplace visibility: %w", err)
 		}
 		if wantsVisibilityUpdate {
-			visibilityValuePrompt := "Enter marketplace visibility (y/yes/true/n/no/false): "
+			visibilityValuePrompt := "Enter marketplace visibility (y/yes/true/n/no/false) (required): "
 			visibilityValue, err := utils.ResourcePrompt("mcr", visibilityValuePrompt, noColor)
 			if err != nil {
 				return nil, err
@@ -335,7 +335,7 @@ func promptUpdateExistingEntries(currentEntries []*megaport.MCRPrefixListEntry, 
 		output.PrintPlain("Entry %d - Current: Action: %s, Prefix: %s, GE: %d, LE: %d", noColor,
 			i+1, entry.Action, entry.Prefix, entry.Ge, entry.Le)
 
-		keepEntryStr, err := utils.ResourcePrompt("mcr", fmt.Sprintf("Keep entry %d? (y/yes/true/n/no/false): ", i+1), noColor)
+		keepEntryStr, err := utils.ResourcePrompt("mcr", fmt.Sprintf("Keep entry %d? (y/yes/true/n/no/false) (required): ", i+1), noColor)
 		if err != nil {
 			return nil, err
 		}
@@ -345,7 +345,7 @@ func promptUpdateExistingEntries(currentEntries []*megaport.MCRPrefixListEntry, 
 		}
 
 		if keepEntry {
-			modifyEntryStr, err := utils.ResourcePrompt("mcr", fmt.Sprintf("Modify entry %d? (y/yes/true/n/no/false): ", i+1), noColor)
+			modifyEntryStr, err := utils.ResourcePrompt("mcr", fmt.Sprintf("Modify entry %d? (y/yes/true/n/no/false) (required): ", i+1), noColor)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/commands/mcr/mcr_prompts.go
+++ b/internal/commands/mcr/mcr_prompts.go
@@ -83,13 +83,16 @@ func promptForUpdateMCRDetails(mcrUID, currentCostCentre string, noColor bool) (
 		return nil, err
 	}
 	if strings.ToLower(marketplaceVisibilityStr) == "yes" {
-		visibilityValuePrompt := "Enter marketplace visibility (true or false): "
+		visibilityValuePrompt := "Enter marketplace visibility (y/yes/n/no): "
 		visibilityValue, err := utils.ResourcePrompt("mcr", visibilityValuePrompt, noColor)
 		if err != nil {
 			return nil, err
 		}
 
-		marketplaceVisibility := strings.ToLower(visibilityValue) == "true"
+		marketplaceVisibility, err := utils.ParseYesNo(visibilityValue)
+		if err != nil {
+			return nil, fmt.Errorf("marketplace visibility: %w", err)
+		}
 		req.MarketplaceVisibility = &marketplaceVisibility
 		fieldsUpdated = true
 	}
@@ -326,18 +329,26 @@ func promptUpdateExistingEntries(currentEntries []*megaport.MCRPrefixListEntry, 
 		output.PrintPlain("Entry %d - Current: Action: %s, Prefix: %s, GE: %d, LE: %d", noColor,
 			i+1, entry.Action, entry.Prefix, entry.Ge, entry.Le)
 
-		keepEntry, err := utils.ResourcePrompt("mcr", fmt.Sprintf("Keep entry %d? (yes/no): ", i+1), noColor)
+		keepEntryStr, err := utils.ResourcePrompt("mcr", fmt.Sprintf("Keep entry %d? (y/yes/n/no): ", i+1), noColor)
 		if err != nil {
 			return nil, err
 		}
+		keepEntry, err := utils.ParseYesNo(keepEntryStr)
+		if err != nil {
+			return nil, fmt.Errorf("keep entry %d: %w", i+1, err)
+		}
 
-		if strings.ToLower(keepEntry) == "yes" {
-			modifyEntry, err := utils.ResourcePrompt("mcr", fmt.Sprintf("Modify entry %d? (yes/no): ", i+1), noColor)
+		if keepEntry {
+			modifyEntryStr, err := utils.ResourcePrompt("mcr", fmt.Sprintf("Modify entry %d? (y/yes/n/no): ", i+1), noColor)
 			if err != nil {
 				return nil, err
 			}
+			modifyEntry, err := utils.ParseYesNo(modifyEntryStr)
+			if err != nil {
+				return nil, fmt.Errorf("modify entry %d: %w", i+1, err)
+			}
 
-			if strings.ToLower(modifyEntry) == "yes" {
+			if modifyEntry {
 				prefix, err := utils.ResourcePrompt("mcr", fmt.Sprintf("Enter new prefix for entry %d (current: %s): ", i+1, entry.Prefix), noColor)
 				if err != nil {
 					return nil, err

--- a/internal/commands/mcr/mcr_prompts_test.go
+++ b/internal/commands/mcr/mcr_prompts_test.go
@@ -248,6 +248,21 @@ func TestPromptForUpdateMCRDetails_InvalidMarketplaceVisibilityGateValue(t *test
 	assert.Contains(t, err.Error(), "not a recognized yes/no answer")
 }
 
+func TestPromptForUpdateMCRDetails_MarketplaceVisibilityGate_NoSkipsUpdate(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+	// name, costCentre, marketplaceVisibility(n), term, asn
+	utils.SetResourcePrompt(mockPromptSequence([]string{
+		"Updated MCR", "", "n", "", "",
+	}))
+
+	req, err := promptForUpdateMCRDetails("mcr-123", "", true)
+	assert.NoError(t, err)
+	assert.Nil(t, req.MarketplaceVisibility)
+	assert.Equal(t, "Updated MCR", req.Name)
+}
+
 func TestPromptForUpdateMCRDetails_CostCentrePreserved(t *testing.T) {
 	originalPrompt := utils.GetResourcePrompt()
 	defer func() { utils.SetResourcePrompt(originalPrompt) }()

--- a/internal/commands/mcr/mcr_prompts_test.go
+++ b/internal/commands/mcr/mcr_prompts_test.go
@@ -218,6 +218,36 @@ func TestPromptForUpdateMCRDetails_InvalidMarketplaceVisibilityValue(t *testing.
 	assert.Contains(t, err.Error(), "not a recognized yes/no answer")
 }
 
+func TestPromptForUpdateMCRDetails_MarketplaceVisibilityGate_ShorthandY(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+	// name, costCentre, marketplaceVisibility(y), visibilityValue(yes)
+	utils.SetResourcePrompt(mockPromptSequence([]string{
+		"", "", "y", "yes", "", "",
+	}))
+
+	req, err := promptForUpdateMCRDetails("mcr-123", "", true)
+	assert.NoError(t, err)
+	require.NotNil(t, req.MarketplaceVisibility)
+	assert.True(t, *req.MarketplaceVisibility)
+}
+
+func TestPromptForUpdateMCRDetails_InvalidMarketplaceVisibilityGateValue(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+	// name, costCentre, marketplaceVisibility(invalid)
+	utils.SetResourcePrompt(mockPromptSequence([]string{
+		"", "", "maybe",
+	}))
+
+	_, err := promptForUpdateMCRDetails("mcr-123", "", true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "update marketplace visibility")
+	assert.Contains(t, err.Error(), "not a recognized yes/no answer")
+}
+
 func TestPromptForUpdateMCRDetails_CostCentrePreserved(t *testing.T) {
 	originalPrompt := utils.GetResourcePrompt()
 	defer func() { utils.SetResourcePrompt(originalPrompt) }()

--- a/internal/commands/mcr/mcr_prompts_test.go
+++ b/internal/commands/mcr/mcr_prompts_test.go
@@ -173,6 +173,51 @@ func TestPromptForUpdateMCRDetails_Success(t *testing.T) {
 	assert.Equal(t, 65030, *req.MCRAsn)
 }
 
+func TestPromptForUpdateMCRDetails_MarketplaceVisibility_YAccepted(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+	// name, costCentre, marketplaceVisibility(yes/no), visibilityValue(y)
+	utils.SetResourcePrompt(mockPromptSequence([]string{
+		"", "", "yes", "y", "", "",
+	}))
+
+	req, err := promptForUpdateMCRDetails("mcr-123", "", true)
+	assert.NoError(t, err)
+	require.NotNil(t, req.MarketplaceVisibility)
+	assert.True(t, *req.MarketplaceVisibility)
+}
+
+func TestPromptForUpdateMCRDetails_MarketplaceVisibility_NoAccepted(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+	// name, costCentre, marketplaceVisibility(yes/no), visibilityValue(n)
+	utils.SetResourcePrompt(mockPromptSequence([]string{
+		"", "", "yes", "n", "", "",
+	}))
+
+	req, err := promptForUpdateMCRDetails("mcr-123", "", true)
+	assert.NoError(t, err)
+	require.NotNil(t, req.MarketplaceVisibility)
+	assert.False(t, *req.MarketplaceVisibility)
+}
+
+func TestPromptForUpdateMCRDetails_InvalidMarketplaceVisibilityValue(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+	// name, costCentre, marketplaceVisibility(yes/no), visibilityValue(invalid)
+	utils.SetResourcePrompt(mockPromptSequence([]string{
+		"", "", "yes", "ture",
+	}))
+
+	_, err := promptForUpdateMCRDetails("mcr-123", "", true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "marketplace visibility")
+	assert.Contains(t, err.Error(), "not a recognized yes/no answer")
+}
+
 func TestPromptForUpdateMCRDetails_CostCentrePreserved(t *testing.T) {
 	originalPrompt := utils.GetResourcePrompt()
 	defer func() { utils.SetResourcePrompt(originalPrompt) }()
@@ -535,6 +580,71 @@ func TestPromptUpdateExistingEntries_DeleteEntry(t *testing.T) {
 	entries, err := promptUpdateExistingEntries(current, true)
 	assert.NoError(t, err)
 	assert.Len(t, entries, 0)
+}
+
+func TestPromptUpdateExistingEntries_KeepUnmodified_ShorthandYN(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+	current := []*megaport.MCRPrefixListEntry{
+		{Prefix: "10.0.0.0/8", Action: "permit", Ge: 16, Le: 24},
+	}
+
+	// keep=y, modify=n -- a "y" answer must keep the entry, not drop it.
+	utils.SetResourcePrompt(mockPromptSequence([]string{"y", "n"}))
+
+	entries, err := promptUpdateExistingEntries(current, true)
+	assert.NoError(t, err)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "10.0.0.0/8", entries[0].Prefix)
+}
+
+func TestPromptUpdateExistingEntries_DeleteEntry_ShorthandN(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+	current := []*megaport.MCRPrefixListEntry{
+		{Prefix: "10.0.0.0/8", Action: "permit"},
+	}
+
+	// keep=n (delete)
+	utils.SetResourcePrompt(mockPromptSequence([]string{"n"}))
+
+	entries, err := promptUpdateExistingEntries(current, true)
+	assert.NoError(t, err)
+	assert.Len(t, entries, 0)
+}
+
+func TestPromptUpdateExistingEntries_InvalidKeepResponse(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+	current := []*megaport.MCRPrefixListEntry{
+		{Prefix: "10.0.0.0/8", Action: "permit"},
+	}
+
+	utils.SetResourcePrompt(mockPromptSequence([]string{"maybe"}))
+
+	_, err := promptUpdateExistingEntries(current, true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "keep entry 1")
+	assert.Contains(t, err.Error(), "not a recognized yes/no answer")
+}
+
+func TestPromptUpdateExistingEntries_InvalidModifyResponse(t *testing.T) {
+	originalPrompt := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(originalPrompt) }()
+
+	current := []*megaport.MCRPrefixListEntry{
+		{Prefix: "10.0.0.0/8", Action: "permit"},
+	}
+
+	utils.SetResourcePrompt(mockPromptSequence([]string{"yes", "maybe"}))
+
+	_, err := promptUpdateExistingEntries(current, true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "modify entry 1")
+	assert.Contains(t, err.Error(), "not a recognized yes/no answer")
 }
 
 func TestPromptForUpdatePrefixFilterListDetails_Success(t *testing.T) {

--- a/internal/commands/mve/mve_prompts.go
+++ b/internal/commands/mve/mve_prompts.go
@@ -175,7 +175,7 @@ func promptMVEVendorConfig(vendorStr string, imageID int, productSize string, mv
 			CloudInit:   cloudInit,
 		}, nil
 	case "cisco":
-		manageLocallyStr, err := utils.ResourcePrompt("mve", "Manage locally (y/yes/n/no) (required): ", noColor)
+		manageLocallyStr, err := utils.ResourcePrompt("mve", "Manage locally (y/yes/true/n/no/false) (required): ", noColor)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/commands/mve/mve_prompts.go
+++ b/internal/commands/mve/mve_prompts.go
@@ -175,11 +175,14 @@ func promptMVEVendorConfig(vendorStr string, imageID int, productSize string, mv
 			CloudInit:   cloudInit,
 		}, nil
 	case "cisco":
-		manageLocallyStr, err := utils.ResourcePrompt("mve", "Manage locally (true/false) (required): ", noColor)
+		manageLocallyStr, err := utils.ResourcePrompt("mve", "Manage locally (y/yes/n/no) (required): ", noColor)
 		if err != nil {
 			return nil, err
 		}
-		manageLocally := strings.ToLower(manageLocallyStr) == "true"
+		manageLocally, err := utils.ParseYesNo(manageLocallyStr)
+		if err != nil {
+			return nil, fmt.Errorf("manage locally: %w", err)
+		}
 
 		adminSSHPublicKey, err := utils.ResourcePrompt("mve", "Enter admin SSH public key (required): ", noColor)
 		if err != nil {

--- a/internal/commands/mve/mve_prompts_test.go
+++ b/internal/commands/mve/mve_prompts_test.go
@@ -436,6 +436,61 @@ func TestPromptMVEVendorConfig_Cisco_WithAdminPassword(t *testing.T) {
 	assert.Equal(t, "s3cr3t!", cisco.AdminPassword)
 }
 
+func TestPromptMVEVendorConfig_Cisco_ManageLocally_ShorthandY(t *testing.T) {
+	origResource := utils.GetResourcePrompt()
+	origSecret := utils.GetSecretResourcePrompt()
+	defer func() {
+		utils.SetResourcePrompt(origResource)
+		utils.SetSecretResourcePrompt(origSecret)
+	}()
+
+	// "y" must be interpreted as true, not silently treated as false.
+	utils.SetResourcePrompt(mockPromptSequence([]string{
+		"y", "admin-ssh", "ssh-key", "cloud-init",
+		"10.0.0.1", "fmc-reg", "fmc-nat",
+	}))
+	utils.SetSecretResourcePrompt(mockPromptSequence([]string{""}))
+
+	cfg, err := promptMVEVendorConfig("cisco", 99, "LARGE", "lbl", true)
+	assert.NoError(t, err)
+	cisco, ok := cfg.(*megaport.CiscoConfig)
+	assert.True(t, ok)
+	assert.True(t, cisco.ManageLocally)
+}
+
+func TestPromptMVEVendorConfig_Cisco_ManageLocally_ShorthandN(t *testing.T) {
+	origResource := utils.GetResourcePrompt()
+	origSecret := utils.GetSecretResourcePrompt()
+	defer func() {
+		utils.SetResourcePrompt(origResource)
+		utils.SetSecretResourcePrompt(origSecret)
+	}()
+
+	utils.SetResourcePrompt(mockPromptSequence([]string{
+		"n", "admin-ssh", "ssh-key", "cloud-init",
+		"10.0.0.1", "fmc-reg", "fmc-nat",
+	}))
+	utils.SetSecretResourcePrompt(mockPromptSequence([]string{""}))
+
+	cfg, err := promptMVEVendorConfig("cisco", 99, "LARGE", "lbl", true)
+	assert.NoError(t, err)
+	cisco, ok := cfg.(*megaport.CiscoConfig)
+	assert.True(t, ok)
+	assert.False(t, cisco.ManageLocally)
+}
+
+func TestPromptMVEVendorConfig_Cisco_InvalidManageLocally(t *testing.T) {
+	origResource := utils.GetResourcePrompt()
+	defer func() { utils.SetResourcePrompt(origResource) }()
+
+	utils.SetResourcePrompt(mockPromptSequence([]string{"ture"}))
+
+	_, err := promptMVEVendorConfig("cisco", 99, "LARGE", "lbl", true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "manage locally")
+	assert.Contains(t, err.Error(), "not a recognized yes/no answer")
+}
+
 func TestPromptMVEVendorConfig_PaloAlto_PlaintextOnly(t *testing.T) {
 	origResource := utils.GetResourcePrompt()
 	origSecret := utils.GetSecretResourcePrompt()

--- a/internal/utils/prompts.go
+++ b/internal/utils/prompts.go
@@ -474,3 +474,16 @@ func SetUpdateResourceTagsPrompt(fn func(map[string]string, bool) (map[string]st
 	defer promptFuncMu.Unlock()
 	updateResourceTagsPromptFn = fn
 }
+
+// ParseYesNo strictly parses a yes/no response, accepting y/yes/true and
+// n/no/false (case-insensitive), and erroring on anything else.
+func ParseYesNo(answer string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(answer)) {
+	case "y", "yes", "true":
+		return true, nil
+	case "n", "no", "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("%q is not a recognized yes/no answer (expected y/yes/true or n/no/false)", answer)
+	}
+}

--- a/internal/utils/prompts_test.go
+++ b/internal/utils/prompts_test.go
@@ -889,3 +889,38 @@ func TestPromptWithCustomReader(t *testing.T) {
 	assert.Contains(t, errBuf.String(), "Enter value:")
 	assert.Empty(t, outBuf.String(), "prompt text must not be written to stdout")
 }
+
+func TestParseYesNo(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    bool
+		wantErr bool
+	}{
+		{name: "y", input: "y", want: true},
+		{name: "Y uppercase", input: "Y", want: true},
+		{name: "yes", input: "yes", want: true},
+		{name: "yes mixed case", input: "Yes", want: true},
+		{name: "true", input: "true", want: true},
+		{name: "true with whitespace", input: "  true  ", want: true},
+		{name: "n", input: "n", want: false},
+		{name: "N uppercase", input: "N", want: false},
+		{name: "no", input: "no", want: false},
+		{name: "false", input: "false", want: false},
+		{name: "invalid typo", input: "ture", wantErr: true},
+		{name: "empty", input: "", wantErr: true},
+		{name: "unrelated word", input: "maybe", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseYesNo(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Three interactive prompts only matched one exact string and silently treated anything else as false or "drop this entry" - a typo like "ture" or "y" instead of "yes" would silently change what got sent to the API.

- MCR marketplace-visibility update prompt: a typo used to silently hide a marketplace-visible MCR.
- MVE Cisco `manageLocally` prompt: an unrecognized answer used to silently order an FMC-managed deployment.
- MCR prefix-filter keep-entry prompt: answering "y" instead of "yes" silently dropped the entry from the list.

All three now go through a shared `utils.ParseYesNo` helper that accepts y/yes/true and n/no/false (case-insensitive) and errors on anything else, matching the pattern already used elsewhere in the CLI (e.g. the users and IX prompts).

Added tests for affirmative, negative, and invalid input at each site, plus a table-driven test for the helper itself.
