### PR TITLE
ESD-1642: Validate empty request and position on users update

### DIFF
--- a/internal/commands/users/users_inputs.go
+++ b/internal/commands/users/users_inputs.go
@@ -79,12 +79,23 @@ func processFlagCreateUserInput(cmd *cobra.Command) (*megaport.CreateUserRequest
 func processJSONUpdateUserInput(jsonStr, jsonFile string) (*megaport.UpdateUserRequest, error) {
 	jsonData, err := utils.ReadJSONInput(jsonStr, jsonFile)
 	if err != nil {
-		return nil, err
+		return nil, exitcodes.NewUsageError(err)
 	}
 
 	req := &megaport.UpdateUserRequest{}
 	if err := json.Unmarshal(jsonData, req); err != nil {
-		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+		return nil, exitcodes.NewUsageError(fmt.Errorf("failed to parse JSON: %w", err))
+	}
+
+	if *req == (megaport.UpdateUserRequest{}) {
+		return nil, exitcodes.NewUsageError(fmt.Errorf("at least one field must be updated"))
+	}
+
+	if req.Position != nil {
+		position := megaport.UserPosition(*req.Position)
+		if *req.Position != "" && !position.IsValid() {
+			return nil, exitcodes.NewUsageError(fmt.Errorf("invalid position: %s. Valid positions: %s", *req.Position, position.ValidPositions()))
+		}
 	}
 
 	return req, nil
@@ -111,6 +122,10 @@ func processFlagUpdateUserInput(cmd *cobra.Command) (*megaport.UpdateUserRequest
 	}
 	if cmd.Flags().Changed("position") {
 		position, _ := cmd.Flags().GetString("position")
+		userPosition := megaport.UserPosition(position)
+		if position != "" && !userPosition.IsValid() {
+			return nil, fmt.Errorf("invalid position: %s. Valid positions: %s", position, userPosition.ValidPositions())
+		}
 		req.Position = &position
 		fieldsUpdated = true
 	}

--- a/internal/commands/users/users_inputs.go
+++ b/internal/commands/users/users_inputs.go
@@ -124,7 +124,7 @@ func processFlagUpdateUserInput(cmd *cobra.Command) (*megaport.UpdateUserRequest
 		position, _ := cmd.Flags().GetString("position")
 		userPosition := megaport.UserPosition(position)
 		if position != "" && !userPosition.IsValid() {
-			return nil, fmt.Errorf("invalid position: %s. Valid positions: %s", position, userPosition.ValidPositions())
+			return nil, exitcodes.NewUsageError(fmt.Errorf("invalid position: %s. Valid positions: %s", position, userPosition.ValidPositions()))
 		}
 		req.Position = &position
 		fieldsUpdated = true

--- a/internal/commands/users/users_inputs_test.go
+++ b/internal/commands/users/users_inputs_test.go
@@ -236,6 +236,10 @@ func TestProcessJSONUpdateUserInput(t *testing.T) {
 			if tt.expectedError != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
+
+				var cliErr *exitcodes.CLIError
+				require.True(t, errors.As(err, &cliErr))
+				assert.Equal(t, exitcodes.Usage, cliErr.Code)
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, req)
@@ -309,9 +313,10 @@ func TestProcessFlagCreateUserInput(t *testing.T) {
 
 func TestProcessFlagUpdateUserInput(t *testing.T) {
 	tests := []struct {
-		name          string
-		flags         map[string]string
-		expectedError string
+		name             string
+		flags            map[string]string
+		expectedError    string
+		expectUsageError bool
 	}{
 		{
 			name:          "no flags changed",
@@ -344,9 +349,10 @@ func TestProcessFlagUpdateUserInput(t *testing.T) {
 			},
 		},
 		{
-			name:          "invalid position",
-			flags:         map[string]string{"position": "Super Admin"},
-			expectedError: "invalid position",
+			name:             "invalid position",
+			flags:            map[string]string{"position": "Super Admin"},
+			expectedError:    "invalid position",
+			expectUsageError: true,
 		},
 	}
 
@@ -369,6 +375,12 @@ func TestProcessFlagUpdateUserInput(t *testing.T) {
 			if tt.expectedError != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
+
+				if tt.expectUsageError {
+					var cliErr *exitcodes.CLIError
+					require.True(t, errors.As(err, &cliErr))
+					assert.Equal(t, exitcodes.Usage, cliErr.Code)
+				}
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, req)

--- a/internal/commands/users/users_inputs_test.go
+++ b/internal/commands/users/users_inputs_test.go
@@ -207,6 +207,16 @@ func TestProcessJSONUpdateUserInput(t *testing.T) {
 			name:      "valid JSON file",
 			writeFile: `{"lastName":"NewLast"}`,
 		},
+		{
+			name:          "empty JSON body",
+			jsonStr:       `{}`,
+			expectedError: "at least one field must be updated",
+		},
+		{
+			name:          "invalid position",
+			jsonStr:       `{"position":"Super Admin"}`,
+			expectedError: "invalid position",
+		},
 	}
 
 	for _, tt := range tests {
@@ -332,6 +342,11 @@ func TestProcessFlagUpdateUserInput(t *testing.T) {
 				"position":   "Finance",
 				"phone":      "+61400000000",
 			},
+		},
+		{
+			name:          "invalid position",
+			flags:         map[string]string{"position": "Super Admin"},
+			expectedError: "invalid position",
 		},
 	}
 


### PR DESCRIPTION
Closes the validation gap between `users update`'s JSON and flag input paths.

- JSON updates with no recognized fields (e.g. `--json '{}'`) now fail with "at least one field must be updated" instead of issuing a no-op API call.
- Position is now validated client-side on the update JSON path and the update flag path, matching the check already done on create.

Fixes ESD-1642.
