### PR TITLE
ESD-1641: Validate environment in config update-profile and import

### DIFF
--- a/internal/commands/config/config_actions.go
+++ b/internal/commands/config/config_actions.go
@@ -29,6 +29,15 @@ func maskAccessKey(key string) string {
 	return "****"
 }
 
+// validateEnvironment rejects any environment value outside the canonical
+// allow-list. Used by create, update, and import so the three paths cannot drift.
+func validateEnvironment(env string) error {
+	if env != "production" && env != "staging" && env != "development" {
+		return fmt.Errorf("environment must be 'production', 'staging', or 'development'")
+	}
+	return nil
+}
+
 func CreateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 	profileName := args[0]
 	// Flag read errors are intentionally ignored — flags are registered by the command builder.

--- a/internal/commands/config/config_actions.go
+++ b/internal/commands/config/config_actions.go
@@ -119,6 +119,14 @@ func UpdateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 	environmentChanged := cmd.Flags().Changed("environment")
 	descriptionChanged := cmd.Flags().Changed("description")
 
+	environment := ""
+	if environmentChanged {
+		environment, _ = cmd.Flags().GetString("environment")
+		if err := validateEnvironment(environment); err != nil {
+			return err
+		}
+	}
+
 	accessKey := ""
 	if accessKeyChanged {
 		accessKey, _ = cmd.Flags().GetString("access-key")
@@ -148,14 +156,6 @@ func UpdateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 				return fmt.Errorf("secret key cannot be empty")
 			}
 			secretKey = strings.TrimSpace(secretKey)
-		}
-	}
-
-	environment := ""
-	if environmentChanged {
-		environment, _ = cmd.Flags().GetString("environment")
-		if err := validateEnvironment(environment); err != nil {
-			return err
 		}
 	}
 

--- a/internal/commands/config/config_actions.go
+++ b/internal/commands/config/config_actions.go
@@ -421,6 +421,9 @@ func ImportConfig(cmd *cobra.Command, args []string, noColor bool) error {
 
 	// Validate and set defaults for profiles
 	for profileName, profile := range importConfig.Profiles {
+		if profile == nil {
+			return fmt.Errorf("profile '%s' has no data", profileName)
+		}
 		if profile.Environment == "" {
 			profile.Environment = "production"
 		}

--- a/internal/commands/config/config_actions.go
+++ b/internal/commands/config/config_actions.go
@@ -41,8 +41,8 @@ func CreateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 		return fmt.Errorf("profile name cannot be empty or whitespace")
 	}
 
-	if environment != "production" && environment != "staging" && environment != "development" {
-		return fmt.Errorf("environment must be 'production', 'staging', or 'development'")
+	if err := validateEnvironment(environment); err != nil {
+		return err
 	}
 
 	manager, err := NewConfigManager()
@@ -145,6 +145,9 @@ func UpdateProfile(cmd *cobra.Command, args []string, noColor bool) error {
 	environment := ""
 	if environmentChanged {
 		environment, _ = cmd.Flags().GetString("environment")
+		if err := validateEnvironment(environment); err != nil {
+			return err
+		}
 	}
 
 	description := ""
@@ -411,6 +414,9 @@ func ImportConfig(cmd *cobra.Command, args []string, noColor bool) error {
 	for profileName, profile := range importConfig.Profiles {
 		if profile.Environment == "" {
 			profile.Environment = "production"
+		}
+		if err := validateEnvironment(profile.Environment); err != nil {
+			return fmt.Errorf("profile '%s' has an invalid environment: %w", profileName, err)
 		}
 		if profile.AccessKey == "" || profile.SecretKey == "" ||
 			profile.AccessKey == "[REDACTED]" || profile.SecretKey == "[REDACTED]" {

--- a/internal/commands/config/config_actions.go
+++ b/internal/commands/config/config_actions.go
@@ -33,7 +33,7 @@ func maskAccessKey(key string) string {
 // allow-list. Used by create, update, and import so the three paths cannot drift.
 func validateEnvironment(env string) error {
 	if env != "production" && env != "staging" && env != "development" {
-		return fmt.Errorf("environment must be 'production', 'staging', or 'development'")
+		return fmt.Errorf("environment must be 'production', 'staging', or 'development' (got %q)", env)
 	}
 	return nil
 }

--- a/internal/commands/config/config_actions_test.go
+++ b/internal/commands/config/config_actions_test.go
@@ -186,6 +186,33 @@ func TestUpdateProfile_ValidEnvironmentAccepted(t *testing.T) {
 	assert.Equal(t, "staging", profiles["test-profile"].Environment)
 }
 
+func TestUpdateProfile_InvalidEnvironmentRejectedBeforePrompting(t *testing.T) {
+	setupTestConfigEnv(t)
+
+	manager, err := NewConfigManager()
+	require.NoError(t, err)
+	err = manager.CreateProfile("test-profile", "old-access", "old-secret", "production", "Old description")
+	require.NoError(t, err)
+
+	orig := utils.GetSecretResourcePrompt()
+	defer utils.SetSecretResourcePrompt(orig)
+	utils.SetSecretResourcePrompt(func(_, _ string, _ bool) (string, error) {
+		t.Fatal("should not prompt for secrets when the environment is rejected first")
+		return "", nil
+	})
+
+	cmd, _ := setupTestCmd()
+	cmd.Flags().String("access-key", "", "")
+	cmd.Flags().String("environment", "bogus", "")
+	require.NoError(t, cmd.ParseFlags([]string{"--access-key=", "--environment=bogus"}))
+
+	_, err = captureBothFromAction(t, func() error {
+		return UpdateProfile(cmd, []string{"test-profile"}, false)
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "environment must be 'production', 'staging', or 'development'")
+}
+
 func TestUseProfile_CMD(t *testing.T) {
 	setupTestConfigEnv(t)
 

--- a/internal/commands/config/config_actions_test.go
+++ b/internal/commands/config/config_actions_test.go
@@ -1016,6 +1016,36 @@ func TestImportConfig_InvalidEnvironmentRejected(t *testing.T) {
 	assert.NotContains(t, profiles, "bad-profile", "nothing should be written when validation fails")
 }
 
+func TestImportConfig_NullProfileEntryRejected(t *testing.T) {
+	configDir := setupTestConfigEnv(t)
+
+	importPath := filepath.Join(configDir, "import.json")
+	importContent := `{
+        "version": 1,
+        "profiles": {
+            "null-profile": null
+        }
+    }`
+	require.NoError(t, os.WriteFile(importPath, []byte(importContent), 0600))
+
+	oldConfirmPrompt := utils.GetConfirmPrompt()
+	utils.SetConfirmPrompt(func(_ string, _ bool) bool {
+		t.Fatal("confirmation should not be requested when validation fails")
+		return true
+	})
+	defer func() { utils.SetConfirmPrompt(oldConfirmPrompt) }()
+
+	cmd, _ := setupTestCmd()
+	cmd.Flags().String("file", importPath, "")
+	require.NoError(t, cmd.ParseFlags([]string{"--file=" + importPath}))
+
+	_, err := captureBothFromAction(t, func() error {
+		return ImportConfig(cmd, nil, false)
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "null-profile")
+}
+
 func TestImportConfig_EmptyEnvironmentDefaultsToProduction(t *testing.T) {
 	configDir := setupTestConfigEnv(t)
 

--- a/internal/commands/config/config_actions_test.go
+++ b/internal/commands/config/config_actions_test.go
@@ -136,6 +136,56 @@ func TestUpdateProfile_CMD(t *testing.T) {
 	assert.Equal(t, "New description", profiles["test-profile"].Description)
 }
 
+func TestUpdateProfile_InvalidEnvironmentRejected(t *testing.T) {
+	setupTestConfigEnv(t)
+
+	manager, err := NewConfigManager()
+	require.NoError(t, err)
+	err = manager.CreateProfile("test-profile", "old-access", "old-secret", "production", "Old description")
+	require.NoError(t, err)
+
+	cmd, _ := setupTestCmd()
+	cmd.Flags().String("environment", "bogus", "")
+	require.NoError(t, cmd.ParseFlags([]string{"--environment=bogus"}))
+
+	_, err = captureBothFromAction(t, func() error {
+		return UpdateProfile(cmd, []string{"test-profile"}, false)
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "environment must be 'production', 'staging', or 'development'")
+
+	manager, err = NewConfigManager()
+	require.NoError(t, err)
+	profiles, err := manager.ListProfiles()
+	require.NoError(t, err)
+	assert.Equal(t, "production", profiles["test-profile"].Environment, "profile should be unchanged after a rejected update")
+}
+
+func TestUpdateProfile_ValidEnvironmentAccepted(t *testing.T) {
+	setupTestConfigEnv(t)
+
+	manager, err := NewConfigManager()
+	require.NoError(t, err)
+	err = manager.CreateProfile("test-profile", "old-access", "old-secret", "production", "Old description")
+	require.NoError(t, err)
+
+	cmd, _ := setupTestCmd()
+	cmd.Flags().String("environment", "staging", "")
+	require.NoError(t, cmd.ParseFlags([]string{"--environment=staging"}))
+
+	outputText, err := captureBothFromAction(t, func() error {
+		return UpdateProfile(cmd, []string{"test-profile"}, false)
+	})
+	require.NoError(t, err)
+	assert.Contains(t, outputText, "Profile 'test-profile' updated successfully")
+
+	manager, err = NewConfigManager()
+	require.NoError(t, err)
+	profiles, err := manager.ListProfiles()
+	require.NoError(t, err)
+	assert.Equal(t, "staging", profiles["test-profile"].Environment)
+}
+
 func TestUseProfile_CMD(t *testing.T) {
 	setupTestConfigEnv(t)
 
@@ -923,6 +973,84 @@ func TestImportConfig_Cancelled(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cancelled by user")
 	assert.Contains(t, outputText, "Import cancelled")
+}
+
+func TestImportConfig_InvalidEnvironmentRejected(t *testing.T) {
+	configDir := setupTestConfigEnv(t)
+
+	importPath := filepath.Join(configDir, "import.json")
+	importContent := `{
+        "version": 1,
+        "profiles": {
+            "bad-profile": {
+                "accessKey": "test-access",
+                "secretKey": "test-secret",
+                "environment": "typo"
+            }
+        }
+    }`
+	require.NoError(t, os.WriteFile(importPath, []byte(importContent), 0600))
+
+	oldConfirmPrompt := utils.GetConfirmPrompt()
+	utils.SetConfirmPrompt(func(_ string, _ bool) bool {
+		t.Fatal("confirmation should not be requested when validation fails")
+		return true
+	})
+	defer func() { utils.SetConfirmPrompt(oldConfirmPrompt) }()
+
+	cmd, _ := setupTestCmd()
+	cmd.Flags().String("file", importPath, "")
+	require.NoError(t, cmd.ParseFlags([]string{"--file=" + importPath}))
+
+	_, err := captureBothFromAction(t, func() error {
+		return ImportConfig(cmd, nil, false)
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad-profile")
+	assert.Contains(t, err.Error(), "environment must be 'production', 'staging', or 'development'")
+
+	manager, err := NewConfigManager()
+	require.NoError(t, err)
+	profiles, err := manager.ListProfiles()
+	require.NoError(t, err)
+	assert.NotContains(t, profiles, "bad-profile", "nothing should be written when validation fails")
+}
+
+func TestImportConfig_EmptyEnvironmentDefaultsToProduction(t *testing.T) {
+	configDir := setupTestConfigEnv(t)
+
+	importPath := filepath.Join(configDir, "import.json")
+	importContent := `{
+        "version": 1,
+        "profiles": {
+            "default-env-profile": {
+                "accessKey": "test-access",
+                "secretKey": "test-secret",
+                "environment": ""
+            }
+        }
+    }`
+	require.NoError(t, os.WriteFile(importPath, []byte(importContent), 0600))
+
+	oldConfirmPrompt := utils.GetConfirmPrompt()
+	utils.SetConfirmPrompt(func(_ string, _ bool) bool { return true })
+	defer func() { utils.SetConfirmPrompt(oldConfirmPrompt) }()
+
+	cmd, _ := setupTestCmd()
+	cmd.Flags().String("file", importPath, "")
+	require.NoError(t, cmd.ParseFlags([]string{"--file=" + importPath}))
+
+	outputText, err := captureBothFromAction(t, func() error {
+		return ImportConfig(cmd, nil, false)
+	})
+	require.NoError(t, err)
+	assert.Contains(t, outputText, "Configuration imported successfully")
+
+	manager, err := NewConfigManager()
+	require.NoError(t, err)
+	profiles, err := manager.ListProfiles()
+	require.NoError(t, err)
+	assert.Equal(t, "production", profiles["default-env-profile"].Environment)
 }
 
 func TestCreateProfile_InteractivePrompt(t *testing.T) {

--- a/internal/commands/config/config_shared.go
+++ b/internal/commands/config/config_shared.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 
 	megaport "github.com/megaport/megaportgo"
@@ -32,6 +33,15 @@ func NewConfigFile() *ConfigFile {
 		Profiles: make(map[string]*Profile),
 		Defaults: make(map[string]interface{}),
 	}
+}
+
+// validateEnvironment rejects any environment value outside the canonical
+// allow-list. Used by create, update, and import so the three paths cannot drift.
+func validateEnvironment(env string) error {
+	if env != "production" && env != "staging" && env != "development" {
+		return fmt.Errorf("environment must be 'production', 'staging', or 'development'")
+	}
+	return nil
 }
 
 // normalizeEnvironment maps short aliases and normalizes the environment string

--- a/internal/commands/config/config_shared.go
+++ b/internal/commands/config/config_shared.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"strings"
 
 	megaport "github.com/megaport/megaportgo"
@@ -33,15 +32,6 @@ func NewConfigFile() *ConfigFile {
 		Profiles: make(map[string]*Profile),
 		Defaults: make(map[string]interface{}),
 	}
-}
-
-// validateEnvironment rejects any environment value outside the canonical
-// allow-list. Used by create, update, and import so the three paths cannot drift.
-func validateEnvironment(env string) error {
-	if env != "production" && env != "staging" && env != "development" {
-		return fmt.Errorf("environment must be 'production', 'staging', or 'development'")
-	}
-	return nil
 }
 
 // normalizeEnvironment maps short aliases and normalizes the environment string


### PR DESCRIPTION
`config create-profile` already rejects any `--environment` outside `production`/`staging`/`development`, but `config update-profile` and `config import` did not, so a bad value only surfaced later at login time.

- Added a shared `validateEnvironment` helper in `config_actions.go`
- Wired it into `CreateProfile`, `UpdateProfile` (when `--environment` changes), and `ImportConfig` (before any profile is written)
- `ImportConfig` also now rejects a null profile entry in the import JSON instead of panicking
- Added test cases for update and import with valid/invalid/empty/null environments
