### PR TITLE
ESD-1643: Share one buffered stdin reader across prompts

### DIFF
--- a/internal/utils/prompts.go
+++ b/internal/utils/prompts.go
@@ -58,6 +58,16 @@ func readStdinLine() (string, error) {
 	return strings.TrimSpace(input), nil
 }
 
+// stdinHasBuffered reports whether the shared reader already holds bytes read
+// ahead from stdin. nativeSecretResourcePrompt checks this before reading
+// straight off the terminal fd: if an earlier prompt's read-ahead already
+// pulled a later answer into this buffer, a raw fd read would never see it.
+func stdinHasBuffered() bool {
+	stdinReaderMu.Lock()
+	defer stdinReaderMu.Unlock()
+	return stdinReader != nil && stdinReader.Buffered() > 0
+}
+
 var promptFn = func(msg string, noColor bool) (string, error) {
 	if !noColor {
 		// Add contextual icon and use Megaport's red

--- a/internal/utils/prompts.go
+++ b/internal/utils/prompts.go
@@ -2,7 +2,9 @@ package utils
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -13,6 +15,49 @@ import (
 // promptFuncMu guards all prompt function pointers.
 var promptFuncMu sync.RWMutex
 
+// stdinReaderMu guards the shared stdin reader below, including reads
+// against it: bufio.Reader is not safe for concurrent use, so the lock
+// covers the read itself rather than just the pointer's lazy creation.
+var stdinReaderMu sync.Mutex
+
+// stdinReader is the single buffered reader every interactive prompt reads
+// through. A bufio.Reader reads ahead in chunks, so if each prompt built its
+// own reader over os.Stdin, bytes buffered past the line one prompt consumed
+// would be discarded when the next prompt created a fresh reader. Sharing one
+// reader across calls keeps that read-ahead available to the next prompt.
+var stdinReader *bufio.Reader
+
+// resetSharedStdinReader drops the cached reader so the next read builds a
+// fresh one over the current os.Stdin. Tests that swap os.Stdin per run call
+// this so the shared reader never holds bytes buffered from a prior test's
+// pipe.
+func resetSharedStdinReader() {
+	stdinReaderMu.Lock()
+	defer stdinReaderMu.Unlock()
+	stdinReader = nil
+}
+
+// readStdinLine reads one line from the shared stdin reader. A final line
+// with no trailing newline before EOF (e.g. piped input with no trailing
+// newline, or the user typing an answer then sending EOF instead of Enter)
+// still returns its content: bufio.Reader.ReadString returns the partial
+// data alongside io.EOF in that case, and the previous per-call
+// fmt.Scanln-based confirm prompt accepted that shape too.
+func readStdinLine() (string, error) {
+	stdinReaderMu.Lock()
+	defer stdinReaderMu.Unlock()
+
+	if stdinReader == nil {
+		stdinReader = bufio.NewReader(os.Stdin)
+	}
+
+	input, err := stdinReader.ReadString('\n')
+	if err != nil && (!errors.Is(err, io.EOF) || input == "") {
+		return "", err
+	}
+	return strings.TrimSpace(input), nil
+}
+
 var promptFn = func(msg string, noColor bool) (string, error) {
 	if !noColor {
 		// Add contextual icon and use Megaport's red
@@ -21,17 +66,10 @@ var promptFn = func(msg string, noColor bool) (string, error) {
 		fmt.Fprint(os.Stderr, "❯ "+msg+" ")
 	}
 
-	reader := bufio.NewReader(os.Stdin)
-	input, err := reader.ReadString('\n')
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(input), nil
+	return readStdinLine()
 }
 
 var confirmPromptFn = func(question string, noColor bool) bool {
-	var response string
-
 	if !noColor {
 		// Add warning icon for confirmation prompts
 		fmt.Fprint(os.Stderr, color.New(color.FgHiRed).Sprint("⚠️  "+question+" "))
@@ -40,16 +78,12 @@ var confirmPromptFn = func(question string, noColor bool) bool {
 		fmt.Fprintf(os.Stderr, "⚠️  %s [y/N] ", question)
 	}
 
-	_, err := fmt.Scanln(&response)
+	input, err := readStdinLine()
 	if err != nil {
-		// Handle empty response (just pressing Enter)
-		if err.Error() == "unexpected newline" {
-			return false // Default to "No"
-		}
-		return false
+		return false // Default to "No", including on an empty-input EOF
 	}
 
-	response = strings.ToLower(strings.TrimSpace(response))
+	response := strings.ToLower(input)
 	return response == "y" || response == "yes"
 }
 
@@ -109,12 +143,7 @@ var resourcePromptFn = func(resourceType string, msg string, noColor bool) (stri
 		fmt.Fprint(os.Stderr, icon+" "+msg+" ")
 	}
 
-	reader := bufio.NewReader(os.Stdin)
-	input, err := reader.ReadString('\n')
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(input), nil
+	return readStdinLine()
 }
 
 // secretResourcePromptFn reads a sensitive value (password, token).
@@ -130,12 +159,7 @@ var secretResourcePromptFn = func(resourceType string, msg string, noColor bool)
 		fmt.Fprint(os.Stderr, icon+" "+msg+" ")
 	}
 
-	reader := bufio.NewReader(os.Stdin)
-	input, err := reader.ReadString('\n')
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(input), nil
+	return readStdinLine()
 }
 
 // passwordPromptFn is set by the platform-specific init in prompts_native.go

--- a/internal/utils/prompts.go
+++ b/internal/utils/prompts.go
@@ -150,7 +150,13 @@ var resourcePromptFn = func(resourceType string, msg string, noColor bool) (stri
 // The default implementation here is the WASM-safe echoing fallback; native
 // builds replace it via init() in prompts_secret_native.go with a TTY-aware
 // version that disables terminal echo using golang.org/x/term.
-var secretResourcePromptFn = func(resourceType string, msg string, noColor bool) (string, error) {
+var secretResourcePromptFn = defaultSecretResourcePrompt
+
+// defaultSecretResourcePrompt is a named function, rather than inlined into
+// the secretResourcePromptFn var above, so it stays directly callable from
+// tests: native builds overwrite that var via init(), so a test referencing
+// the var by then reaches nativeSecretResourcePrompt instead of this.
+func defaultSecretResourcePrompt(resourceType string, msg string, noColor bool) (string, error) {
 	icon := "🔐"
 
 	if !noColor {

--- a/internal/utils/prompts_native.go
+++ b/internal/utils/prompts_native.go
@@ -15,12 +15,21 @@ func init() {
 	SetPasswordPrompt(nativePasswordPrompt)
 }
 
+// nativePasswordPrompt reads a password without echoing it to the terminal.
+// Falls back to the shared buffered reader when it already has bytes
+// buffered: term.ReadPassword reads straight off the fd, so it would never
+// see input an earlier prompt (e.g. a preceding ResourcePrompt in the same
+// flow) already read ahead into that buffer.
 func nativePasswordPrompt(msg string, noColor bool) (string, error) {
 	// \U0001f512 is the lock symbol 🔒
 	if !noColor {
 		fmt.Fprint(os.Stderr, color.New(color.FgHiRed, color.Bold).Sprint("\U0001f512 "+msg+" "))
 	} else {
 		fmt.Fprint(os.Stderr, "\U0001f512 "+msg+" ")
+	}
+
+	if stdinHasBuffered() {
+		return readStdinLine()
 	}
 
 	password, err := term.ReadPassword(int(os.Stdin.Fd()))

--- a/internal/utils/prompts_native_test.go
+++ b/internal/utils/prompts_native_test.go
@@ -49,3 +49,50 @@ func TestNativePasswordPrompt_NonTTYReturnsError(t *testing.T) {
 	_ = outW.Close()
 	<-done
 }
+
+// TestNativePasswordPrompt_UsesSharedReaderWhenDataBuffered is a regression
+// test for the stdinHasBuffered guard: if an earlier prompt in the same flow
+// already read ahead past its own line, nativePasswordPrompt must consume the
+// buffered leftover through the shared reader rather than calling
+// term.ReadPassword, which reads straight off the fd and would never see it.
+func TestNativePasswordPrompt_UsesSharedReaderWhenDataBuffered(t *testing.T) {
+	oldStdin, oldStdout := os.Stdin, os.Stdout
+	defer func() {
+		os.Stdin, os.Stdout = oldStdin, oldStdout
+		resetSharedStdinReader()
+	}()
+
+	inR, inW, err := os.Pipe()
+	require.NoError(t, err)
+	defer inR.Close()
+
+	outR, outW, err := os.Pipe()
+	require.NoError(t, err)
+	defer outR.Close()
+
+	os.Stdin = inR
+	os.Stdout = outW
+	resetSharedStdinReader()
+
+	_, err = inW.WriteString("first\nsecond\n")
+	require.NoError(t, err)
+	require.NoError(t, inW.Close())
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, outR)
+		close(done)
+	}()
+
+	first, err := readStdinLine()
+	require.NoError(t, err)
+	assert.Equal(t, "first", first)
+	require.True(t, stdinHasBuffered())
+
+	pw, err := nativePasswordPrompt("Enter password:", true)
+	require.NoError(t, err)
+	assert.Equal(t, "second", pw)
+
+	_ = outW.Close()
+	<-done
+}

--- a/internal/utils/prompts_native_test.go
+++ b/internal/utils/prompts_native_test.go
@@ -87,6 +87,16 @@ func TestNativePasswordPrompt_UsesSharedReaderWhenDataBuffered(t *testing.T) {
 	first, err := readStdinLine()
 	require.NoError(t, err)
 	assert.Equal(t, "first", first)
+
+	// Read is allowed to return fewer bytes than requested, so the read above
+	// isn't guaranteed to have pulled "second\n" into the buffer on its own.
+	// Peek forces fill() to pull at least one more byte so the assertion
+	// below is deterministic.
+	stdinReaderMu.Lock()
+	_, peekErr := stdinReader.Peek(1)
+	stdinReaderMu.Unlock()
+	require.NoError(t, peekErr)
+
 	require.True(t, stdinHasBuffered())
 
 	pw, err := nativePasswordPrompt("Enter password:", true)

--- a/internal/utils/prompts_secret_native.go
+++ b/internal/utils/prompts_secret_native.go
@@ -17,7 +17,10 @@ func init() {
 
 // nativeSecretResourcePrompt reads a sensitive value without echoing it to
 // the terminal. Falls back to the standard echoed prompt when stdin is not a
-// terminal (piped input, CI) so scripted usage keeps working.
+// terminal (piped input, CI) so scripted usage keeps working, and also when
+// the shared reader already has bytes buffered: term.ReadPassword reads
+// straight off the fd, so it would never see input an earlier prompt already
+// read ahead into that buffer.
 func nativeSecretResourcePrompt(resourceType string, msg string, noColor bool) (string, error) {
 	icon := "🔐"
 
@@ -28,7 +31,7 @@ func nativeSecretResourcePrompt(resourceType string, msg string, noColor bool) (
 	}
 
 	fd := int(os.Stdin.Fd())
-	if !term.IsTerminal(fd) {
+	if !term.IsTerminal(fd) || stdinHasBuffered() {
 		return readStdinLine()
 	}
 

--- a/internal/utils/prompts_secret_native.go
+++ b/internal/utils/prompts_secret_native.go
@@ -3,7 +3,6 @@
 package utils
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"strings"
@@ -30,12 +29,7 @@ func nativeSecretResourcePrompt(resourceType string, msg string, noColor bool) (
 
 	fd := int(os.Stdin.Fd())
 	if !term.IsTerminal(fd) {
-		reader := bufio.NewReader(os.Stdin)
-		input, err := reader.ReadString('\n')
-		if err != nil {
-			return "", err
-		}
-		return strings.TrimSpace(input), nil
+		return readStdinLine()
 	}
 
 	pw, err := term.ReadPassword(fd)

--- a/internal/utils/prompts_test.go
+++ b/internal/utils/prompts_test.go
@@ -894,6 +894,27 @@ func TestDefaultSecretResourcePrompt_Colored(t *testing.T) {
 	assert.Empty(t, stdout)
 }
 
+// TestStdinHasBuffered_TrueAfterReadAhead is a regression test for
+// nativeSecretResourcePrompt's TTY-bypass check: once one read pulls more
+// than one line off stdin in a single chunk (as happens with piped or pasted
+// multi-line input), the remainder sits in the shared reader's internal
+// buffer, and stdinHasBuffered must report that.
+func TestStdinHasBuffered_TrueAfterReadAhead(t *testing.T) {
+	withMockedIO("first\nsecond\n", func() {
+		_, err := readStdinLine()
+		assert.NoError(t, err)
+		assert.True(t, stdinHasBuffered())
+	})
+}
+
+// TestStdinHasBuffered_FalseWhenEmpty covers the reader-not-yet-created case.
+func TestStdinHasBuffered_FalseWhenEmpty(t *testing.T) {
+	withMockedIO("", func() {
+		resetSharedStdinReader()
+		assert.False(t, stdinHasBuffered())
+	})
+}
+
 // Integration test that actually runs the real functions
 func TestPromptsIntegration(t *testing.T) {
 	// Skip in CI environments

--- a/internal/utils/prompts_test.go
+++ b/internal/utils/prompts_test.go
@@ -40,6 +40,11 @@ func withMockedIO(input string, fn func()) (stdout string, stderr string) {
 	os.Stdin = inR
 	os.Stdout = outW
 	os.Stderr = errW
+	// The shared stdin reader (prompts.go) caches a *bufio.Reader over
+	// whatever os.Stdin pointed to when it was built. Reset it so prompt
+	// functions build a fresh one over this test's pipe instead of reusing
+	// (or blocking on) a reader left over from a prior test's now-closed pipe.
+	resetSharedStdinReader()
 	// Restore the globals and close every pipe end on any exit path,
 	// including a panic or t.Fatal (which unwinds via runtime.Goexit), so a
 	// failing subtest doesn't leave stdio redirected or FDs leaked for the
@@ -50,6 +55,7 @@ func withMockedIO(input string, fn func()) (stdout string, stderr string) {
 		os.Stdin = oldStdin
 		os.Stdout = oldStdout
 		os.Stderr = oldStderr
+		resetSharedStdinReader()
 		_ = inR.Close()
 		_ = inW.Close()
 		_ = outR.Close()
@@ -89,8 +95,8 @@ func withMockedIO(input string, fn func()) (stdout string, stderr string) {
 // mockPromptSequence overrides Prompt and ConfirmPrompt for the duration of
 // t with scripted answers, consumed in call order. This drives multi-step
 // flows like the tag-entry loop deterministically, without depending on
-// real stdin/bufio timing (each Prompt call opens a fresh bufio.Reader over
-// stdin, so pacing writes to a pipe would be inherently timing-sensitive).
+// real stdin/bufio timing (pacing writes to a pipe to line up with each
+// Prompt call would be inherently timing-sensitive).
 func mockPromptSequence(t *testing.T, confirmAnswers []bool, promptAnswers []string) {
 	origConfirm := GetConfirmPrompt()
 	origPrompt := GetPrompt()
@@ -741,6 +747,94 @@ func TestConfirmPrompt_StdoutStaysCleanForJSONPiping(t *testing.T) {
 	assert.Contains(t, stderr, "[y/N]")
 }
 
+// TestPrompt_ConsecutivePromptsShareBufferedStdin is a regression test for
+// ESD-1643. A bufio.Reader reads ahead in chunks, so piping in more than one
+// line at once lets the underlying pipe read fill the reader's internal
+// buffer past the first newline. A prompt implementation that built a fresh
+// bufio.Reader per call would discard that buffered second line along with
+// the old reader, and the next prompt would find nothing left to read. This
+// drives two consecutive real Prompt calls off one multi-line input source
+// and asserts each gets its own line.
+func TestPrompt_ConsecutivePromptsShareBufferedStdin(t *testing.T) {
+	originalPrompt := GetPrompt()
+	defer SetPrompt(originalPrompt)
+
+	var first, second string
+	var firstErr, secondErr error
+	stdout, stderr := withMockedIO("first line\nsecond line\n", func() {
+		first, firstErr = Prompt("First:", true)
+		second, secondErr = Prompt("Second:", true)
+	})
+
+	assert.NoError(t, firstErr)
+	assert.NoError(t, secondErr)
+	assert.Equal(t, "first line", first)
+	assert.Equal(t, "second line", second)
+	assert.Contains(t, stderr, "First:")
+	assert.Contains(t, stderr, "Second:")
+	assert.Empty(t, stdout)
+}
+
+// TestConfirmPrompt_DoesNotDesyncSharedStdinReader is a regression test for
+// ESD-1643. confirmPromptFn used to read via fmt.Scanln directly against
+// os.Stdin, independent of the bufio.Reader the text prompts shared, which
+// could desync buffered input between a text prompt and a following confirm
+// prompt. This drives a text prompt followed by a confirm prompt off one
+// piped input source and asserts the confirm prompt sees the second line
+// rather than leftover or missing bytes.
+func TestConfirmPrompt_DoesNotDesyncSharedStdinReader(t *testing.T) {
+	originalPrompt := GetPrompt()
+	originalConfirm := GetConfirmPrompt()
+	defer func() {
+		SetPrompt(originalPrompt)
+		SetConfirmPrompt(originalConfirm)
+	}()
+
+	var name string
+	var err error
+	var confirmed bool
+	stdout, stderr := withMockedIO("my-resource\ny\n", func() {
+		name, err = Prompt("Name:", true)
+		confirmed = ConfirmPrompt("Proceed?", true)
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "my-resource", name)
+	assert.True(t, confirmed)
+	assert.Contains(t, stderr, "Name:")
+	assert.Contains(t, stderr, "Proceed?")
+	assert.Empty(t, stdout)
+}
+
+// TestConfirmPrompt_AcceptsFinalLineWithNoTrailingNewline is a regression
+// test for a behavior change surfaced while switching confirmPromptFn from
+// fmt.Scanln to the shared bufio reader: fmt.Scanln accepts a final token
+// immediately followed by EOF with no trailing newline (e.g. a user answers
+// then sends EOF instead of pressing Enter, or scripted input has no final
+// newline). readStdinLine must keep accepting that shape rather than
+// discarding the partial line as an error.
+func TestConfirmPrompt_AcceptsFinalLineWithNoTrailingNewline(t *testing.T) {
+	stdout, stderr := withMockedIO("y", func() {
+		result := ConfirmPrompt("Continue?", true)
+		assert.True(t, result)
+	})
+	assert.Contains(t, stderr, "Continue?")
+	assert.Empty(t, stdout)
+}
+
+// TestPrompt_AcceptsFinalLineWithNoTrailingNewline mirrors
+// TestConfirmPrompt_AcceptsFinalLineWithNoTrailingNewline for the text
+// Prompt path.
+func TestPrompt_AcceptsFinalLineWithNoTrailingNewline(t *testing.T) {
+	stdout, stderr := withMockedIO("no newline", func() {
+		result, err := Prompt("Enter value:", true)
+		assert.NoError(t, err)
+		assert.Equal(t, "no newline", result)
+	})
+	assert.Contains(t, stderr, "Enter value:")
+	assert.Empty(t, stdout)
+}
+
 // Integration test that actually runs the real functions
 func TestPromptsIntegration(t *testing.T) {
 	// Skip in CI environments
@@ -821,7 +915,10 @@ func TestPromptWithCustomReader(t *testing.T) {
 
 	// Save and restore original stdin
 	oldStdin := os.Stdin
-	defer func() { os.Stdin = oldStdin }()
+	defer func() {
+		os.Stdin = oldStdin
+		resetSharedStdinReader()
+	}()
 
 	// Create a temporary file
 	tmpfile, err := os.CreateTemp("", "test")
@@ -840,6 +937,7 @@ func TestPromptWithCustomReader(t *testing.T) {
 
 	// Replace stdin with our file
 	os.Stdin = tmpfile
+	resetSharedStdinReader()
 
 	// Capture stdout and stderr separately so we can verify the prompt text
 	// lands on stderr, not stdout.

--- a/internal/utils/prompts_test.go
+++ b/internal/utils/prompts_test.go
@@ -835,6 +835,65 @@ func TestPrompt_AcceptsFinalLineWithNoTrailingNewline(t *testing.T) {
 	assert.Empty(t, stdout)
 }
 
+// TestConfirmPrompt_ReturnsFalseOnEmptyStdinEOF is a regression test for the
+// readStdinLine error path: an immediate EOF with no bytes at all (as
+// opposed to a final unterminated line, which is not an error) must still
+// propagate as an error, and confirmPromptFn must default to "No" for it.
+func TestConfirmPrompt_ReturnsFalseOnEmptyStdinEOF(t *testing.T) {
+	stdout, stderr := withMockedIO("", func() {
+		result := ConfirmPrompt("Continue?", true)
+		assert.False(t, result)
+	})
+	assert.Contains(t, stderr, "Continue?")
+	assert.Empty(t, stdout)
+}
+
+// TestResourcePrompt_RealFunctionSharesStdinReader drives the real
+// resourcePromptFn (every other ResourcePrompt test swaps in a mock), so the
+// shared stdin reader plumbing in that path gets exercised too.
+func TestResourcePrompt_RealFunctionSharesStdinReader(t *testing.T) {
+	originalResourcePrompt := GetResourcePrompt()
+	defer SetResourcePrompt(originalResourcePrompt)
+
+	var result string
+	var err error
+	stdout, stderr := withMockedIO("resource input\n", func() {
+		result, err = originalResourcePrompt("port", "Port name:", true)
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "resource input", result)
+	assert.Contains(t, stderr, "🔌 Port name:")
+	assert.Empty(t, stdout)
+}
+
+// TestDefaultSecretResourcePrompt_SharesStdinReader calls the wasm-build
+// default directly. Native builds override secretResourcePromptFn via init()
+// in prompts_secret_native.go, so no test reaches this through the exported
+// SecretResourcePrompt hook; calling it directly here verifies the wasm
+// fallback also reads through the shared stdin reader correctly.
+func TestDefaultSecretResourcePrompt_SharesStdinReader(t *testing.T) {
+	stdout, stderr := withMockedIO("s3cr3t\n", func() {
+		result, err := defaultSecretResourcePrompt("mve", "Admin password:", true)
+		assert.NoError(t, err)
+		assert.Equal(t, "s3cr3t", result)
+	})
+	assert.Contains(t, stderr, "🔐 Admin password:")
+	assert.Empty(t, stdout)
+}
+
+// TestDefaultSecretResourcePrompt_Colored exercises the colored-prompt
+// branch, which TestDefaultSecretResourcePrompt_SharesStdinReader (noColor
+// true) doesn't reach.
+func TestDefaultSecretResourcePrompt_Colored(t *testing.T) {
+	stdout, stderr := withMockedIO("s3cr3t\n", func() {
+		result, err := defaultSecretResourcePrompt("mve", "Admin password:", false)
+		assert.NoError(t, err)
+		assert.Equal(t, "s3cr3t", result)
+	})
+	assert.Contains(t, stderr, "Admin password:")
+	assert.Empty(t, stdout)
+}
+
 // Integration test that actually runs the real functions
 func TestPromptsIntegration(t *testing.T) {
 	// Skip in CI environments

--- a/internal/utils/prompts_test.go
+++ b/internal/utils/prompts_test.go
@@ -903,6 +903,17 @@ func TestStdinHasBuffered_TrueAfterReadAhead(t *testing.T) {
 	withMockedIO("first\nsecond\n", func() {
 		_, err := readStdinLine()
 		assert.NoError(t, err)
+
+		// Read is allowed to return fewer bytes than requested, so the first
+		// read alone isn't guaranteed to have pulled "second\n" into the
+		// buffer. Peek forces fill() to pull at least one more byte so the
+		// assertion below doesn't depend on how much the first read happened
+		// to buffer.
+		stdinReaderMu.Lock()
+		_, peekErr := stdinReader.Peek(1)
+		stdinReaderMu.Unlock()
+		assert.NoError(t, peekErr)
+
 		assert.True(t, stdinHasBuffered())
 	})
 }


### PR DESCRIPTION
Interactive prompts each built their own buffered reader over stdin per call. A buffered reader reads ahead in chunks, so piped or pasted multi-line input left unread bytes sitting in the old reader, and those bytes were silently dropped the moment the next prompt built a fresh one. In multi-field interactive buy/update flows this desynced input between prompts: a value meant for one field could vanish and a later prompt would read the wrong thing or block.

- Route the text, confirm, resource, and secret prompts (native non-TTY fallback included) through one shared, lazily-created buffered reader instead of one per call.
- Move the confirm prompt off its own independent stdin read so it can't desync the shared buffer relative to the text prompts.
- Preserve accepting a final unterminated answer before EOF (piped input with no trailing newline), which the old confirm prompt handled but a naive version of this change initially broke.
- Add regression tests driving two consecutive prompts, and a text-then-confirm prompt pair, off one multi-line input source, plus tests for the no-trailing-newline case.

WASM prompts are unaffected: that build supplies values through injected JS callbacks, not os.Stdin.