### PR TITLE
ESD-1645: Make WithRequiredFlag fail loudly when misordered

### DIFF
--- a/internal/base/cmdbuilder/builder.go
+++ b/internal/base/cmdbuilder/builder.go
@@ -132,8 +132,9 @@ func (b *CommandBuilder) WithRootCmd(rootCmd *cobra.Command) *CommandBuilder {
 //
 // Must be called after the flag has been added to the command (e.g. via
 // WithFlag). Calling it before the flag exists is a builder-ordering bug:
-// Cobra has nothing to mark required, so a warning is printed to stderr
-// instead of silently recording the flag as required.
+// Cobra has nothing to mark required, so a warning is printed to stderr and
+// the flag is never enforced, even though it is still recorded in
+// requiredFlags for documentation.
 func (b *CommandBuilder) WithRequiredFlag(name, description string) *CommandBuilder {
 	if flag := b.cmd.Flags().Lookup(name); flag != nil {
 		if err := b.cmd.MarkFlagRequired(name); err != nil {
@@ -143,7 +144,7 @@ func (b *CommandBuilder) WithRequiredFlag(name, description string) *CommandBuil
 		// Also update the description to indicate it's required
 		flag.Usage = description + " [required]"
 	} else {
-		fmt.Fprintf(os.Stderr, "Warning: WithRequiredFlag(%q) called before the flag was added to the command; it will not be enforced as required\n", name)
+		fmt.Fprintf(os.Stderr, "Warning: WithRequiredFlag(%q) called on command %q before the flag was added; it will not be enforced as required\n", name, b.cmd.Use)
 	}
 
 	// Store for our documentation as well

--- a/internal/base/cmdbuilder/builder.go
+++ b/internal/base/cmdbuilder/builder.go
@@ -128,20 +128,22 @@ func (b *CommandBuilder) WithRootCmd(rootCmd *cobra.Command) *CommandBuilder {
 	return b
 }
 
-// WithRequiredFlag marks a flag as required and adds description
+// WithRequiredFlag marks a flag as required and adds description.
+//
+// Must be called after the flag has been added to the command (e.g. via
+// WithFlag). Calling it before the flag exists is a builder-ordering bug:
+// Cobra has nothing to mark required, so a warning is printed to stderr
+// instead of silently recording the flag as required.
 func (b *CommandBuilder) WithRequiredFlag(name, description string) *CommandBuilder {
-	// Mark the flag in the cobra command
-	if b.cmd.Flags().Lookup(name) != nil {
-		flag := b.cmd.Flags().Lookup(name)
-
-		// Add annotation for Cobra's bash completion
-		if flag.Annotations == nil {
-			flag.Annotations = make(map[string][]string)
+	if flag := b.cmd.Flags().Lookup(name); flag != nil {
+		if err := b.cmd.MarkFlagRequired(name); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to mark flag '%s' as required: %v\n", name, err)
 		}
-		flag.Annotations["cobra_annotation_bash_completion_one_required_flag"] = []string{"true"}
 
 		// Also update the description to indicate it's required
 		flag.Usage = description + " [required]"
+	} else {
+		fmt.Fprintf(os.Stderr, "Warning: WithRequiredFlag(%q) called before the flag was added to the command; it will not be enforced as required\n", name)
 	}
 
 	// Store for our documentation as well

--- a/internal/base/cmdbuilder/builder.go
+++ b/internal/base/cmdbuilder/builder.go
@@ -136,15 +136,11 @@ func (b *CommandBuilder) WithRootCmd(rootCmd *cobra.Command) *CommandBuilder {
 // the flag is never enforced, even though it is still recorded in
 // requiredFlags for documentation.
 func (b *CommandBuilder) WithRequiredFlag(name, description string) *CommandBuilder {
-	if flag := b.cmd.Flags().Lookup(name); flag != nil {
-		if err := b.cmd.MarkFlagRequired(name); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to mark flag '%s' as required: %v\n", name, err)
-		}
-
+	if err := b.cmd.MarkFlagRequired(name); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: WithRequiredFlag(%q) called on command %q before the flag was added; it will not be enforced as required: %v\n", name, b.cmd.Use, err)
+	} else if flag := b.cmd.Flags().Lookup(name); flag != nil {
 		// Also update the description to indicate it's required
 		flag.Usage = description + " [required]"
-	} else {
-		fmt.Fprintf(os.Stderr, "Warning: WithRequiredFlag(%q) called on command %q before the flag was added; it will not be enforced as required\n", name, b.cmd.Use)
 	}
 
 	// Store for our documentation as well

--- a/internal/base/cmdbuilder/builder_test.go
+++ b/internal/base/cmdbuilder/builder_test.go
@@ -343,18 +343,35 @@ func TestWithRequiredFlag(t *testing.T) {
 		assert.Contains(t, err.Error(), "\"name\"")
 	})
 
-	t.Run("flag added after WithRequiredFlag warns loudly instead of silently no-op", func(t *testing.T) {
+	t.Run("required-then-flag ordering warns loudly and stays unenforced even once the flag is added", func(t *testing.T) {
 		var b *CommandBuilder
 		stderr := captureStderr(t, func() {
 			b = NewCommand("test", "test").
-				WithRequiredFlag("nonexistent", "Does not exist")
+				WithRequiredFlag("name", "Name of the resource"). // flag doesn't exist yet
+				WithFlag("name", "", "The name")                  // added too late to be marked required
 		})
 
-		// Should not panic, and should still surface the loud warning.
-		assert.Contains(t, stderr, "nonexistent")
+		// The misordered call warns loudly at the point it happens.
+		assert.Contains(t, stderr, "\"name\"")
 		assert.Contains(t, stderr, "before the flag was added")
-		// Documentation map still records the intent, but nothing enforces it.
-		assert.Equal(t, "Does not exist", b.requiredFlags["nonexistent"])
+
+		// Documentation map still records the intent...
+		assert.Equal(t, "Name of the resource", b.requiredFlags["name"])
+
+		// ...but Cobra never enforces it, even though the flag exists by the
+		// time Build() runs: no annotation, no "[required]" usage suffix, and
+		// running the command without --name succeeds.
+		cmd := b.Build()
+		f := cmd.Flags().Lookup("name")
+		require.NotNil(t, f)
+		assert.Nil(t, f.Annotations)
+		assert.Equal(t, "The name", f.Usage)
+
+		cmd.SetArgs([]string{})
+		cmd.RunE = func(cmd *cobra.Command, args []string) error { return nil }
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+		assert.NoError(t, cmd.Execute())
 	})
 }
 

--- a/internal/base/cmdbuilder/builder_test.go
+++ b/internal/base/cmdbuilder/builder_test.go
@@ -3,6 +3,8 @@ package cmdbuilder
 import (
 	"bytes"
 	"errors"
+	"io"
+	"os"
 	"testing"
 	"time"
 
@@ -11,6 +13,35 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// captureStderr captures what the function writes to os.Stderr.
+// Not parallel-safe: it redirects the global os.Stderr via os.Pipe.
+// Do not call t.Parallel() in tests that use this helper.
+func captureStderr(t *testing.T, fn func()) (result string) {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = io.Copy(&buf, r)
+	}()
+
+	defer func() {
+		_ = w.Close()
+		<-done
+		_ = r.Close()
+		result = buf.String()
+	}()
+
+	fn()
+	return
+}
 
 func TestNewCommand(t *testing.T) {
 	tests := []struct {
@@ -285,11 +316,14 @@ func TestWithDurationFlagP(t *testing.T) {
 }
 
 func TestWithRequiredFlag(t *testing.T) {
-	t.Run("existing flag", func(t *testing.T) {
-		cmd := NewCommand("test", "test").
-			WithFlag("name", "", "The name").
-			WithRequiredFlag("name", "Name of the resource").
-			Build()
+	t.Run("flag added before WithRequiredFlag is enforced", func(t *testing.T) {
+		var cmd *cobra.Command
+		stderr := captureStderr(t, func() {
+			cmd = NewCommand("test", "test").
+				WithFlag("name", "", "The name").
+				WithRequiredFlag("name", "Name of the resource").
+				Build()
+		})
 
 		f := cmd.Flags().Lookup("name")
 		require.NotNil(t, f)
@@ -297,12 +331,29 @@ func TestWithRequiredFlag(t *testing.T) {
 		assert.Equal(t, "Name of the resource [required]", f.Usage)
 		assert.NotNil(t, f.Annotations)
 		assert.Equal(t, []string{"true"}, f.Annotations[cobra.BashCompOneRequiredFlag])
+		assert.Empty(t, stderr, "correctly-ordered call should not warn")
+
+		// Cobra actually enforces it: running without the flag fails.
+		cmd.SetArgs([]string{})
+		cmd.RunE = func(cmd *cobra.Command, args []string) error { return nil }
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "\"name\"")
 	})
 
-	t.Run("non-existing flag does not panic", func(t *testing.T) {
-		b := NewCommand("test", "test").
-			WithRequiredFlag("nonexistent", "Does not exist")
-		// Should not panic, just store in requiredFlags map
+	t.Run("flag added after WithRequiredFlag warns loudly instead of silently no-op", func(t *testing.T) {
+		var b *CommandBuilder
+		stderr := captureStderr(t, func() {
+			b = NewCommand("test", "test").
+				WithRequiredFlag("nonexistent", "Does not exist")
+		})
+
+		// Should not panic, and should still surface the loud warning.
+		assert.Contains(t, stderr, "nonexistent")
+		assert.Contains(t, stderr, "before the flag was added")
+		// Documentation map still records the intent, but nothing enforces it.
 		assert.Equal(t, "Does not exist", b.requiredFlags["nonexistent"])
 	})
 }

--- a/internal/base/cmdbuilder/builder_test.go
+++ b/internal/base/cmdbuilder/builder_test.go
@@ -351,8 +351,11 @@ func TestWithRequiredFlag(t *testing.T) {
 				WithFlag("name", "", "The name")                  // added too late to be marked required
 		})
 
-		// The misordered call warns loudly at the point it happens.
+		// The misordered call warns loudly at the point it happens, naming
+		// both the flag and the command so it's traceable when several
+		// commands share a flag name.
 		assert.Contains(t, stderr, "\"name\"")
+		assert.Contains(t, stderr, "\"test\"")
 		assert.Contains(t, stderr, "before the flag was added")
 
 		// Documentation map still records the intent...
@@ -372,6 +375,19 @@ func TestWithRequiredFlag(t *testing.T) {
 		cmd.SilenceUsage = true
 		cmd.SilenceErrors = true
 		assert.NoError(t, cmd.Execute())
+	})
+
+	t.Run("flag never added at all warns loudly instead of panicking", func(t *testing.T) {
+		var b *CommandBuilder
+		stderr := captureStderr(t, func() {
+			b = NewCommand("test", "test").
+				WithRequiredFlag("nonexistent", "Does not exist")
+		})
+
+		assert.Contains(t, stderr, "\"nonexistent\"")
+		assert.Contains(t, stderr, "before the flag was added")
+		// Documentation map still records the intent, but nothing enforces it.
+		assert.Equal(t, "Does not exist", b.requiredFlags["nonexistent"])
 	})
 }
 


### PR DESCRIPTION
`WithRequiredFlag` silently skipped enforcement when called before the flag was registered on the command, while still recording the flag as required for generated docs and help output. A future misordered builder chain would ship a command whose "required" flag is silently optional.

- Switch to `cmd.MarkFlagRequired`, matching the pattern already used by `ReflagCmd`, instead of hardcoding the cobra annotation string
- Print a stderr warning when the flag isn't registered yet, instead of silently no-opping
- Add tests covering both orderings: flag-then-required (enforced by cobra) and required-then-flag (loud warning, not silently optional)

The two existing call sites (`apply`, `config import`) are already correctly ordered and are unaffected.

ESD-1645
