### PR TITLE
ESD-1646-fix(wasm): sanitize control sequences in data output

### DIFF
--- a/internal/base/output/messages_wasm.go
+++ b/internal/base/output/messages_wasm.go
@@ -306,6 +306,10 @@ func PrintErrorJSON(code int, message string) {
 		out = fmt.Sprintf(`{"error":{"code":%d,"type":"%s","message":%s}}`+"\n",
 			code, exitcodes.TypeName(code), msgJSON)
 	}
+	// Sanitize before this leaves Go: message often echoes an API error
+	// response body, which can carry a control byte the JSON encoder does
+	// not escape (e.g. the C1 range). See wasm.SanitizeTerminalOutput.
+	out = wasm.SanitizeTerminalOutput(out)
 	fmt.Print(out)
 	js.Global().Set("wasmJSONOutput", out)
 }

--- a/internal/base/output/messages_wasm_test.go
+++ b/internal/base/output/messages_wasm_test.go
@@ -1,0 +1,30 @@
+//go:build js && wasm
+
+package output
+
+import (
+	"syscall/js"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPrintErrorJSON_SanitizesMessage verifies that a C1 control character
+// carried in the error message (e.g. echoed from an API error response body)
+// is stripped from wasmJSONOutput. Go's JSON encoder escapes C0 controls
+// (ESC included) as textual "\u00XX" sequences, but passes C1 (0x80-0x9F,
+// some terminals' 8-bit CSI introducer) through as a raw byte, so it reaches
+// xterm unescaped unless this sanitize step removes it.
+func TestPrintErrorJSON_SanitizesMessage(t *testing.T) {
+	js.Global().Delete("wasmJSONOutput")
+
+	// hex(0x9b) is the 8-bit CSI introducer some terminals honor directly.
+	c1 := string(rune(0x9b))
+	PrintErrorJSON(500, "upstream said: acme-corp"+c1+"2Kspoofed")
+
+	output := js.Global().Get("wasmJSONOutput").String()
+	assert.NotContains(t, output, c1, "injected C1 control byte must not reach the host")
+	assert.Contains(t, output, "acme-corp")
+	assert.Contains(t, output, "spoofed")
+	assert.Contains(t, output, `"code": 500`)
+}

--- a/internal/base/output/output_wasm.go
+++ b/internal/base/output/output_wasm.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"syscall/js"
+
+	"github.com/megaport/megaport-cli/internal/wasm"
 )
 
 // wasmBufMu protects the global WASM output buffers from concurrent access.
@@ -50,7 +52,12 @@ func printJSON[T OutputFields](data []T, opts printOptions) error {
 		return err
 	}
 
-	jsonOutput := WasmJSONWriter.String()
+	// Sanitize before this leaves Go: wasmJSONOutput is read back by
+	// GetCapturedOutput/GetCompletionOutput and written to xterm without
+	// escaping, and a field value can carry an API-controlled control byte
+	// that Go's JSON encoder does not escape (e.g. the C1 range). See
+	// wasm.SanitizeTerminalOutput.
+	jsonOutput := wasm.SanitizeTerminalOutput(WasmJSONWriter.String())
 	fmt.Print(jsonOutput)
 	js.Global().Set("wasmJSONOutput", jsonOutput)
 	return nil
@@ -177,7 +184,8 @@ func printCSV[T OutputFields](data []T, opts printOptions) error {
 
 	w.Flush()
 
-	csvOutput := WasmCSVWriter.String()
+	// See the sanitize comment in printJSON above; the same applies to CSV.
+	csvOutput := wasm.SanitizeTerminalOutput(WasmCSVWriter.String())
 	fmt.Print(csvOutput)
 	js.Global().Set("wasmCSVOutput", csvOutput)
 	return nil
@@ -347,7 +355,8 @@ func printXML[T OutputFields](data []T, opts printOptions) error {
 	}
 	WasmXMLWriter.WriteString("\n")
 
-	xmlOutput := WasmXMLWriter.String()
+	// See the sanitize comment in printJSON above; the same applies to XML.
+	xmlOutput := wasm.SanitizeTerminalOutput(WasmXMLWriter.String())
 	fmt.Print(xmlOutput)
 	js.Global().Set("wasmXMLOutput", xmlOutput)
 	return nil

--- a/internal/base/output/table_wasm.go
+++ b/internal/base/output/table_wasm.go
@@ -65,7 +65,12 @@ func printTable[T OutputFields](data []T, noColor bool, opts printOptions) error
 		return err
 	}
 
-	tableOutput := WasmTableWriter.String()
+	// Sanitize before this leaves Go: wasmTableOutput is read back by
+	// GetCapturedOutput/GetCompletionOutput and written to xterm without
+	// escaping, and a colorized cell value (colorizeValue) can carry a
+	// resource name or other API field an attacker controls. SGR color codes
+	// are preserved; see wasm.SanitizeTerminalOutput.
+	tableOutput := wasm.SanitizeTerminalOutput(WasmTableWriter.String())
 
 	// Write the table output to stdout so it can be captured by wasm buffers.
 	fmt.Print(tableOutput)

--- a/internal/base/output/table_wasm_test.go
+++ b/internal/base/output/table_wasm_test.go
@@ -372,6 +372,30 @@ func TestPrintTable_WASM_GlobalVariable(t *testing.T) {
 	assert.Equal(t, bufferContent, globalContent, "Global and buffer content should match")
 }
 
+// TestPrintTable_WASM_SanitizesInjectedControlSequences verifies that a
+// resource name carrying an injected CSI cursor-move sequence (the kind a
+// partner/marketplace listing name could carry) reaches wasmTableOutput with
+// the injected bytes stripped, while the CLI's own SGR color styling for the
+// cell (via colorizeValue) survives.
+func TestPrintTable_WASM_SanitizesInjectedControlSequences(t *testing.T) {
+	data := []SimpleStruct{
+		{ID: 1, Name: "acme-corp\x1b[2K\x1b[Hspoofed", Active: true},
+	}
+
+	js.Global().Delete("wasmTableOutput")
+	WasmTableWriter.Reset()
+
+	err := printTable(data, false, currentPrintOptions())
+	assert.NoError(t, err)
+
+	output := js.Global().Get("wasmTableOutput").String()
+	assert.NotContains(t, output, "\x1b[2K", "injected erase-line sequence must not reach the host")
+	assert.NotContains(t, output, "\x1b[H", "injected cursor-home sequence must not reach the host")
+	assert.Contains(t, output, "acme-corp")
+	assert.Contains(t, output, "spoofed")
+	assert.Contains(t, output, "\x1b[", "the CLI's own SGR color styling for the cell must be preserved")
+}
+
 // TestPrintTable_WASM_ConsoleLogging verifies console logging (basic check)
 func TestPrintTable_WASM_ConsoleLogging(t *testing.T) {
 	data := []SimpleStruct{

--- a/internal/utils/prompts_wasm.go
+++ b/internal/utils/prompts_wasm.go
@@ -5,7 +5,6 @@ package utils
 import (
 	"fmt"
 	"strings"
-	"unicode"
 
 	"github.com/megaport/megaport-cli/internal/wasm"
 )
@@ -19,22 +18,19 @@ import (
 // output (see flush) uses a plain \n because its renderer converts EOLs.
 const promptLineBreak = "\r\n"
 
-// sanitizeForTerminal strips C0 controls, DEL, and C1 controls from text that
-// is folded into a terminal-bound message. The host writes prompt messages to
+// sanitizeForTerminal strips C0/C1 controls, DEL, and ESC from text that is
+// folded into a terminal-bound message. The host writes prompt messages to
 // xterm without escaping, so a crafted resource name or tag value could
 // otherwise inject cursor/erase sequences that rewrite the purchase summary
-// shown before the [y/N]. C1 (0x80-0x9f) is stripped because some terminals
-// treat it as escape controls (e.g. 0x9b as CSI). Only display copies are
-// sanitized; the values stored on the order come from the prompt responses,
-// which are untouched. Structural line breaks are inserted by callers after
-// sanitizing, so they are preserved.
+// shown before the [y/N]. Only display copies are sanitized; the values
+// stored on the order come from the prompt responses, which are untouched.
+// Structural line breaks are inserted by callers after sanitizing, so they
+// are preserved. See wasm.SanitizeTerminalText, which this shares with the
+// prompt buffer; wasm.SanitizeTerminalOutput is the SGR-preserving variant
+// used for data (table/JSON/CSV/XML) output, which has styling to preserve
+// and prompts do not.
 func sanitizeForTerminal(s string) string {
-	return strings.Map(func(r rune) rune {
-		if unicode.IsControl(r) {
-			return -1
-		}
-		return r
-	}, s)
+	return wasm.SanitizeTerminalText(s)
 }
 
 func init() {

--- a/internal/wasm/sanitize.go
+++ b/internal/wasm/sanitize.go
@@ -15,9 +15,12 @@ import "unicode"
 //
 // The CLI's own SGR color sequences (ESC '[' <digits/';'> 'm', emitted by
 // fatih/color for table and status styling) are allowlisted so intended
-// styling survives; every other C0 control, DEL, C1 control, and non-SGR
-// CSI/OSC sequence is removed. \n and \t pass through unchanged since they
-// are structural formatting in a multi-line document. A lone \r is dropped:
+// styling survives; every other C0 control, DEL, and C1 control is dropped
+// outright, and a non-SGR CSI/OSC sequence is neutralized by dropping its
+// introducing ESC (or C1 equivalent), leaving the remainder as inert
+// printable text rather than removing it wholesale. \n and \t pass through
+// unchanged since they are structural formatting in a multi-line document.
+// A lone \r is dropped:
 // unlike \n/\t it is itself a cursor-move (back to column 0) that can
 // overwrite the start of a rendered line with no ESC/CSI involved, so it is
 // only preserved as part of a CRLF pair.

--- a/internal/wasm/sanitize.go
+++ b/internal/wasm/sanitize.go
@@ -16,8 +16,11 @@ import "unicode"
 // The CLI's own SGR color sequences (ESC '[' <digits/';'> 'm', emitted by
 // fatih/color for table and status styling) are allowlisted so intended
 // styling survives; every other C0 control, DEL, C1 control, and non-SGR
-// CSI/OSC sequence is removed. \n, \r, and \t pass through unchanged since
-// they are structural formatting in a multi-line document.
+// CSI/OSC sequence is removed. \n and \t pass through unchanged since they
+// are structural formatting in a multi-line document. A lone \r is dropped:
+// unlike \n/\t it is itself a cursor-move (back to column 0) that can
+// overwrite the start of a rendered line with no ESC/CSI involved, so it is
+// only preserved as part of a CRLF pair.
 //
 // This does not distinguish a CLI-emitted SGR sequence from attacker text
 // that merely happens to match SGR syntax once everything is one string.
@@ -39,7 +42,8 @@ func SanitizeTerminalText(s string) string {
 }
 
 // sanitizeControlSequences removes terminal control bytes from s. When
-// allowSGR is true, \n, \r, and \t are preserved as structural bytes and an
+// allowSGR is true, \n and \t are preserved as structural bytes, \r is
+// preserved only when it is immediately followed by \n (a CRLF pair), and an
 // ESC that introduces a well-formed CSI SGR sequence (ESC '[' <digits/';'>*
 // 'm') is copied through verbatim. Any other ESC is dropped by itself: this
 // leaves the rest of a CSI or OSC sequence (e.g. "[2K" or "]0;evil") as inert
@@ -47,7 +51,8 @@ func SanitizeTerminalText(s string) string {
 // the introducing ESC (or its C1 equivalent) is present. All other Unicode
 // control runes, including DEL and the C1 range (some terminals treat
 // 0x80-0x9f as 8-bit CSI/OSC introducers, e.g. 0x9b as CSI), are dropped
-// outright.
+// outright, including a lone \r: on its own it moves the cursor to column 0,
+// which is a cursor-hijack primitive with no ESC/CSI needed.
 func sanitizeControlSequences(s string, allowSGR bool) string {
 	runes := []rune(s)
 	out := make([]rune, 0, len(runes))
@@ -65,8 +70,13 @@ func sanitizeControlSequences(s string, allowSGR bool) string {
 			// Not an allowlisted sequence: drop just the ESC byte so any
 			// following text is re-evaluated as plain characters, not
 			// re-armed as part of a control sequence.
-		case allowSGR && (r == '\n' || r == '\r' || r == '\t'):
+		case allowSGR && (r == '\n' || r == '\t'):
 			out = append(out, r)
+		case allowSGR && r == '\r':
+			if i+1 < len(runes) && runes[i+1] == '\n' {
+				out = append(out, r)
+			}
+			// Lone \r (not followed by \n): drop it.
 		case unicode.IsControl(r):
 			// Drop C0/C1 controls and DEL.
 		default:

--- a/internal/wasm/sanitize.go
+++ b/internal/wasm/sanitize.go
@@ -1,0 +1,99 @@
+//go:build js && wasm
+
+package wasm
+
+import "unicode"
+
+// SanitizeTerminalOutput strips control sequences from WASM data output
+// (tables, JSON/CSV/XML, narrative messages, errors) before it reaches the
+// host terminal. The host writes this text to xterm via terminal.write()
+// without escaping, so a crafted resource name or API response field
+// carrying ESC/CSI/OSC bytes could otherwise move the cursor or erase
+// unrelated lines and repaint a fake prompt over real content. Some of
+// these fields are third-party controlled (partner/marketplace listings
+// carry other tenants' names; error paths echo API response bodies).
+//
+// The CLI's own SGR color sequences (ESC '[' <digits/';'> 'm', emitted by
+// fatih/color for table and status styling) are allowlisted so intended
+// styling survives; every other C0 control, DEL, C1 control, and non-SGR
+// CSI/OSC sequence is removed. \n, \r, and \t pass through unchanged since
+// they are structural formatting in a multi-line document.
+//
+// This does not distinguish a CLI-emitted SGR sequence from attacker text
+// that merely happens to match SGR syntax once everything is one string.
+// That is an accepted gap: SGR only changes subsequent text color/style, it
+// cannot move the cursor or erase the screen, so the residual risk is
+// cosmetic, not the cursor-hijack/erase attack this sanitizer closes.
+func SanitizeTerminalOutput(s string) string {
+	return sanitizeControlSequences(s, true)
+}
+
+// SanitizeTerminalText strips all C0/C1 controls, DEL, and ESC from a single
+// field value bound for the live prompt channel (see the WASM prompt bridge
+// in internal/utils/prompts_wasm.go). Prompt messages carry no color, so
+// nothing needs to be allowlisted, and callers insert their own structural
+// line breaks after sanitizing each field, so \n/\r/\t are stripped like any
+// other control byte.
+func SanitizeTerminalText(s string) string {
+	return sanitizeControlSequences(s, false)
+}
+
+// sanitizeControlSequences removes terminal control bytes from s. When
+// allowSGR is true, \n, \r, and \t are preserved as structural bytes and an
+// ESC that introduces a well-formed CSI SGR sequence (ESC '[' <digits/';'>*
+// 'm') is copied through verbatim. Any other ESC is dropped by itself: this
+// leaves the rest of a CSI or OSC sequence (e.g. "[2K" or "]0;evil") as inert
+// printable text, since the terminal only interprets it as a command when
+// the introducing ESC (or its C1 equivalent) is present. All other Unicode
+// control runes, including DEL and the C1 range (some terminals treat
+// 0x80-0x9f as 8-bit CSI/OSC introducers, e.g. 0x9b as CSI), are dropped
+// outright.
+func sanitizeControlSequences(s string, allowSGR bool) string {
+	runes := []rune(s)
+	out := make([]rune, 0, len(runes))
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		switch {
+		case r == 0x1b:
+			if allowSGR {
+				if end, ok := sgrSequenceEnd(runes, i); ok {
+					out = append(out, runes[i:end+1]...)
+					i = end
+					continue
+				}
+			}
+			// Not an allowlisted sequence: drop just the ESC byte so any
+			// following text is re-evaluated as plain characters, not
+			// re-armed as part of a control sequence.
+		case allowSGR && (r == '\n' || r == '\r' || r == '\t'):
+			out = append(out, r)
+		case unicode.IsControl(r):
+			// Drop C0/C1 controls and DEL.
+		default:
+			out = append(out, r)
+		}
+	}
+	return string(out)
+}
+
+// sgrSequenceEnd reports whether the ESC at runes[start] begins a CSI SGR
+// sequence and, if so, returns the index of the final 'm'. Only SGR is
+// allowlisted: it is the only CSI class the CLI's own color output emits.
+// Cursor movement, erase, and every other CSI/OSC final byte fall through
+// and are stripped by the caller.
+func sgrSequenceEnd(runes []rune, start int) (int, bool) {
+	if start+1 >= len(runes) || runes[start+1] != '[' {
+		return 0, false
+	}
+	for i := start + 2; i < len(runes); i++ {
+		switch r := runes[i]; {
+		case r >= '0' && r <= '9', r == ';':
+			continue
+		case r == 'm':
+			return i, true
+		default:
+			return 0, false
+		}
+	}
+	return 0, false
+}

--- a/internal/wasm/sanitize_test.go
+++ b/internal/wasm/sanitize_test.go
@@ -1,0 +1,130 @@
+//go:build js && wasm
+
+package wasm
+
+import (
+	"syscall/js"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeTerminalOutputStripsCursorMoveAndErase(t *testing.T) {
+	// A partner/marketplace listing name carrying a cursor-home + erase-line
+	// sequence, the exact shape that could repaint a fake "delete? [y/N]"
+	// line over real table content.
+	evil := "acme-corp\x1b[H\x1b[2Kspoofed"
+	got := SanitizeTerminalOutput(evil)
+
+	assert.NotContains(t, got, "\x1b[H")
+	assert.NotContains(t, got, "\x1b[2K")
+	assert.Contains(t, got, "acme-corp")
+	assert.Contains(t, got, "spoofed")
+}
+
+func TestSanitizeTerminalOutputStripsOSC(t *testing.T) {
+	// OSC 0 (set window title) terminated by BEL.
+	evil := "row\x1b]0;pwned\x07value"
+	got := SanitizeTerminalOutput(evil)
+
+	assert.NotContains(t, got, "\x1b")
+	assert.NotContains(t, got, "\x07")
+	assert.Contains(t, got, "row")
+	assert.Contains(t, got, "value")
+}
+
+func TestSanitizeTerminalOutputStripsC1Control(t *testing.T) {
+	// U+009B is the 8-bit CSI introducer some terminals honor directly.
+	evil := "port2Kspoofed"
+	got := SanitizeTerminalOutput(evil)
+
+	assert.NotContains(t, got, "")
+	assert.Contains(t, got, "port")
+	assert.Contains(t, got, "spoofed")
+}
+
+func TestSanitizeTerminalOutputPreservesSGRColor(t *testing.T) {
+	// fatih/color's SprintFunc output: FgRed + Bold, then reset.
+	colored := "\x1b[31;1mACTIVE\x1b[0m"
+	got := SanitizeTerminalOutput(colored)
+
+	assert.Equal(t, colored, got, "legitimate SGR color sequences must pass through unchanged")
+}
+
+func TestSanitizeTerminalOutputPreservesStructuralWhitespace(t *testing.T) {
+	got := SanitizeTerminalOutput("line one\nline two\r\ncol1\tcol2")
+	assert.Equal(t, "line one\nline two\r\ncol1\tcol2", got)
+}
+
+func TestSanitizeTerminalOutputMixedColorAndInjection(t *testing.T) {
+	// A colorized table cell whose value carries an injected cursor-move: the
+	// SGR wrapper must survive, the injected CSI must not.
+	cell := "\x1b[31mport\x1b[2K\x1b[Hspoofed\x1b[0m"
+	got := SanitizeTerminalOutput(cell)
+
+	assert.Contains(t, got, "\x1b[31m")
+	assert.Contains(t, got, "\x1b[0m")
+	assert.NotContains(t, got, "\x1b[2K")
+	assert.NotContains(t, got, "\x1b[H")
+	assert.Contains(t, got, "port")
+	assert.Contains(t, got, "spoofed")
+}
+
+func TestSanitizeTerminalTextStripsEverythingIncludingNewlines(t *testing.T) {
+	// The prompt-channel variant has no styling to preserve and callers
+	// insert their own line breaks after sanitizing, so newlines in a field
+	// value are stripped like any other control byte.
+	evil := "port\x1b[2K\x1b[Hspoofed\nline2"
+	got := SanitizeTerminalText(evil)
+
+	assert.NotContains(t, got, "\x1b")
+	assert.NotContains(t, got, "\n")
+	assert.Contains(t, got, "port")
+	assert.Contains(t, got, "spoofed")
+	assert.Contains(t, got, "line2")
+}
+
+func TestSanitizeTerminalTextDoesNotAllowlistSGR(t *testing.T) {
+	colored := "\x1b[31mred\x1b[0m"
+	got := SanitizeTerminalText(colored)
+
+	assert.NotContains(t, got, "\x1b")
+	assert.Contains(t, got, "red")
+}
+
+// TestDirectOutputBufferWriteSanitizesStreamedAndBufferedOutput drives an
+// injected CSI cursor-move sequence, alongside a legitimate SGR-colored
+// value, through the actual WASM output path (DirectOutputBuffer.Write ->
+// pushOutputChunk) and asserts the pushed chunk and the buffered content read
+// back via String() are both clean while the color survives.
+func TestDirectOutputBufferWriteSanitizesStreamedAndBufferedOutput(t *testing.T) {
+	resetOutputStreaming()
+	defer resetOutputStreaming()
+
+	var received []string
+	fn := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		if len(args) > 0 {
+			received = append(received, args[0].String())
+		}
+		return nil
+	})
+	defer fn.Release()
+	RegisterOutputCallback(fn.Value)
+
+	row := "\x1b[31mport-1\x1b[2K\x1b[Hspoofed\x1b[0m\n"
+	_, err := WasmOutputBuffer.Write([]byte(row))
+	assert.NoError(t, err)
+
+	assert.Len(t, received, 1, "the write should stream exactly one chunk")
+	pushed := received[0]
+	assert.NotContains(t, pushed, "\x1b[2K", "pushed chunk must not contain the injected erase sequence")
+	assert.NotContains(t, pushed, "\x1b[H", "pushed chunk must not contain the injected cursor-home sequence")
+	assert.Contains(t, pushed, "\x1b[31m", "pushed chunk must retain the CLI's own SGR color")
+	assert.Contains(t, pushed, "port-1")
+	assert.Contains(t, pushed, "spoofed")
+
+	buffered := WasmOutputBuffer.String()
+	assert.NotContains(t, buffered, "\x1b[2K")
+	assert.NotContains(t, buffered, "\x1b[H")
+	assert.Contains(t, buffered, "\x1b[31m")
+}

--- a/internal/wasm/sanitize_test.go
+++ b/internal/wasm/sanitize_test.go
@@ -35,10 +35,13 @@ func TestSanitizeTerminalOutputStripsOSC(t *testing.T) {
 
 func TestSanitizeTerminalOutputStripsC1Control(t *testing.T) {
 	// U+009B is the 8-bit CSI introducer some terminals honor directly.
-	evil := "port2Kspoofed"
+	// Expressed via rune conversion rather than a literal in the source so
+	// the raw control byte never appears in the file itself.
+	c1 := string(rune(0x9b))
+	evil := "port" + c1 + "2Kspoofed"
 	got := SanitizeTerminalOutput(evil)
 
-	assert.NotContains(t, got, "")
+	assert.NotContains(t, got, c1)
 	assert.Contains(t, got, "port")
 	assert.Contains(t, got, "spoofed")
 }
@@ -54,6 +57,17 @@ func TestSanitizeTerminalOutputPreservesSGRColor(t *testing.T) {
 func TestSanitizeTerminalOutputPreservesStructuralWhitespace(t *testing.T) {
 	got := SanitizeTerminalOutput("line one\nline two\r\ncol1\tcol2")
 	assert.Equal(t, "line one\nline two\r\ncol1\tcol2", got)
+}
+
+func TestSanitizeTerminalOutputDropsLoneCarriageReturn(t *testing.T) {
+	// A bare \r (no ESC/CSI at all) moves the cursor to column 0 and can
+	// overwrite the start of a rendered line. Only \r as part of a CRLF pair
+	// is structural; a lone \r must be dropped.
+	got := SanitizeTerminalOutput("acme-corp\rspoofed")
+
+	assert.NotContains(t, got, "\r")
+	assert.Contains(t, got, "acme-corp")
+	assert.Contains(t, got, "spoofed")
 }
 
 func TestSanitizeTerminalOutputMixedColorAndInjection(t *testing.T) {

--- a/internal/wasm/wasm.go
+++ b/internal/wasm/wasm.go
@@ -157,13 +157,14 @@ func (d *DirectOutputBuffer) Write(p []byte) (n int, err error) {
 	debug := debugMode.Load()
 	stream := hasOutputHandler() && !outputHandlerFailed.Load()
 
-	// Only materialize the string when something consumes it (debug logging or a
-	// live handler). Commands can stream many small writes, and in the common
-	// case (no handler, no debug) the []byte->string copy is pure waste.
-	var chunk string
-	if debug || stream {
-		chunk = string(p)
-	}
+	// Sanitize before buffering: the host writes this buffer's contents (both
+	// the streamed chunk below and the full buffer read back later via
+	// String()) straight to xterm without escaping, so a crafted resource
+	// name or API response field carrying control bytes must be neutralized
+	// here rather than at each read site. See SanitizeTerminalOutput. This
+	// makes the []byte->string conversion unconditional, unlike before, since
+	// the buffer itself must now hold sanitized text.
+	chunk := SanitizeTerminalOutput(string(p))
 
 	// Buffer the write under the lock in a closure so the mutex is released
 	// (even on a panic in the debug-logging JS calls) before we push to the
@@ -184,14 +185,14 @@ func (d *DirectOutputBuffer) Write(p []byte) (n int, err error) {
 			js.Global().Get("console").Call("debug", chunk)
 		}
 
-		n, err = d.buffer.Write(p)
+		_, err = d.buffer.WriteString(chunk)
 	}()
 
 	// Stream the chunk live to a registered output handler, if any.
 	if stream {
 		pushOutputChunk(chunk)
 	}
-	return n, err
+	return len(p), err
 }
 
 // TraceCommandExecution logs the command hierarchy and available subcommands when debugMode is on.


### PR DESCRIPTION
Table, JSON, CSV, and XML output in the WASM build was written to the host xterm terminal without stripping control bytes. A crafted resource name (e.g. a partner/marketplace listing) or an echoed API error message carrying embedded ESC/CSI/OSC bytes could move the cursor or erase lines, potentially painting a fake `[y/N]` prompt over real content.

- Add a shared sanitizer in `internal/wasm` that strips C0/C1 controls, DEL, and non-SGR CSI/OSC sequences while preserving the CLI's own SGR color styling
- Wire it into every WASM data egress point: the direct output buffer, table/JSON/CSV/XML rendering, and the JSON error envelope
- The existing prompt-channel sanitizer now shares the same underlying logic instead of its own copy

Out of scope: the native output path, frontend/portal config, and stored order values (only display copies are sanitized).
