### PR TITLE
fix(tests): repair provisioning integration suite compile and servicekeys stubs

### DIFF
--- a/internal/commands/ports/ports_integration_test.go
+++ b/internal/commands/ports/ports_integration_test.go
@@ -96,18 +96,6 @@ func newBuyLAGPortCmd() *cobra.Command {
 	return cmd
 }
 
-func newUpdatePortCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "update"}
-	cmd.Flags().Bool("interactive", false, "")
-	cmd.Flags().String("json", "", "")
-	cmd.Flags().String("json-file", "", "")
-	cmd.Flags().String("name", "", "")
-	cmd.Flags().Bool("marketplace-visibility", false, "")
-	cmd.Flags().String("cost-centre", "", "")
-	cmd.Flags().Int("term", 0, "")
-	return cmd
-}
-
 func newDeletePortCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "delete"}
 	cmd.Flags().BoolP("force", "f", false, "")

--- a/internal/commands/servicekeys/servicekeys_lifecycle_integration_test.go
+++ b/internal/commands/servicekeys/servicekeys_lifecycle_integration_test.go
@@ -162,6 +162,9 @@ func newCreateServiceKeyCmdLifecycle() *cobra.Command {
 	cmd.Flags().Bool("active", false, "")
 	cmd.Flags().Bool("pre-approved", false, "")
 	cmd.Flags().Int("vlan", 0, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().Bool("interactive", false, "")
 	return cmd
 }
 
@@ -172,6 +175,9 @@ func newUpdateServiceKeyCmdLifecycle() *cobra.Command {
 	cmd.Flags().Bool("single-use", false, "")
 	cmd.Flags().String("description", "", "")
 	cmd.Flags().Bool("active", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().Bool("interactive", false, "")
 	return cmd
 }
 


### PR DESCRIPTION
Two fixes for the provisioning integration test job.

**Compile failure:** `newUpdatePortCmd` was declared in both `ports_actions_test.go` (untagged, compiles in every build) and `ports_integration_test.go` (`integration && provisioning`), so the tagged build failed with a redeclaration error. Drop the duplicate from the integration file.

**Service key lifecycle failures:** the tests fail at the first `CreateServiceKey` call with `failed to read --json flag: flag accessed but not defined: json`. PR #504 (ESD-1591) rerouted servicekeys create through `utils.ResolveInput`, which reads the `json`, `json-file`, and `interactive` flags to pick the input mode, but the test command stubs predate that change and never defined those flags. Add them to the create and update stubs (update reads the same flags and only avoids the failure by discarding the error).