### PR TITLE
fix(servicekeys): define input-mode flags on lifecycle test command stubs

### DIFF
--- a/internal/commands/servicekeys/servicekeys_lifecycle_integration_test.go
+++ b/internal/commands/servicekeys/servicekeys_lifecycle_integration_test.go
@@ -162,6 +162,9 @@ func newCreateServiceKeyCmdLifecycle() *cobra.Command {
 	cmd.Flags().Bool("active", false, "")
 	cmd.Flags().Bool("pre-approved", false, "")
 	cmd.Flags().Int("vlan", 0, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().Bool("interactive", false, "")
 	return cmd
 }
 
@@ -172,6 +175,9 @@ func newUpdateServiceKeyCmdLifecycle() *cobra.Command {
 	cmd.Flags().Bool("single-use", false, "")
 	cmd.Flags().String("description", "", "")
 	cmd.Flags().Bool("active", false, "")
+	cmd.Flags().String("json", "", "")
+	cmd.Flags().String("json-file", "", "")
+	cmd.Flags().Bool("interactive", false, "")
 	return cmd
 }
 


### PR DESCRIPTION
The service key provisioning integration tests fail at the first `CreateServiceKey` call with `failed to read --json flag: flag accessed but not defined: json`.

PR #504 (ESD-1591) rerouted servicekeys create through `utils.ResolveInput`, which reads the `json`, `json-file`, and `interactive` flags to pick the input mode. The lifecycle tests build a stub cobra command that predates that change and never defined those flags, so the flag lookup errors before any API call.

- Add `json`, `json-file`, and `interactive` to the create and update command stubs in `servicekeys_lifecycle_integration_test.go`. Update reads the same flags (it just discards the error today), so its stub gets them too.