### PR TITLE
ESD-1666: Route Cobra command errors to result.error in the WASM CLI

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -26,12 +26,14 @@ jobs:
         run: make wasm-vet
       - name: Run WASM unit tests
         # Runs the WASM tests that are safe under the bare go_js_wasm_exec (node)
-        # runtime. ./cmd/megaport and the whole ./internal/base/output wasm suite
-        # run cleanly under node; the rest need a browser host (fetch, JS bridge
-        # globals, stdin pipes) and are verified manually in-browser.
+        # runtime. The root package `.` (executeMegaportCommandAsync bridge tests)
+        # runs under node now that TestMain installs an in-memory localStorage shim;
+        # ./cmd/megaport and the whole ./internal/base/output wasm suite run cleanly
+        # too. The rest need a browser host (fetch, JS bridge globals, stdin pipes)
+        # and are verified manually in-browser.
         run: |
           export PATH="$PATH:$(go env GOROOT)/lib/wasm"
-          GOOS=js GOARCH=wasm go test -v -tags js,wasm ./cmd/megaport ./internal/base/output
+          GOOS=js GOARCH=wasm go test -v -tags js,wasm . ./cmd/megaport ./internal/base/output
       - name: Run WASM output-streaming unit tests
         # internal/wasm's browser-only tests live in wasm_browser_test.go behind
         # the `browser` build tag, so the default js,wasm run compiles only the

--- a/cmd/megaport/colors_wasm_test.go
+++ b/cmd/megaport/colors_wasm_test.go
@@ -25,7 +25,7 @@ func TestWasmColor_DefaultRunEnablesColor(t *testing.T) {
 	color.NoColor = true // start from the hostile js/wasm default
 
 	wasm.ResetOutputBuffers()
-	ExecuteWithArgs([]string{"megaport-cli", "ports", "list", "--output", "invalid"})
+	_ = ExecuteWithArgs([]string{"megaport-cli", "ports", "list", "--output", "invalid"})
 
 	assert.False(t, color.NoColor, "a default run should enable fatih color in the browser")
 }
@@ -39,7 +39,7 @@ func TestWasmColor_NoColorFlagDisablesColor(t *testing.T) {
 	color.NoColor = false
 
 	wasm.ResetOutputBuffers()
-	ExecuteWithArgs([]string{"megaport-cli", "ports", "list", "--no-color", "--output", "invalid"})
+	_ = ExecuteWithArgs([]string{"megaport-cli", "ports", "list", "--no-color", "--output", "invalid"})
 
 	assert.True(t, color.NoColor, "--no-color should disable fatih color")
 }
@@ -52,12 +52,12 @@ func TestWasmColor_NoStaleFlagAcrossRuns(t *testing.T) {
 	defer func() { color.NoColor = orig }()
 
 	wasm.ResetOutputBuffers()
-	ExecuteWithArgs([]string{"megaport-cli", "ports", "list", "--no-color", "--output", "invalid"})
+	_ = ExecuteWithArgs([]string{"megaport-cli", "ports", "list", "--no-color", "--output", "invalid"})
 	assert.True(t, color.NoColor, "sanity: --no-color run disables color")
 
 	// --help returns before PersistentPreRunE runs, so only the ExecuteWithArgs
 	// reset can clear the prior run's flag.
 	wasm.ResetOutputBuffers()
-	ExecuteWithArgs([]string{"megaport-cli", "ports", "list", "--help"})
+	_ = ExecuteWithArgs([]string{"megaport-cli", "ports", "list", "--help"})
 	assert.False(t, color.NoColor, "a subsequent non --no-color run must re-enable color")
 }

--- a/cmd/megaport/common_wasm.go
+++ b/cmd/megaport/common_wasm.go
@@ -30,36 +30,30 @@ var (
 		SilenceUsage:  true,  // Don't show usage on errors
 		SilenceErrors: false, // Do show errors
 		// Long will be set by the help builder later
-		Run: func(cmd *cobra.Command, args []string) {
+		// RunE (not Run) so an unknown command surfaces as a returned error:
+		// ExecuteWithArgs routes that to result.error, which the host renders as a
+		// failure and uses to emit failure telemetry. Printing the message to the
+		// output buffer instead (the old behavior) left result.error empty, so the
+		// host treated the failure as success (ESD-1666).
+		RunE: func(cmd *cobra.Command, args []string) error {
 			// If we reach here with args, it means an unknown command was used
 			if len(args) > 0 {
 				// Special messages for commands not available in WASM
 				switch args[0] {
 				case "config":
-					fmt.Fprintf(cmd.OutOrStderr(), "Error: the 'config' command is not available in the browser version\n\n")
-					fmt.Fprintf(cmd.OutOrStderr(), "Configuration is managed through the web UI login form.\n")
-					fmt.Fprintf(cmd.OutOrStderr(), "Use the --env flag to specify environment: megaport-cli ports list --env staging\n")
-					return
+					return fmt.Errorf("the 'config' command is not available in the browser version\n\nConfiguration is managed through the web UI login form.\nUse the --env flag to specify environment: megaport-cli ports list --env staging")
 				case "completion":
-					fmt.Fprintf(cmd.OutOrStderr(), "Error: the 'completion' command is not available in the browser version\n\n")
-					fmt.Fprintf(cmd.OutOrStderr(), "Shell completion is not applicable in a browser environment.\n")
-					return
+					return fmt.Errorf("the 'completion' command is not available in the browser version\n\nShell completion is not applicable in a browser environment")
 				case "generate-docs":
-					fmt.Fprintf(cmd.OutOrStderr(), "Error: the 'generate-docs' command is not available in the browser version\n\n")
-					fmt.Fprintf(cmd.OutOrStderr(), "Documentation generation is a development tool, not available in WASM.\n")
-					return
+					return fmt.Errorf("the 'generate-docs' command is not available in the browser version\n\nDocumentation generation is a development tool, not available in WASM")
 				case "version":
-					fmt.Fprintf(cmd.OutOrStderr(), "Error: the 'version' command is not available in the browser version\n\n")
-					fmt.Fprintf(cmd.OutOrStderr(), "Version information is managed by the web application.\n")
-					return
+					return fmt.Errorf("the 'version' command is not available in the browser version\n\nVersion information is managed by the web application")
 				}
-				// Show error for other unknown commands
-				fmt.Fprintf(cmd.OutOrStderr(), "Error: unknown command %q for %q\n\n", args[0], cmd.CommandPath())
-				fmt.Fprintf(cmd.OutOrStderr(), "Run 'megaport-cli --help' for usage\n")
-				return
+				// Error for other unknown commands
+				return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
 			}
 			// No args - just show help
-			_ = cmd.Help()
+			return cmd.Help()
 		},
 	}
 

--- a/cmd/megaport/error_routing_wasm_test.go
+++ b/cmd/megaport/error_routing_wasm_test.go
@@ -3,6 +3,7 @@
 package megaport
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 	"syscall/js"
@@ -130,4 +131,49 @@ func TestExecuteWithArgs_StreamedError_ReturnsNil(t *testing.T) {
 	require.True(t, wasm.DidStreamOutput(), "the action should have streamed its error")
 	assert.NoError(t, err, "a streamed error must not also be returned for result.error")
 	assert.NotEmpty(t, strings.Join(streamed, ""), "the streamed error should have reached the handler")
+}
+
+// TestExecuteWithArgs_JSONError_ReturnsNil covers the machine-readable branch:
+// a *CLIError raised under --output json is already surfaced as a structured
+// envelope, so ExecuteWithArgs returns nil (no separate result.error) to avoid
+// sitting a red Error: line on top of otherwise-valid JSON.
+func TestExecuteWithArgs_JSONError_ReturnsNil(t *testing.T) {
+	wasm.ResetOutputBuffers()
+
+	cmd := &cobra.Command{
+		Use: "jsonerrortest",
+		RunE: utils.WrapRunE(func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("boom")
+		}),
+	}
+	rootCmd.AddCommand(cmd)
+	defer rootCmd.RemoveCommand(cmd)
+
+	err := ExecuteWithArgs([]string{"megaport-cli", "--output", "json", "jsonerrortest"})
+
+	assert.NoError(t, err, "a JSON-envelope error must not also be returned for result.error")
+
+	out := wasm.GetCapturedOutput()
+	assert.Contains(t, out, "boom", "the JSON envelope should carry the failure message in output")
+	assert.Contains(t, out, "{", "output should be a JSON envelope, not a plain-text block")
+}
+
+// TestExecuteWithArgs_BrowserUnavailableCommands_RouteError covers the root
+// RunE special cases: config/completion/generate-docs/version are not registered
+// in WASM, so each must return its "not available in the browser version"
+// explanation as an error for result.error, not print it into output.
+func TestExecuteWithArgs_BrowserUnavailableCommands_RouteError(t *testing.T) {
+	for _, name := range []string{"config", "completion", "generate-docs", "version"} {
+		t.Run(name, func(t *testing.T) {
+			wasm.ResetOutputBuffers()
+
+			err := ExecuteWithArgs([]string{"megaport-cli", name})
+
+			require.Error(t, err, "an unavailable command must return an error")
+			assert.Contains(t, err.Error(), "not available in the browser version",
+				"the returned error should explain the command is unavailable")
+			assert.NotContains(t, wasm.GetCapturedOutput(), "not available in the browser version",
+				"the explanation must route to result.error, not output")
+		})
+	}
 }

--- a/cmd/megaport/error_routing_wasm_test.go
+++ b/cmd/megaport/error_routing_wasm_test.go
@@ -1,0 +1,133 @@
+//go:build js && wasm
+
+package megaport
+
+import (
+	"net/http"
+	"strings"
+	"syscall/js"
+	"testing"
+
+	"github.com/megaport/megaport-cli/internal/base/output"
+	"github.com/megaport/megaport-cli/internal/utils"
+	"github.com/megaport/megaport-cli/internal/wasm"
+	megaport "github.com/megaport/megaportgo"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecuteWithArgs_UnknownCommand_RoutesErrorNotOutput is the ESD-1666
+// regression test: a Cobra parser-layer failure (the ticket's `location list`
+// repro) must be returned as an error so the host can route it to result.error,
+// not buried in the captured output. Only the usage hint stays in output.
+func TestExecuteWithArgs_UnknownCommand_RoutesErrorNotOutput(t *testing.T) {
+	wasm.ResetOutputBuffers()
+
+	err := ExecuteWithArgs([]string{"megaport-cli", "location", "list"})
+
+	require.Error(t, err, "an unknown command must return an error")
+	assert.Contains(t, err.Error(), "unknown command", "the returned error should name the failure")
+
+	out := wasm.GetCapturedOutput()
+	assert.NotContains(t, out, "unknown command", "the error text must not stay in output")
+	assert.Contains(t, out, "Run 'megaport-cli --help'", "the usage hint may stay in output")
+}
+
+// TestExecuteWithArgs_MissingRequiredArg_RoutesError covers the other parser-layer
+// failure named in the ticket: a command that requires an argument (cobra.ExactArgs)
+// invoked without one. Cobra's arg validation fails before RunE and is not a
+// *CLIError, so it must route to the returned error, not sit in output.
+func TestExecuteWithArgs_MissingRequiredArg_RoutesError(t *testing.T) {
+	wasm.ResetOutputBuffers()
+
+	// `vxc get` is built with WithArgs(cobra.ExactArgs(1)); omit the UID.
+	err := ExecuteWithArgs([]string{"megaport-cli", "vxc", "get"})
+
+	require.Error(t, err, "a missing required arg must return an error")
+	assert.Contains(t, err.Error(), "arg(s)", "the returned error should name the arg-count failure")
+
+	out := wasm.GetCapturedOutput()
+	assert.NotContains(t, out, "arg(s)", "the error text must not stay in output")
+}
+
+// TestExecuteWithArgs_Success_ReturnsNil guards the other half of the contract:
+// a command that succeeds returns no error, so the host never sets result.error
+// on success. --help returns before any network call is made.
+func TestExecuteWithArgs_Success_ReturnsNil(t *testing.T) {
+	wasm.ResetOutputBuffers()
+
+	err := ExecuteWithArgs([]string{"megaport-cli", "--help"})
+
+	assert.NoError(t, err, "a successful command must not return an error")
+	assert.NotEmpty(t, wasm.GetCapturedOutput(), "help output should still be captured")
+}
+
+// TestExecuteWithArgs_UnknownCommand_WithHandler_RoutesError is the Portal
+// scenario: a live-output handler is registered, and the ticket's `location list`
+// repro fails at the parser layer. Because cobra's error print is silenced, the
+// error never streams as a normal chunk, so ExecuteWithArgs returns it for
+// result.error (red Error: line + failure telemetry) while only the usage hint
+// streams to the terminal.
+func TestExecuteWithArgs_UnknownCommand_WithHandler_RoutesError(t *testing.T) {
+	wasm.ResetOutputBuffers()
+
+	var streamed []string
+	fn := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		if len(args) > 0 {
+			streamed = append(streamed, args[0].String())
+		}
+		return nil
+	})
+	defer fn.Release()
+	wasm.RegisterOutputCallback(fn.Value)
+	defer wasm.UnregisterOutputCallback()
+
+	err := ExecuteWithArgs([]string{"megaport-cli", "location", "list"})
+
+	require.Error(t, err, "an unknown command must return an error even with a handler")
+	assert.Contains(t, err.Error(), "unknown command", "the returned error should name the failure")
+	assert.NotContains(t, strings.Join(streamed, ""), "unknown command",
+		"the error text must reach result.error, not stream as an uncolored chunk")
+}
+
+// TestExecuteWithArgs_StreamedError_ReturnsNil locks in the no-double-render
+// rule: when an action streams its own error to a live-output handler before
+// returning, ExecuteWithArgs returns nil so the host does not render a second
+// red Error: line on top of the streamed text.
+func TestExecuteWithArgs_StreamedError_ReturnsNil(t *testing.T) {
+	t.Setenv("MEGAPORT_ACCESS_TOKEN", "some-token")
+
+	wasm.ResetOutputBuffers()
+
+	var streamed []string
+	fn := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		if len(args) > 0 {
+			streamed = append(streamed, args[0].String())
+		}
+		return nil
+	})
+	defer fn.Release()
+	wasm.RegisterOutputCallback(fn.Value)
+	defer wasm.UnregisterOutputCallback()
+
+	cmd := &cobra.Command{
+		Use: "streamederrortest",
+		RunE: utils.WrapRunE(func(cmd *cobra.Command, args []string) error {
+			apiErr := &megaport.ErrorResponse{
+				Response: &http.Response{StatusCode: 500, Header: http.Header{}, Request: &http.Request{}},
+				Message:  "boom",
+			}
+			output.PrintError("Failed: %v", false, apiErr)
+			return apiErr
+		}),
+	}
+	rootCmd.AddCommand(cmd)
+	defer rootCmd.RemoveCommand(cmd)
+
+	err := ExecuteWithArgs([]string{"megaport-cli", "streamederrortest"})
+
+	require.True(t, wasm.DidStreamOutput(), "the action should have streamed its error")
+	assert.NoError(t, err, "a streamed error must not also be returned for result.error")
+	assert.NotEmpty(t, strings.Join(streamed, ""), "the streamed error should have reached the handler")
+}

--- a/cmd/megaport/ix_wasm_test.go
+++ b/cmd/megaport/ix_wasm_test.go
@@ -32,7 +32,7 @@ func TestIXModuleRegistered(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			wasm.ResetOutputBuffers()
-			ExecuteWithArgs(tc.args)
+			_ = ExecuteWithArgs(tc.args)
 			out := wasm.GetCapturedOutput()
 			assert.NotContains(t, out, "unknown command", "%v should be a registered command", tc.args)
 			assert.Contains(t, out, tc.usage, "%v help should show its usage path", tc.args)

--- a/cmd/megaport/megaport_wasm.go
+++ b/cmd/megaport/megaport_wasm.go
@@ -17,7 +17,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func ExecuteWithArgs(args []string) {
+// ExecuteWithArgs runs the command tree against args and returns the error the
+// host should surface as result.error, or nil. The error is returned only when
+// it hasn't already reached the user another way: the JSON envelope branch and
+// any path where output already streamed or was captured return nil, so the
+// host doesn't double-render a message the terminal already shows.
+func ExecuteWithArgs(args []string) error {
 	// Reset all flags on the command tree so that flag values from a previous
 	// execution don't leak into the current one. Cobra marks flags as "Changed"
 	// after parsing, and this state persists when the same command tree is reused
@@ -50,12 +55,14 @@ func ExecuteWithArgs(args []string) {
 		argsToUse = args[1:]
 	}
 
-	// Disable automatic usage on errors so we can control the output.
-	// Also reset SilenceErrors: a prior JSON-mode failure may have set it true
-	// via cmd.Root().SilenceErrors = true in a RunE wrapper, and the command
-	// tree is reused across WASM invocations.
+	// Disable automatic usage and error printing so we own the failure output.
+	// SilenceErrors must be true: cobra otherwise writes "Error: ..." to the
+	// output buffer during Execute, which under a live-output handler streams to
+	// the terminal before ExecuteWithArgs can route the error to result.error,
+	// re-introducing the uncolored-failure/no-telemetry bug (ESD-1666). Set
+	// unconditionally since the command tree is reused across WASM invocations.
 	rootCmd.SilenceUsage = true
-	rootCmd.SilenceErrors = false
+	rootCmd.SilenceErrors = true
 
 	// Set the args on the root command
 	rootCmd.SetArgs(argsToUse)
@@ -66,51 +73,52 @@ func ExecuteWithArgs(args []string) {
 	// flag, used by WrapRunE / WrapColorAwareRunE).
 	executedCmd, err := rootCmd.ExecuteC()
 
-	if err != nil {
-		// When the error is a *CLIError returned by a RunE wrapper in JSON mode,
-		// the wrapper has already written the structured JSON error via
-		// PrintErrorJSON. Skip the plain-text block to avoid corrupting
-		// machine-readable output. We gate on *CLIError (not just the --output
-		// flag) because errors that occur before a wrapper runs (e.g., flag
-		// parse errors) are not *CLIError and still need the plain-text block.
-		var cliErr *exitcodes.CLIError
-		if errors.As(err, &cliErr) && resolveOutputFormat(executedCmd) == utils.FormatJSON {
-			// Reset the buffer to remove any plain-text output written before
-			// the error (commands may call output.PrintError etc. before
-			// returning), then re-emit a single clean JSON envelope so the
-			// buffer contains only valid JSON.
-			wasm.ResetOutputBuffers()
-			output.PrintErrorJSON(cliErr.Code, cliErr.Error())
-			return
-		}
-		// When a live-output handler is registered the error has already
-		// streamed during execution (the RunE wrapper's PrintError, or cobra's
-		// own error print). Streamed chunks cannot be retracted, so the
-		// reset-and-rewrite used by the capture path would double-render the
-		// error in the terminal. Skip it; only surface an error here if nothing
-		// streamed at all (e.g. a flag-parse failure on a command whose
-		// SilenceErrors latched true on a prior run), so the failure is not silent.
-		if wasm.HasOutputHandler() {
-			// Emit a fallback only when nothing streamed AND nothing was
-			// captured. If a wrapper or cobra already wrote the error into the
-			// buffer (e.g. a throwing handler failed to deliver it), completion
-			// returns that captured buffer, so appending here would duplicate it.
-			// Emitting only when the buffer is empty keeps the failure from being
-			// silent without doubling it up.
-			if !wasm.DidStreamOutput() && wasm.WasmOutputBuffer.String() == "" {
-				fmt.Fprintf(wasm.WasmOutputBuffer, "Error: %v\n\n", err)
-				fmt.Fprintf(wasm.WasmOutputBuffer, "Run 'megaport-cli --help' to see the list of available commands.\n")
-			}
-			return
-		}
-
-		// Capture path (no handler): clear anything written before the error and
-		// rewrite a single clean error block for the returned result.
-		wasm.ResetOutputBuffers()
-
-		fmt.Fprintf(wasm.WasmOutputBuffer, "Error: %v\n\n", err)
-		fmt.Fprintf(wasm.WasmOutputBuffer, "Run 'megaport-cli --help' to see the list of available commands.\n")
+	if err == nil {
+		return nil
 	}
+
+	// When the error is a *CLIError returned by a RunE wrapper in JSON mode,
+	// the wrapper has already written the structured JSON error via
+	// PrintErrorJSON. Skip the plain-text block to avoid corrupting
+	// machine-readable output, and return nil: the JSON envelope is the
+	// surfaced failure, so routing it to result.error too would sit a red
+	// Error: line on top of the machine-readable output. We gate on *CLIError
+	// (not just the --output flag) because errors that occur before a wrapper
+	// runs (e.g., flag parse errors) are not *CLIError and still need routing.
+	var cliErr *exitcodes.CLIError
+	if errors.As(err, &cliErr) && resolveOutputFormat(executedCmd) == utils.FormatJSON {
+		// Reset the buffer to remove any plain-text output written before
+		// the error (commands may call output.PrintError etc. before
+		// returning), then re-emit a single clean JSON envelope so the
+		// buffer contains only valid JSON.
+		wasm.ResetOutputBuffers()
+		output.PrintErrorJSON(cliErr.Code, cliErr.Error())
+		return nil
+	}
+	// When a live-output handler is registered the error may already have
+	// streamed during execution (the RunE wrapper's PrintError, or cobra's own
+	// error print). Streamed chunks cannot be retracted, so returning the error
+	// as result.error too would double-render it in the terminal.
+	if wasm.HasOutputHandler() {
+		// Only surface the error when nothing streamed AND nothing was captured
+		// (e.g. a flag-parse failure before any command ran): keep the usage
+		// hint in output and return the error so the host renders it and emits
+		// failure telemetry. Otherwise the error is already in the terminal or
+		// the captured buffer, so return nil to avoid duplicating it.
+		if !wasm.DidStreamOutput() && wasm.WasmOutputBuffer.String() == "" {
+			fmt.Fprintf(wasm.WasmOutputBuffer, "Run 'megaport-cli --help' to see the list of available commands.\n")
+			return err
+		}
+		return nil
+	}
+
+	// Capture path (no handler): clear anything written before the error and
+	// keep only the usage hint in output. The failure message itself is
+	// returned so the host can route it to result.error rather than burying it
+	// in result.output uncolored.
+	wasm.ResetOutputBuffers()
+	fmt.Fprintf(wasm.WasmOutputBuffer, "Run 'megaport-cli --help' to see the list of available commands.\n")
+	return err
 }
 
 // resolveOutputFormat returns the --output value for the command that ran.

--- a/cmd/megaport/megaport_wasm.go
+++ b/cmd/megaport/megaport_wasm.go
@@ -55,12 +55,9 @@ func ExecuteWithArgs(args []string) error {
 		argsToUse = args[1:]
 	}
 
-	// Disable automatic usage and error printing so we own the failure output.
-	// SilenceErrors must be true: cobra otherwise writes "Error: ..." to the
-	// output buffer during Execute, which under a live-output handler streams to
-	// the terminal before ExecuteWithArgs can route the error to result.error,
-	// re-introducing the uncolored-failure/no-telemetry bug (ESD-1666). Set
-	// unconditionally since the command tree is reused across WASM invocations.
+	// Own the failure output. SilenceErrors stops cobra writing "Error: ..." to
+	// the buffer before we can route it to result.error. Set unconditionally
+	// because the command tree is reused across invocations.
 	rootCmd.SilenceUsage = true
 	rootCmd.SilenceErrors = true
 
@@ -77,14 +74,11 @@ func ExecuteWithArgs(args []string) error {
 		return nil
 	}
 
-	// When the error is a *CLIError returned by a RunE wrapper in JSON mode,
-	// the wrapper has already written the structured JSON error via
-	// PrintErrorJSON. Skip the plain-text block to avoid corrupting
-	// machine-readable output, and return nil: the JSON envelope is the
-	// surfaced failure, so routing it to result.error too would sit a red
-	// Error: line on top of the machine-readable output. We gate on *CLIError
-	// (not just the --output flag) because errors that occur before a wrapper
-	// runs (e.g., flag parse errors) are not *CLIError and still need routing.
+	// A *CLIError in JSON mode already wrote the structured envelope via
+	// PrintErrorJSON, so re-emit a clean one and return nil (routing it to
+	// result.error too would stack a red line on machine-readable output).
+	// Gate on *CLIError, not the flag: pre-wrapper errors (e.g. flag parse)
+	// aren't *CLIError and still need routing.
 	var cliErr *exitcodes.CLIError
 	if errors.As(err, &cliErr) && resolveOutputFormat(executedCmd) == utils.FormatJSON {
 		// Reset the buffer to remove any plain-text output written before

--- a/cmd/megaport/modules_wasm_test.go
+++ b/cmd/megaport/modules_wasm_test.go
@@ -32,7 +32,7 @@ func TestReadOnlyModulesRegistered(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			wasm.ResetOutputBuffers()
-			ExecuteWithArgs(tc.args)
+			_ = ExecuteWithArgs(tc.args)
 			out := wasm.GetCapturedOutput()
 			assert.NotContains(t, out, "unknown command", "%v should be a registered command", tc.args)
 			assert.Contains(t, out, tc.usage, "%v help should show its usage path", tc.args)
@@ -63,7 +63,7 @@ func TestAccountPartnerAdminModulesRegistered(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			wasm.ResetOutputBuffers()
-			ExecuteWithArgs(tc.args)
+			_ = ExecuteWithArgs(tc.args)
 			out := wasm.GetCapturedOutput()
 			// An unregistered command falls back to root help, which lacks
 			// this command's Usage: block, so Contains is the real check.

--- a/cmd/megaport/nat_gateway_wasm_test.go
+++ b/cmd/megaport/nat_gateway_wasm_test.go
@@ -31,7 +31,7 @@ func TestNATGatewayModuleRegistered(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			wasm.ResetOutputBuffers()
-			ExecuteWithArgs(tc.args)
+			_ = ExecuteWithArgs(tc.args)
 			out := wasm.GetCapturedOutput()
 			assert.NotContains(t, out, "unknown command", "%v should be a registered command", tc.args)
 			assert.Contains(t, out, tc.usage, "%v help should show its usage path", tc.args)

--- a/cmd/megaport/session_expired_wasm_test.go
+++ b/cmd/megaport/session_expired_wasm_test.go
@@ -57,7 +57,7 @@ func TestExecuteWithArgs_SessionExpired_StreamsMarkerToHandler(t *testing.T) {
 	rootCmd.AddCommand(cmd)
 	defer rootCmd.RemoveCommand(cmd)
 
-	ExecuteWithArgs([]string{"megaport-cli", "sessionexpiredtest"})
+	_ = ExecuteWithArgs([]string{"megaport-cli", "sessionexpiredtest"})
 
 	require.True(t, wasm.DidStreamOutput(), "the error was streamed to the handler")
 	assert.Contains(t, strings.Join(streamed, ""), utils.SessionExpiredMarker,

--- a/cmd/megaport/unknown_flags_wasm_test.go
+++ b/cmd/megaport/unknown_flags_wasm_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/megaport/megaport-cli/internal/wasm"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestExecuteWithArgs_RejectsUnknownFlags is the ESD-1634 regression test:
@@ -31,10 +32,13 @@ func TestExecuteWithArgs_RejectsUnknownFlags(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			wasm.ResetOutputBuffers()
-			ExecuteWithArgs(tc.args)
-			out := wasm.GetCapturedOutput()
-			assert.Contains(t, out, "unknown flag", "%v should report the unknown flag", tc.args)
-			assert.NotContains(t, out, "required flag(s)", "%v should not fall through to a required-flag error", tc.args)
+			err := ExecuteWithArgs(tc.args)
+			require.Error(t, err, "%v should return an error", tc.args)
+			assert.Contains(t, err.Error(), "unknown flag", "%v should report the unknown flag", tc.args)
+			assert.NotContains(t, err.Error(), "required flag(s)", "%v should not fall through to a required-flag error", tc.args)
+			// The failure must land in result.error (the returned error), not be
+			// buried in result.output; only the usage hint stays in output.
+			assert.NotContains(t, wasm.GetCapturedOutput(), "unknown flag", "%v error text must not stay in output", tc.args)
 		})
 	}
 }
@@ -61,7 +65,7 @@ func TestExecuteWithArgs_ValidTraversalStillResolves(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			wasm.ResetOutputBuffers()
-			ExecuteWithArgs(tc.args)
+			_ = ExecuteWithArgs(tc.args)
 			out := wasm.GetCapturedOutput()
 			assert.NotContains(t, out, "unknown flag", "%v should not be treated as an unknown flag", tc.args)
 			assert.NotContains(t, out, "unknown command", "%v should be a registered command", tc.args)

--- a/internal/wasm/sanitize.go
+++ b/internal/wasm/sanitize.go
@@ -34,12 +34,12 @@ func SanitizeTerminalOutput(s string) string {
 	return sanitizeControlSequences(s, true)
 }
 
-// SanitizeTerminalText strips all C0/C1 controls, DEL, and ESC from a single
-// field value bound for the live prompt channel (see the WASM prompt bridge
-// in internal/utils/prompts_wasm.go). Prompt messages carry no color, so
-// nothing needs to be allowlisted, and callers insert their own structural
-// line breaks after sanitizing each field, so \n/\r/\t are stripped like any
-// other control byte.
+// SanitizeTerminalText strips all C0/C1 controls, DEL, and ESC from a value
+// bound for a channel that carries no color of its own: the live prompt channel
+// (see the WASM prompt bridge in internal/utils/prompts_wasm.go) and the async
+// result.error field, which the host renders as its own styled error line.
+// Nothing needs to be allowlisted, and \n/\r/\t are stripped like any other
+// control byte since callers supply their own structural line breaks.
 func SanitizeTerminalText(s string) string {
 	return sanitizeControlSequences(s, false)
 }

--- a/main_wasm.go
+++ b/main_wasm.go
@@ -95,7 +95,7 @@ func executeMegaportCommandAsync(this js.Value, args []js.Value) interface{} {
 			if r := recover(); r != nil {
 				once.Do(func() {
 					callback.Invoke(map[string]interface{}{
-						"error": fmt.Sprintf("Command panicked: %v", r),
+						"error": wasm.SanitizeTerminalText(fmt.Sprintf("Command panicked: %v", r)),
 					})
 				})
 			}
@@ -129,16 +129,17 @@ func executeMegaportCommandAsync(this js.Value, args []js.Value) interface{} {
 			resultObj := map[string]interface{}{
 				"output": result,
 			}
-			// Route a command failure to result.error so the host can render it
-			// as an error and emit failure telemetry, instead of leaving it
-			// uncolored in result.output. ExecuteWithArgs returns nil when the
-			// error already reached the terminal another way, so this does not
-			// double-render. Sanitize first: a parser error can echo a user-typed
-			// flag or command name verbatim (pflag's "unknown flag: --%s"), and
-			// the host writes result.error straight to xterm, so control bytes
-			// must be neutralized here the way WasmOutputBuffer does for output.
+			// Route a command failure to result.error so the host renders it as
+			// an error and emits failure telemetry instead of leaving it uncolored
+			// in result.output. ExecuteWithArgs returns nil when the error already
+			// reached the terminal, so this does not double-render. Sanitize with
+			// SanitizeTerminalText (strip all control bytes), not the SGR-allowing
+			// SanitizeTerminalOutput: a parser error can echo a user-typed flag
+			// verbatim (pflag's "unknown flag: --%s") and the host writes
+			// result.error straight to xterm, and the error line carries no color
+			// of its own (the host styles it), so no escape sequence should survive.
 			if execErr != nil {
-				resultObj["error"] = wasm.SanitizeTerminalOutput(execErr.Error())
+				resultObj["error"] = wasm.SanitizeTerminalText(execErr.Error())
 			}
 			callback.Invoke(resultObj)
 		})

--- a/main_wasm.go
+++ b/main_wasm.go
@@ -119,16 +119,28 @@ func executeMegaportCommandAsync(this js.Value, args []js.Value) interface{} {
 		// Ensure Cobra gets all our commands
 		megaport.EnsureRootCommandOutput(wasm.WasmOutputBuffer)
 
-		megaport.ExecuteWithArgs(originalArgs)
+		execErr := megaport.ExecuteWithArgs(originalArgs)
 
 		// When a live-output handler is registered the narrative has already
 		// streamed to the host; GetCompletionOutput returns only the structured
 		// document (or "") so the host does not double-render it.
 		result := wasm.GetCompletionOutput()
 		once.Do(func() {
-			callback.Invoke(map[string]interface{}{
+			resultObj := map[string]interface{}{
 				"output": result,
-			})
+			}
+			// Route a command failure to result.error so the host can render it
+			// as an error and emit failure telemetry, instead of leaving it
+			// uncolored in result.output. ExecuteWithArgs returns nil when the
+			// error already reached the terminal another way, so this does not
+			// double-render. Sanitize first: a parser error can echo a user-typed
+			// flag or command name verbatim (pflag's "unknown flag: --%s"), and
+			// the host writes result.error straight to xterm, so control bytes
+			// must be neutralized here the way WasmOutputBuffer does for output.
+			if execErr != nil {
+				resultObj["error"] = wasm.SanitizeTerminalOutput(execErr.Error())
+			}
+			callback.Invoke(resultObj)
 		})
 	}()
 

--- a/main_wasm.go
+++ b/main_wasm.go
@@ -129,15 +129,11 @@ func executeMegaportCommandAsync(this js.Value, args []js.Value) interface{} {
 			resultObj := map[string]interface{}{
 				"output": result,
 			}
-			// Route a command failure to result.error so the host renders it as
-			// an error and emits failure telemetry instead of leaving it uncolored
-			// in result.output. ExecuteWithArgs returns nil when the error already
-			// reached the terminal, so this does not double-render. Sanitize with
-			// SanitizeTerminalText (strip all control bytes), not the SGR-allowing
-			// SanitizeTerminalOutput: a parser error can echo a user-typed flag
-			// verbatim (pflag's "unknown flag: --%s") and the host writes
-			// result.error straight to xterm, and the error line carries no color
-			// of its own (the host styles it), so no escape sequence should survive.
+			// Route failures to result.error so the host colors them and fires
+			// failure telemetry (ExecuteWithArgs returns nil when the error already
+			// reached the terminal, so no double-render). SanitizeTerminalText strips
+			// every control byte: the message can echo a user-typed flag verbatim
+			// and the host writes result.error straight to xterm under its own color.
 			if execErr != nil {
 				resultObj["error"] = wasm.SanitizeTerminalText(execErr.Error())
 			}

--- a/main_wasm_test.go
+++ b/main_wasm_test.go
@@ -35,6 +35,15 @@ func TestMain(m *testing.M) {
 	js.Global().Set("executeMegaportCommand", js.FuncOf(executeMegaportCommand))
 	js.Global().Set("executeMegaportCommandAsync", js.FuncOf(executeMegaportCommandAsync))
 
+	// The bare-node WASM test host has no localStorage, so the config-file and
+	// localStorage helpers, which call it directly, panic and take down the whole
+	// test binary. Install a minimal in-memory shim so those tests run for real
+	// under node; a browser host already provides localStorage, so only shim when
+	// it is absent.
+	if js.Global().Get("localStorage").IsUndefined() {
+		js.Global().Call("eval", `(function(){var s={};globalThis.localStorage={getItem:function(k){return Object.prototype.hasOwnProperty.call(s,k)?s[k]:null;},setItem:function(k,v){s[k]=String(v);},removeItem:function(k){delete s[k];},clear:function(){s={};}};})();`)
+	}
+
 	os.Exit(m.Run())
 }
 
@@ -217,8 +226,8 @@ func TestExecuteMegaportCommandAsync_InvalidCallback(t *testing.T) {
 
 // TestOutputBufferReset verifies output buffers reset between commands
 func TestOutputBufferReset(t *testing.T) {
-	result1 := invokeAsyncAndWait(t, "version")
-	assert.True(t, result1.Get("error").IsUndefined(), "version command returned an error: %v", result1.Get("error"))
+	result1 := invokeAsyncAndWait(t, "ports --help")
+	assert.True(t, result1.Get("error").IsUndefined(), "ports --help command returned an error: %v", result1.Get("error"))
 	output1 := result1.Get("output").String()
 
 	result2 := invokeAsyncAndWait(t, "--help")
@@ -467,7 +476,7 @@ func TestConcurrentCommands(t *testing.T) {
 		executeMegaportCmdAsync.Invoke(js.ValueOf(cmd), callback)
 	}
 
-	invoke("version")
+	invoke("ports --help")
 	invoke("--help")
 
 	results := make(map[string]string, 2)
@@ -480,7 +489,7 @@ func TestConcurrentCommands(t *testing.T) {
 		}
 	}
 
-	assert.NotEmpty(t, results["version"])
+	assert.NotEmpty(t, results["ports --help"])
 	assert.NotEmpty(t, results["--help"])
-	assert.NotEqual(t, results["version"], results["--help"])
+	assert.NotEqual(t, results["ports --help"], results["--help"])
 }

--- a/main_wasm_test.go
+++ b/main_wasm_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/megaport/megaport-cli/internal/base/output"
 	"github.com/megaport/megaport-cli/internal/wasm"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestMain mirrors main()'s registration (minus the blocking channel wait):
@@ -124,6 +125,41 @@ func invokeAsyncAndWait(t *testing.T, cmd string) js.Value {
 		t.Fatalf("executeMegaportCommandAsync callback never fired for command %q", cmd)
 		return errResult("test helper: callback never fired")
 	}
+}
+
+// TestExecuteMegaportCommandAsync_UnknownCommand_RoutesToError is the ESD-1666
+// bridge-level regression: an unknown command must populate result.error so the
+// Portal renders the red Error: line and emits the failure telemetry event,
+// rather than leaving the failure only in result.output (uncolored, uncounted).
+func TestExecuteMegaportCommandAsync_UnknownCommand_RoutesToError(t *testing.T) {
+	wasm.ResetOutputBuffers()
+
+	result := invokeAsyncAndWait(t, "location list")
+
+	errVal := result.Get("error")
+	require.False(t, errVal.IsUndefined(), "unknown command should populate result.error")
+	assert.Contains(t, errVal.String(), "unknown command")
+
+	if out := result.Get("output"); !out.IsUndefined() {
+		assert.NotContains(t, out.String(), "unknown command", "error text must not also be in result.output")
+	}
+}
+
+// TestExecuteMegaportCommandAsync_ErrorIsSanitized guards the security fix that
+// rides along with ESD-1666: a parser error echoes a user-typed flag name
+// verbatim (pflag's "unknown flag: --%s"), and the host writes result.error
+// straight to xterm. Routing that error to result.error must not bypass the
+// control-byte sanitization WasmOutputBuffer applies to result.output, or a
+// crafted flag name becomes a terminal-injection vector.
+func TestExecuteMegaportCommandAsync_ErrorIsSanitized(t *testing.T) {
+	wasm.ResetOutputBuffers()
+
+	// An unknown flag whose name embeds an ESC-based clear-screen sequence.
+	result := invokeAsyncAndWait(t, "locations list --\x1b[2Jevil")
+
+	errVal := result.Get("error")
+	require.False(t, errVal.IsUndefined(), "an unknown flag should populate result.error")
+	assert.NotContains(t, errVal.String(), "\x1b", "control bytes must be stripped from result.error")
 }
 
 // TestExecuteMegaportCommandAsync_Callback verifies async command with callback


### PR DESCRIPTION
Parser-layer failures in the WASM CLI (unknown command, invalid flags, missing required args) wrote the error into `result.output` and left `result.error` empty. The Portal keys success/failure off `result.error`, so those failures rendered uncolored and never fired the `cli_terminal_command_failed` telemetry event (ENG-33590). This routes the failure to `result.error` instead.

- `ExecuteWithArgs` now returns the failure error; the async bridge sets `result.error` from it and keeps only the usage hint in `result.output`.
- The root command's unknown-command handling is now `RunE` returning a real error, instead of printing `Error: ...` to the output buffer (that was why `location list` never reached `result.error`).
- `SilenceErrors` is set so cobra doesn't stream its own `Error:` line before we can route it (which would double-render under a live-output handler).
- The JSON-envelope and streamed-error paths still return `nil`, so an error already shown to the terminal isn't rendered twice.
- `result.error` (and the panic-recovery error) is sanitized with `SanitizeTerminalText`, which strips every control byte: a parser error can echo a user-typed flag name verbatim and the host writes `result.error` straight to xterm, and the host styles the error line itself so no escape sequence needs to survive.
- Made the WASM root-package tests run under bare node: added an in-memory `localStorage` shim in `TestMain` (the config-file and localStorage tests previously panicked, which masked later failures) and repointed two tests off the now-unavailable `version` command.

No Portal-side changes required.

**Verified against Portal source (web-monorepo)**
- The Portal writes `result.error` straight to xterm via `terminal.write(\`\x1b[31mError: ${result.error}\x1b[0m\r\n\`)` (`useXtermShell.ts`), no HTML escaping, wrapped in its own red SGR. So the sanitization is genuinely required and `SanitizeTerminalText` (strip all control bytes) is the right choice: the host supplies the color, nothing in the message should survive.
- Telemetry (`onError`) fires only when `result.error` is non-empty (`useXtermShell.ts` -> `useCliTelemetry.ts`, event `cli_terminal_command_result_error`), confirming the fix is what makes failure telemetry fire.
- The Portal never registers an output handler (only a prompt handler), so in production `HasOutputHandler()` is false and every failure takes the capture path. That means command-execution errors (an action calling `output.PrintError`) also route to `result.error` there, so telemetry fires for those too. The streamed-error "no telemetry" case only applies to a hypothetical consumer that registers a live-output handler, which the Portal does not.