### PR TITLE
ESD-1689: Test BGP JSON validation errors at a non-zero connection index

### DIFF
--- a/internal/commands/vxc/vxc_inputs_test.go
+++ b/internal/commands/vxc/vxc_inputs_test.go
@@ -1026,6 +1026,49 @@ func TestParseVRouterConfigBGP(t *testing.T) {
 			},
 			expectedError: "importWhitelist must be a number",
 		},
+		{
+			name: "second of two BGP connections wrong type reports index 1, not index 0",
+			config: map[string]interface{}{
+				"connectType": "VROUTER",
+				"interfaces": []interface{}{
+					map[string]interface{}{
+						"bgpConnections": []interface{}{
+							map[string]interface{}{
+								"peerAsn":        65000.0,
+								"localIpAddress": "192.168.1.1",
+								"peerIpAddress":  "192.168.1.2",
+							},
+							map[string]interface{}{"shutdown": "yes"},
+						},
+					},
+				},
+			},
+			expectedError: "shutdown must be a boolean in BGP connection 1 of interface 0",
+		},
+		{
+			name: "third of three BGP connections wrong type reports index 2",
+			config: map[string]interface{}{
+				"connectType": "VROUTER",
+				"interfaces": []interface{}{
+					map[string]interface{}{
+						"bgpConnections": []interface{}{
+							map[string]interface{}{
+								"peerAsn":        65000.0,
+								"localIpAddress": "192.168.1.1",
+								"peerIpAddress":  "192.168.1.2",
+							},
+							map[string]interface{}{
+								"peerAsn":        65001.0,
+								"localIpAddress": "192.168.1.3",
+								"peerIpAddress":  "192.168.1.4",
+							},
+							map[string]interface{}{"medIn": "lots"},
+						},
+					},
+				},
+			},
+			expectedError: "medIn must be a number in BGP connection 2 of interface 0",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adds test coverage proving `parseBGPConnections` reports the correct connection index when the bad-type field is on a non-first entry in a multi-connection `bgpConnections` array, not just index 0. Every existing case only ever exercised a single-entry array, so the index arithmetic at a non-zero position was never proven correct.

- Two new subtests in `TestParseVRouterConfigBGP`: one with a bad field on the second of two connections (index 1), one on the third of three (index 2).
- Test-only change, no production code touched.

Verified the assertions are load-bearing by temporarily swapping the `j`/`ifaceIndex` arguments in production code and confirming both new subtests fail, then reverting.
